### PR TITLE
feat: roles filter

### DIFF
--- a/config/properties.php
+++ b/config/properties.php
@@ -36,6 +36,10 @@ return [
                 'surname',
                 'email',
             ],
+            'filter' => [
+                'status',
+                'roles',
+            ],
         ],
 
         // media

--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -159,7 +159,7 @@ class SchemaComponent extends Component
         ];
         $response = ApiClientProvider::getApiClient()->get('/roles', $query);
 
-        return Hash::extract((array)$response, 'data.{n}.attributes.name');
+        return (array)Hash::extract((array)$response, 'data.{n}.attributes.name');
     }
 
     /**

--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -134,7 +134,32 @@ class SchemaComponent extends Component
      */
     protected function fetchSchema(string $type)
     {
-        return ApiClientProvider::getApiClient()->schema($type);
+        $schema = ApiClientProvider::getApiClient()->schema($type);
+        // add special property `roles` to `users`
+        if ($type === 'users') {
+            $schema['properties']['roles'] = [
+                'type' => 'string',
+                'enum' => $this->fetchRoles(),
+            ];
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Fetch `roles` names
+     *
+     * @return array
+     */
+    protected function fetchRoles(): array
+    {
+        $query = [
+            'fields' => 'name',
+            'page_size' => 100,
+        ];
+        $response = ApiClientProvider::getApiClient()->get('/roles', $query);
+
+        return Hash::extract((array)$response, 'data.{n}.attributes.name');
     }
 
     /**

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -252,4 +252,48 @@ class SchemaComponentTest extends TestCase
         $message = $this->Schema->request->getSession()->read('Flash.flash.0.message');
         static::assertEquals('Client Exception', $message);
     }
+
+    /**
+     * Test `fetchSchema` for `users`.
+     *
+     * @return void
+     * @covers ::fetchSchema()
+     * @covers ::fetchRoles()
+     */
+    public function testFetchRoles()
+    {
+        $roles = [
+            'data' => [
+                [
+                    'attributes' => [
+                        'name' => 'admin',
+                    ],
+                ],
+                [
+                    'attributes' => [
+                        'name' => 'manager',
+                    ],
+                ],
+            ],
+        ];
+
+        // Setup mock API client.
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->method('get')
+                ->willReturn($roles);
+
+        ApiClientProvider::setApiClient($apiClient);
+        Cache::clearAll();
+        $result = $this->Schema->getSchema('users');
+        static::assertNotEmpty($result);
+        static::assertNotEmpty($result['properties']['roles']);
+
+        $expected = [
+            'type' => 'string',
+            'enum' => ['admin', 'manager'],
+        ];
+        static::assertEquals($expected, $result['properties']['roles']);
+    }
 }

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -283,6 +283,8 @@ class SchemaComponentTest extends TestCase
             ->getMock();
         $apiClient->method('get')
                 ->willReturn($roles);
+        $apiClient->method('schema')
+                ->willReturn([]);
 
         ApiClientProvider::setApiClient($apiClient);
         Cache::clearAll();


### PR DESCRIPTION
This PR adds a `roles` filter for users like any other `enum` based filter on properties.

A special virtual property is added to `users` JSON SCHEMA that can be used as filter.

bedita/bedita#1668 is needed to make this filter work
