### PR TITLE
New modules configuration

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -415,8 +415,8 @@ return [
      *  'sort' - sort order to be used in index; use a field name prepending optionl `-` sign
      *          to indicate a descendant order, f.i. '-title' will sort by title in reverse alphabetical order
      *          (default is '-id'),
-     *  'class' - additional class to use in module box; could be `icon-article`,
-     *          have a look in `webroot/css/be-icons-codes.css` for a complete list
+     *  'icon' - icon code, f.i. `icon-article`, have a look in
+     *      `webroot/css/be-icons-codes.css` for a complete list of codes
      */
     'Modules' => [
         'objects' => [
@@ -432,22 +432,22 @@ return [
         'documents' => [
             'shortLabel' => 'docs',
             'color' => '#cc4700',
-            // 'class' => 'icon-article',
+            // 'icon' => 'icon-article',
         ],
         'events' => [
             'shortLabel' => 'evt',
             'color' => '#09c',
-            // 'class' => 'icon-music',
+            // 'icon' => 'icon-music',
         ],
         'news' => [
             // 'shortLabel' => 'new',
             'color' => '#036',
             // 'sort' => 'title',
-            // 'class' => 'icon-newspaper',
+            // 'icon' => 'icon-newspaper',
         ],
         'locations' => [
             'color' => '#641',
-            'class' => 'icon-map-pin',
+            'icon' => 'icon-map-pin',
         ],
         'media' => [
             'shortLabel' => 'med',
@@ -457,19 +457,19 @@ return [
         'images' => [
             'shortLabel' => 'img',
             'color' => '#d5002b',
-            // 'class' => 'icon-picture',
+            // 'icon' => 'icon-picture',
         ],
         'videos' => [
             'color' => '#d5002b',
-            // 'class' => 'icon-video',
+            // 'icon' => 'icon-video',
         ],
         'audio' => [
             'color' => '#d5002b',
-            // 'class' => 'icon-music',
+            // 'icon' => 'icon-music',
         ],
         'files' => [
             'color' => '#d5002b',
-            // 'class' => 'icon-article',
+            // 'icon' => 'icon-article',
         ],
         'users' => [
             'shortLabel' => 'usr',
@@ -479,7 +479,7 @@ return [
             // 'shortLabel' => 'pro',
             'color' => '#093',
             // 'sort' => 'title',
-            // 'class' => 'address-book',
+            // 'icon' => 'address-book',
         ],
     ],
 

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -403,18 +403,20 @@ return [
     /**
      * Modules configuration.
      *
-     * Array having as key actual API endpoint like `documents`, `users`....
+     * Keys must be actual API endpoint names like `documents`, `users` or `folders`.
+     * Modules order will follow key order of this configuration.
      *
      * Array value may contain:
      *
-     *  'label' - module label to display, if not set key is used
+     *  'label' - module label to display, if not set `key` will be used
      *  'shortLabel' - short label, 3 character recommended
      *  'color' - primary color code,
      *  'secondaryColor' - secondary color code,
-     *  'sort' - sort order to be used in index, use a field name prepending optionl `-` sign
-     *          to indicate a descendant order, f.i. '-title' sort by title in reverse alphabetical order
+     *  'sort' - sort order to be used in index; use a field name prepending optionl `-` sign
+     *          to indicate a descendant order, f.i. '-title' will sort by title in reverse alphabetical order
      *          (default is '-id'),
-     *  'class' - additional class to use in module box (could be `icon-article`, `icon-rocket`...)
+     *  'class' - additional class to use in module box; could be `icon-article`,
+     *          have a look in `webroot/css/be-icons-codes.css` for a complete list
      */
     'Modules' => [
         'objects' => [

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -403,44 +403,81 @@ return [
     /**
      * Modules configuration.
      *
-     * Contains an array of settings to use for modules configuration.
+     * Array having as key actual API endpoint like `documents`, `users`....
      *
-     * ## Options
+     * Array value may contain:
      *
-     * - `order` - The order in which modules will be displayed.
+     *  'label' - module label to display, if not set key is used
+     *  'shortLabel' - short label, 3 character recommended
+     *  'color' - primary color code,
+     *  'secondaryColor' - secondary color code,
+     *  'sort' - sort order to be used in index, use a field name prepending optionl `-` sign
+     *          to indicate a descendant order, f.i. '-title' sort by title in reverse alphabetical order
+     *          (default is '-id'),
+     *  'class' - additional class to use in module box (could be `icon-article`, `icon-rocket`...)
      */
     'Modules' => [
-        'order' => [
-            'objects',
-            'folders',
-            'documents',
-            'events',
-            'news',
-            'locations',
-            'media',
-            'images',
-            'videos',
-            'audio',
-            'files',
-            'users',
-            'profiles',
+        'objects' => [
+            'shortLabel' => 'obj',
+            'color' => '#230637',
+            'secondaryColor' => '#d95700',
+            'sort' => '-modified',
         ],
-
-        'colors' => [
-            'objects' => '#230637',
-            'folders' => '#072440',
-            'documents' => '#cc4700',
-            'media' => '#a80019',
-            'images' => '#d5002b',
-            'videos' => '#d5002b',
-            'audio' => '#d5002b',
-            'files' => '#d5002b',
-            'events' => '#09c',
-            'locations' => '#641',
-            'news' => '#036',
-            'users' => '#000000',
-            'profiles' => '#093',
-            'trash' => '#000000',
+        'folders' => [
+            // 'shortLabel' => 'fol',
+            'color' => '#072440',
+        ],
+        'documents' => [
+            'shortLabel' => 'docs',
+            'color' => '#cc4700',
+            // 'class' => 'icon-article',
+        ],
+        'events' => [
+            'shortLabel' => 'evt',
+            'color' => '#09c',
+            // 'class' => 'icon-music',
+        ],
+        'news' => [
+            // 'shortLabel' => 'new',
+            'color' => '#036',
+            // 'sort' => 'title',
+            // 'class' => 'icon-newspaper',
+        ],
+        'locations' => [
+            'color' => '#641',
+            'class' => 'icon-map-pin',
+        ],
+        'media' => [
+            'shortLabel' => 'med',
+            'color' => '#a80019',
+            'sort' => '-modified',
+        ],
+        'images' => [
+            'shortLabel' => 'img',
+            'color' => '#d5002b',
+            // 'class' => 'icon-picture',
+        ],
+        'videos' => [
+            'color' => '#d5002b',
+            // 'class' => 'icon-video',
+        ],
+        'audio' => [
+            'color' => '#d5002b',
+            // 'class' => 'icon-music',
+        ],
+        'files' => [
+            'color' => '#d5002b',
+            // 'class' => 'icon-article',
+        ],
+        'users' => [
+            'shortLabel' => 'usr',
+            'color' => '#000000',
+        ],
+        'profiles' => [
+            // 'shortLabel' => 'pro',
+            'color' => '#093',
+            // 'sort' => 'title',
+            // 'class' => 'address-book',
         ],
     ],
 

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -80,10 +80,8 @@ class ModulesController extends AppController
             return $result;
         }
 
-        $query = $this->request->getQueryParams();
-
         try {
-            $response = $this->apiClient->getObjects($this->objectType, $query);
+            $response = $this->apiClient->getObjects($this->objectType, $this->indexQuery());
         } catch (BEditaClientException $e) {
             $this->log($e, LogLevel::ERROR);
             $this->Flash->error($e->getMessage(), ['params' => $e]);
@@ -117,6 +115,26 @@ class ModulesController extends AppController
         $this->setObjectNav($objects);
 
         return null;
+    }
+
+    /**
+     * Retrieve `index` module query string
+     *
+     * @return array
+     */
+    protected function indexQuery()
+    {
+        $query = $this->request->getQueryParams();
+        // return URL query string if `filter`, `sort`, or `q` are set
+        $subQuery = array_intersect_key($query, array_flip(['filter', 'sort', 'q']));
+        if (!empty($subQuery)) {
+            return $query;
+        }
+
+        // set sort order: use `currentModule.sort` or default '-id'
+        $query['sort'] = (string)Hash::get($this->viewVars, 'currentModule.sort', '-id');
+
+        return $query;
     }
 
     /**

--- a/src/Template/Element/Menu/menu.twig
+++ b/src/Template/Element/Menu/menu.twig
@@ -4,8 +4,8 @@
         <nav role="menu">
             {# Core object modules #}
             {% for name, module in modules if name != 'trash' %}
-                {% set label = __(name|humanize) %}
-                {% set shortLabel = label[0:3] %}
+                {% set label = __(module.label|default(name)|humanize) %}
+                {% set shortLabel = module.shortLabel|default(label[0:3]) %}
                 {% if label|length > 8 %}
                     {% set label = label[0:3] %}
                 {% endif %}

--- a/src/Template/Element/custom_colors.twig
+++ b/src/Template/Element/custom_colors.twig
@@ -1,7 +1,8 @@
 <style type="text/css">
 
     {# module colors #}
-    {% for name, color in config('Modules.colors', []) %}
+    {% for name, module in modules if module.color %}
+        {% set color = module.color %}
         :root { --color-{{ name }}: {{ color }}; }
         .has-background-module-{{ name }} { background-color: {{ color }} !important; }
         .has-border-module-{{ name }} { border-color: {{ color }} !important; }

--- a/src/Template/Pages/Dashboard/index.twig
+++ b/src/Template/Pages/Dashboard/index.twig
@@ -6,8 +6,8 @@
         <section class="dashboard-section">
             <div class="dashboard-items">
             {% for name, module in modules if not in_array(name, ['trash', 'objects', 'users', 'folders', 'publications']) %}
-                {% set title = __(name|humanize) %}
-                {% set class = 'dashboard-item has-background-module-' ~ name %}
+                {% set title = __(module.label|default(name)|humanize) %}
+                {% set class = 'dashboard-item has-background-module-%s %s'|format(name, module.class)|trim %}
                 {% if module.hints.multiple_types %}
                     {% set class = class ~ ' icon-th-large-1' %}
                 {% endif %}
@@ -41,9 +41,9 @@
                     { '_name': 'modules:list', 'object_type': 'objects' },
                     { 'title': __('All objects'), 'class': 'dashboard-item has-background-module-objects icon-th-large-1', } )|raw }}
 
-                <a href="#" class="dashboard-item has-background-black icon-list-1" disabled>{{ __('All categories') }}</a>
+                {# <a href="#" class="dashboard-item has-background-black icon-list-1" disabled>{{ __('All categories') }}</a> #}
 
-                <a href="#" class="dashboard-item has-background-black icon-tag" disabled>{{ __('All tags') }}</a>
+                {# <a href="#" class="dashboard-item has-background-black icon-tag" disabled>{{ __('All tags') }}</a> #}
             </div>
         </section>
 
@@ -60,13 +60,17 @@
 
         <section class="dashboard-section">
             <div class="dashboard-items dashboard-utility">
-                {{ Html.link(__('Trash can'),
-                    { '_name': 'trash:list' },
-                    { 'title': __('Trash'), 'class': 'dashboard-item has-background-black icon-trash-2' } )|raw }}
+                {% if modules.trash %}
+                    {{ Html.link(__('Trash can'),
+                        { '_name': 'trash:list' },
+                        { 'title': __('Trash'), 'class': 'dashboard-item has-background-black icon-trash-2' } )|raw }}
+                {% endif %}
 
-                {{ Html.link(__('System users'),
-                    {'_name': 'modules:list', 'object_type': 'users'},
-                    {'title': __('System users'), 'class': 'dashboard-item has-background-black icon-group' } )|raw }}
+                {% if modules.users %}
+                    {{ Html.link(__('System users'),
+                        {'_name': 'modules:list', 'object_type': 'users'},
+                        {'title': __('System users'), 'class': 'dashboard-item has-background-black icon-group' } )|raw }}
+                {% endif %}
             </div>
         </section>
 
@@ -93,7 +97,7 @@
                     { '_name': 'user_profile:view' },
                     { 'title': __('User Profile'), 'class': 'dashboard-item has-background-black icon-user' } )|raw }}
 
-                <a href="#" class="dashboard-item has-background-black icon-cog" disabled>{{ __('Settings') }}</a>
+                {# <a href="#" class="dashboard-item has-background-black icon-cog" disabled>{{ __('Settings') }}</a> #}
             </div>
         </section>
         {% endif %}

--- a/src/Template/Pages/Dashboard/index.twig
+++ b/src/Template/Pages/Dashboard/index.twig
@@ -7,7 +7,7 @@
             <div class="dashboard-items">
             {% for name, module in modules if not in_array(name, ['trash', 'objects', 'users', 'folders', 'publications']) %}
                 {% set title = __(module.label|default(name)|humanize) %}
-                {% set class = 'dashboard-item has-background-module-%s %s'|format(name, module.class)|trim %}
+                {% set class = 'dashboard-item has-background-module-%s'|format(name) %}
                 {% if module.hints.multiple_types %}
                     {% set class = class ~ ' icon-th-large-1' %}
                 {% endif %}

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -72,12 +72,11 @@ class LayoutHelper extends Helper
         if (!empty($currentModule) && !empty($currentModule['name'])) {
             $name = $currentModule['name'];
             $label = Hash::get($currentModule, 'label', $name);
-            $class = (string)Hash::get($currentModule, 'class');
 
             return $this->Html->link(
                 Inflector::humanize($label),
                 ['_name' => 'modules:list', 'object_type' => $name],
-                ['class' => trim(sprintf('has-background-module-%s %s', $name, $class))]
+                ['class' => sprintf('has-background-module-%s', $name)]
             );
         }
 

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -71,11 +71,13 @@ class LayoutHelper extends Helper
         $currentModule = (array)$this->getView()->get('currentModule');
         if (!empty($currentModule) && !empty($currentModule['name'])) {
             $name = $currentModule['name'];
+            $label = Hash::get($currentModule, 'label', $name);
+            $class = (string)Hash::get($currentModule, 'class');
 
             return $this->Html->link(
-                Inflector::humanize($name),
+                Inflector::humanize($label),
                 ['_name' => 'modules:list', 'object_type' => $name],
-                ['class' => sprintf('has-background-module-%s', $name)]
+                ['class' => trim(sprintf('has-background-module-%s %s', $name, $class))]
             );
         }
 

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -303,7 +303,6 @@ class ModulesComponentTest extends TestCase
                     'supporto',
                     'gustavo',
                     'trash',
-                    'plugin',
                 ],
                 [
                     'resources' => [
@@ -331,21 +330,16 @@ class ModulesComponentTest extends TestCase
                     ],
                 ],
                 [
-                    'bedita',
-                    'supporto',
-                ],
-                [
-                    [
-                        'name' => 'plugin',
-                    ],
+                    'bedita' => [],
+                    'supporto' => [],
                 ],
             ],
             'ok (trash first)' => [
                 [
                     'trash',
                     'supporto',
-                    'bedita',
                     'gustavo',
+                    'bedita',
                 ],
                 [
                     'resources' => [
@@ -373,8 +367,8 @@ class ModulesComponentTest extends TestCase
                     ],
                 ],
                 [
-                    'trash',
-                    'supporto',
+                    'trash' => [],
+                    'supporto' => [],
                 ],
             ],
             'client exception' => [
@@ -393,17 +387,17 @@ class ModulesComponentTest extends TestCase
      *
      * @param string[]|\Exception $expected Expected result.
      * @param array|\Exception $meta Response to `/home` endpoint.
-     * @param string[] $order Configured modules order.
+     * @param array $modules Modules configuration.
      * @return void
      *
      * @dataProvider getModulesProvider()
+     * @covers ::modulesFromMeta()
      * @covers ::getMeta()
      * @covers ::getModules()
      */
-    public function testGetModules($expected, $meta, array $order = [], array $plugins = []): void
+    public function testGetModules($expected, $meta, array $modules = []): void
     {
-        Configure::write('Modules.order', $order);
-        Configure::write('Modules.plugins', $plugins);
+        Configure::write('Modules', $modules);
 
         if ($expected instanceof \Exception) {
             $this->expectException(get_class($expected));
@@ -472,7 +466,7 @@ class ModulesComponentTest extends TestCase
                     'version' => 'v4.0.0-gustavo',
                 ],
                 [
-                    'gustavo',
+                    'gustavo' => [],
                 ],
             ],
             'with current module' => [
@@ -508,7 +502,7 @@ class ModulesComponentTest extends TestCase
                     'version' => 'v4.0.0-gustavo',
                 ],
                 [
-                    'gustavo',
+                    'gustavo' => [],
                 ],
                 'supporto',
             ],
@@ -532,16 +526,16 @@ class ModulesComponentTest extends TestCase
      * @param string|null $currentModule Expected current module name.
      * @param array $project Expected project info.
      * @param array $meta Response to `/home` endpoint.
-     * @param string[] $order Configured modules order.
+     * @param string[] $config Modules configuration.
      * @param string|null $currentModuleName Current module.
      * @return void
      *
      * @dataProvider startupProvider()
      * @covers ::startup()
      */
-    public function testBeforeRender($userId, $modules, ?string $currentModule, array $project, array $meta, array $order = [], ?string $currentModuleName = null): void
+    public function testBeforeRender($userId, $modules, ?string $currentModule, array $project, array $meta, array $config = [], ?string $currentModuleName = null): void
     {
-        Configure::write('Modules.order', $order);
+        Configure::write('Modules', $config);
 
         if ($userId) {
             $this->Auth->setUser(['id' => $userId]);

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -175,6 +175,7 @@ class ModulesControllerTest extends TestCase
      * Test `index` method
      *
      * @covers ::index()
+     * @covers ::indexQuery()
      *
      * @return void
      */
@@ -200,6 +201,7 @@ class ModulesControllerTest extends TestCase
      * Session filter data must be empty
      *
      * @covers ::index()
+     * @covers ::indexQuery()
      *
      * @return void
      */


### PR DESCRIPTION
Modules configuration has been changed.

### New structure

Array keys must be actual API endpoint names like `documents`, `users` or `folders`.
Modules order will follow key order of this configuration.

Array value may contain:
 
- `'label' `- module label to display, if not set `key` will be used
- `'shortLabel'` - short label, 3 character recommended
- `'color'` - primary color code,
- `'secondaryColor' `- secondary color code,
- `'sort'` - sort order to be used in index; use a field name prepending optionl `-` sign to indicate a descendant order, f.i. `'-title'` will sort by title in reverse alphabetical order (default is `'-id'`),
- `'icon'` - icon code, f.i. `icon-article`, have a look in `webroot/css/be-icons-codes.css` for a complete list of codes

### Example

```php
    
    'Modules' => [
        'documents' => [
            'shortLabel' => 'docs',
            'color' => '#cc4700',
            'secondaryColor' => '#cc0000',
            'class' => 'icon-article',
            'sort' => '-modified',
        ],
        'events' => [
            'shortLabel' => 'evt',
            'color' => '#09c',
            // 'class' => 'icon-music',
        ],
      ]
```
