### PR TITLE
Avoid attributes conflicts on failed `save`

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -365,7 +365,7 @@ class ModulesComponent extends Component
         }
         $key = sprintf('failedSave.%s.%s', $type, $data['id']);
         $session = $this->getController()->request->getSession();
-        unset($data['id']); // remove 'id', data may be merged with attributes
+        unset($data['id']); // remove 'id', avoid future merged with attributes
         $session->write($key, $data);
         $session->write(sprintf('%s__timestamp', $key), time());
     }

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -180,8 +180,8 @@ class ModulesController extends AppController
 
         $object = $response['data'];
 
-        // if previous post save failed, recover data from session.
-        $this->Modules->updateFromFailedSave($object);
+        // setup `currentAttributes` and recover failure data from session.
+        $this->Modules->setupAttributes($object);
 
         $included = (!empty($response['included'])) ? $response['included'] : [];
         $this->set(compact('object', 'included', 'schema'));

--- a/src/Template/Element/Form/core_properties.twig
+++ b/src/Template/Element/Form/core_properties.twig
@@ -12,9 +12,8 @@
 
         {{ Form.hidden('id', {'value': (object) ? object.id : resource.id})|raw }}
 
-        {% if (object.attributes or resource.attributes) and (_view.getRequest().getParam('action') != 'clone') %}
-        {% set attributes = (object.attributes) ? object.attributes : resource.attributes %}
-        {{ Form.hidden('_actualAttributes', {'value': attributes|json_encode})|raw }}
+        {% if (currentAttributes) and (_view.getRequest().getParam('action') != 'clone') %}
+        {{ Form.hidden('_actualAttributes', {'value': currentAttributes})|raw }}
         {% endif %}
     </div>
 </section>

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -863,7 +863,8 @@ class ModulesComponentTest extends TestCase
 
         // verify data
         $key = sprintf('failedSave.%s.%s', $type, $expected['id']);
-        $actual = $this->Modules->request->getSession()->read($key);
+        $actual = $this->Modules->getController()->request->getSession()->read($key);
+        unset($expected['id']);
         static::assertEquals($expected, $actual);
     }
 
@@ -872,6 +873,7 @@ class ModulesComponentTest extends TestCase
      *
      * @return void
      *
+     * @covers ::setupAttributes()
      * @covers ::updateFromFailedSave()
      */
     public function testUpdateFromFailedSave(): void
@@ -885,13 +887,10 @@ class ModulesComponentTest extends TestCase
             ],
         ];
         $recover = [ 'name' => 'gustavo' ];
-        $key = sprintf('failedSave.%s.%s', $object['type'], $object['id']);
-        $session = $this->Modules->request->getSession();
-        $session->write($key, $recover);
-        $session->write(sprintf('%s__timestamp', $key), time());
+        $this->Modules->setDataFromFailedSave('documents', $recover + ['id' => 999]);
 
         // verify data
-        $this->Modules->updateFromFailedSave($object);
+        $this->Modules->setupAttributes($object);
         $expected = $object;
         $expected['attributes'] = array_merge($object['attributes'], $recover);
         static::assertEquals($expected, $object);


### PR DESCRIPTION
This PR fixes two problem handling form after failed save:

* `id` was merged in attributes and then removed from `_actualAttributes` save => on the following save after failure a new object was created
* `_actualAttributes` should contain only current object data from API, instead it had also data from failed form => on the next save some changes where lost
