### PR TITLE
fix: popup action id

### DIFF
--- a/src/Template/Layout/js/app/components/menu.js
+++ b/src/Template/Layout/js/app/components/menu.js
@@ -41,7 +41,7 @@ export default {
             let urlPath = '';
             if (this.popUpAction == 'search') {
                 urlPath += "/objects?q=";
-            } else if (this.popUpAction == 'go') {
+            } else if (this.popUpAction == 'id') {
                 urlPath += "/view/";
             }
 


### PR DESCRIPTION
This fixes the top right "redir by uname/id", visible clicking on cube icon.