### PR TITLE
fix: CsrfExceptions in bootstrap

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -218,7 +218,7 @@ Type::build('timestamp')
  *
  * Array having `controller` as key and actions array as value.
  */
-Configure::write('CrsfExceptions', [
+Configure::write('CsrfExceptions', [
     'PropertyTypes' => ['save'],
     'Modules' => ['saveJson'],
 ]);


### PR DESCRIPTION
`CsrfExceptions` instead of wrong `CrsfExceptions` in `bootstrap.php`. It solves a problem in file upload for relations attach.