### PR TITLE
handle _element in properties group config

### DIFF
--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -130,6 +130,9 @@ class PropertiesComponent extends Component
                 if (array_key_exists($item, $attributes)) {
                     $p[$item] = $attributes[$item];
                 }
+                if (array_key_exists('_element', $items)) {
+                    $p['_element'] = $item;
+                }
             }
             $properties[$group] = $p;
             if ($group !== 'other') {


### PR DESCRIPTION
This provides inclusion of `_element` in custom group `Properties` config.

I.e.:
```
'persons' => [
    'view' => [ 
        'hobbies' => [
            '_element' => 'MyPlugin.Form/hobbies',
            'hobbies',
        ],
    ],
],
```