### PR TITLE
Config relations order

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -501,6 +501,18 @@ return [
         //         'surname',
         //         'username',
         //     ],
+        //     'relations' => [
+        //         'foo_with',
+        //         'fooed_by',
+        //     ],
+        //     'filter' => [
+        //         'select_field',
+        //         'another_one',
+        //     ],
+        //     'bulk' => [
+        //         'status',
+        //         'other_field',
+        //     ],
         // ],
     // ],
 

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -475,6 +475,9 @@ return [
      *      + 'advanced' for power users
      *      + 'other' remaining attributes
      *  - 'index' properties to display in index view (other than id, status and modified)
+     *  - 'relations' relations ordering by relation name
+     *  - 'filter' filters to display
+     *  - 'bulk' bulk actions list
      */
     // 'Properties' => [
         // 'foos' => [

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -502,8 +502,13 @@ return [
         //         'username',
         //     ],
         //     'relations' => [
-        //         'foo_with',
-        //         'fooed_by',
+        //         'main' => [
+        //             'foo_with',
+        //             'fooed_by',
+        //         ],
+        //         'aside' => [
+        //             'fooing',
+        //         ],
         //     ],
         //     'filter' => [
         //         'select_field',

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -482,13 +482,13 @@ class ModulesComponent extends Component
     /**
      * Retrieve associative array with names as keys and labels as values.
      *
-     * @param array $schema Relations schema.
+     * @param array $relationsSchema Relations schema.
      * @param array $names Relation names.
      * @return array
      */
     protected function relationLabels(array &$relationsSchema, array $names): array
     {
-        return array_combine(
+        return (array)array_combine(
             $names,
             array_map(
                 function ($r) use ($relationsSchema) {

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -454,9 +454,10 @@ class ModulesComponent extends Component
      *
      * @param array $schema Relations schema.
      * @param array $relationships The object.
+     * @param array $order order Ordered names.
      * @return void
      */
-    public function setupRelationsMeta(array $schema, array $relationships): void
+    public function setupRelationsMeta(array $schema, array $relationships, array $order = []): void
     {
         // relations between objects
         $relationsSchema = array_intersect_key($schema, $relationships);
@@ -464,6 +465,8 @@ class ModulesComponent extends Component
         $resourceRelations = array_diff(array_keys($relationships), array_keys($relationsSchema), self::FIXED_RELATIONSHIPS);
         // set objectRelations array with name as key and label as value
         $relationNames = array_keys($relationsSchema);
+        $relationNames = array_unique(array_intersect($order, $relationNames) + $relationNames);
+
         $objectRelations = array_combine(
             $relationNames,
             array_map(

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -180,4 +180,17 @@ class PropertiesComponent extends Component
     {
         return $this->getConfig(sprintf('Properties.%s.bulk', $type), $this->defaultGroups['bulk']);
     }
+
+    /**
+     * List of ordered relations to display.
+     * Relations not included will be displayed after these.
+     *
+     * @param string $type Object type name
+     *
+     * @return array
+     */
+    public function relationsList(string $type): array
+    {
+        return $this->getConfig(sprintf('Properties.%s.relations', $type), []);
+    }
 }

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -205,7 +205,11 @@ class ModulesController extends AppController
         $this->set('properties', $this->Properties->viewGroups($object, $this->objectType));
 
         // setup relations metadata
-        $this->Modules->setupRelationsMeta($this->Schema->getRelationsSchema(), $object['relationships']);
+        $this->Modules->setupRelationsMeta(
+            $this->Schema->getRelationsSchema(),
+            $object['relationships'],
+            $this->Properties->relationsList($this->objectType)
+        );
 
         // set objectNav
         $objectNav = $this->getObjectNav((string)$id);

--- a/src/Template/Element/Form/relations.twig
+++ b/src/Template/Element/Form/relations.twig
@@ -1,7 +1,7 @@
-{% if objectRelations %}
+{% if relations %}
 <section class="relations">
 
-    {% for relationName, relationLabel in objectRelations %}
+    {% for relationName, relationLabel in relations %}
 
         <property-view inline-template :tab-open="tabsOpen" ref={{ relationName }}>
             <section class="fieldset">

--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -77,10 +77,13 @@
                 {% element 'Form/advanced_properties' %}
 
                 {% element 'Form/resource_relations' %}
+
+                {# aside relations view #}
+                {% element 'Form/relations' {'relations': objectRelations.aside} %}
             </div>
 
-            {# relations view #}
-            {% element 'Form/relations' %}
+            {# main relations view #}
+            {% element 'Form/relations' {'relations': objectRelations.main} %}
 
             {# Set `_jsonKeys` hidden input from config #}
             {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': config('_jsonKeys', [])|join(',')})|raw }}

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1017,6 +1017,60 @@ class ModulesComponentTest extends TestCase
                     'media_of' => [],
                 ],
             ],
+            'ordered' => [
+                [
+                    'relationsSchema' => [
+                        'has_media' => [
+                            'attributes' => [
+                                'name' => 'has_media',
+                                'label' => 'Has Media',
+                                'inverse_name' => 'media_of',
+                                'inverse_label' => 'Media Of',
+                            ],
+                        ],
+                        'attach' => [
+                            'attributes' => [
+                                'name' => 'attach',
+                                'label' => 'Attach',
+                                'inverse_name' => 'attached_to',
+                                'inverse_label' => 'Attached To',
+                            ],
+                        ],
+                    ],
+                    'resourceRelations' => [],
+                    'objectRelations' => [
+                        'attach' => 'Attach',
+                        'has_media' => 'Has Media',
+                    ],
+                ],
+                [
+                    'has_media' => [
+                        'attributes' => [
+                            'name' => 'has_media',
+                            'label' => 'Has Media',
+                            'inverse_name' => 'media_of',
+                            'inverse_label' => 'Media Of',
+                        ],
+                    ],
+                    'attach' => [
+                        'attributes' => [
+                            'name' => 'attach',
+                            'label' => 'Attach',
+                            'inverse_name' => 'attached_to',
+                            'inverse_label' => 'Attached To',
+                        ],
+                    ],
+                ],
+                [
+                    'has_media' => [],
+                    'attach' => [],
+                ],
+                [
+                    'attach',
+                    'has_media',
+                ],
+            ],
+
         ];
     }
 
@@ -1031,10 +1085,11 @@ class ModulesComponentTest extends TestCase
      * @param array $expected Expected result.
      * @param array $schema Schema array.
      * @param array $relationships Relationships array.
+     * @param array $order Order array.
      */
-    public function testSetupRelationsMeta(array $expected, array $schema, array $relationships)
+    public function testSetupRelationsMeta(array $expected, array $schema, array $relationships, array $order = [])
     {
-        $this->Modules->setupRelationsMeta($schema, $relationships);
+        $this->Modules->setupRelationsMeta($schema, $relationships, $order);
 
         $viewVars = $this->Modules->getController()->viewVars;
         foreach ($expected as $key => $value) {

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -972,7 +972,12 @@ class ModulesComponentTest extends TestCase
                         ],
                     ],
                     'resourceRelations' => [],
-                    'objectRelations' => ['has_media' => 'Has Media'],
+                    'objectRelations' => [
+                        'main' => [
+                            'has_media' => 'Has Media',
+                        ],
+                        'aside' => [],
+                    ],
                 ],
                 [
                     'has_media' => [
@@ -1001,7 +1006,12 @@ class ModulesComponentTest extends TestCase
                         ],
                     ],
                     'resourceRelations' => [],
-                    'objectRelations' => ['media_of' => 'Media Of'],
+                    'objectRelations' => [
+                        'main' => [
+                            'media_of' => 'Media Of',
+                        ],
+                        'aside' => [],
+                    ],
                 ],
                 [
                     'media_of' => [
@@ -1039,8 +1049,12 @@ class ModulesComponentTest extends TestCase
                     ],
                     'resourceRelations' => [],
                     'objectRelations' => [
-                        'attach' => 'Attach',
-                        'has_media' => 'Has Media',
+                        'main' => [
+                            'attach' => 'Attach',
+                        ],
+                        'aside' => [
+                            'has_media' => 'Has Media',
+                        ],
                     ],
                 ],
                 [
@@ -1066,8 +1080,12 @@ class ModulesComponentTest extends TestCase
                     'attach' => [],
                 ],
                 [
-                    'attach',
-                    'has_media',
+                    'main' => [
+                        'attach',
+                    ],
+                    'aside' => [
+                        'has_media',
+                    ],
                 ],
             ],
 
@@ -1081,6 +1099,7 @@ class ModulesComponentTest extends TestCase
      *
      * @dataProvider setupRelationsProvider
      * @covers ::setupRelationsMeta()
+     * @covers ::relationLabels()
      *
      * @param array $expected Expected result.
      * @param array $schema Schema array.

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -95,6 +95,24 @@ class PropertiesComponentTest extends TestCase
     }
 
     /**
+     * Test `relationsList()` method.
+     *
+     * @return void
+     *
+     * @covers ::relationsList()
+     */
+    public function testRelationsList(): void
+    {
+        $index = ['has_food', 'is_tired', 'sleeps_with'];
+        Configure::write('Properties.cats.relations', $index);
+
+        $this->createComponent();
+
+        $list = $this->Properties->relationsList('cats');
+        static::assertEquals($index, $list);
+    }
+
+    /**
      * Data provider for `testViewGroups` test case.
      *
      * @return array


### PR DESCRIPTION
This PR introduces relation order configuration in object view.

With a configuration like this
```
 'Properties' => [
        'cats' => [
             'view' => [
                 // usual config
             ],
            'index' => [
                 // usual config
            ],
           'relations' => [
               'main' => [
                   'purr_with',
                   'tired_of',
               ],
               'aside' => [
                   'meow_to',
               ],
           ],
],
```

* on the right (aside) column `meow_to` will be displayed
* on the main column `purr_with` and `tired_of` will be the first relations displayed, the others after

 
