### PR TITLE
Allow folders deselection

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -249,7 +249,7 @@ class AppController extends Controller
     }
 
     /**
-     * Handle `parents` or `parent` relationship looking at `_changedParens` input flag
+     * Handle `parents` or `parent` relationship looking at `_changedParents` input flag
      *
      * @param string $type Object type
      * @param array $data Form data
@@ -272,7 +272,7 @@ class AppController extends Controller
             return;
         }
 
-        // remaining case: all parents deseleced => replace with empty set
+        // remaining case: all parents deselected => replace with empty set
         $data['relations'][$relation] = ['replaceRelated' => []];
     }
 

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -161,6 +161,7 @@ class AppController extends Controller
         $data = (array)$this->request->getData();
 
         $this->specialAttributes($type, $data);
+        $this->setupParentsRelation($type, $data);
         $this->prepareRelations($data);
         $this->changedAttributes($data);
 
@@ -221,7 +222,6 @@ class AppController extends Controller
      */
     protected function prepareRelations(array &$data): void
     {
-        $this->setupParentsRelation($data);
         // relations data for view/save - prepare api calls
         if (!empty($data['relations'])) {
             $api = [];
@@ -249,26 +249,31 @@ class AppController extends Controller
     }
 
     /**
-     * Handle `parents` relationship looking at `_changedParens` input flag
+     * Handle `parents` or `parent` relationship looking at `_changedParens` input flag
      *
+     * @param string $type Object type
      * @param array $data Form data
      * @return void
      */
-    protected function setupParentsRelation(array &$data): void
+    protected function setupParentsRelation(string $type, array &$data): void
     {
         $changedParents = (bool)Hash::get($data, '_changedParents');
         unset($data['_changedParents']);
-        if ($changedParents && !empty($data['relations']['parents'])) {
+        $relation = 'parents';
+        if ($type === 'folders') {
+            $relation = 'parent';
+        }
+        if ($changedParents && !empty($data['relations'][$relation])) {
             return;
         }
         if (empty($changedParents)) {
-            unset($data['relations']['parents']);
+            unset($data['relations'][$relation]);
 
             return;
         }
 
         // remaining case: all parents deseleced => replace with empty set
-        $data['relations']['parents'] = ['replaceRelated' => []];
+        $data['relations'][$relation] = ['replaceRelated' => []];
     }
 
     /**

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -221,6 +221,7 @@ class AppController extends Controller
      */
     protected function prepareRelations(array &$data): void
     {
+        $this->setupParentsRelation($data);
         // relations data for view/save - prepare api calls
         if (!empty($data['relations'])) {
             $api = [];
@@ -237,7 +238,7 @@ class AppController extends Controller
                             $ids
                         );
                     }
-                    if (!empty($relatedIds)) {
+                    if ($method === 'replaceRelated' || !empty($relatedIds)) {
                         $api[] = compact('method', 'id', 'relation', 'relatedIds');
                     }
                 }
@@ -245,6 +246,29 @@ class AppController extends Controller
             $data['_api'] = $api;
         }
         unset($data['relations']);
+    }
+
+    /**
+     * Handle `parents` relationship looking at `_changedParens` input flag
+     *
+     * @param array $data Form data
+     * @return void
+     */
+    protected function setupParentsRelation(array &$data): void
+    {
+        $changedParents = (bool)Hash::get($data, '_changedParents');
+        unset($data['_changedParents']);
+        if ($changedParents && !empty($data['relations']['parents'])) {
+            return;
+        }
+        if (empty($changedParents)) {
+            unset($data['relations']['parents']);
+
+            return;
+        }
+
+        // remaining case: all parents deseleced => replace with empty set
+        $data['relations']['parents'] = ['replaceRelated' => []];
     }
 
     /**

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -263,17 +263,15 @@ class AppController extends Controller
         if ($type === 'folders') {
             $relation = 'parent';
         }
-        if ($changedParents && !empty($data['relations'][$relation])) {
-            return;
-        }
         if (empty($changedParents)) {
             unset($data['relations'][$relation]);
 
             return;
         }
-
-        // remaining case: all parents deselected => replace with empty set
-        $data['relations'][$relation] = ['replaceRelated' => []];
+        if (empty($data['relations'][$relation])) {
+            // all parents deselected => replace with empty set
+            $data['relations'][$relation] = ['replaceRelated' => []];
+        }
     }
 
     /**

--- a/src/Template/Element/Form/trees.twig
+++ b/src/Template/Element/Form/trees.twig
@@ -24,7 +24,7 @@
                 :multiple-choice={{ options.multiple }}>
             </tree-view>
             {{ Form.unlockField('relations.' ~ relationName ~ '.replaceRelated')}}
-            {{ Form.hidden('_changedParents', {'value': '0', 'id': 'changedParents', 'ref': 'changedParents'})|raw }}
+            {{ Form.hidden('_changedParents', {'value': '0', 'id': 'changedParents'})|raw }}
             {{ Form.unlockField('_changedParents')}}
         </div>
     </section>

--- a/src/Template/Element/Form/trees.twig
+++ b/src/Template/Element/Form/trees.twig
@@ -24,6 +24,8 @@
                 :multiple-choice={{ options.multiple }}>
             </tree-view>
             {{ Form.unlockField('relations.' ~ relationName ~ '.replaceRelated')}}
+            {{ Form.hidden('_changedParents', {'value': '0', 'id': 'changedParents', 'ref': 'changedParents'})|raw }}
+            {{ Form.unlockField('_changedParents')}}
         </div>
     </section>
 </property-view>

--- a/src/Template/Layout/js/app/components/tree-view/tree-view.js
+++ b/src/Template/Layout/js/app/components/tree-view/tree-view.js
@@ -379,6 +379,7 @@ export default {
          * @return {void}
          */
         toggleFolderRelation(event) {
+            document.getElementById('changedParents').value = 1;
             if (this.multipleChoice) {
                 let index = this.parents.findIndex(({ id }) => id == this.node.id);
                 if (event.target.checked) {

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -398,6 +398,72 @@ class AppControllerTest extends TestCase
                     ],
                 ],
             ],
+            'remove parent' => [
+                'documents', // object_type
+                [
+                    'id' => '1',
+                    '_api' => [ // expected new property in data
+                        [
+                            'method' => 'replaceRelated',
+                            'id' => '1',
+                            'relation' => 'parents',
+                            'relatedIds' => [],
+                        ],
+                    ],
+                ],
+                [ // data provided
+                    'id' => '1', // fake document id
+                    'relations' => [],
+                    '_changedParents' => true,
+                ],
+            ],
+
+            'no parents action' => [
+                'folders', // object_type
+                [
+                    'id' => '2',
+                ],
+                [ // data provided
+                    'id' => '2',
+                    'relations' => [
+                        'parent' => [
+                            'replaceRelated' => [
+                                '{ "id": "1", "type": "folders"}',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'replace parents' => [
+                'documents', // object_type
+                [
+                    'id' => '2',
+                    '_api' => [ // expected new property in data
+                        [
+                            'method' => 'replaceRelated',
+                            'id' => '2',
+                            'relation' => 'parents',
+                            'relatedIds' => [
+                                [
+                                    'id' => '1',
+                                    'type' => 'folders',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [ // data provided
+                    'id' => '2',
+                    'relations' => [
+                        'parents' => [
+                            'replaceRelated' => [
+                                '{ "id": "1", "type": "folders"}',
+                            ],
+                        ],
+                    ],
+                    '_changedParents' => true,
+                ],
+            ],
         ];
     }
 
@@ -411,6 +477,7 @@ class AppControllerTest extends TestCase
      * @covers ::prepareRequest()
      * @covers ::specialAttributes()
      * @covers ::prepareRelations()
+     * @covers ::setupParentsRelation()
      * @covers ::changedAttributes()
      * @dataProvider prepareRequestProvider()
      *
@@ -424,7 +491,7 @@ class AppControllerTest extends TestCase
             ],
             'post' => $data,
             'params' => [
-                'object_type' => 'documents',
+                'object_type' => $objectType,
             ],
         ];
 


### PR DESCRIPTION
This PR fixes #472 

A new `_changedParents` hidden input flag was added in order to keep trak of a user action on folders.

* on no user action `relations.parent(s)` is alway removed from POST data (no change is needed) 
* upon user action if `relation.parent(s)` is set => no change
* upon user action if no `relation.parent(s)` is set in POST data a `replace` with and empty set is added
 
 