### PR TITLE
fix: use dynamic relation name on locations-view

### DIFF
--- a/src/Template/Element/Form/locations.twig
+++ b/src/Template/Element/Form/locations.twig
@@ -2,6 +2,7 @@
 <locations-view
     apikey="{{ config('Location.google.key') }}"
     apiurl="{{ config('Location.google.url') }}"
+    relation-name="{{ relationName }}"
     :object="{{ object|json_encode }}"
 ></locations-view>
 {{ Form.unlockField('relations.' ~ relationName ~ '.replaceRelated')}}

--- a/src/Template/Layout/js/app/components/locations-view/locations-view.js
+++ b/src/Template/Layout/js/app/components/locations-view/locations-view.js
@@ -23,7 +23,7 @@ export default {
     template: `<div class="locations">
         <div v-if="!locations" class="is-loading-spinner"></div>
         <div v-if="locations" v-for="(location, index) in locations">
-            <location-view :key='locationSymbol(location)' :index='index' :locationdata='location' :apikey='apikey' :apiurl='apiurl' />
+            <location-view :key='locationSymbol(location)' :index='index' :locationdata='location' :apikey='apikey' :apiurl='apiurl' :relation-name='relationName' />
         </div>
         <div v-if="locations" class="buttons is-flex mt-1">
             <button @click.prevent @click="onAddNew"><: t('add new') :></button>
@@ -31,9 +31,10 @@ export default {
     </div>`,
 
     props: {
-        object: Object,
         apikey: String,
         apiurl: String,
+        relationName: String,
+        object: Object,
     },
 
     data() {
@@ -43,7 +44,7 @@ export default {
     },
 
     async created() {
-        const requestUrl = `${window.location.href}/relatedJson/has_location`;
+        const requestUrl = `${window.location.href}/relatedJson/${this.relationName}`;
         this.locations = (await (await fetch(requestUrl, options)).json()).data;
 
         // add params for location that does not have them


### PR DESCRIPTION
Use dynamic relation name instead of hardcoded `has_location` for `location-view` components.