### PR TITLE
feat: add .po loader to webpack plugin config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,6 @@
         "post-install-cmd": "App\\Console\\Installer::postInstall",
         "post-create-project-cmd": "App\\Console\\Installer::postInstall",
         "post-update-cmd": "App\\Console\\Installer::postInstall",
-        "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump",
         "check": [
             "@test",
             "@cs-check"

--- a/webpack.config.plugin.js
+++ b/webpack.config.plugin.js
@@ -30,8 +30,7 @@ module.exports = {
 
     resolve: {
         alias: aliases,
-
-        extensions: ['.js', '.vue', '.json', '.scss', '.css'],
+        extensions: ['.js', '.vue', '.json', '.scss', '.css', 'po'],
     },
 
     optimization: {
@@ -56,7 +55,7 @@ module.exports = {
                         ['@babel/preset-env', {
                             modules: false,
                             browsers: ['> 99%'],
-                            useBuiltIns: "usage",
+                            useBuiltIns: 'usage',
                         }]
                     ]
                 }
@@ -79,9 +78,17 @@ module.exports = {
                     }
                 ],
             },
+            {
+                test: /\.po$/,
+                use: [
+                    { loader: 'json-loader' },
+                    { loader: './webpack-gettext-loader' },
+                ],
+            },
         ]
     },
-    devtool: devMode ? "source-map" : false,
+
+    devtool: devMode ? 'source-map' : false,
 
     watch: devMode,
 


### PR DESCRIPTION
Add webpack rule to handle `.po` files inside plugins, to let them use `ttag` translations system.