### PR TITLE
feat: date format ISO_8601 YYYY-MM-DDTHH:mm:ssZ

### DIFF
--- a/src/Template/Layout/js/app/components/date-input.js
+++ b/src/Template/Layout/js/app/components/date-input.js
@@ -73,7 +73,8 @@ export default {
         options.formatDate = (dateObj, format) => {
             // this value goes to the hidden input which will be saved, needs to be a correct ISO8601
             if (format === 'Z') {
-                return moment(dateObj).toISOString();
+
+                return moment(dateObj, moment.ISO_8601).format('YYYY-MM-DDTHH:mm:ssZ');
             }
             // or else timezone infos will be added to date string
             let now = new Date();

--- a/src/Template/Layout/js/app/components/date-input.js
+++ b/src/Template/Layout/js/app/components/date-input.js
@@ -73,7 +73,6 @@ export default {
         options.formatDate = (dateObj, format) => {
             // this value goes to the hidden input which will be saved, needs to be a correct ISO8601
             if (format === 'Z') {
-
                 return moment(dateObj, moment.ISO_8601).format('YYYY-MM-DDTHH:mm:ssZ');
             }
             // or else timezone infos will be added to date string


### PR DESCRIPTION
This fixes #320 
Date format in javascript: `moment.ISO_8601` + `YYYY-MM-DDTHH:mm:ssZ`.