### PR TITLE
Handle relations, categories and date ranges in new object form

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -170,6 +170,12 @@ Router::scope('/', function (RouteBuilder $routes) {
         ['_name' => 'modules:list']
     );
     $routes->connect(
+        '/:object_type/view/new',
+        ['controller' => 'Modules', 'action' => 'create'],
+        ['_name' => 'modules:create']
+    );
+
+    $routes->connect(
         '/:object_type/view/:id',
         ['controller' => 'Modules', 'action' => 'view'],
         ['pass' => ['id'], '_name' => 'modules:view']
@@ -215,11 +221,6 @@ Router::scope('/', function (RouteBuilder $routes) {
         '/:object_type/view/:id/relationData/:relation',
         ['controller' => 'Modules', 'action' => 'relationData'],
         ['pass' => ['id', 'relation'], '_name' => 'modules:relationData']
-    );
-    $routes->connect(
-        '/:object_type/create',
-        ['controller' => 'Modules', 'action' => 'create'],
-        ['_name' => 'modules:create']
     );
     $routes->connect(
         '/:object_type/save',

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -453,7 +453,7 @@ class ModulesComponent extends Component
      * Setup relations information metadata.
      *
      * @param array $schema Relations schema.
-     * @param array $relationships The object.
+     * @param array $relationships The object relationships.
      * @return void
      */
     public function setupRelationsMeta(array $schema, array $relationships): void

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -15,7 +15,6 @@ namespace App\Controller\Component;
 
 use App\Core\Exception\UploadException;
 use App\Utility\OEmbed;
-use BEdita\SDK\BEditaClient;
 use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Cache\Cache;
@@ -481,5 +480,23 @@ class ModulesComponent extends Component
         );
 
         $this->getController()->set(compact('relationsSchema', 'resourceRelations', 'objectRelations'));
+    }
+
+    /**
+     * Get related types from relation name.
+     *
+     * @param array $schema Relations schema.
+     * @param string $relation Relation name.
+     * @return array
+     */
+    public function relatedTypes(array $schema, string $relation): array
+    {
+        $relationsSchema = (array)Hash::get($schema, $relation);
+        $name = (string)Hash::get($relationsSchema, 'attributes.name');
+        if ($name === $relation) {
+            return (array)Hash::get($relationsSchema, 'right');
+        }
+
+        return (array)Hash::get($relationsSchema, 'left');
     }
 }

--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -146,8 +146,9 @@ class SchemaComponent extends Component
             ];
         }
         $categories = $this->fetchCategories($type);
+        $objectTypeMeta = $this->fetchObjectTypeMeta($type);
 
-        return $schema + array_filter(compact('categories'));
+        return $schema + $objectTypeMeta + array_filter(compact('categories'));
     }
 
     /**
@@ -164,6 +165,28 @@ class SchemaComponent extends Component
         $response = ApiClientProvider::getApiClient()->get('/roles', $query);
 
         return (array)Hash::extract((array)$response, 'data.{n}.attributes.name');
+    }
+
+    /**
+     * Fetch object type metadata
+     *
+     * @param string $type Object type.
+     * @return array
+     */
+    protected function fetchObjectTypeMeta(string $type): array
+    {
+        $query = [
+            'fields' => 'associations,relations',
+        ];
+        $response = ApiClientProvider::getApiClient()->get(
+            sprintf('/model/object_types/%s', $type),
+            $query
+        );
+
+        return [
+            'associations' => (array)Hash::get((array)$response, 'data.attributes.associations'),
+            'relations' => (array)Hash::get((array)$response, 'data.meta.relations'),
+        ];
     }
 
     /**

--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -185,7 +185,7 @@ class SchemaComponent extends Component
 
         return [
             'associations' => (array)Hash::get((array)$response, 'data.attributes.associations'),
-            'relations' => (array)Hash::get((array)$response, 'data.meta.relations'),
+            'relations' => array_flip((array)Hash::get((array)$response, 'data.meta.relations')),
         ];
     }
 

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -463,10 +463,10 @@ class ModulesController extends AppController
     }
 
     /**
-     * Relation data load callig api `GET /:object_type/:id/related/:relation`
+     * Relation data load via API => `GET /:object_type/:id/related/:relation`
      *
-     * @param string|int $id the object identifier.
-     * @param string $relation the relating name.
+     * @param string|int $id The object ID.
+     * @param string $relation The relation name.
      * @return void
      */
     public function relatedJson($id, string $relation): void

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -278,6 +278,10 @@ class ModulesController extends AppController
         $this->set('properties', $this->Properties->viewGroups($object, $this->objectType));
         $this->ProjectConfiguration->read();
 
+        // setup relations metadata
+        $relationships = array_flip((array)Hash::get($schema, 'relations'));
+        $this->Modules->setupRelationsMeta($this->Schema->getRelationsSchema(), $relationships);
+
         return null;
     }
 

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -570,12 +570,12 @@ class ModulesController extends AppController
             'parent' => '/folders',
             'parents' => '/folders',
         ];
-        $defaultUrl = Hash::get($defaults, $relation);
+        $defaultUrl = (string)Hash::get($defaults, $relation);
         if (!empty($defaultUrl)) {
             return $defaultUrl;
         }
 
-        $schema = $this->Schema->getSchema();
+        $schema = (array)$this->Schema->getSchema();
         $types = (array)Hash::get($schema, sprintf('relations.%s.types', $relation));
         if (count($types) === 1) {
             return sprintf('/%s', $types[0]);

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -575,13 +575,13 @@ class ModulesController extends AppController
             return $defaultUrl;
         }
 
-        $schema = (array)$this->Schema->getSchema();
-        $types = (array)Hash::get($schema, sprintf('relations.%s.types', $relation));
+        $relationsSchema = $this->Schema->getRelationsSchema();
+        $types = $this->Modules->relatedTypes($relationsSchema, $relation);
         if (count($types) === 1) {
             return sprintf('/%s', $types[0]);
         }
 
-        return '/objects?filter[type]= ' . implode($types);
+        return '/objects?filter[type][]=' . implode('&filter[type][]=', $types);
     }
 
     /**

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -279,7 +279,7 @@ class ModulesController extends AppController
         $this->ProjectConfiguration->read();
 
         // setup relations metadata
-        $relationships = array_flip((array)Hash::get($schema, 'relations'));
+        $relationships = (array)Hash::get($schema, 'relations');
         $this->Modules->setupRelationsMeta($this->Schema->getRelationsSchema(), $relationships);
 
         return null;
@@ -296,21 +296,13 @@ class ModulesController extends AppController
         $requestData = $this->prepareRequest($this->objectType);
 
         try {
-            if (!empty($requestData['_api'])) {
-                foreach ($requestData['_api'] as $api) {
-                    extract($api); // method, id, type, relation, relatedIds
-                    if (in_array($method, ['addRelated', 'removeRelated', 'replaceRelated'])) {
-                        $this->apiClient->{$method}($id, $this->objectType, $relation, $relatedIds);
-                    }
-                }
-            }
-            unset($requestData['_api']);
-
             // upload file (if available)
             $this->Modules->upload($requestData);
 
             // save data
             $response = $this->apiClient->save($this->objectType, $requestData);
+            $objectId = (string)Hash::get($response, 'data.id');
+            $this->saveRelated($requestData, $objectId);
         } catch (InternalErrorException | BEditaClientException | UploadException $e) {
             // Error! Back to object view or index.
             $this->log($e, LogLevel::ERROR);
@@ -334,6 +326,30 @@ class ModulesController extends AppController
             'object_type' => $this->objectType,
             'id' => Hash::get($response, 'data.id'),
         ]);
+    }
+
+    /**
+     * Save related objects reading from `_api` key in request data.
+     *
+     * @param array $requestData Request data
+     * @param string $id Object ID
+     * @return void
+     */
+    protected function saveRelated(array &$requestData, string $id): void
+    {
+        $apiRequest = (array)Hash::get($requestData, '_api');
+        unset($requestData['_api']);
+        if (empty($apiRequest)) {
+            return;
+        }
+        foreach ($apiRequest as $api) {
+            $method = (string)Hash::get($api, 'method');
+            $relation = (string)Hash::get($api, 'relation');
+            $relatedIds = (array)Hash::get($api, 'relatedIds');
+            if (in_array($method, ['addRelated', 'removeRelated', 'replaceRelated'])) {
+                $this->apiClient->{$method}($id, $this->objectType, $relation, $relatedIds);
+            }
+        }
     }
 
     /**
@@ -455,6 +471,13 @@ class ModulesController extends AppController
      */
     public function relatedJson($id, string $relation): void
     {
+        if ($id === 'new') {
+            $this->set('data', []);
+            $this->set('_serialize', ['data']);
+
+            return;
+        }
+
         $this->request->allowMethod(['get']);
         $query = $this->Modules->prepareQuery($this->request->getQueryParams());
         try {
@@ -505,29 +528,16 @@ class ModulesController extends AppController
      * Relation data load callig api `GET /:object_type/:id/relationships/:relation`
      * Json response
      *
-     * @param string|int $id the object identifier.
-     * @param string $relation the relating name.
+     * @param string|int $id The object ID.
+     * @param string $relation The relation name.
      * @return void
      */
     public function relationshipsJson($id, string $relation): void
     {
         $this->request->allowMethod(['get']);
-        $path = sprintf('/%s/%s/%s', $this->objectType, $id, $relation);
+        $available = $this->availableRelationshipsUrl($relation);
 
         try {
-            switch ($relation) {
-                case 'children':
-                    $available = '/objects';
-                    break;
-                case 'parent':
-                case 'parents':
-                    $available = '/folders';
-                    break;
-                default:
-                    $response = $this->apiClient->get($path, ['page_size' => 1]); // page_size 1: we need just the available
-                    $available = $response['links']['available'];
-            }
-
             $query = $this->Modules->prepareQuery($this->request->getQueryParams());
             $response = $this->apiClient->get($available, $query);
 
@@ -545,6 +555,33 @@ class ModulesController extends AppController
 
         $this->set((array)$response);
         $this->set('_serialize', array_keys($response));
+    }
+
+    /**
+     * Retrieve URL to get objects available for a relation
+     *
+     * @param string $relation The relation name.
+     * @return string
+     */
+    protected function availableRelationshipsUrl(string $relation): string
+    {
+        $defaults = [
+            'children' => '/objects',
+            'parent' => '/folders',
+            'parents' => '/folders',
+        ];
+        $defaultUrl = Hash::get($defaults, $relation);
+        if (!empty($defaultUrl)) {
+            return $defaultUrl;
+        }
+
+        $schema = $this->Schema->getSchema();
+        $types = (array)Hash::get($schema, sprintf('relations.%s.types', $relation));
+        if (count($types) === 1) {
+            return sprintf('/%s', $types[0]);
+        }
+
+        return '/objects?filter[type]= ' . implode($types);
     }
 
     /**

--- a/src/Template/Element/Form/calendar.twig
+++ b/src/Template/Element/Form/calendar.twig
@@ -1,6 +1,6 @@
-{# Calendar: use date_ranges if set in object attributes#}
+{# Calendar: use date_ranges if `DateRanges` association is set #}
 
-{% if object.attributes.date_ranges is defined %}
+{% if in_array('DateRanges', schema.associations) %}
 <property-view inline-template :tab-open="tabsOpen">
 <section class="fieldset">
     <header @click.prevent="toggleVisibility()"

--- a/src/Template/Element/Form/related_translations.twig
+++ b/src/Template/Element/Form/related_translations.twig
@@ -1,4 +1,4 @@
-{% if object and object.relationships.translations %}
+{% if schema.properties.lang %}
 
     <property-view inline-template :tab-open="tabsOpen" :tab-open-at-start="false" ref={{ resourceName }}>
         <section class="fieldset order-{{ cssOrder }}" :class="isOpen? '' : 'closed'">
@@ -21,6 +21,7 @@
                     {% set options = Schema.controlOptions('lang', object.attributes.lang, schema.properties.lang) %}
                     {{ Form.control('lang', options)|raw }}
 
+                {% if object.relationships.translations %}
                     {{ Html.link(__('Add translation'), {
                         '_name': 'translations:add',
                         'object_type': object.type,
@@ -29,8 +30,10 @@
                         'target': '_blank',
                         'class' : 'icon-plus button mt-1',
                     })|raw }}
+                {% endif %}
                 </div>
 
+                {% if object.relationships.translations %}
                 <relation-view inline-template
                     relation-name={{ resourceName }}
                     config-paginate-sizes={{ config('Pagination.sizeAvailable')|json_encode()|raw }}
@@ -65,6 +68,7 @@
 
                     </div>
                 </relation-view>
+                {% endif %}
             </div>
 
         </section>

--- a/src/Template/Element/Form/trees.twig
+++ b/src/Template/Element/Form/trees.twig
@@ -17,13 +17,17 @@
                 {% set options = { 'multiple': 'false' }%}
             {% else %}
                 {% set relationName = 'parents' %}
-                {% set paths = included|map(o => o.meta.path ~ '/' ~ object.id) %}
+                {% if not object.id %}
+                    {% set paths = [] %}
+                {% else %}
+                    {% set paths = included|map(o => o.meta.path ~ '/' ~ object.id) %}
+                {% endif %}
                 {% set options = { 'multiple': 'true' }%}
             {% endif %}
 
             <tree-view
                 relation-name={{ relationName }}
-                :object-id={{ object.id }}
+                :object-id={{ object.id|default(0) }}
                 :object-paths='{{ paths|json_encode|raw }}'
                 :multiple-choice={{ options.multiple }}>
             </tree-view>

--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -68,7 +68,7 @@
                     {% element 'Form/roles' %}
                 {% endif %}
 
-                {% if modules.folders and _view.getRequest().getParam('action') != 'create' and _view.getRequest().getParam('action') != 'clone' %}
+                {% if modules.folders and _view.getRequest().getParam('action') != 'clone' %}
                     {% element 'Form/trees' %}
                 {% endif %}
 

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1041,4 +1041,37 @@ class ModulesComponentTest extends TestCase
             $this->assertEquals($value, $viewVars[$key]);
         }
     }
+
+    /**
+     * Test `relatedTypes` method
+     *
+     * @return void
+     * @covers ::relatedTypes()
+     */
+    public function testRelatedTypes()
+    {
+        $schema = [
+            'has_media' => [
+                'attributes' => [
+                    'name' => 'has_media',
+                    'inverse_name' => 'media_of',
+                ],
+                'left' => ['documents'],
+                'right' => ['media'],
+            ],
+            'media_of' => [
+                'attributes' => [
+                    'name' => 'has_media',
+                    'inverse_name' => 'media_of',
+                ],
+                'left' => ['documents'],
+                'right' => ['media'],
+            ],
+        ];
+
+        $types = $this->Modules->relatedTypes($schema, 'has_media');
+        static::assertEquals(['media'], $types);
+        $types = $this->Modules->relatedTypes($schema, 'media_of');
+        static::assertEquals(['documents'], $types);
+    }
 }

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -60,6 +60,8 @@ class SchemaComponentTest extends TestCase
             'type as argument' => [
                 [
                     'type' => 'object',
+                    'associations' => [],
+                    'relations' => [],
                 ],
                 [
                     'type' => 'object',
@@ -69,6 +71,8 @@ class SchemaComponentTest extends TestCase
             'type from config' => [
                 [
                     'type' => 'object',
+                    'associations' => [],
+                    'relations' => [],
                 ],
                 [
                     'type' => 'object',
@@ -373,13 +377,33 @@ class SchemaComponentTest extends TestCase
             ->setConstructorArgs(['https://api.example.org'])
             ->getMock();
         $apiClient->method('get')
-            ->willThrowException(new BEditaClientException(''));
+            ->will($this->returnCallback([$this, 'mockApiCallback']));
         $apiClient->method('schema')
             ->willReturn(['type' => 'object']);
 
         ApiClientProvider::setApiClient($apiClient);
         Cache::clearAll();
         $result = $this->Schema->getSchema('documents');
-        static::assertEquals(['type' => 'object'], $result);
+        $expected = [
+            'type' => 'object',
+            'associations' => [],
+            'relations' => [],
+        ];
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Mock API callback
+     *
+     * @return array
+     */
+    public function mockApiCallback(): array
+    {
+        $args = func_get_args();
+        if ($args[0] === '/model/categories?filter[type]=documents') {
+            throw new BEditaClientException('');
+        }
+
+        return [];
     }
 }

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -406,4 +406,38 @@ class SchemaComponentTest extends TestCase
 
         return [];
     }
+
+    /**
+     * Test `fetchObjectTypeMeta` method.
+     *
+     * @return void
+     * @covers ::fetchObjectTypeMeta()
+     */
+    public function testFetchObjectTypeMeta()
+    {
+        $objectType = [
+            'data' => [
+                'attributes' => [
+                    'associations' => ['Categories'],
+                ],
+                'meta' => [
+                    'relations' => ['has_media'],
+                ],
+            ],
+        ];
+
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->method('get')
+            ->willReturn($objectType);
+        $apiClient->method('schema')
+            ->willReturn(['type' => 'object']);
+
+        ApiClientProvider::setApiClient($apiClient);
+
+        $result = $this->Schema->getSchema('documents');
+        static::assertEquals(['Categories'], $result['associations']);
+        static::assertEquals(['has_media' => 0], $result['relations']);
+    }
 }

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -14,9 +14,9 @@
 
 namespace App\Test\TestCase\Controller;
 
+use App\Controller\Component\ModulesComponent;
 use App\Controller\Component\SchemaComponent;
 use App\Controller\ModulesController;
-use Aura\Intl\Exception;
 use BEdita\SDK\BEditaClient;
 use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;
@@ -46,6 +46,16 @@ class ModulesControllerSample extends ModulesController
     public function descendants(): array
     {
         return parent::descendants();
+    }
+
+    /**
+     * Public version of parent function (protected)
+     *
+     * @return void
+     */
+    public function availableRelationshipsUrl(string $relation): string
+    {
+        return parent::availableRelationshipsUrl($relation);
     }
 
     /**
@@ -653,6 +663,24 @@ class ModulesControllerTest extends TestCase
     }
 
     /**
+     * Test `relatedJson` method on `new` object
+     *
+     * @covers ::relatedJson()
+     *
+     * @return void
+     */
+    public function testRelatedJsonNew(): void
+    {
+        // Setup controller for test
+        $this->setupController();
+
+        // do controller call
+        $this->controller->relatedJson('new', 'has_media');
+
+        static::assertEquals([], $this->controller->viewVars['data']);
+    }
+
+    /**
      * Data provider for `testRelationshipsJson` test case.
      *
      * @return array
@@ -973,6 +1001,34 @@ class ModulesControllerTest extends TestCase
         $actual = $this->controller->getSchemaForIndex($type);
 
         static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `availableRelationshipsUrl` method
+     *
+     * @covers ::availableRelationshipsUrl()
+     *
+     * @return void
+     */
+    public function testAvailableRelationshipsUrl()
+    {
+        $this->setupController();
+        $url = $this->controller->availableRelationshipsUrl('children');
+        static::assertEquals('/objects', $url);
+
+        $this->controller->Modules = $this->createMock(ModulesComponent::class);
+        $this->controller->Modules->method('relatedTypes')
+            ->willReturn(['documents']);
+
+        $url = $this->controller->availableRelationshipsUrl('test_relation');
+        static::assertEquals('/documents', $url);
+
+        $this->controller->Modules = $this->createMock(ModulesComponent::class);
+        $this->controller->Modules->method('relatedTypes')
+            ->willReturn(['images', 'profiles']);
+
+        $url = $this->controller->availableRelationshipsUrl('test_relation');
+        static::assertEquals('/objects?filter[type][]=images&filter[type][]=profiles', $url);
     }
 
     /**

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -1032,6 +1032,49 @@ class ModulesControllerTest extends TestCase
     }
 
     /**
+     * Test `saveRelated` method
+     *
+     * @covers ::saveRelated()
+     *
+     * @return void
+     */
+    public function testSaveRelated()
+    {
+        $this->setupController([
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+        ]);
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://media.example.org'])
+            ->getMock();
+        $apiClient->method('save')
+            ->willReturn(['data' => ['id' => 1]]);
+        $apiClient->method('addRelated')
+            ->willReturn([]);
+
+        $this->controller->apiClient = $apiClient;
+
+        $requestData = [];
+        $result = $this->controller->save($requestData, '1');
+        static::assertEquals(302, $result->getStatusCode());
+        static::assertEquals('/documents/view/1', $result->getHeaderLine('Location'));
+
+        $requestData = [
+            '_api' => [
+                [
+                    'method' => 'addRelated',
+                    'relation' => '',
+                    'relatedIds' => [],
+                ],
+            ],
+        ];
+        $result = $this->controller->save($requestData, '1');
+        static::assertEquals(302, $result->getStatusCode());
+        static::assertEquals('/documents/view/1', $result->getHeaderLine('Location'));
+    }
+
+    /**
      * Get test object id
      *
      * @return void


### PR DESCRIPTION
[bedita/bedita#1710 is recommended] 

This PR enables use of related objects, folders, categories/tags and calendar date ranges on newly created objects.

New route for new objects form has been created `/:object_type/view/new` to have consistent rules on Ajax calls like `/:object_type/view/:id/relatedJson/:relation`

`new` URL path final part could probably be changed to other strings like `_new` or `0`

