### PR TITLE
fix: method should be `public`

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -357,7 +357,7 @@ class ModulesComponent extends Component
      * @param array $data The data to store into session.
      * @return void
      */
-    protected function setDataFromFailedSave($type, $data): void
+    public function setDataFromFailedSave($type, $data): void
     {
         if (empty($data) || empty($data['id']) || empty($type)) {
             return;

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -844,11 +844,7 @@ class ModulesComponentTest extends TestCase
         $expected = [ 'id' => 999, 'name' => 'gustavo' ];
         $type = 'documents';
 
-        // call method 'setDataFromFailedSave'
-        $reflectionClass = new \ReflectionClass($this->Modules);
-        $method = $reflectionClass->getMethod('setDataFromFailedSave');
-        $method->setAccessible(true);
-        $method->invokeArgs($this->Modules, [ $type, $expected ]);
+        $this->Modules->setDataFromFailedSave($type, $expected);
 
         // verify data
         $key = sprintf('failedSave.%s.%s', $type, $expected['id']);


### PR DESCRIPTION
Method should be `public` otherwise we get this error:

```Call to protected method App\Controller\Component\ModulesComponent::setDataFromFailedSave() from context 'App\Controller\ModulesController'```