### PR TITLE
Unlock fields, by '<moduleName>.<fieldName>` setting

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -14,6 +14,7 @@ namespace App\Controller;
 
 use App\Core\Exception\UploadException;
 use BEdita\SDK\BEditaClientException;
+use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\Response;
@@ -65,6 +66,22 @@ class ModulesController extends AppController
         $this->set('objectType', $this->objectType);
 
         return parent::beforeRender($event);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function beforeFilter(Event $event): ?Response
+    {
+        $currentModule = $this->Modules->getConfig('currentModuleName');
+        $key = sprintf('%s.unlockedFields', $currentModule);
+        $unlocked = (array)Configure::read($key);
+        if (!empty($unlocked)) {
+            $this->Security->setConfig('unlockedFields', $unlocked);
+        }
+
+        return parent::beforeFilter($event);
     }
 
     /**


### PR DESCRIPTION
In some contexts (i.e. plugins customizations of fields rendering) we need to unlock specific fields.
Usually we use `{{ Form.unlockField(fieldName) }}` in `twig` templates.
When no twig templates are involved, submit causes a Security error.

This provides a workaround.
Set a config to unlock fields as follows:
```
Configure::write(
    'animals.unlockedFields',
    array_merge(
        (array)Configure::read('animals.unlockedFields'),
        [
            'eyes', 'legs',
        ]
    )
);
```
`ModulesController::beforeRender` will set `unlockedField` `['eyes', 'legs']`, when current module is `animals`.