### PR TITLE
fix: extract only `streams` from `included`

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -190,7 +190,9 @@ class ModulesController extends AppController
         $this->Modules->setupAttributes($object);
 
         $included = (!empty($response['included'])) ? $response['included'] : [];
-        $this->set(compact('object', 'included', 'schema'));
+        $typeIncluded = (array)Hash::combine($included, '{n}.id', '{n}', '{n}.type');
+        $streams = Hash::get($typeIncluded, 'streams');
+        $this->set(compact('object', 'included', 'schema', 'streams'));
         $this->set('properties', $this->Properties->viewGroups($object, $this->objectType));
 
         // relatinos between objects

--- a/src/Template/Element/Form/media.twig
+++ b/src/Template/Element/Form/media.twig
@@ -1,4 +1,4 @@
-{% if included or object.attributes.provider_extra.html %}
+{% if streams or object.attributes.provider_extra.html %}
 <property-view inline-template :tab-open="tabsOpen" :is-default-open=true :tab-open-at-start=true>
 <section class="fieldset order-1" id="included" :class="isOpen? '' : 'closed'">
 
@@ -14,17 +14,10 @@
                 style="padding-bottom: {{ 100 * object.attributes.provider_extra.height / object.attributes.provider_extra.width }}%;">
                 {{ object.attributes.provider_extra.html|raw }}
             </div>
-        {% endif %}
+        {% else %}
 
-        {# Display included streams#}
-        {% if included %}
-
-        {% set hasFile = false %}
-        {# cycle over included elements, show only streams #}
-        {% for o in included %}
-            {% if o.type == 'streams' %}
-            {% set hasFile = true %}
-            {% set stream = o %}
+            {# Show first stream #}
+            {% set stream = streams|first %}
 
             {# the stream #}
             <div class="stream">
@@ -82,16 +75,13 @@
                     </tbody>
                 </table>
             </div>
-            {% endif %}
-        {% endfor %}
-        {% endif %}
 
-        {% if hasFile %}
         <h3>{{ __('Change File') }}</h3>
         <div class="tab-container">
             {{ Form.control('file', { 'type': 'file', 'label': false }) | raw }}
             {{ Form.control('model-type', { 'type': 'hidden', 'value': object.type}) | raw }}
         </div>
+
         {% endif %}
 
     </div>

--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -46,8 +46,8 @@
 
                 {% element 'Form/custom_left' %}
 
-                {# media streams & other resources included #}
-                {% element 'Form/included' %}
+                {# show media stream or embed external provider #}
+                {% element 'Form/media' %}
 
                 {# map #}
                 {% element 'Form/map' %}


### PR DESCRIPTION
Avoid unwanted empty `Media` tab in object view when no media is displayed