### PR TITLE
Safe login redirects

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -88,7 +88,7 @@ class AppController extends Controller
     /**
      * Return route array for login redirect.
      * When request is not a get, return route without redirect.
-     * When request uri path has attribute webroot, return route without redirect.
+     * When request uri path equals request attribute webroot (the app 'webroot'), return route without redirect.
      * Return route with redirect, otherwise.
      *
      * @return array
@@ -102,7 +102,7 @@ class AppController extends Controller
             return $route;
         }
 
-        // if redirect is webroot, return route without redirect.
+        // if redirect is app webroot, return route without redirect.
         $redirect = $this->request->getUri()->getPath();
         if ($redirect === $this->request->getAttribute('webroot')) {
             return $route;

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -93,7 +93,7 @@ class AppController extends Controller
      *
      * @return array
      */
-    protected function loginRedirectRoute() :array
+    protected function loginRedirectRoute(): array
     {
         $route = ['_name' => 'login'];
 

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -75,11 +75,7 @@ class AppController extends Controller
         if (!empty($tokens)) {
             $this->apiClient->setupTokens($tokens);
         } elseif (!in_array($this->request->getPath(), ['/login'])) {
-            $route = ['_name' => 'login'];
-            $redirect = $this->request->getUri()->getPath();
-            if ($redirect !== $this->request->getAttribute('webroot')) {
-                $route += compact('redirect');
-            }
+            $route = $this->loginRedirectRoute();
             $this->Flash->error(__('Login required'));
 
             return $this->redirect($route);
@@ -87,6 +83,32 @@ class AppController extends Controller
         $this->setupOutputTimezone();
 
         return null;
+    }
+
+    /**
+     * Return route array for login redirect.
+     * When request is not a get, return route without redirect.
+     * When request uri path has attribute webroot, return route without redirect.
+     * Return route with redirect, otherwise.
+     *
+     * @return array
+     */
+    protected function loginRedirectRoute() :array
+    {
+        $route = ['_name' => 'login'];
+
+        // if request is not a get, return route without redirect.
+        if (!$this->request->is('get')) {
+            return $route;
+        }
+
+        // if redirect is webroot, return route without redirect.
+        $redirect = $this->request->getUri()->getPath();
+        if ($redirect === $this->request->getAttribute('webroot')) {
+            return $route;
+        }
+
+        return $route + compact('redirect');
     }
 
     /**

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -142,6 +142,47 @@ class AppControllerTest extends TestCase
     }
 
     /**
+     * Data provider for `testLoginRedirectRoute` test case.
+     *
+     * @return array
+     */
+    public function loginRedirectRouteProvider(): array
+    {
+        return [
+            'request is not a get' => [
+                ['environment' => ['REQUEST_METHOD' => 'POST']], // config
+                ['_name' => 'login'], // expected
+            ],
+            'webroot' => [
+                ['environment' => ['REQUEST_METHOD' => 'GET'], 'webroot' => '/'], // config
+                ['_name' => 'login'], // expected
+            ],
+            'redirect to /' => [
+                ['environment' => ['REQUEST_METHOD' => 'GET'], 'params' => ['object_type' => 'documents']], // config
+                ['_name' => 'login', 'redirect' => '/'], // expected
+            ],
+        ];
+    }
+
+    /**
+     * test 'loginRedirectRoute'.
+     *
+     * @covers ::loginRedirectRoute()
+     * @dataProvider loginRedirectRouteProvider()
+     *
+     * @return void
+     */
+    public function testLoginRedirectRoute($config, $expected): void
+    {
+        $this->setupController($config);
+        $reflectionClass = new \ReflectionClass($this->AppController);
+        $method = $reflectionClass->getMethod('loginRedirectRoute');
+        $method->setAccessible(true);
+        $actual = $method->invokeArgs($this->AppController, []);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
      * test `setupOutputTimezone`
      *
      * @covers ::setupOutputTimezone

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -153,7 +153,7 @@ class AppControllerTest extends TestCase
                 ['environment' => ['REQUEST_METHOD' => 'POST']], // config
                 ['_name' => 'login'], // expected
             ],
-            'webroot' => [
+            'request app webroot' => [
                 ['environment' => ['REQUEST_METHOD' => 'GET'], 'webroot' => '/'], // config
                 ['_name' => 'login'], // expected
             ],


### PR DESCRIPTION
This fixes #357 

When request is not get, after login redirect points to '/'.
When request is get and is webroot, after login redirect points to '/'.
Otherwise, normal redirects to referer.