### PR TITLE
Don't delete cache on null $revision

### DIFF
--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -117,7 +117,7 @@ class SchemaComponent extends Component
             return false;
         }
         $cacheRevision = empty($schema['revision']) ? null : $schema['revision'];
-        if ($cacheRevision === $revision) {
+        if ($revision === null || $cacheRevision === $revision) {
             return $schema;
         }
         // remove from cache if revision don't match


### PR DESCRIPTION
Avoid model schema cache removal if schema `revision` hash is not known.
 