### PR TITLE
Phpspreadsheet

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "cakephp/plugin-installer": "^1.1",
         "josegonzalez/dotenv": "2.*",
         "mobiledetect/mobiledetectlib": "2.*",
-        "mpdf/mpdf": "^8.0",
         "phpoffice/phpspreadsheet": "^1.15",
         "wikimedia/composer-merge-plugin": "^1.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,13 @@
     ],
     "require": {
         "php": ">=7.1",
-        "bedita/web-tools": "^1.5.0",
         "bedita/i18n": "^1.5",
+        "bedita/web-tools": "^1.5.0",
         "cakephp/plugin-installer": "^1.1",
         "josegonzalez/dotenv": "2.*",
         "mobiledetect/mobiledetectlib": "2.*",
+        "mpdf/mpdf": "^8.0",
+        "phpoffice/phpspreadsheet": "^1.15",
         "wikimedia/composer-merge-plugin": "^1.4"
     },
     "require-dev": {

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -598,9 +598,13 @@ return [
      * Export default settings
      *
      * - limit => max number of exported elements on export all
+     * - formats => array of formats enabled for export
+     * - default => default format
      */
     // 'Export' => [
     //     'limit' => 10000,
+    //     'formats' => ['csv', 'ods', 'xlsx'],
+    //     'default' => 'xlsx'
     // ],
 
     /**

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -585,7 +585,11 @@ return [
      */
     // 'Export' => [
     //     'limit' => 10000,
-    //     'formats' => ['csv', 'ods', 'xlsx'],
+    //     'formats' => [
+    //        'CSV' => 'csv', // label => value
+    //        'Open Document' => 'ods',
+    //        'MS Excel' => 'xlsx'
+    //     ],
     //     'default' => 'xlsx'
     // ],
 

--- a/src/Controller/Component/ExportComponent.php
+++ b/src/Controller/Component/ExportComponent.php
@@ -1,0 +1,186 @@
+<?php
+namespace App\Controller\Component;
+
+use Cake\Controller\Component;
+use Cake\Controller\ComponentRegistry;
+use Cake\Http\Response;
+use Cake\Utility\Hash;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
+use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
+
+/**
+ * Export component
+ */
+class ExportComponent extends Component
+{
+    /**
+     * Spreadsheet columns int/letter mapping.
+     *
+     * @var array
+     */
+    public const LETTERS = [
+        1 => 'A', 2 => 'B', 3 => 'C', 4 => 'D', 5 => 'E', 6 => 'F', 7 => 'G', 8 => 'H', 9 => 'I', 10 => 'J',
+        11 => 'K', 12 => 'L', 13 => 'M', 14 => 'N', 15 => 'O', 16 => 'P', 17 => 'Q', 18 => 'R', 19 => 'S', 20 => 'T',
+        21 => 'U', 22 => 'V', 23 => 'W', 24 => 'X', 25 => 'Y', 26 => 'Z',
+    ];
+
+    /**
+     * Default properties for spreadsheet
+     *
+     * @var array
+     */
+    protected $defaultSpreadheetProperties = [
+        'creator' => 'BEdita Manager',
+        'lastModifiedBy' => 'BEdita Manager',
+        'title' => '',
+        'subject' => '',
+        'description' => '',
+        'keywords' => '',
+        'category' => '',
+    ];
+
+    /**
+     * Create spreadsheet with data from rows, using properties.
+     *
+     * @param array $rows THe data
+     * @param array $properties The properties
+     * @return Spreadsheet
+     */
+    public function spreadsheet(array $rows, array $properties = []): Spreadsheet
+    {
+        $spreadsheet = new Spreadsheet();
+
+        // set properties
+        $properties = array_merge($this->defaultSpreadheetProperties, $properties);
+        foreach ($properties as $property => $value) {
+            $spreadsheet->getProperties()->{sprintf('set%s', ucfirst($property))}($value);
+        }
+
+        // create the worksheet
+        $spreadsheet->setActiveSheetIndex(0);
+
+        // set first row, column names
+        if (!empty($rows)) {
+            $first = array_values(array_shift($rows));
+            foreach ($first as $k => $v) {
+                $spreadsheet->getActiveSheet()->setCellValue(sprintf('%s1', self::LETTERS[$k + 1]), $v);
+            }
+        }
+
+        // fill data
+        $spreadsheet->getActiveSheet()->fromArray($rows, null, 'A2');
+
+        // set autofilter
+        $spreadsheet->getActiveSheet()->setAutoFilter($spreadsheet->getActiveSheet()->calculateWorksheetDimension());
+
+        return $spreadsheet;
+    }
+
+    /**
+     * Create spreadsheet file into memory and redirect output to download it as csv
+     *
+     * @param Spreadsheet $spreadsheet The spreadsheet
+     * @param string $filename The file name
+     * @return void
+     */
+    public function csv(Spreadsheet $spreadsheet, string $filename = 'export.csv'): void
+    {
+        $options = compact('filename') + ['format' => 'text/csv'];
+        $this->download($spreadsheet, 'Csv', $options);
+    }
+
+    /**
+     * Create spreadsheet file into memory and redirect output to download it as ods
+     *
+     * @param Spreadsheet $spreadsheet The spreadsheet
+     * @param string $filename The file name
+     * @return void
+     */
+    public function ods(Spreadsheet $spreadsheet, string $filename = 'export.ods'): void
+    {
+        $options = compact('filename') + ['format' => 'application/vnd.oasis.opendocument.spreadsheet'];
+        $this->download($spreadsheet, 'Ods', $options);
+    }
+
+    /**
+     * Create spreadsheet file into memory and redirect output to download it as pdf
+     *
+     * @param Spreadsheet $spreadsheet The spreadsheet
+     * @param string $filename The file name
+     * @return void
+     */
+    public function pdf(Spreadsheet $spreadsheet, string $filename = 'export.pdf'): void
+    {
+        IOFactory::registerWriter('Pdf', Mpdf::class);
+        $spreadsheet->getActiveSheet()->setShowGridLines(false);
+        $spreadsheet->getActiveSheet()->getPageSetup()->setOrientation(PageSetup::ORIENTATION_LANDSCAPE);
+        $spreadsheet->getActiveSheet()->getPageSetup()->setPaperSize(PageSetup::PAPERSIZE_A4);
+        $options = compact('filename') + ['format' => 'application/pdf'];
+        $this->download($spreadsheet, 'Pdf', $options);
+    }
+
+    /**
+     * Create spreadsheet file into memory and redirect output to download it as xls
+     *
+     * @param Spreadsheet $spreadsheet The spreadsheet
+     * @param string $filename The file name
+     * @return void
+     */
+    public function xls(Spreadsheet $spreadsheet, string $filename = 'export.xls'): void
+    {
+        $options = compact('filename') + ['format' => 'application/vnd.ms-excel'];
+        $this->download($spreadsheet, 'Xls', $options);
+    }
+
+    /**
+     * Create spreadsheet file into memory and redirect output to download it as xlsx
+     *
+     * @param Spreadsheet $spreadsheet The spreadsheet
+     * @param string $filename The file name
+     * @return void
+     */
+    public function xlsx(Spreadsheet $spreadsheet, string $filename = 'export.xlsx'): void
+    {
+        $options = compact('filename') + ['format' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'];
+        $this->download($spreadsheet, 'Xlsx', $options);
+    }
+
+    /**
+     * Just exit. Useful having a separated function, to better handling unit tests.
+     *
+     * @return void
+     * @codeCoverageIgnore
+     */
+    public function exit(): void
+    {
+        exit;
+    }
+
+    /**
+     * Create spreadsheet and set it as download.
+     *
+     * @param Spreadsheet $spreadsheet The spreadsheet
+     * @param string $extension The extension, can be 'Csv', 'Ods', 'Pdf', 'Xls', 'Xlsx'
+     * @param array $options The options
+     * @return void
+     * @codeCoverageIgnore
+     */
+    protected function download(Spreadsheet $spreadsheet, string $extension, array $options): void
+    {
+        // Redirect output to a client’s web browser (Xlsx)
+        header(sprintf('Content-Type: %s', Hash::get($options, 'format')));
+        header(sprintf('Content-Disposition: attachment;filename="%s"', Hash::get($options, 'filename')));
+        header(sprintf('Cache-Control: max-age=%d', Hash::get($options, 'max-age', 0)));
+
+        // If you're serving to IE over SSL, then the following may be needed
+        header('Expires: Mon, 26 Jul 1997 05:00:00 GMT'); // Date in the past
+        header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT'); // always modified
+        header('Cache-Control: cache, must-revalidate'); // HTTP/1.1
+        header('Pragma: public'); // HTTP/1.0
+
+        $writer = IOFactory::createWriter($spreadsheet, $extension);
+        $writer->save('php://output');
+    }
+}

--- a/src/Controller/Component/ExportComponent.php
+++ b/src/Controller/Component/ExportComponent.php
@@ -2,19 +2,22 @@
 namespace App\Controller\Component;
 
 use Cake\Controller\Component;
-use Cake\Controller\ComponentRegistry;
-use Cake\Http\Response;
 use Cake\Utility\Hash;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
-use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
-use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
 
 /**
  * Export component. Utility to create csv, ods and xlsx spreadsheets.
  */
 class ExportComponent extends Component
 {
+    /**
+     * Allowed formats for export
+     *
+     * @var array
+     */
+    const ALLOWED_FORMATS = ['csv', 'ods', 'xlsx'];
+
     /**
      * Spreadsheet columns int/letter mapping.
      *
@@ -42,13 +45,26 @@ class ExportComponent extends Component
     ];
 
     /**
+     * Check if format is allowed
+     *
+     * @param string $format The format
+     * @return bool
+     */
+    public function checkFormat(string $format): bool
+    {
+        return in_array($format, static::ALLOWED_FORMATS);
+    }
+
+    /**
      * Create spreadsheet with data from rows, using properties.
      *
-     * @param array $rows THe data
+     * @param string $format The format
+     * @param array $rows The data
+     * @param string $filename The file name
      * @param array $properties The properties
-     * @return Spreadsheet
+     * @return array
      */
-    public function spreadsheet(array $rows, array $properties = []): Spreadsheet
+    public function format(string $format, array $rows, string $filename, array $properties = []): array
     {
         $spreadsheet = new Spreadsheet();
 
@@ -75,7 +91,7 @@ class ExportComponent extends Component
         // set autofilter
         $spreadsheet->getActiveSheet()->setAutoFilter($spreadsheet->getActiveSheet()->calculateWorksheetDimension());
 
-        return $spreadsheet;
+        return $this->{$format}($spreadsheet, $filename);
     }
 
     /**

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -209,7 +209,7 @@ class ExportController extends AppController
      * @param array $fields The fields
      * @return void
      */
-    private function fillRowFields(&$row, $data, $fields)
+    private function fillRowFields(&$row, $data, $fields): void
     {
         foreach ($fields as $field) {
             $row[$field] = '';

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -48,9 +48,8 @@ class ExportController extends AppController
      */
     public function export(): ?Response
     {
-        // allow only specific export formats: csv, ods, xlsx
         $format = (string)$this->request->getData('format');
-        if (!in_array($format, ['csv', 'ods', 'xlsx'])) {
+        if (!$this->Export->checkFormat($format)) {
             return null;
         }
         // check request (allowed methods and required parameters)
@@ -64,9 +63,8 @@ class ExportController extends AppController
         $rows = $this->rows($data['objectType'], $ids);
 
         // create spreadsheet and return as download
-        $spreadsheet = $this->Export->spreadsheet($rows);
         $filename = sprintf('%s_%s.%s', $data['objectType'], date('Ymd-His'), $format);
-        $data = $this->Export->{$format}($spreadsheet, $filename);
+        $data = $this->Export->format($format, $rows, $filename);
 
         // output
         $response = $this->response->withStringBody(Hash::get($data, 'content'));

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -18,6 +18,8 @@ use Cake\Utility\Hash;
 
 /**
  * Export controller: upload and load using filters
+ *
+ * @property \App\Controller\Component\ExportComponent $Export
  */
 class ExportController extends AppController
 {
@@ -29,12 +31,28 @@ class ExportController extends AppController
     const DEFAULT_EXPORT_LIMIT = 10000;
 
     /**
-     * Export data in csv format
+     * {@inheritDoc}
+     * {@codeCoverageIgnore}
+     */
+    public function initialize(): void
+    {
+        parent::initialize();
+
+        $this->loadComponent('Export');
+    }
+
+    /**
+     * Export data to format specified by user
      *
      * @return \Cake\Http\Response
      */
     public function export(): Response
     {
+        // allow only specific export formats: csv, ods, pdf, xls, xlsx
+        $format = $this->request->getData('format');
+        if (!in_array($format, ['csv', 'ods', 'pdf', 'xls', 'xlsx'])) {
+            return null;
+        }
         // check request (allowed methods and required parameters)
         $data = $this->checkRequest([
             'allowedMethods' => ['post'],
@@ -42,11 +60,19 @@ class ExportController extends AppController
         ]);
         $ids = $this->request->getData('ids');
 
-        // load csv data for objects by object type and ids
-        $rows = $this->csvRows($data['objectType'], $ids);
+        // load data for objects by object type and ids
+        $rows = $this->rows($data['objectType'], $ids);
 
-        // save data to csv and output it to browser
-        return $this->csv($rows, $data['objectType']);
+        // create spreadsheet and return as download
+        $spreadsheet = $this->Export->spreadsheet($rows);
+        $filename = sprintf('%s_%s.%s', $data['objectType'], date('Ymd-His'), $format);
+        $data = $this->Export->{$format}($spreadsheet, $filename);
+
+        // output
+        $response = $this->response->withStringBody(Hash::get($data, 'content'));
+        $response = $response->withType(Hash::get($data, 'contentType'));
+
+        return $response->withDownload($filename);
     }
 
     /**
@@ -59,10 +85,10 @@ class ExportController extends AppController
      * @param string $ids Object IDs comma separated string
      * @return array
      */
-    protected function csvRows(string $objectType, string $ids = ''): array
+    protected function rows(string $objectType, string $ids = ''): array
     {
         if (empty($ids)) {
-            return $this->csvAll($objectType);
+            return $this->rowsAll($objectType);
         }
 
         $data = [];
@@ -74,12 +100,12 @@ class ExportController extends AppController
     }
 
     /**
-     * Load all CSV data for a given type using limit and query filters.
+     * Load all data for a given type using limit and query filters.
      *
      * @param string $objectType Object type
      * @return array
      */
-    protected function csvAll(string $objectType): array
+    protected function rowsAll(string $objectType): array
     {
         $data = [];
         $limit = Configure::read('Export.limit', self::DEFAULT_EXPORT_LIMIT);
@@ -159,67 +185,6 @@ class ExportController extends AppController
         }
 
         return $fields;
-    }
-
-    /**
-     * Create csv data (string) per rows/objects and output it to browser
-     *
-     * @param array $rows The rows data
-     * @param string $objectType The object type
-     * @return \Cake\Http\Response
-     */
-    private function csv(array $rows, string $objectType): Response
-    {
-        $result = $this->processCsv($rows, $objectType);
-        extract($result); // => $filename, $csv
-
-        return $this->outputCsv($filename, $csv);
-    }
-
-    /**
-     * Output csv file.
-     *
-     * @param string $filename The file name.
-     * @param string $csv The csv string data.
-     * @return \Cake\Http\Response
-     */
-    protected function outputCsv($filename, $csv): Response
-    {
-        $response = $this->response->withStringBody($csv);
-        $response = $response->withType('text/csv');
-
-        return $response->withDownload(sprintf('%s.csv', $filename));
-    }
-
-    /**
-     * Process data (string) per rows/objects.
-     * Create a temporary csv file.
-     * Return filename and csv string in an array.
-     *
-     * @param array $rows The rows data.
-     * @param string $objectType The object type.
-     * @return array
-     */
-    private function processCsv(array $rows, string $objectType): array
-    {
-        $csv = '';
-        $fields = array_shift($rows);
-        $filename = sprintf('%s_%s', $objectType, date('Ymd-His'));
-        $tmpfilename = tempnam('/tmp', $filename);
-        if ($tmpfilename) {
-            $fp = fopen($tmpfilename, 'w+');
-            if (!empty($fp)) {
-                fputcsv($fp, $fields);
-                foreach ($rows as $row) {
-                    fputcsv($fp, $row);
-                }
-                $csv = file_get_contents($tmpfilename);
-                fclose($fp);
-            }
-        }
-        unlink($tmpfilename);
-
-        return compact('csv', 'filename');
     }
 
     /**

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -44,12 +44,12 @@ class ExportController extends AppController
     /**
      * Export data to format specified by user
      *
-     * @return \Cake\Http\Response
+     * @return \Cake\Http\Response|null
      */
-    public function export(): Response
+    public function export(): ?Response
     {
         // allow only specific export formats: csv, ods, xlsx
-        $format = $this->request->getData('format');
+        $format = (string)$this->request->getData('format');
         if (!in_array($format, ['csv', 'ods', 'xlsx'])) {
             return null;
         }

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -48,9 +48,9 @@ class ExportController extends AppController
      */
     public function export(): Response
     {
-        // allow only specific export formats: csv, ods, pdf, xls, xlsx
+        // allow only specific export formats: csv, ods, xlsx
         $format = $this->request->getData('format');
-        if (!in_array($format, ['csv', 'ods', 'pdf', 'xls', 'xlsx'])) {
+        if (!in_array($format, ['csv', 'ods', 'xlsx'])) {
             return null;
         }
         // check request (allowed methods and required parameters)

--- a/src/Template/Element/Modules/index_bulk.twig
+++ b/src/Template/Element/Modules/index_bulk.twig
@@ -56,11 +56,15 @@
         {% if not currentModule.hints.multiple_types %}
             {{ Form.create(null, {'id': 'form-export', 'url': {'_name': 'export:export', 'object_type': objectType}})|raw }}
 
-                {% set formats = config('Export.formats', ['csv']) %}
-                {% set defaultFormat = config('Export.default', 'csv') %}
+                {% set formats = config('Export.formats', {
+                    'CSV': 'csv',
+                    'Open Document': 'ods',
+                    'MS Excel': 'xlsx'
+                }) %}
+                {% set defaultFormat = config('Export.default', 'xslx') %}
                 <select name="format" id="exportformat">
-                {% for format in formats %}
-                    <option value="{{ format }}" {% if format == defaultFormat %}selected="selected"{% endif %}>{{ format|humanize }}</option>
+                {% for label,format in formats %}
+                    <option value="{{ format }}" {% if format == defaultFormat %}selected="selected"{% endif %}>{{ label }}</option>
                 {% endfor %}
                 </select>
                 {{ Form.unlockField('format') }}

--- a/src/Template/Element/Modules/index_bulk.twig
+++ b/src/Template/Element/Modules/index_bulk.twig
@@ -56,6 +56,15 @@
         {% if not currentModule.hints.multiple_types %}
             {{ Form.create(null, {'id': 'form-export', 'url': {'_name': 'export:export', 'object_type': objectType}})|raw }}
 
+                <select name="format" id="exportformat">
+                    <option value="csv">Csv</option>
+                    <option value="ods">Ods</option>
+                    <option value="pdf">Pdf</option>
+                    <option value="xls">Xls</option>
+                    <option value="xlsx">Xlsx</option>
+                </select>
+                {{ Form.unlockField('format') }}
+
                 <input type="hidden" name="ids" v-model="selectedRows">
                 {{ Form.unlockField('ids') }}
                 {{ Form.hidden('objectType', {'value': objectType})|raw }}

--- a/src/Template/Element/Modules/index_bulk.twig
+++ b/src/Template/Element/Modules/index_bulk.twig
@@ -56,12 +56,12 @@
         {% if not currentModule.hints.multiple_types %}
             {{ Form.create(null, {'id': 'form-export', 'url': {'_name': 'export:export', 'object_type': objectType}})|raw }}
 
+                {% set formats = config('Export.formats', ['csv']) %}
+                {% set defaultFormat = config('Export.default', 'csv') %}
                 <select name="format" id="exportformat">
-                    <option value="csv">Csv</option>
-                    <option value="ods">Ods</option>
-                    <option value="pdf">Pdf</option>
-                    <option value="xls">Xls</option>
-                    <option value="xlsx">Xlsx</option>
+                {% for format in formats %}
+                    <option value="{{ format }}" {% if format == defaultFormat %}selected="selected"{% endif %}>{{ format|humanize }}</option>
+                {% endfor %}
                 </select>
                 {{ Form.unlockField('format') }}
 

--- a/tests/TestCase/Controller/Component/ExportComponentTest.php
+++ b/tests/TestCase/Controller/Component/ExportComponentTest.php
@@ -54,7 +54,7 @@ class ExportComponentTest extends TestCase
      */
     public function testSpreadsheet(): void
     {
-        $spreadsheet = $this->Export->spreadsheet([], []);
+        $spreadsheet = $this->Export->spreadsheet([['name', 'surname'], ['John', 'Doe'], ['Johanna', 'Doe']], ['title' => 'Test Spreadsheet']);
         $actual = get_class($spreadsheet);
         $expected = \PhpOffice\PhpSpreadsheet\Spreadsheet::class;
         static::assertEquals($expected, $actual);

--- a/tests/TestCase/Controller/Component/ExportComponentTest.php
+++ b/tests/TestCase/Controller/Component/ExportComponentTest.php
@@ -85,7 +85,7 @@ class ExportComponentTest extends TestCase
     public function formatProvider(): array
     {
         return [
-            '1 A' => [ // array $properties, array $expected
+            '1 A' => [
                 'csv', // format
                 [['Name', 'Surname'], ['John', 'Doe'], ['Anna', 'Doe']], // rows
                 'test.csv', // filename

--- a/tests/TestCase/Controller/Component/ExportComponentTest.php
+++ b/tests/TestCase/Controller/Component/ExportComponentTest.php
@@ -1,0 +1,130 @@
+<?php
+namespace App\Test\TestCase\Controller\Component;
+
+use App\Controller\Component\ExportComponent;
+use Cake\Controller\ComponentRegistry;
+use Cake\TestSuite\TestCase;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+
+/**
+ * Test utility class, to mock some methods
+ */
+class MyExportComponent extends ExportComponent
+{
+    protected $test = null;
+    public function download(Spreadsheet $spreadsheet, string $extension, array $options): void
+    {
+        $this->test = compact('spreadsheet', 'extension', 'options');
+    }
+    public function exit(): void
+    {
+        // do nothing
+    }
+}
+
+/**
+ * {@see \App\Controller\Component\ExportComponent} Test Case
+ *
+ * @coversDefaultClass \App\Controller\Component\ExportComponent
+ */
+class ExportComponentTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \App\Controller\Component\ExportComponent
+     */
+    public $Export;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $registry = new ComponentRegistry();
+        $this->Export = new MyExportComponent($registry);
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->Export);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test `spreadsheet` method
+     *
+     * @covers ::spreadsheet()
+     * @return void
+     */
+    public function testSpreadsheet(): void
+    {
+        $spreadsheet = $this->Export->spreadsheet([], []);
+        $actual = get_class($spreadsheet);
+        $expected = \PhpOffice\PhpSpreadsheet\Spreadsheet::class;
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Provider for `testFormats()`.
+     *
+     * @return array
+     */
+    public function formatsProvider(): array
+    {
+        return [
+            'csv' => [
+                'csv',
+                'text/csv',
+            ],
+            'ods' => [
+                'ods',
+                'application/vnd.oasis.opendocument.spreadsheet',
+            ],
+            'pdf' => [
+                'pdf',
+                'application/pdf',
+            ],
+            'xls' => [
+                'xls',
+                'application/vnd.ms-excel',
+            ],
+            'xlsx' => [
+                'xlsx',
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            ],
+        ];
+    }
+
+    /**
+     * Test `csv`, `ods`, `pdf`, `xls` and `xlsx` method
+     *
+     * @covers ::csv()
+     * @covers ::ods()
+     * @covers ::pdf()
+     * @covers ::xls()
+     * @covers ::xlsx()
+     * @dataProvider formatsProvider()
+     * @return void
+     */
+    public function testFormats(string $method, string $format): void
+    {
+        $spreadsheet = $this->Export->spreadsheet([], []);
+        $filename = sprintf('test.%s', $method);
+        $this->Export->{$method}($spreadsheet, $filename);
+        $options = compact('filename', 'format');
+        $extension = ucfirst($method);
+        $expected = compact('spreadsheet', 'extension', 'options');
+        $actual = $this->Export->test;
+        static::assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
This provides export to csv|ods|xlsx using Phpspreadsheet (https://phpspreadsheet.readthedocs.io/en/latest/).

Available formats can be set in configuration as follows:
```
'Export' => [
    'limit' => 10000,
    'formats' => [
        'CSV' => 'csv',
        'Open Document' => 'ods',
        'MS Excel' => 'xlsx'
    ],
    'default' => 'xlsx'
],
```