### PR TITLE
Plaintext form control

### DIFF
--- a/tests/TestCase/Core/Utility/FormTest.php
+++ b/tests/TestCase/Core/Utility/FormTest.php
@@ -210,14 +210,14 @@ class FormTest extends TestCase
                         ],
                         [
                             'value' => 'de',
-                            'text' => 'Deutsh',
+                            'text' => 'Deutsch',
                         ],
                     ],
                 ],
                 [
                     'Project.config.I18n.languages' => [
                         'en' => 'English',
-                        'de' => 'Deutsh',
+                        'de' => 'Deutsch',
                     ],
                 ],
             ],

--- a/tests/TestCase/Core/Utility/FormTest.php
+++ b/tests/TestCase/Core/Utility/FormTest.php
@@ -483,7 +483,8 @@ class FormTest extends TestCase
      * @dataProvider controlProvider()
      * @covers ::control
      * @covers ::jsonControl
-     * @covers ::textareaControl
+     * @covers ::richtextControl
+     * @covers ::plaintextControl
      * @covers ::datetimeControl
      * @covers ::dateControl
      * @covers ::checkboxControl

--- a/tests/TestCase/Core/Utility/FormTest.php
+++ b/tests/TestCase/Core/Utility/FormTest.php
@@ -38,10 +38,17 @@ class FormTest extends TestCase
                 ],
             ],
             'html' => [
-                'textarea',
+                'richtext',
                 [
                     'type' => 'string',
                     'contentMediaType' => 'text/html',
+                ],
+            ],
+            'txt' => [
+                'plaintext',
+                [
+                    'type' => 'string',
+                    'contentMediaType' => 'text/plain',
                 ],
             ],
             'date-time' => [
@@ -326,14 +333,23 @@ class FormTest extends TestCase
                     'value' => json_encode($value),
                 ],
             ],
-            'textarea' => [
+            'richtext' => [
                 [],
-                'textarea',
+                'richtext',
                 $value,
                 [
                     'type' => 'textarea',
                     'v-richeditor' => 'true',
                     'ckconfig' => 'configNormal',
+                    'value' => $value,
+                ],
+            ],
+            'plaintext' => [
+                [],
+                'textarea',
+                $value,
+                [
+                    'type' => 'textarea',
                     'value' => $value,
                 ],
             ],

--- a/tests/TestCase/Core/Utility/FormTest.php
+++ b/tests/TestCase/Core/Utility/FormTest.php
@@ -14,6 +14,7 @@
 namespace App\Test\TestCase\Core\Utility;
 
 use App\Core\Utility\Form;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -65,10 +66,16 @@ class FormTest extends TestCase
                     'format' => 'date',
                 ],
             ],
-            'number' => [
+            'integer' => [
                 'number',
                 [
                     'type' => 'integer',
+                ],
+            ],
+            'number' => [
+                'number',
+                [
+                    'type' => 'number',
                 ],
             ],
             'checkbox' => [
@@ -157,6 +164,12 @@ class FormTest extends TestCase
      *
      * @dataProvider controlTypeFromSchemaProvider()
      * @covers ::controlTypeFromSchema()
+     * @covers ::typeFromString()
+     * @covers ::typeFromNumber()
+     * @covers ::typeFromInteger()
+     * @covers ::typeFromBoolean()
+     * @covers ::typeFromArray()
+     * @covers ::typeFromObject()
      */
     public function testControlTypeFromSchema(string $expected, $schema): void
     {
@@ -186,6 +199,29 @@ class FormTest extends TestCase
                     'type' => 'text',
                 ],
             ],
+            'lang options' => [
+                'lang',
+                [
+                    'type' => 'select',
+                    'options' => [
+                        [
+                            'value' => 'en',
+                            'text' => 'English',
+                        ],
+                        [
+                            'value' => 'de',
+                            'text' => 'Deutsh',
+                        ],
+                    ],
+                ],
+                [
+                    'Project.config.I18n.languages' => [
+                        'en' => 'English',
+                        'de' => 'Deutsh',
+                    ],
+                ],
+            ],
+
             'status' => [
                 'status',
                 [
@@ -279,6 +315,7 @@ class FormTest extends TestCase
      *
      * @param string $name The field name.
      * @param array $expected Expected result.
+     * @param array $config Configuration.
      * @return void
      *
      * @dataProvider customControlOptionsProvider()
@@ -299,8 +336,11 @@ class FormTest extends TestCase
      * @covers ::typeFromArray
      * @covers ::typeFromObject
      */
-    public function testCustomControlOptions(string $name, array $expected): void
+    public function testCustomControlOptions(string $name, array $expected, array $config = []): void
     {
+        if (!empty($config)) {
+            Configure::write($config);
+        }
         $actual = Form::customControlOptions($name);
 
         static::assertSame($expected, $actual);
@@ -346,7 +386,7 @@ class FormTest extends TestCase
             ],
             'plaintext' => [
                 [],
-                'textarea',
+                'plaintext',
                 $value,
                 [
                     'type' => 'textarea',


### PR DESCRIPTION
bedita/bedita#1716 is recommended to hava actual `plaintext` support

This PR adds `plaintext` form control via plain `textarea` to handle long plain text fields properly

Plain text fields will be displayed with this JSON Schema:

```json
{
 "type": "string",
 "contentMediaType": "text/plain"
}
``` 