### PR TITLE
fix: update key name in new `/config`

### DIFF
--- a/src/Controller/Component/ProjectConfigurationComponent.php
+++ b/src/Controller/Component/ProjectConfigurationComponent.php
@@ -81,7 +81,7 @@ class ProjectConfigurationComponent extends Component
     {
         $response = (array)ApiClientProvider::getApiClient()->get('config', ['page_size' => 100]);
 
-        $config = Hash::combine($response, 'data.{n}.id', 'data.{n}.attributes.content');
+        $config = Hash::combine($response, 'data.{n}.attributes.name', 'data.{n}.attributes.content');
         array_walk(
             $config,
             function (&$value, $key) {

--- a/tests/TestCase/Controller/Component/ProjectConfigurationComponentTest.php
+++ b/tests/TestCase/Controller/Component/ProjectConfigurationComponentTest.php
@@ -62,9 +62,10 @@ class ProjectConfigurationComponentTest extends TestCase
                     'Simple' => ['a' => 2],
                 ],
                 [
-                    'id' => 'Simple',
+                    'id' => '13',
                     'type' => 'config',
                     'attributes' => [
+                        'name' => 'Simple',
                         'content' => '{"a":2}',
                     ],
                 ],


### PR DESCRIPTION
Update `/config` read after https://github.com/bedita/bedita/pull/1706

Configuration `key` is now in `attributes.name` 
