### PR TITLE
Multi project setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /composer.local.json
 /config/app.php
 /config/.env
+/config/projects/*
 /coverage/*
 /index.html
 /logs/*

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -611,4 +611,12 @@ return [
     //         'token' => '###',
     //     ],
     // ],
+
+    /**
+     * Project data that can override data from `/home` API call
+     * Currently only `name` is used
+     */
+    // 'Project' => [
+    //     'name' => 'My Project',
+    // ],
 ];

--- a/src/Application.php
+++ b/src/Application.php
@@ -16,6 +16,7 @@ use App\Middleware\ProjectMiddleware;
 use BEdita\I18n\Middleware\I18nMiddleware;
 use BEdita\WebTools\BaseApplication;
 use Cake\Core\Configure;
+use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\Middleware\CsrfProtectionMiddleware;
@@ -126,5 +127,24 @@ class Application extends BaseApplication
         });
 
         return $csrf;
+    }
+
+    /**
+     * Load project configuration if corresponding config file is found
+     *
+     * @param string $project The project name.
+     * @param string $projectsPath The project configuration files base path.
+     * @return void
+     */
+    public static function loadProjectConfig(string $project, string $projectsPath): void
+    {
+        if (empty($project)) {
+            return;
+        }
+
+        if (file_exists($projectsPath . $project . '.php')) {
+            Configure::config('projects', new PhpConfig($projectsPath));
+            Configure::load($project, 'projects');
+        }
     }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -132,11 +132,11 @@ class Application extends BaseApplication
     /**
      * Load project configuration if corresponding config file is found
      *
-     * @param string $project The project name.
+     * @param string|null $project The project name.
      * @param string $projectsPath The project configuration files base path.
      * @return void
      */
-    public static function loadProjectConfig(string $project, string $projectsPath): void
+    public static function loadProjectConfig(?string $project, string $projectsPath): void
     {
         if (empty($project)) {
             return;

--- a/src/Application.php
+++ b/src/Application.php
@@ -12,6 +12,7 @@
  */
 namespace App;
 
+use App\Middleware\ProjectMiddleware;
 use BEdita\I18n\Middleware\I18nMiddleware;
 use BEdita\WebTools\BaseApplication;
 use Cake\Core\Configure;
@@ -33,7 +34,6 @@ class Application extends BaseApplication
     {
         parent::bootstrap();
         $this->addPlugin('BEdita/WebTools', ['bootstrap' => true]);
-        $this->loadFromConfig();
     }
 
     /**
@@ -47,10 +47,11 @@ class Application extends BaseApplication
 
     /**
      * Load plugins from 'Plugins' configuration
+     * This method will be invoked by `ProjectMiddleware`
      *
      * @return void
      */
-    public function loadFromConfig(): void
+    public function loadPluginsFromConfig(): void
     {
         $plugins = Configure::read('Plugins');
         if ($plugins) {
@@ -84,6 +85,10 @@ class Application extends BaseApplication
             ->add(new AssetMiddleware([
                 'cacheTime' => Configure::read('Asset.cacheTime'),
             ]))
+
+            // Load current project configuration if `multiproject` instance
+            // Manager plugins will also be loaded here via
+            ->add(new ProjectMiddleware($this))
 
             // Add I18n middleware.
             ->add(new I18nMiddleware([

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -47,6 +47,7 @@ class AppController extends Controller
         $this->loadComponent('App.Flash', ['clear' => true]);
         $this->loadComponent('Security');
 
+        // API config may not be set in `login` for a multi-project setup
         if (Configure::check('API.apiBaseUrl')) {
             $this->apiClient = ApiClientProvider::getApiClient();
         }

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -47,8 +47,9 @@ class AppController extends Controller
         $this->loadComponent('App.Flash', ['clear' => true]);
         $this->loadComponent('Security');
 
-        $options = ['Log' => (array)Configure::read('API.log', [])];
-        $this->apiClient = ApiClientProvider::getApiClient($options);
+        if (Configure::check('API.apiBaseUrl')) {
+            $this->apiClient = ApiClientProvider::getApiClient();
+        }
 
         $this->loadComponent('Auth', [
             'authenticate' => [

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -118,7 +118,7 @@ class ModulesComponent extends Component
      */
     public function getModules(): array
     {
-        $modulesOrder = Configure::read('Modules.order');
+        $modulesOrder = (array)Configure::read('Modules.order');
 
         $meta = $this->getMeta();
         $modules = collection(Hash::get($meta, 'resources', []))

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -163,8 +163,9 @@ class ModulesComponent extends Component
     public function getProject(): array
     {
         $meta = $this->getMeta();
+        // Project name may be set via `config` and it takes precedence if set
         $project = [
-            'name' => Hash::get($meta, 'project.name', ''),
+            'name' => (string)Configure::read('Project.name', Hash::get($meta, 'project.name')),
             'version' => Hash::get($meta, 'version', ''),
             'colophon' => '', // TODO: populate this value.
         ];

--- a/src/Controller/Component/ProjectConfigurationComponent.php
+++ b/src/Controller/Component/ProjectConfigurationComponent.php
@@ -33,13 +33,13 @@ class ProjectConfigurationComponent extends Component
     public const CACHE_CONFIG = '_project_config_';
 
     /**
-     * Read project configuration from API using cache ad write it in `Project` config key.
+     * Read project configuration from API using cache ad write it in `Project.config` config key.
      *
      * @return array Project configuration in `key => value` format.
      */
     public function read(): array
     {
-        $config = Configure::read('Project');
+        $config = Configure::read('Project.config');
         if (!empty($config)) {
             return $config;
         }
@@ -51,7 +51,7 @@ class ProjectConfigurationComponent extends Component
                 },
                 self::CACHE_CONFIG
             );
-            Configure::write('Project', $config);
+            Configure::write('Project.config', $config);
         } catch (BEditaClientException $e) {
             // Something bad happened
             $this->log($e, LogLevel::ERROR);

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -81,7 +81,7 @@ class PropertiesComponent extends Component
     public function initialize(array $config)
     {
         Configure::load('properties');
-        $propConfig = array_merge(Configure::read('DefaultProperties'), Configure::read('Properties'));
+        $propConfig = array_merge(Configure::read('DefaultProperties'), (array)Configure::read('Properties'));
         $this->setConfig('Properties', $propConfig);
         parent::initialize($config);
     }

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -15,6 +15,7 @@ namespace App\Controller\Component;
 
 use Cake\Controller\Component;
 use Cake\Core\Configure;
+use Cake\Utility\Hash;
 
 /**
  * Component to handle properties view in modules.
@@ -113,7 +114,7 @@ class PropertiesComponent extends Component
     {
         $properties = $used = [];
         $keep = $this->getConfig(sprintf('Properties.%s.view._keep', $type), []);
-        $attributes = array_merge(array_fill_keys($keep, ''), $object['attributes']);
+        $attributes = array_merge(array_fill_keys($keep, ''), (array)Hash::get($object, 'attributes'));
         $attributes = array_diff_key($attributes, array_flip($this->excluded));
         $defaults = array_merge($this->getConfig(sprintf('Properties.%s.view', $type), []), $this->defaultGroups['view']);
         unset($defaults['_keep']);

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -56,13 +56,12 @@ class LoginController extends AppController
     }
 
     /**
-     * Perform login via POST.
+     * Perform login auth request via POST.
      *
      * @return \Cake\Http\Response|null
      */
     protected function authRequest(): ?Response
     {
-        $user = null;
         $reason = __('Invalid username or password');
         try {
             $user = $this->Auth->identify();

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -52,9 +52,18 @@ class LoginController extends AppController
             return null;
         }
 
-        // Attempted login.
+        return $this->authRequest();
+    }
+
+    /**
+     * Perform login via POST.
+     *
+     * @return \Cake\Http\Response|null
+     */
+    protected function authRequest(): ?Response
+    {
         $user = null;
-        $reason = 'Invalid username or password';
+        $reason = __('Invalid username or password');
         try {
             $user = $this->Auth->identify();
         } catch (BEditaClientException $e) {

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -66,8 +66,8 @@ class LoginController extends AppController
         $reason = __('Invalid username or password');
         // Load project config if `multi project` setup
         Application::loadProjectConfig(
-            $this->request->getData('project'),
-            $this->getConfig('projectsPath')
+            (string)$this->request->getData('project'),
+            (string)$this->getConfig('projectsPath')
         );
         try {
             $user = $this->Auth->identify();
@@ -155,9 +155,9 @@ class LoginController extends AppController
     /**
      * Logout and redirect to login page.
      *
-     * @return \Cake\Http\Response
+     * @return \Cake\Http\Response|null
      */
-    public function logout(): Response
+    public function logout(): ?Response
     {
         $this->request->allowMethod(['get']);
         $redirect = $this->redirect($this->Auth->logout());

--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -16,8 +16,8 @@ use App\Controller\ModulesController;
 use BEdita\SDK\BEditaClientException;
 use BEdita\SDK\BEditaException;
 use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
-use Cake\Network\Exception\NotFoundException;
 use Cake\Utility\Hash;
 use Psr\Log\LogLevel;
 

--- a/src/Controller/UserProfileController.php
+++ b/src/Controller/UserProfileController.php
@@ -62,11 +62,12 @@ class UserProfileController extends AppController
         } catch (BEditaClientException $e) {
             $this->log($e, LogLevel::ERROR);
             $this->Flash->error($e->getMessage(), ['params' => $e]);
+            $response = [];
         }
 
         $revision = Hash::get($response, 'meta.schema.users.revision', null);
         $schema = $this->Schema->getSchema('users', $revision);
-        $object = $response['data'];
+        $object = (array)Hash::get($response, 'data');
         $this->set('schema', $schema);
         $this->set('object', $object);
         $this->set('properties', $this->Properties->viewGroups($object, 'user_profile'));

--- a/src/Middleware/ProjectMiddleware.php
+++ b/src/Middleware/ProjectMiddleware.php
@@ -36,7 +36,7 @@ class ProjectMiddleware
     /**
      * Projects config base path
      *
-     * @var Application
+     * @var string
      */
     protected $projectsConfigPath = CONFIG . 'projects' . DS;
 

--- a/src/Middleware/ProjectMiddleware.php
+++ b/src/Middleware/ProjectMiddleware.php
@@ -13,8 +13,6 @@
 namespace App\Middleware;
 
 use App\Application;
-use Cake\Core\Configure;
-use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Http\ServerRequest;
 use Psr\Http\Message\ResponseInterface;
 
@@ -67,7 +65,7 @@ class ProjectMiddleware
     public function __invoke(ServerRequest $request, ResponseInterface $response, $next): ResponseInterface
     {
         $project = $this->detectProject($request);
-        $this->loadProjectConfig((string)$project);
+        Application::loadProjectConfig((string)$project, $this->projectsConfigPath);
         $this->Application->loadPluginsFromConfig();
 
         return $next($request, $response);
@@ -88,24 +86,5 @@ class ProjectMiddleware
         }
 
         return (string)$session->read('_project');
-    }
-
-    /**
-     * Load project configuration if corresponding config file is found
-     *
-     * @param string $project The project name.
-     * @return void
-     */
-    protected function loadProjectConfig(string $project): void
-    {
-        if (empty($project)) {
-            return;
-        }
-
-        $path = $this->projectsConfigPath . $project;
-        if (file_exists($path . '.php')) {
-            Configure::config('projects', new PhpConfig($this->projectsConfigPath));
-            Configure::load($project, 'projects');
-        }
     }
 }

--- a/src/Middleware/ProjectMiddleware.php
+++ b/src/Middleware/ProjectMiddleware.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Middleware;
+
+use App\Application;
+use Cake\Core\Configure;
+use Cake\Core\Configure\Engine\PhpConfig;
+use Cake\Http\ServerRequest;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Project middleware.
+ *
+ * Multi projects support (optional): detect current `_project` name in session and try to load matching config file from `config/projects` folder.
+ * After that app plugins are loaded via configuration.
+ */
+class ProjectMiddleware
+{
+    /**
+     * Application instance
+     *
+     * @var Application
+     */
+    protected $Application;
+
+    /**
+     * Projects config base path
+     *
+     * @var Application
+     */
+    protected $projectsConfigPath = CONFIG . 'projects' . DS;
+
+    /**
+     * Constructor
+     *
+     * @param Application $app The application instance.
+     * @param string $configPath Projects config path.
+     */
+    public function __construct(Application $app, string $configPath = null)
+    {
+        $this->Application = $app;
+        if (!empty($configPath)) {
+            $this->projectsConfigPath = $configPath;
+        }
+    }
+
+    /**
+     * Look for `_project` key in session, if found load configuration file.
+     * Then call `Application::loadPluginsFromConfig()` to load plugins
+     *
+     * @param \Cake\Http\ServerRequest $request The request.
+     * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @param callable $next Callback to invoke the next middleware.
+     *
+     * @return \Psr\Http\Message\ResponseInterface A response
+     */
+    public function __invoke(ServerRequest $request, ResponseInterface $response, $next): ResponseInterface
+    {
+        $project = $this->detectProject($request);
+        $this->loadProjectConfig((string)$project);
+        $this->Application->loadPluginsFromConfig();
+
+        return $next($request, $response);
+    }
+
+    /**
+     * Detect project in use from session, if any
+     * On empty session or missing project name `null` is returned
+     *
+     * @param ServerRequest $request The request.
+     * @return string|null
+     */
+    protected function detectProject(ServerRequest $request): ?string
+    {
+        $session = $request->getSession();
+        if (empty($session) || !$session->check('_project')) {
+            return null;
+        }
+
+        return (string)$session->read('_project');
+    }
+
+    /**
+     * Load project configuration if corresponding config file is found
+     *
+     * @param string $project The project name.
+     * @return void
+     */
+    protected function loadProjectConfig(string $project): void
+    {
+        if (empty($project)) {
+            return;
+        }
+
+        $path = $this->projectsConfigPath . $project;
+        if (file_exists($path . '.php')) {
+            Configure::config('projects', new PhpConfig($this->projectsConfigPath));
+            Configure::load($project, 'projects');
+        }
+    }
+}

--- a/src/Template/Layout/default.twig
+++ b/src/Template/Layout/default.twig
@@ -114,7 +114,9 @@ BEdita 4 ~ @ 2018 from ChannelWeb & Chialab with love
     {# vendors.bundle it's only generated when vendors are imported statically, uncomment if you do so #}
     {# {{ Html.script('vendors.bundle')|raw }} #}
 
-    {{ Link.pluginsJsBundle()|raw }}
+    {% if _view.name != 'Login' %}
+        {{ Link.pluginsJsBundle()|raw }}
+    {% endif %}
 
     {{ Link.jsBundle([ 'manifest', 'vendors', 'app' ])|raw }}
 

--- a/src/Template/Pages/Login/login.twig
+++ b/src/Template/Pages/Login/login.twig
@@ -13,6 +13,7 @@
         'type': 'select',
         'options': projects,
         'label': false,
+        'style': 'margin-bottom: 1rem; width: 100%;',
     })|raw }}
     {% endif %}
 

--- a/src/Template/Pages/Login/login.twig
+++ b/src/Template/Pages/Login/login.twig
@@ -8,6 +8,14 @@
         'url': {'_name': 'login', 'redirect': _view.request.getQuery('redirect') },
     })|raw }}
 
+    {% if projects %}
+    {{ Form.control('project', {
+        'type': 'select',
+        'options': projects,
+        'label': false,
+    })|raw }}
+    {% endif %}
+
     {{ Form.control('username', {
         'autocomplete': 'username',
         'autocorrect': 'off',

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -57,13 +57,13 @@ class ApplicationTest extends TestCase
     }
 
     /**
-     * Test load from config method
+     * Test `loadPluginsFromConfig` method
      *
      * @return void
      *
      * @covers ::loadPluginsFromConfig()
      */
-    public function testLoadConfig()
+    public function testLoadPlugins()
     {
         $app = new Application(CONFIG);
         $app->bootstrap();
@@ -87,5 +87,23 @@ class ApplicationTest extends TestCase
         $this->assertFalse($app->getPlugins()->has('DebugKit'));
         $this->assertTrue($app->getPlugins()->has('Bake'));
         Configure::write('debug', $debug);
+    }
+
+    /**
+     * Test `loadProjectConfig` method
+     *
+     * @return void
+     *
+     * @covers ::loadProjectConfig()
+     */
+    public function testLoadProjectConfig()
+    {
+        $projectsPath = TESTS . 'files' . DS . 'projects' . DS;
+        Configure::write('Project.name', null);
+        Application::loadProjectConfig('none', $projectsPath);
+        static::assertNull(Configure::read('Project.name'));
+
+        Application::loadProjectConfig('test', $projectsPath);
+        static::assertEquals('Test', Configure::read('Project.name'));
     }
 }

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -13,6 +13,7 @@
 namespace App\Test\TestCase;
 
 use App\Application;
+use App\Middleware\ProjectMiddleware;
 use BEdita\I18n\Middleware\I18nMiddleware;
 use Cake\Core\Configure;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
@@ -49,9 +50,10 @@ class ApplicationTest extends TestCase
 
         static::assertInstanceOf(ErrorHandlerMiddleware::class, $middleware->get(0));
         static::assertInstanceOf(AssetMiddleware::class, $middleware->get(1));
-        static::assertInstanceOf(I18nMiddleware::class, $middleware->get(2));
-        static::assertInstanceOf(RoutingMiddleware::class, $middleware->get(3));
-        static::assertInstanceOf(CsrfProtectionMiddleware::class, $middleware->get(4));
+        static::assertInstanceOf(ProjectMiddleware::class, $middleware->get(2));
+        static::assertInstanceOf(I18nMiddleware::class, $middleware->get(3));
+        static::assertInstanceOf(RoutingMiddleware::class, $middleware->get(4));
+        static::assertInstanceOf(CsrfProtectionMiddleware::class, $middleware->get(5));
     }
 
     /**
@@ -59,7 +61,7 @@ class ApplicationTest extends TestCase
      *
      * @return void
      *
-     * @covers ::loadFromConfig()
+     * @covers ::loadPluginsFromConfig()
      */
     public function testLoadConfig()
     {
@@ -75,13 +77,13 @@ class ApplicationTest extends TestCase
         $app->getPlugins()->remove('Bake');
         Configure::write('debug', 1);
         Configure::write('Plugins', $pluginsConfig);
-        $app->loadFromConfig();
+        $app->loadPluginsFromConfig();
         $this->assertTrue($app->getPlugins()->has('DebugKit'));
         $this->assertTrue($app->getPlugins()->has('Bake'));
         $app->getPlugins()->remove('DebugKit');
         $app->getPlugins()->remove('Bake');
         Configure::write('debug', 0);
-        $app->loadFromConfig();
+        $app->loadPluginsFromConfig();
         $this->assertFalse($app->getPlugins()->has('DebugKit'));
         $this->assertTrue($app->getPlugins()->has('Bake'));
         Configure::write('debug', $debug);

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -130,6 +130,19 @@ class ModulesComponentTest extends TestCase
                 new \RuntimeException('I am some other kind of exception', 999),
                 new \RuntimeException('I am some other kind of exception', 999),
             ],
+            'config' => [
+                [
+                    'name' => 'Gustavo',
+                    'version' => '4.1.2',
+                    'colophon' => '',
+                ],
+                [
+                    'version' => '4.1.2',
+                ],
+                [
+                    'name' => 'Gustavo',
+                ],
+            ],
         ];
     }
 
@@ -138,14 +151,16 @@ class ModulesComponentTest extends TestCase
      *
      * @param array|\Exception $expected Expected result.
      * @param array|\Exception $meta Response to `/home` endpoint.
+     * @param array $config Project config to set.
      * @return void
      *
      * @dataProvider getProjectProvider()
      * @covers ::getMeta()
      * @covers ::getProject()
      */
-    public function testGetProject($expected, $meta): void
+    public function testGetProject($expected, $meta, $config = []): void
     {
+        Configure::write('Project', $config);
         if ($expected instanceof \Exception) {
             $this->expectException(get_class($expected));
             $this->expectExceptionCode($expected->getCode());

--- a/tests/TestCase/Controller/Component/ProjectConfigurationComponentTest.php
+++ b/tests/TestCase/Controller/Component/ProjectConfigurationComponentTest.php
@@ -86,7 +86,7 @@ class ProjectConfigurationComponentTest extends TestCase
      */
     public function testRead($expected, $config): void
     {
-        Configure::write('Project', null);
+        Configure::write('Project.config', null);
         // Setup mock API client.
         $apiClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs(['https://api.example.org'])
@@ -100,7 +100,7 @@ class ProjectConfigurationComponentTest extends TestCase
 
         $project = $this->ProjectConfiguration->read();
         static::assertSame($expected, $project);
-        static::assertSame($expected, Configure::read('Project'));
+        static::assertSame($expected, Configure::read('Project.config'));
     }
 
     /**
@@ -112,7 +112,7 @@ class ProjectConfigurationComponentTest extends TestCase
     public function testReadFromConf(): void
     {
         $data = ['Conf' => true];
-        Configure::write('Project', $data);
+        Configure::write('Project.config', $data);
         $project = $this->ProjectConfiguration->read();
         static::assertSame($data, $project);
     }
@@ -125,7 +125,7 @@ class ProjectConfigurationComponentTest extends TestCase
      */
     public function testReadError(): void
     {
-        Configure::write('Project', null);
+        Configure::write('Project.config', null);
         Cache::clear(false, ProjectConfigurationComponent::CACHE_CONFIG);
         // Setup mock API client.
         $apiClient = $this->getMockBuilder(BEditaClient::class)

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -104,6 +104,7 @@ class SchemaComponentTest extends TestCase
      * @covers ::fetchSchema()
      * @covers ::getSchema()
      * @covers ::loadWithRevision()
+     * @covers ::cacheKey()
      */
     public function testGetSchema($expected, $schema, ?string $type, array $config = []): void
     {

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -14,8 +14,6 @@
 namespace App\Test\TestCase\Controller;
 
 use App\Controller\LoginController;
-use BEdita\SDK\BEditaClient;
-use BEdita\SDK\BEditaClientException;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 
@@ -26,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class LoginControllerTest extends TestCase
 {
-
     /**
      * Test subject
      *
@@ -67,7 +64,7 @@ class LoginControllerTest extends TestCase
      *
      * @covers ::login()
      * @covers ::userTimezone()
-     *
+     * @covers ::setupCurrentProject()
      * @return void
      */
     public function testLogin(): void
@@ -165,6 +162,58 @@ class LoginControllerTest extends TestCase
 
         $response = $this->Login->login();
         static::assertNull($response);
+    }
+
+    /**
+     * Test `loadAvailableProjects` method with GET
+     *
+     * @covers ::loadAvailableProjects()
+     *
+     * @return void
+     */
+    public function testLoadAvailableProjects(): void
+    {
+        $this->setupController([
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+        ]);
+
+        $this->Login->setConfig('projectsSearch', TESTS . 'files' . DS . 'projects' . DS . '*.php');
+
+        $response = $this->Login->login();
+        static::assertNull($response);
+        $viewVars = $this->Login->viewVars;
+        static::assertArrayHasKey('projects', $viewVars);
+        $expected = [
+            [
+                'value' => 'test',
+                'text' => 'Test',
+            ],
+        ];
+        static::assertEquals($expected, $viewVars['projects']);
+    }
+
+    /**
+     * Test `setupCurrentProject` method
+     *
+     * @covers ::setupCurrentProject()
+     *
+     * @return void
+     */
+    public function testSetupCurrentProject(): void
+    {
+        $this->setupController([
+            'post' => [
+                'username' => env('BEDITA_ADMIN_USR'),
+                'password' => env('BEDITA_ADMIN_PWD'),
+                'project' => 'test',
+            ],
+        ]);
+
+        $response = $this->Login->login();
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('test', $this->Login->request->getSession()->read('_project'));
     }
 
     /**

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -179,7 +179,7 @@ class LoginControllerTest extends TestCase
             ],
         ]);
 
-        $this->Login->setConfig('projectsSearch', TESTS . 'files' . DS . 'projects' . DS . '*.php');
+        $this->Login->setConfig('projectsPath', TESTS . 'files' . DS . 'projects' . DS);
 
         $response = $this->Login->login();
         static::assertNull($response);

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -234,6 +234,8 @@ class LoginControllerTest extends TestCase
         $response = $this->Login->logout();
         static::assertEquals(302, $response->getStatusCode());
         static::assertEquals('/login', $response->getHeaderLine('Location'));
+        static::assertNull($this->Login->request->getSession()->read('Auth'));
+        static::assertNull($this->Login->request->getSession()->read('_project'));
     }
 
     /**

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -60,9 +60,9 @@ class LoginControllerTest extends TestCase
     }
 
     /**
-     * Test `login` method, no user timezone set
+     * Test `authRequest` method, no user timezone set
      *
-     * @covers ::login()
+     * @covers ::authRequest()
      * @covers ::userTimezone()
      * @covers ::setupCurrentProject()
      * @return void
@@ -128,7 +128,7 @@ class LoginControllerTest extends TestCase
     /**
      * Test `login` fail method
      *
-     * @covers ::login()
+     * @covers ::authRequest()
      *
      * @return void
      */

--- a/tests/TestCase/Middleware/ProjectMiddlewareTest.php
+++ b/tests/TestCase/Middleware/ProjectMiddlewareTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Test\Middleware;
+
+use App\Application;
+use App\Middleware\ProjectMiddleware;
+use Cake\Core\Configure;
+use Cake\Http\Cookie\Cookie;
+use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Response;
+use Cake\Http\ServerRequestFactory;
+use Cake\I18n\I18n;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
+
+/**
+ * {@see \App\Middleware\ProjectMiddleware} Test Case
+ *
+ * @coversDefaultClass \App\Middleware\ProjectMiddleware
+ */
+class ProjectMiddlewareTest extends TestCase
+{
+    /**
+     * Fake next middleware
+     *
+     * @var callable
+     */
+    protected $nextMiddleware;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->nextMiddleware = function ($req, $res) {
+            return $res;
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $this->nextMiddleware = null;
+    }
+
+    /**
+     * Data provider for `testInvoke()`
+     *
+     * @return array
+     */
+    public function invokeProvider(): array
+    {
+        return [
+            'test project' => [
+                [
+                    'name' => 'Test',
+                ],
+                [
+                    '_project' => 'test',
+                ],
+            ],
+            'no project' => [
+                null,
+                [
+                    'gustavo' => 'supporto',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `__invoke` method.
+     *
+     * @param int $expected The HTTP status code expected
+     * @param array $data Request session data
+     * @param array $server The server vars
+     * @return void
+     *
+     * @dataProvider invokeProvider
+     * @covers ::__construct()
+     * @covers ::__invoke()
+     * @covers ::detectProject()
+     * @covers ::loadProjectConfig()
+     */
+    public function testInvoke($expected, $data): void
+    {
+        $request = ServerRequestFactory::fromGlobals();
+        $request->getSession()->write($data);
+        $response = new Response();
+        $app = new Application(CONFIG);
+        $middleware = new ProjectMiddleware($app, TESTS . 'files' . DS . 'projects' . DS);
+        $response = $middleware($request, $response, $this->nextMiddleware);
+
+        $project = Configure::read('Project');
+        static::assertEquals($expected, $project);
+        Configure::write('Project', null);
+    }
+}

--- a/tests/TestCase/Middleware/ProjectMiddlewareTest.php
+++ b/tests/TestCase/Middleware/ProjectMiddlewareTest.php
@@ -15,13 +15,9 @@ namespace App\Test\Middleware;
 use App\Application;
 use App\Middleware\ProjectMiddleware;
 use Cake\Core\Configure;
-use Cake\Http\Cookie\Cookie;
-use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
-use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
-use Cake\Utility\Hash;
 
 /**
  * {@see \App\Middleware\ProjectMiddleware} Test Case
@@ -94,7 +90,6 @@ class ProjectMiddlewareTest extends TestCase
      * @covers ::__construct()
      * @covers ::__invoke()
      * @covers ::detectProject()
-     * @covers ::loadProjectConfig()
      */
     public function testInvoke($expected, $data): void
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,4 +26,11 @@ require dirname(__DIR__) . '/config/bootstrap.php';
 
 \Cake\Cache\Cache::disable();
 
+if (empty(\Cake\Core\Configure::read('API'))) {
+    \Cake\Core\Configure::write('API', [
+        'apiBaseUrl' => env('BEDITA_API'),
+        'apiKey' => env('BEDITA_API_KEY'),
+    ]);
+}
+
 $_SERVER['PHP_SELF'] = '/';

--- a/tests/files/projects/test.php
+++ b/tests/files/projects/test.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'Project' => [
+        'name' => 'Test',
+    ],
+];

--- a/tests/files/projects/undefined.php
+++ b/tests/files/projects/undefined.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'undefined',
+];


### PR DESCRIPTION
This PR enables `multi project` setup to be used (for now) in development/test environments.

## Activation

* create a PHP configuration file for each project under `config/projects`, those files are git-ignored
* each file MUST contain at least following keys:
```php
    'Project' => [
        'name' => 'My Project',
    ],

    'API' => [
        'apiBaseUrl' => '{my API url}',
        'apiKey' => '{my API key}',
    ],
```
* good and recommended practice is to add at least also `Modules` and `Properties` keys for a better UI customization
* add `Plugins` key to load custom project-related plugins
* in main `confg/app.php` comment the above mentioned keys (`Project`, `API`, `Modules`, `Properties` and `Plugins`)

Upon login a combo to select the project will appear.

## How it works

* upon login `project` is passed via POST and corresponding configuration file is loaded
* internally the configuration file name is used as `project` name
* on successful login `project` name is set  in session in `_project` key
* `ProjectMiddleware` is responsible to load the requested configuration file reading session key and also to load configured plugins (via `Plugins` config)

## 'Project' key

When `Project` key is used in configuration, either in `config/app.php` for single project setup or in `config/projects/{myproject}.php`, like:

```php
    'Project' => [
      'name' => 'My Project',
    ],
```
`My Project` will be the project name visible in dashboard top left box and in footer, overriding `/home` API response `meta.project.name`

To avoid conflicts project configuration loaded via API will now be stored in `Project.config` key.

