### PR TITLE
Cleanup api calls

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -163,20 +163,20 @@ class AppController extends Controller
                     }
                 }
             }
-
-            $data['api'] = $api;
+            $data['_api'] = $api;
         }
+        unset($data['relations']);
 
         // prepare attributes: only modified attributes
-        if (!empty($data['actualAttributes'])) {
-            $attributes = json_decode($data['actualAttributes'], true);
+        if (!empty($data['_actualAttributes'])) {
+            $attributes = json_decode($data['_actualAttributes'], true);
             foreach ($attributes as $key => $value) {
                 // remove unchanged attributes from $data
                 if (isset($data[$key]) && !$this->hasFieldChanged($value, $data[$key])) {
                     unset($data[$key]);
                 }
             }
-            unset($data['actualAttributes']);
+            unset($data['_actualAttributes']);
         }
 
         return $data;

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -263,14 +263,15 @@ class ModulesController extends AppController
         $requestData = $this->prepareRequest($this->objectType);
 
         try {
-            if (!empty($requestData['api'])) {
-                foreach ($requestData['api'] as $api) {
+            if (!empty($requestData['_api'])) {
+                foreach ($requestData['_api'] as $api) {
                     extract($api); // method, id, type, relation, relatedIds
                     if (in_array($method, ['addRelated', 'removeRelated', 'replaceRelated'])) {
                         $this->apiClient->{$method}($id, $this->objectType, $relation, $relatedIds);
                     }
                 }
             }
+            unset($requestData['_api']);
 
             // upload file (if available)
             $this->Modules->upload($requestData);

--- a/src/Template/Element/Form/core_properties.twig
+++ b/src/Template/Element/Form/core_properties.twig
@@ -14,7 +14,7 @@
 
         {% if object.attributes or resource.attributes %}
         {% set attributes = (object.attributes) ? object.attributes : resource.attributes %}
-        {{ Form.hidden('actualAttributes', {'value': attributes|json_encode})|raw }}
+        {{ Form.hidden('_actualAttributes', {'value': attributes|json_encode})|raw }}
         {% endif %}
     </div>
 </section>

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -251,6 +251,18 @@ class AppControllerTest extends TestCase
                     'jsonKey2' => '{"gin":"vodka","fritz":"kola"}',
                 ]
             ],
+            'actual attrs' => [ // test '_actualAttributes'
+                'documents', // object_type
+                [ // expected
+                    'description' => 'dido',
+                ],
+                [ // data provided
+                    'title' => 'bibo',
+                    'description' => 'dido',
+                    '_actualAttributes' => '{"title":"bibo","description":""}',
+                ]
+            ],
+
             'users' => [ // test: removing password from data
                 'users', // object_type
                 [ 'name' => 'giova' ], // expected
@@ -264,12 +276,7 @@ class AppControllerTest extends TestCase
                 'documents', // object_type
                 [
                     'id' => '1',
-                    'relations' => [
-                        'attach' => [
-                            'addRelated' => '[{ "id": "44", "type": "images"}]'
-                        ]
-                    ],
-                    'api' => [ // expected new property in data
+                    '_api' => [ // expected new property in data
                         [
                             'method' => 'addRelated',
                             'id' => '1',


### PR DESCRIPTION
* use `_` prefix for auxiliary data to avoid naming conflicts
* unset `relations` and `_api` internal array before sending a save request