### PR TITLE
Remove empty attribtes on new resources/objects

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -204,6 +204,11 @@ class AppController extends Controller
             unset($data['_actualAttributes']);
         }
 
+        // cleanup attributes on new objects/resources
+        if (empty($data['id'])) {
+            $data = array_filter($data);
+        }
+
         return $data;
     }
 

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -309,13 +309,25 @@ class AppControllerTest extends TestCase
             'fields null value' => [ // fields with value null, not changed and changed
                 'documents', // object_type
                 [ // expected
+                    'id' => 23,
                     'title' => null, // null, changed
                     // 'description' => null, not changed
                 ],
                 [ // data provided
+                    'id' => 23,
                     'title' => null,
                     'description' => null,
                     '_actualAttributes' => '{"title":"bibo","description":null}',
+                ],
+            ],
+            'fields null new' => [ // fields with value null on new resources
+                'documents', // object_type
+                [ // expected
+                    'description' => 'some text',
+                ],
+                [ // data provided
+                    'title' => null,
+                    'description' => 'some text',
                 ],
             ],
             'users' => [ // test: removing password from data


### PR DESCRIPTION
This PR introduces a small change in `AppController::prepareRequest()` 

On new resources/objects remove empty attributes in order to use creation defaults properly.
 