### PR TITLE
Fix project I18n after multi-project

### DIFF
--- a/src/Core/Utility/Form.php
+++ b/src/Core/Utility/Form.php
@@ -252,14 +252,14 @@ class Form
     }
 
     /**
-     * Options for lang
-     * If available, use config `Project.I18n.languages`
+     * Options for lang, using configuration loaded from API
+     * If available, use config `Project.config.I18n.languages`
      *
      * @return array
      */
     protected static function langOptions(): array
     {
-        $languages = Configure::read('Project.I18n.languages');
+        $languages = Configure::read('Project.config.I18n.languages');
         if (empty($languages)) {
             return [
                 'type' => 'text',

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -348,7 +348,7 @@ class SchemaHelperTest extends TestCase
      */
     public function testLang()
     {
-        Configure::write('Project.I18n', null);
+        Configure::write('Project.config.I18n', null);
         $actual = $this->Schema->controlOptions('lang', null, []);
         static::assertSame(['type' => 'text', 'value' => null], $actual);
 
@@ -358,7 +358,7 @@ class SchemaHelperTest extends TestCase
                 'de' => 'German',
             ],
         ];
-        Configure::write('Project.I18n', $i18n);
+        Configure::write('Project.config.I18n', $i18n);
         $actual = $this->Schema->controlOptions('lang', null, []);
 
         $expected = [


### PR DESCRIPTION
After #377 project configuration via API is loaded in `Project.config` key.
*I18n* config is stored in `Project.config.I18n` now 