### PR TITLE
Use relation labels

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -28,15 +28,6 @@ use Psr\Log\LogLevel;
  */
 class ModulesController extends AppController
 {
-    protected const FIXED_RELATIONSHIPS = [
-        'parent',
-        'children',
-        'parents',
-        'translations',
-        'streams',
-        'roles',
-    ];
-
     /**
      * Object type currently used
      *
@@ -195,13 +186,8 @@ class ModulesController extends AppController
         $this->set(compact('object', 'included', 'schema', 'streams'));
         $this->set('properties', $this->Properties->viewGroups($object, $this->objectType));
 
-        // relations between objects
-        $relationsSchema = array_intersect_key($this->Schema->getRelationsSchema(), $object['relationships']);
-        // relations between objects and resources
-        $resourceRelations = array_diff(array_keys($object['relationships']), array_keys($relationsSchema), self::FIXED_RELATIONSHIPS);
-
-        $this->set(compact('relationsSchema', 'resourceRelations'));
-        $this->set('objectRelations', array_keys($relationsSchema));
+        // setup relations metadata
+        $this->Modules->setupRelationsMeta($this->Schema->getRelationsSchema(), $object['relationships']);
 
         // set objectNav
         $objectNav = $this->getObjectNav((string)$id);

--- a/src/Template/Element/Form/relations.twig
+++ b/src/Template/Element/Form/relations.twig
@@ -7,7 +7,7 @@
 {% if objectRelations %}
 <section class="relations">
 
-    {% for relationName in objectRelations %}
+    {% for relationName, relationLabel in objectRelations %}
 
         <div class="relation">
             <property-view inline-template :tab-open="tabsOpen" ref={{ relationName }}>
@@ -15,7 +15,7 @@
 
                     <header @click.prevent="toggleVisibility();" class="tab unselectable" v-bind:class="isLoading? 'is-loading-spinner' : ''">
                         <h2>
-                            {{ relationName|humanize|lower }}
+                            {{ relationLabel }}
                             <span class="tag is-smallest is-black mx-05"
                                 :class="!totalObjects? 'empty' : ''"><: totalObjects :>
                             </span>

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -956,4 +956,95 @@ class ModulesComponentTest extends TestCase
         $result = $this->Modules->prepareQuery($query);
         static::assertEquals($expected, $result);
     }
+
+    /**
+     * Data provider for `testSetupRelationsMeta`
+     *
+     * @return void
+     */
+    public function setupRelationsProvider()
+    {
+        return [
+            'simple' => [
+                [
+                    'relationsSchema' => [
+                        'has_media' => [
+                            'attributes' => [
+                                'name' => 'has_media',
+                                'label' => 'Has Media',
+                                'inverse_name' => 'media_of',
+                                'inverse_label' => 'Media Of',
+                            ],
+                        ],
+                    ],
+                    'resourceRelations' => [],
+                    'objectRelations' => ['has_media' => 'Has Media'],
+                ],
+                [
+                    'has_media' => [
+                        'attributes' => [
+                            'name' => 'has_media',
+                            'label' => 'Has Media',
+                            'inverse_name' => 'media_of',
+                            'inverse_label' => 'Media Of',
+                        ],
+                    ],
+                ],
+                [
+                    'has_media' => [],
+                ],
+            ],
+            'inverse' => [
+                [
+                    'relationsSchema' => [
+                        'media_of' => [
+                            'attributes' => [
+                                'name' => 'has_media',
+                                'label' => 'Has Media',
+                                'inverse_name' => 'media_of',
+                                'inverse_label' => 'Media Of',
+                            ],
+                        ],
+                    ],
+                    'resourceRelations' => [],
+                    'objectRelations' => ['media_of' => 'Media Of'],
+                ],
+                [
+                    'media_of' => [
+                        'attributes' => [
+                            'name' => 'has_media',
+                            'label' => 'Has Media',
+                            'inverse_name' => 'media_of',
+                            'inverse_label' => 'Media Of',
+                        ],
+                    ],
+                ],
+                [
+                    'media_of' => [],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `setupRelationsMeta` method
+     *
+     * @return void
+     *
+     * @dataProvider setupRelationsProvider
+     * @covers ::setupRelationsMeta()
+     *
+     * @param array $expected Expected result.
+     * @param array $schema Schema array.
+     * @param array $relationships Relationships array.
+     */
+    public function testSetupRelationsMeta(array $expected, array $schema, array $relationships)
+    {
+        $this->Modules->setupRelationsMeta($schema, $relationships);
+
+        $viewVars = $this->Modules->getController()->viewVars;
+        foreach ($expected as $key => $value) {
+            $this->assertEquals($value, $viewVars[$key]);
+        }
+    }
 }


### PR DESCRIPTION
This PR improves object relations view: object relation tabs will display relation label as title instead of `humanized` relation name. 
Label or inverse label are displayed depending on relation side.

A new `ModulesComponent::setupRelationsMeta()` has been added
