### PR TITLE
Feat: categories in schema

### DIFF
--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -135,6 +135,9 @@ class SchemaComponent extends Component
     protected function fetchSchema(string $type)
     {
         $schema = ApiClientProvider::getApiClient()->schema($type);
+        if (empty($schema)) {
+            return false;
+        }
         // add special property `roles` to `users`
         if ($type === 'users') {
             $schema['properties']['roles'] = [
@@ -176,7 +179,12 @@ class SchemaComponent extends Component
             'page_size' => 100,
         ];
         $url = sprintf('/model/categories?filter[type]=%s', $type);
-        $response = ApiClientProvider::getApiClient()->get($url, $query);
+        try {
+            $response = ApiClientProvider::getApiClient()->get($url, $query);
+        } catch (BEditaClientException $ex) {
+            // we ignore filter errors for now
+            $response = [];
+        }
 
         return array_map(
             function ($item) {

--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -143,6 +143,19 @@ class SchemaComponent extends Component
             ];
         }
 
+        // add special property `categories` if available for type
+        $categories = $this->fetchCategories($type);
+        if (!empty($categories)) {
+            $schema['properties']['categories'] = [
+                'type' => 'array',
+                'uniqueItems' => true,
+                'item' => [
+                    'type' => 'string',
+                    'enum' => $categories,
+                ],
+            ];
+        }
+
         return $schema;
     }
 
@@ -158,6 +171,24 @@ class SchemaComponent extends Component
             'page_size' => 100,
         ];
         $response = ApiClientProvider::getApiClient()->get('/roles', $query);
+
+        return (array)Hash::extract((array)$response, 'data.{n}.attributes.name');
+    }
+
+    /**
+     * Fetch `categories`
+     * This should be called only for types having `"Categories"` association
+     *
+     * @param string $type Object type name
+     * @return array
+     */
+    protected function fetchCategories(string $type): array
+    {
+        $query = [
+            'page_size' => 100,
+        ];
+        $url = sprintf('/model/categories?filter[type]=%s', $type);
+        $response = ApiClientProvider::getApiClient()->get($url, $query);
 
         return (array)Hash::extract((array)$response, 'data.{n}.attributes.name');
     }

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -298,4 +298,60 @@ class SchemaComponentTest extends TestCase
         ];
         static::assertEquals($expected, $result['properties']['roles']);
     }
+
+    /**
+     * Test `fetchSchema` for `categories`.
+     *
+     * @return void
+     * @covers ::fetchSchema()
+     * @covers ::fetchCategories()
+     */
+    public function testFetchCategories()
+    {
+        $categories = [
+            'data' => [
+                [
+                    'id' => '1',
+                    'attributes' => [
+                        'name' => 'cat-1',
+                        'label' => 'Category 1',
+                    ],
+                ],
+                [
+                    'id' => '2',
+                    'attributes' => [
+                        'name' => 'cat-2',
+                        'label' => 'Category 2',
+                    ],
+                ],
+            ],
+        ];
+
+        // Setup mock API client.
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->method('get')
+                ->willReturn($categories);
+        $apiClient->method('schema')
+                ->willReturn([]);
+
+        ApiClientProvider::setApiClient($apiClient);
+        Cache::clearAll();
+        $result = $this->Schema->getSchema('documents');
+        static::assertNotEmpty($result);
+        static::assertNotEmpty($result['categories']);
+
+        $expected = [
+            [
+                'name' => 'cat-1',
+                'label' => 'Category 1',
+            ],
+            [
+                'name' => 'cat-2',
+                'label' => 'Category 2',
+            ],
+        ];
+        static::assertEquals($expected, $result['categories']);
+    }
 }

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -88,6 +88,11 @@ class SchemaComponentTest extends TestCase
                 new \RuntimeException('I am some other kind of exception', 999),
                 'you-are-not-my-type',
             ],
+            'no schema' => [
+                false,
+                [],
+                'some-type',
+            ],
         ];
     }
 
@@ -284,7 +289,7 @@ class SchemaComponentTest extends TestCase
         $apiClient->method('get')
                 ->willReturn($roles);
         $apiClient->method('schema')
-                ->willReturn([]);
+                ->willReturn(['type' => 'object']);
 
         ApiClientProvider::setApiClient($apiClient);
         Cache::clearAll();
@@ -332,9 +337,9 @@ class SchemaComponentTest extends TestCase
             ->setConstructorArgs(['https://api.example.org'])
             ->getMock();
         $apiClient->method('get')
-                ->willReturn($categories);
+            ->willReturn($categories);
         $apiClient->method('schema')
-                ->willReturn([]);
+            ->willReturn(['type' => 'object']);
 
         ApiClientProvider::setApiClient($apiClient);
         Cache::clearAll();
@@ -353,5 +358,28 @@ class SchemaComponentTest extends TestCase
             ],
         ];
         static::assertEquals($expected, $result['categories']);
+    }
+
+    /**
+     * Test `fetchCategories` with API error.
+     *
+     * @return void
+     * @covers ::fetchCategories()
+     */
+    public function testFetchCategoriesFail()
+    {
+        // Setup mock API client.
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->method('get')
+            ->willThrowException(new BEditaClientException(''));
+        $apiClient->method('schema')
+            ->willReturn(['type' => 'object']);
+
+        ApiClientProvider::setApiClient($apiClient);
+        Cache::clearAll();
+        $result = $this->Schema->getSchema('documents');
+        static::assertEquals(['type' => 'object'], $result);
     }
 }


### PR DESCRIPTION
Object type categories are added to cached `schema` array in `categories` key if available.

Improvement needed: from `GET /schema/{type}` we should know if categories are available, defined for the type - probably an `associations` key could be added to JSON SCHEMA response
