### PR TITLE
fix: remove missing favicons from meta

### DIFF
--- a/src/Template/Element/meta.twig
+++ b/src/Template/Element/meta.twig
@@ -2,8 +2,6 @@
 <meta name="description" content="">
 <meta name="author" content="">
 
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-
 {#
 <link rel="manifest" href="/site.webmanifest">
 <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#ffffff">

--- a/src/Template/Element/meta.twig
+++ b/src/Template/Element/meta.twig
@@ -3,8 +3,6 @@
 <meta name="author" content="">
 
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 
 {#
 <link rel="manifest" href="/site.webmanifest">


### PR DESCRIPTION
Remove from meta favicons links (not in webroot folder).
This avoids a 404 error on loading favicons.