### PR TITLE
Improve config defaults

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -456,7 +456,7 @@ return [
      *      + 'other' remaining attributes
      *  - 'index' properties to display in index view (other than id, status and modified)
      */
-    'Properties' => [
+    // 'Properties' => [
         // 'foos' => [
         //     'view' => [
         //         '_keep' => [
@@ -479,7 +479,7 @@ return [
         //         'username',
         //     ],
         // ],
-    ],
+    // ],
 
     /**
      * Custom view elements configuration.
@@ -494,11 +494,11 @@ return [
      * ```
      * In this example: if current module is `documents` => `Form/included` element is loaded from `MyPlugin` plugin
      */
-    'Elements' => [
-        // 'documents' => [
-        //     'Form/included' => 'MyPlugin',
-        // ],
-    ],
+    // 'Elements' => [
+    //     // 'documents' => [
+    //     //     'Form/included' => 'MyPlugin',
+    //     // ],
+    // ],
 
     /**
      * Additional plugins to load with this format: 'PluginName' => load options array
@@ -510,12 +510,12 @@ return [
      * - `ignoreMissing` - boolean - (default: false) Set to true to ignore missing bootstrap/routes files.
      * - `autoload` - boolean - (default: false) Whether or not you want an autoloader registered
      */
-    'Plugins' => [
+    // 'Plugins' => [
         // 'MyPlugin' => ['autoload' => true, 'bootstrap' => true, 'routes' => true], // a simple plugin
 
         // Uncomment to enable `DebugKit` - 'debug' mode is required
         //'DebugKit' => ['bootstrap' => true, 'debugOnly' => true],
-    ],
+    // ],
 
     /**
      * Plugin modules settings.
@@ -523,40 +523,39 @@ return [
      * Default empty.
      * Configuration generally written by plugins via bootstrap.
      */
-    'PluginModules' => [
-        /*
-        // plugin module example
-        // unique name
-        'My Module' => [
-            'title' => 'My Module',
-            // routing rules
-            'route' => Router::url(['_name': 'my_module:index']),
-            // css class
-            'class' => [
-                'dashboard' => 'has-background-black icon-sample',
-                'menu' => 'has-background-black',
-            ],
-        ],
-        */
-    ],
+    // 'PluginModules' => [
+
+    //     // plugin module example
+    //     // unique name
+    //     'My Module' => [
+    //         'title' => 'My Module',
+    //         // routing rules
+    //         'route' => Router::url(['_name': 'my_module:index']),
+    //         // css class
+    //         'class' => [
+    //             'dashboard' => 'has-background-black icon-sample',
+    //             'menu' => 'has-background-black',
+    //         ],
+    //     ],
+    // ],
 
     /**
      * Pagination default settings
      *
      * - sizeAvailable => available page size on modules view index
      */
-    'Pagination' => [
-        'sizeAvailable' => [10, 20, 50, 100],
-    ],
+    // 'Pagination' => [
+    //     'sizeAvailable' => [10, 20, 50, 100],
+    // ],
 
     /**
      * Export default settings
      *
      * - limit => max number of exported elements on export all
      */
-    'Export' => [
-        'limit' => 10000,
-    ],
+    // 'Export' => [
+    //     'limit' => 10000,
+    // ],
 
     /**
      * I18n setup for frontend.

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -78,6 +78,11 @@ try {
         ],
         'switchLangUrl' => '/lang',
     ]);
+    // default pagination
+    Configure::write('Pagination', [
+        'sizeAvailable' => [10, 20, 50, 100],
+    ]);
+
     Configure::load('app', 'default');
 
     Configure::config('ini', new IniConfig());

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -146,8 +146,8 @@ class ModulesComponent extends Component
                 return -$idx;
             })
             ->toList();
-        $plugins = Configure::read('Modules.plugins');
-        if ($plugins) {
+        $plugins = (array)Configure::read('Modules.plugins');
+        if (!empty($plugins)) {
             $modules = array_merge($modules, $plugins);
         }
         $this->modules = Hash::combine($modules, '{n}.name', '{n}');

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -22,6 +22,13 @@ use Cake\Utility\Hash;
 class ExportController extends AppController
 {
     /**
+     * Default max number of exported items
+     *
+     * @var int
+     */
+    const DEFAULT_EXPORT_LIMIT = 10000;
+
+    /**
      * Export data in csv format
      *
      * @return \Cake\Http\Response
@@ -56,8 +63,8 @@ class ExportController extends AppController
     {
         $data = [];
         if (empty($ids)) { // empty ids? then get all (multi api calls)
-            // read export limit from config, default 10000
-            $limit = Configure::read('Export.limit', 10000);
+            // read export limit from config
+            $limit = Configure::read('Export.limit', self::DEFAULT_EXPORT_LIMIT);
             $pageCount = 1;
             $total = 0;
             $query = ['page_size' => 100];

--- a/src/Template/Element/Menu/menu.twig
+++ b/src/Template/Element/Menu/menu.twig
@@ -12,7 +12,7 @@
     {% endfor %}
 
     {# Plugin modules #}
-    {% for k, plugin in config('PluginModules') %}
+    {% for k, plugin in config('PluginModules', []) %}
         <li class="{{ plugin.class.menu }}">
             {{ Html.link(__(plugin.title|humanize)|slice(0, 2),
                 plugin.route,

--- a/src/Template/Element/custom_colors.twig
+++ b/src/Template/Element/custom_colors.twig
@@ -1,7 +1,7 @@
 <style type="text/css">
 
     {# set modules colors #}
-    {% for name, color in config('Modules.colors') %}
+    {% for name, color in config('Modules.colors', []) %}
 
         .has-background-module-{{ name }} {
             background-color: {{ color }} !important;

--- a/src/Template/Pages/Dashboard/index.twig
+++ b/src/Template/Pages/Dashboard/index.twig
@@ -14,7 +14,7 @@
                 {{ Html.link(__(title), {'_name': 'modules:list', 'object_type': name}, {'title': __(title)})|raw }}
             </li>
         {% endfor %}
-        {% for k, plugin in config('PluginModules') %}
+        {% for k, plugin in config('PluginModules', []) %}
             <li class="{{ plugin.class.dashboard }}">
                 {{ Html.link(__(plugin.title|humanize), plugin.route, {'title': __(plugin.title|humanize)})|raw }}
             </li>


### PR DESCRIPTION
In this PR configuration defaults are changed in order to avoid presence of these keys:

* Properties
* Elements
* Plugins
* PluginModules
* Pagination
* Export

All those keys are absent/commented as default and should be used/decommented only when new values are needed.
