### PR TITLE
Index columns: sort link only for sortable fields

### DIFF
--- a/src/Template/Element/Modules/index_table_header.twig
+++ b/src/Template/Element/Modules/index_table_header.twig
@@ -7,7 +7,11 @@
 
     {% for prop in properties %}
         <div class="{{ Link.sortClass(prop) }}">
-            <a href="{{ Link.sortUrl(prop) }}">{{ __(prop)|humanize }}</a>
+            {% if Schema.sortable(prop) %}
+                <a href="{{ Link.sortUrl(prop) }}">{{ __(prop)|humanize }}</a>
+            {% else %}
+                {{ __(prop)|humanize }}
+            {% endif %}
         </div>
     {% endfor %}
 

--- a/src/Template/Element/Modules/index_table_header.twig
+++ b/src/Template/Element/Modules/index_table_header.twig
@@ -20,15 +20,27 @@
     {% endif %}
 
     <div class="narrow {{ Link.sortClass('status') }}">
-        <a href="{{ Link.sortUrl('status') }}">{{ __('status') }}</a>
+        {% if Schema.sortable('status') %}
+            <a href="{{ Link.sortUrl('status') }}">{{ __('status') }}</a>
+        {% else %}
+            {{ __('status') }}
+        {% endif %}
     </div>
 
     <div class="{{ Link.sortClass('modified') }}">
-        <a href="{{ Link.sortUrl('modified') }}">{{ __('modified') }}</a>
+        {% if Schema.sortable('modified') %}
+            <a href="{{ Link.sortUrl('modified') }}">{{ __('modified') }}</a>
+        {% else %}
+            {{ __('modified') }}
+        {% endif %}
     </div>
 
     <div class="narrow {{ Link.sortClass('id') }}">
-        <a href="{{ Link.sortUrl('id') }}">{{ __('id') }}</a>
+        {% if Schema.sortable('id') %}
+            <a href="{{ Link.sortUrl('id') }}">{{ __('id') }}</a>
+        {% else %}
+            {{ __('id') }}
+        {% endif %}
     </div>
 
     <div></div>

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -199,20 +199,28 @@ class SchemaHelper extends Helper
     }
 
     /**
-     * Check if field is sortable.
-     * When field is in 'Properties.nosort' list, it's not sortable.
+     * Verify field's schema, return true if field is sortable.
      *
      * @param string $field The field to check
      * @return bool
      */
     public function sortable(string $field): bool
     {
-        $objectType = (string)$this->getView()->getRequest()->getParam('object_type');
-        $fields = (array)Configure::read(sprintf('Properties.%s.nosort', $objectType));
-        if (empty($fields)) {
-            return true;
-        }
+        $schema = (array)$this->_View->get('schema');
+        $schema = Hash::get($schema, sprintf('properties.%s', $field), []);
 
-        return !in_array($field, $fields);
+        // empty schema, then not sortable
+        if (empty($schema)) {
+            return false;
+        }
+        $type = self::typeFromSchema($schema);
+
+        // not sortable: 'array', 'object'
+        if (in_array($type, ['array', 'object'])) {
+            return false;
+        }
+        // other types are sortable: 'string', 'number', 'integer', 'boolean', 'date-time', 'date'
+
+        return true;
     }
 }

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -197,4 +197,22 @@ class SchemaHelper extends Helper
 
         return $fields;
     }
+
+    /**
+     * Check if field is sortable.
+     * When field is in 'Properties.nosort' list, it's not sortable.
+     *
+     * @param string $field The field to check
+     * @return bool
+     */
+    public function sortable(string $field): bool
+    {
+        $objectType = (string)$this->getView()->getRequest()->getParam('object_type');
+        $fields = (array)Configure::read(sprintf('Properties.%s.nosort', $objectType));
+        if (empty($fields)) {
+            return true;
+        }
+
+        return !in_array($field, $fields);
+    }
 }

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -64,10 +64,6 @@ class SchemaHelperTest extends TestCase
             ],
         ];
         Configure::write('Control', $control);
-        // set properties not sortable
-        $properties = (array)Configure::read('Properties');
-        $properties['dummies']['nosort'] = ['not_sortable_1', 'not_sortable_2'];
-        Configure::write('Properties', $properties);
     }
 
     /**
@@ -573,16 +569,89 @@ class SchemaHelperTest extends TestCase
     public function sortableProvider(): array
     {
         return [
-            'sortable' => [
-                'anything',
-                true,
-            ],
-            'not sortable 1' => [
-                'not_sortable_1',
+            'no schema, default not sortable' => [
+                'dummy_no_schema',
+                [],
                 false,
             ],
-            'not sortable 2' => [
-                'not_sortable_2',
+            'string: sortable' => [
+                'dummy_string',
+                ['type' => 'string'],
+                true,
+            ],
+            'number: sortable' => [
+                'dummy_number',
+                ['type' => 'number'],
+                true,
+            ],
+            'integer: sortable' => [
+                'dummy_integer',
+                ['type' => 'integer'],
+                true,
+            ],
+            'boolean: sortable' => [
+                'dummy_boolean',
+                ['type' => 'boolean'],
+                true,
+            ],
+            'date-time: sortable' => [
+                'dummy_date-time',
+                ['type' => 'date-time'],
+                true,
+            ],
+            'date: sortable' => [
+                'dummy_date',
+                ['type' => 'date'],
+                true,
+            ],
+            'array: not sortable' => [
+                'dummy_array',
+                ['type' => 'array'],
+                false,
+            ],
+            'object: not sortable' => [
+                'dummy_object',
+                ['type' => 'object'],
+                false,
+            ],
+            'oneOf, string: sortable' => [
+                'dummy_oneof_string',
+                ['oneOf' => [['type' => 'null'], ['type' => 'string']],],
+                true,
+            ],
+            'oneOf, number: sortable' => [
+                'dummy_oneof_number',
+                ['oneOf' => [['type' => 'null'], ['type' => 'number']],],
+                true,
+            ],
+            'oneOf, integer: sortable' => [
+                'dummy_oneof_integer',
+                ['oneOf' => [['type' => 'null'], ['type' => 'integer']],],
+                true,
+            ],
+            'oneOf, boolean: sortable' => [
+                'dummy_oneof_boolean',
+                ['oneOf' => [['type' => 'null'], ['type' => 'boolean']],],
+                true,
+            ],
+            'oneOf, date-time: sortable' => [
+                'dummy_oneof_date-time',
+                ['oneOf' => [['type' => 'null'], ['type' => 'date-time']],],
+                true,
+            ],
+            'oneOf, date: sortable' => [
+                'dummy_oneof_date',
+                ['oneOf' => [['type' => 'null'], ['type' => 'date']],],
+                true,
+            ],
+            'oneOf, array: not sortable' => [
+                'dummy_oneof_array',
+                ['oneOf' => [['type' => 'null'], ['type' => 'array']],],
+                false,
+            ],
+            'oneOf, object: not sortable' => [
+                'dummy_oneof_object',
+                ['oneOf' => [['type' => 'null'], ['type' => 'object']],],
                 false,
             ],
         ];
@@ -592,14 +661,21 @@ class SchemaHelperTest extends TestCase
      * Test `sortable` method
      *
      * @param string $field The field
+     * @param array $schema The property schema
      * @param bool $expected Expected result
      * @return void
      *
      * @dataProvider sortableProvider()
      * @covers ::sortable()
      */
-    public function testSortable(string $field, bool $expected): void
+    public function testSortable(string $field, array $schema, bool $expected): void
     {
+        $view = $this->Schema->getView();
+        $view->set('schema', [
+            'properties' => [
+                $field => $schema,
+            ],
+        ]);
         $actual = $this->Schema->sortable($field);
         static::assertSame($expected, $actual);
     }

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -616,42 +616,42 @@ class SchemaHelperTest extends TestCase
             ],
             'oneOf, string: sortable' => [
                 'dummy_oneof_string',
-                ['oneOf' => [['type' => 'null'], ['type' => 'string']],],
+                ['oneOf' => [['type' => 'null'], ['type' => 'string']]],
                 true,
             ],
             'oneOf, number: sortable' => [
                 'dummy_oneof_number',
-                ['oneOf' => [['type' => 'null'], ['type' => 'number']],],
+                ['oneOf' => [['type' => 'null'], ['type' => 'number']]],
                 true,
             ],
             'oneOf, integer: sortable' => [
                 'dummy_oneof_integer',
-                ['oneOf' => [['type' => 'null'], ['type' => 'integer']],],
+                ['oneOf' => [['type' => 'null'], ['type' => 'integer']]],
                 true,
             ],
             'oneOf, boolean: sortable' => [
                 'dummy_oneof_boolean',
-                ['oneOf' => [['type' => 'null'], ['type' => 'boolean']],],
+                ['oneOf' => [['type' => 'null'], ['type' => 'boolean']]],
                 true,
             ],
             'oneOf, date-time: sortable' => [
                 'dummy_oneof_date-time',
-                ['oneOf' => [['type' => 'null'], ['type' => 'date-time']],],
+                ['oneOf' => [['type' => 'null'], ['type' => 'date-time']]],
                 true,
             ],
             'oneOf, date: sortable' => [
                 'dummy_oneof_date',
-                ['oneOf' => [['type' => 'null'], ['type' => 'date']],],
+                ['oneOf' => [['type' => 'null'], ['type' => 'date']]],
                 true,
             ],
             'oneOf, array: not sortable' => [
                 'dummy_oneof_array',
-                ['oneOf' => [['type' => 'null'], ['type' => 'array']],],
+                ['oneOf' => [['type' => 'null'], ['type' => 'array']]],
                 false,
             ],
             'oneOf, object: not sortable' => [
                 'dummy_oneof_object',
-                ['oneOf' => [['type' => 'null'], ['type' => 'object']],],
+                ['oneOf' => [['type' => 'null'], ['type' => 'object']]],
                 false,
             ],
         ];


### PR DESCRIPTION
This provides "sortable link" in modules index only for properties whose schema type is sortable.

For now:

 - field types not sortable: 'array', 'object'
 - field types sortable: 'string', 'number', 'integer', 'boolean', 'date-time', 'date'
 - no schema (i.e. abstract objects): not sortable

Future: sortable property in api response

