### PR TITLE
Translation add: all attributes

### DIFF
--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -37,7 +37,7 @@ class TranslationsController extends ModulesController
         $this->request->allowMethod(['get']);
 
         try {
-            $response = $this->apiClient->getObject($id);
+            $response = $this->apiClient->getObject($id, $this->objectType);
         } catch (BEditaClientException $e) {
             // Error! Back to index.
             $this->log($e, LogLevel::ERROR);


### PR DESCRIPTION
This fixes an issue on `/:objectType/translation/:id/add` page: page load only `object` attributes.
Expected behavior: page loads all `:objectType` attributes.