### PR TITLE
Persistent open tabs on a module

### DIFF
--- a/src/Template/Element/Form/advanced_properties.twig
+++ b/src/Template/Element/Form/advanced_properties.twig
@@ -1,5 +1,5 @@
 {% if properties.advanced %}
-<property-view inline-template :tab-open="tabsOpen">
+<property-view inline-template :tab-open="tabsOpen" tab-name="advanced">
     <section class="fieldset">
 
         <header @click.prevent="toggleVisibility()"

--- a/src/Template/Element/Form/calendar.twig
+++ b/src/Template/Element/Form/calendar.twig
@@ -1,7 +1,7 @@
 {# Calendar: use date_ranges if `DateRanges` association is set #}
 
 {% if in_array('DateRanges', schema.associations) %}
-<property-view inline-template :tab-open="tabsOpen">
+<property-view inline-template :tab-open="tabsOpen" tab-name="calendar">
 <section class="fieldset">
     <header @click.prevent="toggleVisibility()"
         class="tab unselectable"

--- a/src/Template/Element/Form/categories.twig
+++ b/src/Template/Element/Form/categories.twig
@@ -1,5 +1,5 @@
 {% if schema.categories is defined %}
-    <property-view inline-template :tab-open="tabsOpen">
+    <property-view inline-template :tab-open="tabsOpen" tab-name="categories">
 
         <section class="fieldset">
             <header @click.prevent="toggleVisibility()"

--- a/src/Template/Element/Form/history.twig
+++ b/src/Template/Element/Form/history.twig
@@ -1,4 +1,4 @@
-<property-view inline-template :tab-open="tabsOpen">
+<property-view inline-template :tab-open="tabsOpen" tab-name="history">
     <section class="history">
         <section class="fieldset">
             <header @click.prevent="toggleVisibility()" class="tab unselectable" :class="isOpen ? 'open has-border-module-{{ currentModule.name }}' : ''">

--- a/src/Template/Element/Form/meta.twig
+++ b/src/Template/Element/Form/meta.twig
@@ -1,7 +1,7 @@
 {% set meta = (object) ? object.meta : resource.meta %}
 
 {% if meta %}
-<property-view inline-template :tab-open="tabsOpen">
+<property-view inline-template :tab-open="tabsOpen" tab-name="meta">
     <section class="fieldset">
 
         <header @click.prevent="toggleVisibility()"

--- a/src/Template/Element/Form/other_properties.twig
+++ b/src/Template/Element/Form/other_properties.twig
@@ -3,7 +3,7 @@
 {% for group, props in otherProperties %}
     {% if props %}
 
-    <property-view inline-template :tab-open="tabsOpen">
+    <property-view inline-template :tab-open="tabsOpen" tab-name="{{ group }}">
 
         <section class="fieldset">
             <header @click.prevent="toggleVisibility()"

--- a/src/Template/Element/Form/related_translations.twig
+++ b/src/Template/Element/Form/related_translations.twig
@@ -1,6 +1,5 @@
 {% if schema.properties.lang %}
-
-    <property-view inline-template :tab-open="tabsOpen" :tab-open-at-start="false" ref={{ resourceName }}>
+    <property-view inline-template :tab-open="tabsOpen" tab-name="translations" ref={{ resourceName }}>
         <section class="fieldset order-{{ cssOrder }}" :class="isOpen? '' : 'closed'">
 
             <header @click.prevent="toggleVisibility();"

--- a/src/Template/Element/Form/relations.twig
+++ b/src/Template/Element/Form/relations.twig
@@ -3,7 +3,7 @@
 
     {% for relationName, relationLabel in relations %}
 
-        <property-view inline-template :tab-open="tabsOpen" ref={{ relationName }}>
+        <property-view inline-template :tab-open="tabsOpen" tab-name="rel-{{ relationName }}" ref={{ relationName }}>
             <section class="fieldset">
 
                 <header @click.prevent="toggleVisibility()"

--- a/src/Template/Element/Form/relations.twig
+++ b/src/Template/Element/Form/relations.twig
@@ -3,7 +3,7 @@
 
     {% for relationName, relationLabel in relations %}
 
-        <property-view inline-template :tab-open="tabsOpen" tab-name="rel-{{ relationName }}" ref={{ relationName }}>
+        <property-view inline-template :tab-open="tabsOpen" tab-name="relation_{{ relationName }}" ref={{ relationName }}>
             <section class="fieldset">
 
                 <header @click.prevent="toggleVisibility()"

--- a/src/Template/Element/Form/roles.twig
+++ b/src/Template/Element/Form/roles.twig
@@ -1,6 +1,6 @@
 {% set relationName = 'roles' %}
 
-<property-view inline-template :tab-open="tabsOpen">
+<property-view inline-template :tab-open="tabsOpen" tab-name="roles">
 
     <section class="fieldset">
 

--- a/src/Template/Element/Form/trees.twig
+++ b/src/Template/Element/Form/trees.twig
@@ -1,6 +1,6 @@
 {% set relationName = 'parents' %}
 
-<property-view inline-template :tab-open="tabsOpen">
+<property-view inline-template :tab-open="tabsOpen" tab-name="trees">
     <section class="fieldset">
 
         <header @click.prevent="toggleVisibility()"

--- a/src/Template/Layout/js/app/components/property-view/property-view.js
+++ b/src/Template/Layout/js/app/components/property-view/property-view.js
@@ -13,6 +13,8 @@
  *
  */
 
+const STORAGE_TABS_KEY = 'tabs_open_' + BEDITA.currentModule.name;
+
 export default {
     components: {
         TreeView: () => import(/* webpackChunkName: "tree-view" */'app/components/tree-view/tree-view'),
@@ -29,9 +31,13 @@ export default {
             type: Boolean,
             default: false,
         },
+        tabName: {
+            type: String,
+            default: null,
+        },
         tabOpenAtStart: {
             type: Boolean,
-            default: false,
+            default: null,
         },
         isDefaultOpen: {
             type: Boolean,
@@ -49,7 +55,11 @@ export default {
     },
 
     mounted() {
-        this.isOpen = this.tabOpenAtStart;
+        if (this.tabOpenAtStart !== null) {
+            this.isOpen = this.tabOpenAtStart;
+            return;
+        }
+        this.isOpen = this.checkTabOpen();
     },
 
     watch: {
@@ -61,6 +71,7 @@ export default {
     methods: {
         toggleVisibility() {
             this.isOpen = !this.isOpen;
+            this.updateStorage();
         },
         onToggleLoading(status) {
             this.isLoading = status;
@@ -75,6 +86,33 @@ export default {
         },
         switchListView() {
             this.listView = true;
+        },
+        checkTabOpen() {
+            if (!this.tabName) {
+                return false;
+            }
+            let tabs = this.readTabsOpen();
+            return (tabs.indexOf(this.tabName) >= 0);
+        },
+        readTabsOpen() {
+            let tabs = [];
+            if (localStorage.getItem(STORAGE_TABS_KEY)) {
+                tabs = JSON.parse(localStorage.getItem(STORAGE_TABS_KEY));
+            }
+            return tabs;
+        },
+        updateStorage() {
+            if (!this.tabName) {
+                return;
+            }
+            let tabs = this.readTabsOpen();
+            const pos = tabs.indexOf(this.tabName);
+            if (this.isOpen && pos < 0) {
+                tabs.push(this.tabName);
+            } else if (!this.isOpen && pos >= 0) {
+                tabs.splice(pos, 1);
+            }
+            localStorage.setItem(STORAGE_TABS_KEY, JSON.stringify(tabs));
         },
     }
 }


### PR DESCRIPTION
With this PR open tabs in object details view (properties groups or related objects) are persisted using `localStorage`