### PR TITLE
fix: use `array_merge` instead of +

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -469,7 +469,7 @@ class ModulesComponent extends Component
         $aside = array_intersect((array)Hash::get($order, 'aside'), $relationNames);
         $relationNames = array_diff($relationNames, $aside);
         $main = array_intersect((array)Hash::get($order, 'main'), $relationNames);
-        $main = array_unique($main + $relationNames);
+        $main = array_unique(array_merge($main, $relationNames));
 
         $objectRelations = [
             'main' => $this->relationLabels($relationsSchema, $main),

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1051,9 +1051,9 @@ class ModulesComponentTest extends TestCase
                     'objectRelations' => [
                         'main' => [
                             'attach' => 'Attach',
+                            'has_media' => 'Has Media',
                         ],
                         'aside' => [
-                            'has_media' => 'Has Media',
                         ],
                     ],
                 ],
@@ -1084,7 +1084,6 @@ class ModulesComponentTest extends TestCase
                         'attach',
                     ],
                     'aside' => [
-                        'has_media',
                     ],
                 ],
             ],
@@ -1111,8 +1110,11 @@ class ModulesComponentTest extends TestCase
         $this->Modules->setupRelationsMeta($schema, $relationships, $order);
 
         $viewVars = $this->Modules->getController()->viewVars;
+
+        static::assertEquals(array_keys($expected), array_keys($viewVars));
+
         foreach ($expected as $key => $value) {
-            $this->assertEquals($value, $viewVars[$key]);
+            static::assertEquals($value, $viewVars[$key]);
         }
     }
 


### PR DESCRIPTION
This PR fixes a problem in `relations` configuration.

A test has been changed in `tests/TestCase/Controller/Component/ModulesComponentTest.php` that fails on previous version.
