### PR TITLE
`Project.name` in configuration overrides `/home`

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -611,4 +611,12 @@ return [
     //         'token' => '###',
     //     ],
     // ],
+
+    /**
+     * Project data that can override data from `/home` API call
+     * Currently only `name` is used
+     */
+    // 'Project' => [
+    //     'name' => 'My Project',
+    // ],
 ];

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -163,8 +163,9 @@ class ModulesComponent extends Component
     public function getProject(): array
     {
         $meta = $this->getMeta();
+        // Project name may be set via `config` and it takes precedence if set
         $project = [
-            'name' => Hash::get($meta, 'project.name', ''),
+            'name' => (string)Configure::read('Project.name', Hash::get($meta, 'project.name')),
             'version' => Hash::get($meta, 'version', ''),
             'colophon' => '', // TODO: populate this value.
         ];

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -130,6 +130,19 @@ class ModulesComponentTest extends TestCase
                 new \RuntimeException('I am some other kind of exception', 999),
                 new \RuntimeException('I am some other kind of exception', 999),
             ],
+            'config' => [
+                [
+                    'name' => 'Gustavo',
+                    'version' => '4.1.2',
+                    'colophon' => '',
+                ],
+                [
+                    'version' => '4.1.2',
+                ],
+                [
+                    'name' => 'Gustavo',
+                ],
+            ],
         ];
     }
 
@@ -138,14 +151,16 @@ class ModulesComponentTest extends TestCase
      *
      * @param array|\Exception $expected Expected result.
      * @param array|\Exception $meta Response to `/home` endpoint.
+     * @param array $config Project config to set.
      * @return void
      *
      * @dataProvider getProjectProvider()
      * @covers ::getMeta()
      * @covers ::getProject()
      */
-    public function testGetProject($expected, $meta): void
+    public function testGetProject($expected, $meta, $config = []): void
     {
+        Configure::write('Project', $config);
         if ($expected instanceof \Exception) {
             $this->expectException(get_class($expected));
             $this->expectExceptionCode($expected->getCode());


### PR DESCRIPTION
Setting in configuration

```php
    'Project' => [
      'name' => 'My Project',
    ],
```
`My Project` will be the project name visible in dashboard top left box and in footer, overriding `/home` API response `meta.project.name`
