### PR TITLE
fix: properly save fields with null value

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -173,7 +173,7 @@ class AppController extends Controller
             $attributes = json_decode($data['_actualAttributes'], true);
             foreach ($attributes as $key => $value) {
                 // remove unchanged attributes from $data
-                if (isset($data[$key]) && !$this->hasFieldChanged($value, $data[$key])) {
+                if (array_key_exists($key, $data) && !$this->hasFieldChanged($value, $data[$key])) {
                     unset($data[$key]);
                 }
             }
@@ -192,8 +192,11 @@ class AppController extends Controller
      */
     protected function hasFieldChanged($value1, $value2)
     {
+        if ($value1 === $value2) {
+            return false; // not changed
+        }
         if (($value1 === null || $value1 === '') && ($value2 === null || $value2 === '')) {
-            return false;
+            return false; // not changed
         }
         if (is_bool($value1) && !is_bool($value2)) { // i.e. true / "1"
             return $value1 !== boolval($value2);

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -265,7 +265,18 @@ class AppControllerTest extends TestCase
                     '_actualAttributes' => '{"title":"bibo","description":""}',
                 ]
             ],
-
+            'fields null value' => [ // fields with value null, not changed and changed
+                'documents', // object_type
+                [ // expected
+                    'title' => null, // null, changed
+                    // 'description' => null, not changed
+                ],
+                [ // data provided
+                    'title' => null,
+                    'description' => null,
+                    '_actualAttributes' => '{"title":"bibo","description":null}',
+                ]
+            ],
             'users' => [ // test: removing password from data
                 'users', // object_type
                 [ 'name' => 'giova' ], // expected


### PR DESCRIPTION
This resolves a bug... when saving data with null value.
I.e. `object.extra = null`. 
Actual behaviour: system always saves field, even though its value has not changed.
Expected behaviour: system saves field, only if its value has changed.
