### PR TITLE
fix: translation promises

### DIFF
--- a/src/Template/Element/translation.twig
+++ b/src/Template/Element/translation.twig
@@ -44,6 +44,9 @@
                             'ref': 'translateTo',
                         }) %}
                     {% endif %}
+                    {% if translation.attributes.lang %}
+                        {% set options = options|merge({'readonly': true}) %}
+                    {% endif %}
 
                     {{ Form.control('lang', options)|raw }}
 

--- a/src/Template/Element/translation.twig
+++ b/src/Template/Element/translation.twig
@@ -37,7 +37,8 @@
                             'label': languageLabel,
                             'value': translation.attributes.lang,
                             'options': langOptions,
-                            'class': 'mr-2 mb-1'
+                            'class': 'mr-2 mb-1',
+                            'ref': 'translateTo',
                         }) %}
                     {% else %}
                         {% set options = options|merge({

--- a/src/Template/Element/translation.twig
+++ b/src/Template/Element/translation.twig
@@ -1,3 +1,4 @@
+{% do _view.assign('title', __('Translations')) %}
 {% do _view.assign('bodyViewClass', 'translation-module') %}
 {% set translatable = Schema.translatableFields(schema.properties) %}
 
@@ -30,20 +31,17 @@
 
                 <section class="fieldset is-flex wrap">
                     {% set languageLabel = "#{__('Language')} (#{__('original')}: #{object.attributes.lang})" %}
-                    {% set options = Schema.controlOptions('lang', null, []) %}
+                    {% set options = Schema.controlOptions('lang', null, [])|default({})|merge({
+                        'label': languageLabel,
+                        'value': translation.attributes.lang,
+                    }) %}
+
                     {% if options.options %}
                         {% set langOptions = options.options|filter((v, k) => v.value != object.attributes.lang) %}
                         {% set options = options|merge({
-                            'label': languageLabel,
-                            'value': translation.attributes.lang,
                             'options': langOptions,
                             'class': 'mr-2 mb-1',
                             'ref': 'translateTo',
-                        }) %}
-                    {% else %}
-                        {% set options = options|merge({
-                            'label': languageLabel,
-                            'value': translation.attributes.lang,
                         }) %}
                     {% endif %}
 

--- a/src/Template/Layout/js/app/helpers/api-translation.js
+++ b/src/Template/Layout/js/app/helpers/api-translation.js
@@ -17,7 +17,7 @@ const methods = {
     *     ]
     * }
     */
-    async autoTranslate(text, from, to) {
+   autoTranslate(text, from, to) {
         if (!text) {
             return;
         }
@@ -34,13 +34,12 @@ const methods = {
             },
             body: formData,
         };
-
-        await fetch(`${window.location.origin}/translate`, options)
+        return fetch(`${window.location.origin}/translate`, options)
             .catch(error => {
                 console.error(error);
                 return error;
             })
-            .then(r => response.json());
+            .then(r => r.json());
     },
 }
 

--- a/src/Template/Layout/js/app/pages/modules/view.js
+++ b/src/Template/Layout/js/app/pages/modules/view.js
@@ -38,18 +38,17 @@ export default {
         async translateAll(data, e) {
             const el = e.currentTarget;
             el.classList.add('is-loading-spinner');
-
-            await Promise.all(
-                Object.keys(data).map(key =>
-                    this.fetchTranslation(data[key])
-                )
-            ).catch((error) => {
-                    alert(error);
-                    console.log(error);
-                })
-            .finally(() => {
-                el.classList.remove('is-loading-spinner');
-            });
+            try {
+                await Promise.all(
+                    Object.keys(data).map(key =>
+                        this.fetchTranslation(data[key])
+                    )
+                );
+            } catch (error) {
+                alert(error);
+                console.log(error);
+            }
+            el.classList.remove('is-loading-spinner');
         },
 
         translate(object, e) {
@@ -66,8 +65,8 @@ export default {
                 });
         },
 
-        async fetchTranslation(object) {
-            await this.$helpers.autoTranslate(object.content, object.from, object.to)
+        fetchTranslation(object) {
+            return this.$helpers.autoTranslate(object.content, object.from, object.to)
                 .catch(r => {
                     throw new Error(`Unablea to translate field ${object.field}`);
                 })

--- a/src/Template/Layout/js/app/pages/modules/view.js
+++ b/src/Template/Layout/js/app/pages/modules/view.js
@@ -66,6 +66,10 @@ export default {
         },
 
         fetchTranslation(object) {
+            if (!object.to) {
+                object.to = this.$refs.translateTo.value;
+            }
+
             return this.$helpers.autoTranslate(object.content, object.from, object.to)
                 .catch(r => {
                     throw new Error(`Unablea to translate field ${object.field}`);

--- a/src/Template/Layout/js/app/pages/modules/view.js
+++ b/src/Template/Layout/js/app/pages/modules/view.js
@@ -67,6 +67,7 @@ export default {
 
         fetchTranslation(object) {
             if (!object.to) {
+                // use `value` from select on new translations
                 object.to = this.$refs.translateTo.value;
             }
 


### PR DESCRIPTION
This PR fixes a couple of problems on translations

* an error involving js `promises` that was causing systematic errors
* avoid language change when a translation has been created => auto-translation could use previous language
