### PR TITLE
Refactor plugin modules configuration

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -405,12 +405,16 @@ return [
      *
      * Keys must be actual API endpoint names like `documents`, `users` or `folders`.
      * Modules order will follow key order of this configuration.
+     * In case of core or plugin modules not directly served by ModulesController
+     * (generally modules not related tobject types) a 'route' attribute can be specified for
+     * custom controller and action rules.
      *
      * Array value may contain:
      *
      *  'label' - module label to display, if not set `key` will be used
      *  'shortLabel' - short label, 3 character recommended
      *  'color' - primary color code,
+     *  'route' - (optional) custom route, used by plugin modules mainly
      *  'secondaryColor' - secondary color code,
      *  'sort' - sort order to be used in index; use a field name prepending optionl `-` sign
      *          to indicate a descendant order, f.i. '-title' will sort by title in reverse alphabetical order
@@ -551,9 +555,9 @@ return [
      * Where options array may contain
      *
      * - `debugOnly` - boolean - (default: false) Whether or not you want to load the plugin when in 'debug' mode only
-     * - `bootstrap` - boolean - (default: false) Whether or not you want the $plugin/config/bootstrap.php file loaded.
-     * - `routes` - boolean - (default: false) Whether or not you want to load the $plugin/config/routes.php file.
-     * - `ignoreMissing` - boolean - (default: false) Set to true to ignore missing bootstrap/routes files.
+     * - `bootstrap` - boolean - (default: true) Whether or not you want the $plugin/config/bootstrap.php file loaded.
+     * - `routes` - boolean - (default: true) Whether or not you want to load the $plugin/config/routes.php file.
+     * - `ignoreMissing` - boolean - (default: true) Set to true to ignore missing bootstrap/routes files.
      * - `autoload` - boolean - (default: false) Whether or not you want an autoloader registered
      */
     // 'Plugins' => [
@@ -561,28 +565,6 @@ return [
 
         // Uncomment to enable `DebugKit` - 'debug' mode is required
         //'DebugKit' => ['bootstrap' => true, 'debugOnly' => true],
-    // ],
-
-    /**
-     * Plugin modules settings.
-     *
-     * Default empty.
-     * Configuration generally written by plugins via bootstrap.
-     */
-    // 'PluginModules' => [
-
-    //     // plugin module example
-    //     // unique name
-    //     'My Module' => [
-    //         'title' => 'My Module',
-    //         // routing rules
-    //         'route' => Router::url(['_name': 'my_module:index']),
-    //         // css class
-    //         'class' => [
-    //             'dashboard' => 'has-background-black icon-sample',
-    //             'menu' => 'has-background-black',
-    //         ],
-    //     ],
     // ],
 
     /**

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -406,7 +406,7 @@ return [
      * Keys must be actual API endpoint names like `documents`, `users` or `folders`.
      * Modules order will follow key order of this configuration.
      * In case of core or plugin modules not directly served by ModulesController
-     * (generally modules not related tobject types) a 'route' attribute can be specified for
+     * (generally modules not related to bject types) a 'route' attribute can be specified for
      * custom controller and action rules.
      *
      * Array value may contain:
@@ -414,7 +414,7 @@ return [
      *  'label' - module label to display, if not set `key` will be used
      *  'shortLabel' - short label, 3 character recommended
      *  'color' - primary color code,
-     *  'route' - (optional) custom route, used by plugin modules mainly
+     *  'route' - (optional) custom route (named route or absolute/relative URL) used by plugin modules mainly
      *  'secondaryColor' - secondary color code,
      *  'sort' - sort order to be used in index; use a field name prepending optionl `-` sign
      *          to indicate a descendant order, f.i. '-title' will sort by title in reverse alphabetical order

--- a/src/Application.php
+++ b/src/Application.php
@@ -29,6 +29,19 @@ use Cake\Routing\Middleware\RoutingMiddleware;
 class Application extends BaseApplication
 {
     /**
+     * Default plugin options
+     *
+     * @var array
+     */
+    const PLUGIN_DEFAULTS = [
+        'debugOnly' => false,
+        'autoload' => false,
+        'bootstrap' => true,
+        'routes' => true,
+        'ignoreMissing' => true,
+    ];
+
+    /**
      * {@inheritDoc}
      */
     public function bootstrap()
@@ -55,21 +68,12 @@ class Application extends BaseApplication
      */
     public function loadPluginsFromConfig(): void
     {
-        $plugins = Configure::read('Plugins', []);
-        if ($plugins) {
-            $defaults = [
-                'debugOnly' => false,
-                'autoload' => false,
-                'bootstrap' => false,
-                'routes' => false,
-                'ignoreMissing' => false,
-            ];
-            foreach ($plugins as $plugin => $options) {
-                $options = array_merge($defaults, $options);
-                if (!$options['debugOnly'] || ($options['debugOnly'] && Configure::read('debug'))) {
-                    $this->addPlugin($plugin, $options);
-                    $this->plugins->get($plugin)->bootstrap($this);
-                }
+        $plugins = (array)Configure::read('Plugins');
+        foreach ($plugins as $plugin => $options) {
+            $options = array_merge(self::PLUGIN_DEFAULTS, $options);
+            if (!$options['debugOnly'] || ($options['debugOnly'] && Configure::read('debug'))) {
+                $this->addPlugin($plugin, $options);
+                $this->plugins->get($plugin)->bootstrap($this);
             }
         }
     }

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -130,7 +130,7 @@ class ModulesComponent extends Component
         $modules = (array)Configure::read('Modules');
         $pluginModules = array_filter($modules, function ($item) {
             return !empty($item['route']);
-       });
+        });
         $metaModules = $this->modulesFromMeta();
         $modules = array_intersect_key($modules, $metaModules);
         array_walk(

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -128,6 +128,9 @@ class ModulesComponent extends Component
     public function getModules(): array
     {
         $modules = (array)Configure::read('Modules');
+        $pluginModules = array_filter($modules, function ($item) {
+            return !empty($item['route']);
+       });
         $metaModules = $this->modulesFromMeta();
         $modules = array_intersect_key($modules, $metaModules);
         array_walk(
@@ -136,7 +139,11 @@ class ModulesComponent extends Component
                 $data = array_merge((array)Hash::get($metaModules, $key), $data);
             }
         );
-        $this->modules = array_merge($modules, array_diff_key($metaModules, $modules));
+        $this->modules = array_merge(
+            $modules,
+            array_diff_key($metaModules, $modules),
+            $pluginModules
+        );
 
         return $this->modules;
     }

--- a/src/Template/Element/Menu/menu.twig
+++ b/src/Template/Element/Menu/menu.twig
@@ -2,7 +2,7 @@
     <div class="menu-bar">
 
         <nav role="menu">
-            {# Core object modules #}
+            {# Core modules #}
             {% for name, module in modules if name != 'trash' %}
                 {% set label = __(module.label|default(name)|humanize) %}
                 {% set shortLabel = module.shortLabel|default(label[0:3]) %}
@@ -10,27 +10,16 @@
                     {% set label = label[0:3] %}
                 {% endif %}
 
-                <a href="{{ Url.build({ '_name': 'modules:list', 'object_type': name, 'plugin': null }) }}"
-                    title="{{ __('Open module') }} {{ __(name|humanize) }}"
+                {% if module.route %}
+                    {% set url = Url.build(module.route) %}
+                {% else %}
+                    {% set url = Url.build({ '_name': 'modules:list', 'object_type': name, 'plugin': null }) %}
+                {% endif %}
+                <a href="{{ url }}" title="{{ __('Open module') }} {{ __(name|humanize) }}"
                     class="menu-item {{ name == currentModule.name ? 'current' : '' }}">
                     <span class="menu-item-color-bar has-background-module-{{ name }}" aria-hidden="true"></span>
                     <span class="menu-item-label">{{ label }}</span>
                     <span class="menu-item-short-label">{{ shortLabel }}</span>
-                </a>
-            {% endfor %}
-
-            {# Plugin modules #}
-            {% for pluginName, plugin in config('PluginModules') %}
-                {% set label = __(plugin.title|humanize) %}
-                {% if label|length > 7 %}
-                    {% set label = label[0:3] %}
-                {% endif %}
-
-                <a href="{{ Url.build(plugin.route) }}"
-                    title="{{ __('Open module') }} {{ __(pluginName|humanize) }}"
-                    class="menu-item {{ pluginName == currentModule.name ? 'current' : '' }}">
-                    <span class="menu-item-color-bar has-background-module-{{ pluginName }}" aria-hidden="true"></span>
-                    <span class="menu-item-label">{{ label }}</span>
                 </a>
             {% endfor %}
         </nav>

--- a/src/Template/Pages/Dashboard/index.twig
+++ b/src/Template/Pages/Dashboard/index.twig
@@ -12,14 +12,13 @@
                     {% set class = class ~ ' icon-th-large-1' %}
                 {% endif %}
 
-                <a href="{{ Url.build({ '_name': 'modules:list', 'object_type': name })|raw }}" class="{{ class }}">
+                {% if module.route %}
+                    {% set url = Url.build(module.route) %}
+                {% else %}
+                    {% set url = Url.build({ '_name': 'modules:list', 'object_type': name, 'plugin': null }) %}
+                {% endif %}
+                <a href="{{ url }}" class="{{ class }}">
                     <span>{{ title }}</span>
-                </a>
-            {% endfor %}
-
-            {% for k, plugin in config('PluginModules', []) %}
-                <a href="{{ Url.build(plugin.route)|raw }}" class="{{ plugin.class.dashboard }}">
-                    <span>{{ plugin.title|humanize }}</span>
                 </a>
             {% endfor %}
             </div>


### PR DESCRIPTION
In this PR:

* `PluginModules` configuration has been removed 
* a module served by a plugin or not using `ModulesController` can be specified in `Modules` configuration using `route` attribute where a named route or relative/absolute rule cab be used 
* loaded plugin default options have been changed, a simpler config like this can now be used
```
    'Plugins' => [
        'MyPlugin' => [],
    ],
``` 