### PR TITLE
feat: introduce API proxy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "bedita/web-tools": "^1.1",
+        "bedita/web-tools": "^1.4.2",
         "bedita/i18n": "^1.5",
         "cakephp/plugin-installer": "^1.1",
         "josegonzalez/dotenv": "2.*",

--- a/config/routes.php
+++ b/config/routes.php
@@ -151,6 +151,11 @@ Router::scope('/', function (RouteBuilder $routes) {
         ['pass' => ['id'], '_name' => 'modules:uname']
     );
 
+    // API proxy
+    $routes->scope('/api', ['_namePrefix' => 'api:'], function (RouteBuilder $routes) {
+        $routes->get('/**', ['controller' => 'Api', 'action' => 'get'], 'get');
+    });
+
     // Modules.
     $routes->connect(
         '/:object_type',

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Controller;
+
+use BEdita\WebTools\Controller\ApiProxyTrait;
+
+/**
+ * ApiController class.
+ *
+ * It proxies requests to BEdita 4 API.
+ * The response will be the raw json response of the API itself.
+ * Links of API host is masked with manager host.
+ */
+class ApiController extends AppController
+{
+    use ApiProxyTrait;
+}


### PR DESCRIPTION
This PR introduce a route to proxy requests to BEdita 4 API.

For example calling `GET /api/folders` the `GET /folders` request will be send to BE4 API and the raw response obtained will be forward to the client.