### PR TITLE
Don't merge `app.php` config in bootstrap

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -83,7 +83,7 @@ try {
         'sizeAvailable' => [10, 20, 50, 100],
     ]);
 
-    Configure::load('app', 'default');
+    Configure::load('app', 'default', false);
 
     Configure::config('ini', new IniConfig());
     Configure::load('version', 'ini');


### PR DESCRIPTION
This PR fixes a problem in configuration data.

If `Pagination.sizeAvailable` or `I18n` is set in `config/app.php` currently we end up having merged arrays.

For example  `'Pagination.sizeAvailable'` can become `[10, 20, 50, 100, 10, 20, 50, 100]`

