### PR TITLE
Code sniffer update & fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "cakephp/bake": "^1.11",
         "cakephp/debug_kit": "^3.19.0",
-        "cakephp/cakephp-codesniffer": "^3.1",
+        "cakephp/cakephp-codesniffer": "~3.3.0",
         "psy/psysh": "@stable",
         "phpunit/phpunit": "^6.0"
     },

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -546,7 +546,7 @@ return [
      * - sizeAvailable => available page size on modules view index
      */
     'Pagination' => [
-        'sizeAvailable' => [10, 20, 50, 100]
+        'sizeAvailable' => [10, 20, 50, 100],
     ],
 
     /**

--- a/config/properties.php
+++ b/config/properties.php
@@ -19,7 +19,7 @@ return [
             'view' => [
                 '_keep' => [
                     'password',
-                    'confirm-password'
+                    'confirm-password',
                 ],
                 'core' => [
                     'username',
@@ -54,7 +54,7 @@ return [
                 '_keep' => [
                     'old_password',
                     'password',
-                    'confirm-password'
+                    'confirm-password',
                 ],
                 // intentionally left blank (no title displayed)
                 ' ' => [
@@ -114,7 +114,7 @@ return [
                     'hidden',
                     'enabled',
                     'table',
-                    'parent_name'
+                    'parent_name',
                 ],
             ],
             'index' => [

--- a/config/schema_properties.php
+++ b/config/schema_properties.php
@@ -21,28 +21,28 @@ return [
                 '$id' => '/properties/name',
                 'title' => 'Name',
                 'description' => 'model unique name',
-                'maxLength' => 32
+                'maxLength' => 32,
             ],
             'singular' => [
                 'type' => 'string',
                 '$id' => '/properties/singular',
                 'title' => 'Singular name',
                 'description' => 'Model unique singular name',
-                'maxLength' => 32
+                'maxLength' => 32,
             ],
             'description' => [
                 'oneOf' => [
                     [
-                        'type' => 'null'
+                        'type' => 'null',
                     ],
                     [
                         'type' => 'string',
-                        'contentMediaType' => 'text/html'
+                        'contentMediaType' => 'text/html',
                     ],
                 ],
                 '$id' => '/properties/description',
                 'title' => 'Description',
-                'description' => 'object type description'
+                'description' => 'object type description',
             ],
             'is_abstract' => [
                 'type' => 'boolean',
@@ -61,7 +61,7 @@ return [
             'associations' => [
                 'oneOf' => [
                     [
-                        'type' => 'null'
+                        'type' => 'null',
                     ],
                     [
                         'type' => 'object',
@@ -69,12 +69,12 @@ return [
                 ],
                 '$id' => '/properties/associations',
                 'title' => 'Associations',
-                'description' => 'Object type entity associations'
+                'description' => 'Object type entity associations',
             ],
             'hidden' => [
                 'oneOf' => [
                     [
-                        'type' => 'null'
+                        'type' => 'null',
                     ],
                     [
                         'type' => 'object',
@@ -82,7 +82,7 @@ return [
                 ],
                 '$id' => '/properties/hidden',
                 'title' => 'Hidden',
-                'description' => 'Object type entity associations'
+                'description' => 'Object type entity associations',
             ],
         ],
 
@@ -100,12 +100,12 @@ return [
                 '$id' => '/properties/name',
                 'title' => 'Name',
                 'description' => 'property unique name',
-                'maxLength' => 32
+                'maxLength' => 32,
             ],
             'params' => [
                 'oneOf' => [
                     [
-                        'type' => 'null'
+                        'type' => 'null',
                     ],
                     [
                         'type' => 'object',
@@ -113,7 +113,7 @@ return [
                 ],
                 '$id' => '/properties/hidden',
                 'title' => 'Params',
-                'description' => 'Property params, JSON Schema format'
+                'description' => 'Property params, JSON Schema format',
             ],
         ],
 
@@ -137,7 +137,7 @@ return [
                 '$id' => '/properties/inverse_name',
                 'title' => 'Inverse name',
                 'description' => 'Relation unique inverse name',
-                'maxLength' => 32
+                'maxLength' => 32,
             ],
             'inverse_label' => [
                 'type' => 'string',
@@ -150,26 +150,26 @@ return [
                 '$id' => '/properties/name',
                 'title' => 'Name',
                 'description' => 'Relation unique name',
-                'maxLength' => 32
+                'maxLength' => 32,
             ],
             'description' => [
                 'oneOf' => [
                     [
-                        'type' => 'null'
+                        'type' => 'null',
                     ],
                     [
                         'type' => 'string',
-                        'contentMediaType' => 'text/html'
+                        'contentMediaType' => 'text/html',
                     ],
                 ],
                 '$id' => '/properties/description',
                 'title' => 'Description',
-                'description' => 'Relation description'
+                'description' => 'Relation description',
             ],
             'params' => [
                 'oneOf' => [
                     [
-                        'type' => 'null'
+                        'type' => 'null',
                     ],
                     [
                         'type' => 'object',
@@ -177,7 +177,7 @@ return [
                 ],
                 '$id' => '/properties/hidden',
                 'title' => 'Params',
-                'description' => 'Property params, JSON Schema format'
+                'description' => 'Property params, JSON Schema format',
             ],
         ],
     ],

--- a/src/Application.php
+++ b/src/Application.php
@@ -59,7 +59,7 @@ class Application extends BaseApplication
                 'autoload' => false,
                 'bootstrap' => false,
                 'routes' => false,
-                'ignoreMissing' => false
+                'ignoreMissing' => false,
             ];
             foreach ($plugins as $plugin => $options) {
                 $options = array_merge($_defaults, $options);
@@ -82,7 +82,7 @@ class Application extends BaseApplication
 
             // Handle plugin/theme assets like CakePHP normally does.
             ->add(new AssetMiddleware([
-                'cacheTime' => Configure::read('Asset.cacheTime')
+                'cacheTime' => Configure::read('Asset.cacheTime'),
             ]))
 
             // Add I18n middleware.

--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -40,7 +40,7 @@ class Installer
         'tmp/cache/persistent',
         'tmp/cache/views',
         'tmp/sessions',
-        'tmp/tests'
+        'tmp/tests',
     ];
 
     /**

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -72,7 +72,7 @@ class PropertiesComponent extends Component
      * @var array
      */
     protected $excluded = [
-        'date_ranges'
+        'date_ranges',
     ];
 
     /**

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -602,7 +602,7 @@ class ModulesController extends AppController
                 } catch (BEditaClientException $e) {
                     $errors[] = [
                         'id' => $id,
-                        'message' => $e->getAttributes()
+                        'message' => $e->getAttributes(),
                     ];
                 }
             }

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -293,7 +293,7 @@ class AppControllerTest extends TestCase
                     '_jsonKeys' => 'jsonKey1,jsonKey2',
                     'jsonKey1' => '{"a":1,"b":2,"c":3}',
                     'jsonKey2' => '{"gin":"vodka","fritz":"kola"}',
-                ]
+                ],
             ],
             'actual attrs' => [ // test '_actualAttributes'
                 'documents', // object_type
@@ -304,7 +304,7 @@ class AppControllerTest extends TestCase
                     'title' => 'bibo',
                     'description' => 'dido',
                     '_actualAttributes' => '{"title":"bibo","description":""}',
-                ]
+                ],
             ],
             'fields null value' => [ // fields with value null, not changed and changed
                 'documents', // object_type
@@ -316,7 +316,7 @@ class AppControllerTest extends TestCase
                     'title' => null,
                     'description' => null,
                     '_actualAttributes' => '{"title":"bibo","description":null}',
-                ]
+                ],
             ],
             'users' => [ // test: removing password from data
                 'users', // object_type
@@ -325,7 +325,7 @@ class AppControllerTest extends TestCase
                     'name' => 'giova',
                     'password' => '',
                     'confirm-password' => '',
-                ]
+                ],
             ],
             'relations' => [
                 'documents', // object_type
@@ -340,20 +340,20 @@ class AppControllerTest extends TestCase
                                 [
                                     'id' => '44',
                                     'type' => 'images',
-                                ]
-                            ]
-                        ]
-                    ]
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
                 [ // data provided
                     'id' => '1', // fake document id
                     'relations' => [
                         'attach' => [
-                            'addRelated' => '[{ "id": "44", "type": "images"}]' // fake attached image
-                        ]
-                    ]
-                ]
-            ]
+                            'addRelated' => '[{ "id": "44", "type": "images"}]', // fake attached image
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -473,9 +473,9 @@ class AppControllerTest extends TestCase
                     ],
                     'post' => [
                         'password' => 'bibo',
-                    ]
+                    ],
                 ],
-            ]
+            ],
         ];
     }
 

--- a/tests/TestCase/Controller/Component/ProjectConfigurationComponentTest.php
+++ b/tests/TestCase/Controller/Component/ProjectConfigurationComponentTest.php
@@ -65,7 +65,7 @@ class ProjectConfigurationComponentTest extends TestCase
                     'id' => 'Simple',
                     'type' => 'config',
                     'attributes' => [
-                        'content' => '{"a":2}'
+                        'content' => '{"a":2}',
                     ],
                 ],
             ],

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -155,7 +155,7 @@ class PropertiesComponentTest extends TestCase
                     'core' => [
                         'something',
                     ],
-                ]
+                ],
             ],
             'other' => [
                 [
@@ -192,7 +192,7 @@ class PropertiesComponentTest extends TestCase
                     'advanced' => [
                         'json_field',
                     ],
-                ]
+                ],
             ],
             'new order' => [
                 [
@@ -227,7 +227,7 @@ class PropertiesComponentTest extends TestCase
                         'uname',
                         'status',
                     ],
-                ]
+                ],
             ],
             'custom groups' => [
                 [
@@ -265,14 +265,14 @@ class PropertiesComponentTest extends TestCase
                     'custom' => [
                         'model',
                     ],
-                ]
+                ],
             ],
             'other body' => [
                 [
                     'core' => [
                         'title' => 'Example',
                         'body' => 'some text',
-                        'lang' => 'en'
+                        'lang' => 'en',
                     ],
                     'publish' => [
                     ],
@@ -285,7 +285,7 @@ class PropertiesComponentTest extends TestCase
                     'attributes' => [
                         'title' => 'Example',
                         'body' => 'some text',
-                        'lang' => 'en'
+                        'lang' => 'en',
                     ],
                 ],
                 'foos',
@@ -295,7 +295,7 @@ class PropertiesComponentTest extends TestCase
                         'body',
                         'lang',
                     ],
-                ]
+                ],
             ],
             'other defaults' => [
                 [
@@ -308,7 +308,7 @@ class PropertiesComponentTest extends TestCase
                     ],
                     'other' => [
                         'body' => 'some text',
-                        'lang' => 'en'
+                        'lang' => 'en',
                     ],
                 ],
                 [
@@ -319,7 +319,7 @@ class PropertiesComponentTest extends TestCase
                         'date_ranges' => [],
                     ],
                 ],
-                'foos'
+                'foos',
             ],
 
         ];

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -177,20 +177,20 @@ class SchemaComponentTest extends TestCase
                             'data' => [
                                 [
                                     'id' => '3',
-                                    'type' => 'object_types'
-                                ]
+                                    'type' => 'object_types',
+                                ],
                             ],
                         ],
                         'right_object_types' => [
                             'data' => [
                                 [
                                     'id' => '9',
-                                    'type' => 'object_types'
+                                    'type' => 'object_types',
                                 ],
                             ],
                         ],
                     ],
-                ]
+                ],
             ],
             'included' => [
                 [
@@ -207,7 +207,7 @@ class SchemaComponentTest extends TestCase
                         'name' => 'images',
                     ],
                 ],
-            ]
+            ],
         ];
 
         // Setup mock API client.

--- a/tests/TestCase/Controller/ExportControllerTest.php
+++ b/tests/TestCase/Controller/ExportControllerTest.php
@@ -264,7 +264,7 @@ class ExportControllerTest extends TestCase
                         'data' => [
                             0 => $this->testdata['input']['gustavo'],
                             1 => $this->testdata['input']['johndoe'],
-                        ]
+                        ],
                     ],
                 ], // input
                 [
@@ -419,7 +419,7 @@ class ExportControllerTest extends TestCase
                     'response' => [
                         'data' => [
                             0 => $this->testdata['input']['gustavo'],
-                        ]
+                        ],
                     ],
                 ], // input
                 [
@@ -437,7 +437,7 @@ class ExportControllerTest extends TestCase
                                     'category' => 'developer',
                                 ],
                             ],
-                        ]
+                        ],
                     ],
                     'key' => 'user',
                 ], // input

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -76,7 +76,7 @@ class LoginControllerTest extends TestCase
             'post' => [
                 'username' => env('BEDITA_ADMIN_USR'),
                 'password' => env('BEDITA_ADMIN_PWD'),
-            ]
+            ],
         ]);
 
         $response = $this->Login->login();
@@ -116,8 +116,8 @@ class LoginControllerTest extends TestCase
             'post' => [
                 'username' => env('BEDITA_ADMIN_USR'),
                 'password' => env('BEDITA_ADMIN_PWD'),
-                'timezone_offset' => '7200 0'
-            ]
+                'timezone_offset' => '7200 0',
+            ],
         ]);
 
         $response = $this->Login->login();
@@ -141,7 +141,7 @@ class LoginControllerTest extends TestCase
             'post' => [
                 'username' => 'wronguser',
                 'password' => 'wrongpwd',
-            ]
+            ],
         ]);
 
         $response = $this->Login->login();

--- a/tests/TestCase/Controller/ModelControllerTest.php
+++ b/tests/TestCase/Controller/ModelControllerTest.php
@@ -47,7 +47,7 @@ class ModelControllerTest extends TestCase
         ],
         'params' => [
             'resource_type' => 'object_types',
-        ]
+        ],
     ];
 
     /**
@@ -103,7 +103,7 @@ class ModelControllerTest extends TestCase
                     'roles' => [ 'admin' ],
                 ],
                 null,
-            ]
+            ],
         ];
     }
 
@@ -182,7 +182,7 @@ class ModelControllerTest extends TestCase
         $this->setupController([
             'params' => [
                 'resource_type' => 'documents',
-            ]
+            ],
         ]);
         $result = $this->ModelController->index();
         static::assertTrue(($result instanceof Response));
@@ -231,7 +231,7 @@ class ModelControllerTest extends TestCase
             'emptyRequest' => [
                 new BadRequestException('empty request'),
                 [],
-                ''
+                '',
             ],
             'addPropertyTypesRequest' => [
                 [
@@ -241,10 +241,10 @@ class ModelControllerTest extends TestCase
                         'attributes' => [
                                 'name' => 'giovanni',
                                 'params' => [
-                                        'type' => 'string'
-                                ]
+                                        'type' => 'string',
+                                ],
                         ],
-                    ]
+                    ],
                 ],
                 [
                     'addPropertyTypes' => [
@@ -253,10 +253,10 @@ class ModelControllerTest extends TestCase
                             'params' => json_encode([
                                 'type' => 'string',
                             ]),
-                        ]
+                        ],
                     ],
                 ],
-                'saved'
+                'saved',
             ],
             'editPropertyTypesRequest' => [
                 [
@@ -266,10 +266,10 @@ class ModelControllerTest extends TestCase
                         'attributes' => [
                                 'name' => 'enrico',
                                 'params' => [
-                                        'type' => 'object'
+                                        'type' => 'object',
                                 ],
                         ],
-                    ]
+                    ],
                 ],
                 [
                     'editPropertyTypes' => [
@@ -280,17 +280,17 @@ class ModelControllerTest extends TestCase
                                 'params' => [
                                     'type' => 'object',
                                 ],
-                            ]
-                        ]
+                            ],
+                        ],
                     ],
                 ],
-                'edited'
+                'edited',
             ],
             'removePropertyTypesRequest' => [
                 [ '12' ],
                 [
                     'removePropertyTypes' => [
-                        '12'
+                        '12',
                     ],
                 ],
                 'removed',

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -528,15 +528,15 @@ class ModulesControllerTest extends TestCase
             'save' => [
                 [
                     'code' => 200,
-                    'message' => 'OK'
+                    'message' => 'OK',
                 ],
                 [
                     'params' => [
-                        'object_type' => 'images'
+                        'object_type' => 'images',
                     ],
                     'body' => [
                         'title' => 'bibo',
-                    ]
+                    ],
                 ],
             ],
             'exception' => [
@@ -550,9 +550,9 @@ class ModulesControllerTest extends TestCase
                     ],
                     'body' => [
                         'title' => 'bibo',
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -945,8 +945,8 @@ class ModulesControllerTest extends TestCase
                         'enum2',
                         'enum3',
                     ],
-                ]
-            ]
+                ],
+            ],
         ];
         $expected = [
             'properties' => [
@@ -958,8 +958,8 @@ class ModulesControllerTest extends TestCase
                         'enum2',
                         'enum3',
                     ],
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->setupController();
@@ -1013,7 +1013,7 @@ class ModulesControllerTest extends TestCase
         if ($o == null) {
             $response = $this->client->save('documents', [
                 'title' => 'modules controller test document',
-                'uname' => $this->uname
+                'uname' => $this->uname,
             ]);
             $o = $response['data'];
         }

--- a/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -209,7 +209,7 @@ class TranslationsControllerTest extends TestCase
                 [
                     'id' => $this->getTestTranslationId($objectId, 'documents', 'it'),
                     'object_id' => $objectId,
-                ]
+                ],
             ],
             'params' => [
                 'object_type' => 'documents',

--- a/tests/TestCase/Core/Result/ResultTest.php
+++ b/tests/TestCase/Core/Result/ResultTest.php
@@ -79,7 +79,7 @@ class ResultTest extends TestCase
             'message' => [
                 '',
                 'info',
-            ]
+            ],
         ];
     }
 

--- a/tests/TestCase/Utility/OEmbedTest.php
+++ b/tests/TestCase/Utility/OEmbedTest.php
@@ -67,7 +67,7 @@ class OEmbedTest extends TestCase
                         'provider_name' => 'YouTube',
                         'thumbnail_url' => 'https://i.ytimg.com/vi/_qSYCXHNvJo/hqdefault.jpg',
                         'provider_url' => 'https://www.youtube.com/',
-                    ]
+                    ],
                 ],
                 'https://www.youtube.com/watch?v=_qSYCXHNvJo',
                 [

--- a/tests/TestCase/View/Helper/ArrayHelperTest.php
+++ b/tests/TestCase/View/Helper/ArrayHelperTest.php
@@ -104,7 +104,7 @@ class ArrayHelperTest extends TestCase
                     'title' => 'string',
                     'description' => 'string',
                     'uname' => 'string',
-                    'status' => 'string'
+                    'status' => 'string',
                 ], // expected
                 [
                     'title' => 'string',
@@ -114,9 +114,9 @@ class ArrayHelperTest extends TestCase
                     'extra' => 'object',
                 ], // data
                 [
-                    'extra'
+                    'extra',
                 ], // keys to remove
-            ]
+            ],
         ];
     }
 
@@ -159,9 +159,9 @@ class ArrayHelperTest extends TestCase
                 ], // data
                 [
                     'extra',
-                    'description'
+                    'description',
                 ], // keys to keep
-            ]
+            ],
         ];
     }
 

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -249,21 +249,21 @@ class LayoutHelperTest extends TestCase
                 '<a href="/user_profile" class="has-background-black icon-user">UserProfile</a>',
                 'UserProfile',
                 [
-                    'moduleLink' => ['_name' => 'user_profile:view']
+                    'moduleLink' => ['_name' => 'user_profile:view'],
                 ],
             ],
             'import' => [
                 '<a href="/import" class="has-background-black icon-download-alt">Import</a>',
                 'Import',
                 [
-                    'moduleLink' => ['_name' => 'import:index']
+                    'moduleLink' => ['_name' => 'import:index'],
                 ],
             ],
             'objects' => [
                 '<a href="/objects" class="has-background-module-objects">Objects</a>',
                 'Module',
                 [
-                    'currentModule' => ['name' => 'objects']
+                    'currentModule' => ['name' => 'objects'],
                 ],
             ],
         ];

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -94,7 +94,7 @@ class SchemaHelperTest extends TestCase
                     'type' => 'string',
                 ],
                 'status',
-                'on'
+                'on',
             ],
             'password' => [
                 // expected result
@@ -110,7 +110,7 @@ class SchemaHelperTest extends TestCase
                     'type' => 'string',
                 ],
                 'password',
-                ''
+                '',
             ],
             'confirm-password' => [
                 // expected result
@@ -130,7 +130,7 @@ class SchemaHelperTest extends TestCase
                     'type' => 'string',
                 ],
                 'confirm-password',
-                ''
+                '',
             ],
             'json' => [
                 // expected result


### PR DESCRIPTION
With `CakePHP CodeSniffer 3.3.0` a new rule was added: last element in a multi-line array MUST end with comma

In this PR 

* Automatic fix `phpcbf` 
* make Code Sniffer version is `< 3.4` 