### PR TITLE
Fix I18n config from API

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -405,4 +405,23 @@ class ModulesComponent extends Component
         $session->delete($key);
         $session->delete($timestampKey);
     }
+
+    /**
+     * Prepare query string to make BE4 API call
+     *
+     * @param array $query Input query string
+     * @return array
+     */
+    public function prepareQuery(array $query): array
+    {
+        // cleanup `filter`, remove empty keys
+        $filter = array_filter((array)Hash::get($query, 'filter'));
+        $remove = array_flip(['count', 'page_items', 'page_count', 'filter']);
+        $query = array_diff_key($query, $remove);
+        if (!empty($filter)) {
+            $query += compact('filter');
+        }
+
+        return $query;
+    }
 }

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -439,8 +439,9 @@ class ModulesController extends AppController
     public function relatedJson($id, string $relation): void
     {
         $this->request->allowMethod(['get']);
+        $query = $this->Modules->prepareQuery($this->request->getQueryParams());
         try {
-            $response = $this->apiClient->getRelated($id, $this->objectType, $relation, $this->request->getQueryParams());
+            $response = $this->apiClient->getRelated($id, $this->objectType, $relation, $query);
         } catch (BEditaClientException $error) {
             $this->log($error, LogLevel::ERROR);
 
@@ -467,9 +468,9 @@ class ModulesController extends AppController
     public function resourcesJson($id, string $type): void
     {
         $this->request->allowMethod(['get']);
-
+        $query = $this->Modules->prepareQuery($this->request->getQueryParams());
         try {
-            $response = $this->apiClient->get($type, $this->request->getQueryParams());
+            $response = $this->apiClient->get($type, $query);
         } catch (BEditaClientException $error) {
             $this->log($error, LogLevel::ERROR);
 
@@ -510,7 +511,8 @@ class ModulesController extends AppController
                     $available = $response['links']['available'];
             }
 
-            $response = $this->apiClient->get($available, $this->request->getQueryParams());
+            $query = $this->Modules->prepareQuery($this->request->getQueryParams());
+            $response = $this->apiClient->get($available, $query);
 
             $this->getThumbsUrls($response);
         } catch (BEditaClientException $ex) {
@@ -548,7 +550,8 @@ class ModulesController extends AppController
 
         $thumbs = '/media/thumbs?ids=' . implode(',', $ids) . '&options[w]=400'; // TO-DO this hardcoded 400 should be in param/conf of some sort
 
-        $thumbsResponse = $this->apiClient->get($thumbs, $this->request->getQueryParams());
+        $query = $this->Modules->prepareQuery($this->request->getQueryParams());
+        $thumbsResponse = $this->apiClient->get($thumbs, $query);
 
         $thumbsUrl = $thumbsResponse['meta']['thumbnails'];
 

--- a/src/Core/Utility/Form.php
+++ b/src/Core/Utility/Form.php
@@ -252,14 +252,14 @@ class Form
     }
 
     /**
-     * Options for lang
-     * If available, use config `Project.I18n.languages`
+     * Options for lang, using configuration loaded from API
+     * If available, use config `Project.config.I18n.languages`
      *
      * @return array
      */
     protected static function langOptions(): array
     {
-        $languages = Configure::read('Project.I18n.languages');
+        $languages = Configure::read('Project.config.I18n.languages');
         if (empty($languages)) {
             return [
                 'type' => 'text',

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -896,4 +896,65 @@ class ModulesComponentTest extends TestCase
         $expected['attributes'] = array_merge($object['attributes'], $recover);
         static::assertEquals($expected, $object);
     }
+
+    /**
+     * Data provider for `testPrepareQuery`
+     *
+     * @return void
+     */
+    public function prepareQueryProvider()
+    {
+        return [
+            'simple' => [
+                [
+                    'page_size' => 7,
+                    'q' => 'gustavo',
+                ],
+                [
+                    'page_items' => 32,
+                    'page_size' => 7,
+                    'count' => 123,
+                    'q' => 'gustavo',
+                    'filter' => [],
+                ],
+            ],
+
+            'filter 1' => [
+                [
+                    'filter' => [
+                        'type' => 'documents',
+                    ],
+                ],
+                [
+                    'filter' => [
+                        'type' => 'documents',
+                        'b' => null,
+                    ],
+                ],
+            ],
+            'filter 2' => [
+                [],
+                [
+                    'filter' => [
+                        'type' => null,
+                        'a' => '',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `prepareQuery` method.
+     *
+     * @return void
+     *
+     * @dataProvider prepareQueryProvider
+     * @covers ::prepareQuery()
+     */
+    public function testPrepareQuery(array $expected, array $query): void
+    {
+        $result = $this->Modules->prepareQuery($query);
+        static::assertEquals($expected, $result);
+    }
 }

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -348,7 +348,7 @@ class SchemaHelperTest extends TestCase
      */
     public function testLang()
     {
-        Configure::write('Project.I18n', null);
+        Configure::write('Project.config.I18n', null);
         $actual = $this->Schema->controlOptions('lang', null, []);
         static::assertSame(['type' => 'text', 'value' => null], $actual);
 
@@ -358,7 +358,7 @@ class SchemaHelperTest extends TestCase
                 'de' => 'German',
             ],
         ];
-        Configure::write('Project.I18n', $i18n);
+        Configure::write('Project.config.I18n', $i18n);
         $actual = $this->Schema->controlOptions('lang', null, []);
 
         $expected = [


### PR DESCRIPTION
After #377 project configuration via API is loaded in `Project.config` key.
*I18n* config is stored in `Project.config.I18n` now 