### PR TITLE
Use relations count from API and don't preload all related objects

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -150,7 +150,8 @@ class ModulesController extends AppController
         $this->request->allowMethod(['get']);
 
         try {
-            $response = $this->apiClient->getObject($id, $this->objectType);
+            $query = ['count' => 'all'];
+            $response = $this->apiClient->getObject($id, $this->objectType, $query);
         } catch (BEditaClientException $e) {
             // Error! Back to index.
             $this->log($e, LogLevel::ERROR);

--- a/src/Template/Element/Form/relation.twig
+++ b/src/Template/Element/Form/relation.twig
@@ -2,6 +2,7 @@
     :relation-data='{{ relationSchema|json_encode|raw }}'
     :list-view=listView
     relation-name={{ relationName }}
+    :pre-count={{ preCount }}
     config-paginate-sizes={{ config('Pagination.sizeAvailable')|json_encode()|raw }}
     ref="relation"
     @loading="onToggleLoading" @count="onCount">

--- a/src/Template/Element/Form/relations.twig
+++ b/src/Template/Element/Form/relations.twig
@@ -3,7 +3,9 @@
 
     {% for relationName, relationLabel in relations %}
 
-        <property-view inline-template :tab-open="tabsOpen" tab-name="relation_{{ relationName }}" ref={{ relationName }}>
+        {% set preCount = object.relationships[relationName].meta.count|default(-1) %}
+        <property-view inline-template :tab-open="tabsOpen" tab-name="relation_{{ relationName }}"
+            ref={{ relationName }} :pre-count={{ preCount }}>
             <section class="fieldset">
 
                 <header @click.prevent="toggleVisibility()"
@@ -24,6 +26,7 @@
                         'relationName': relationName,
                         'relationSchema': relationsSchema[relationName],
                         'listView': listView,
+                        'preCount': preCount,
                     } %}
                 </div>
 

--- a/src/Template/Layout/js/app/components/property-view/property-view.js
+++ b/src/Template/Layout/js/app/components/property-view/property-view.js
@@ -78,6 +78,7 @@ export default {
     methods: {
         toggleVisibility() {
             this.isOpen = !this.isOpen;
+            this.checkLoadRelated();
             this.updateStorage();
         },
         onToggleLoading(status) {
@@ -120,6 +121,11 @@ export default {
                 tabs.splice(pos, 1);
             }
             localStorage.setItem(STORAGE_TABS_KEY, JSON.stringify(tabs));
+        },
+        checkLoadRelated() {
+            if (this.isOpen && this.$refs.relation) {
+                this.$refs.relation.loadRelatedObjects();
+            }
         },
     }
 }

--- a/src/Template/Layout/js/app/components/property-view/property-view.js
+++ b/src/Template/Layout/js/app/components/property-view/property-view.js
@@ -43,6 +43,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        preCount: {
+            type: Number,
+            default: -1,
+        },
     },
 
     data() {
@@ -60,6 +64,9 @@ export default {
             return;
         }
         this.isOpen = this.checkTabOpen();
+        if (this.preCount >= 0) {
+            this.totalObjects = this.preCount;
+        }
     },
 
     watch: {

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -57,6 +57,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        preCount: {
+            type: Number,
+            default: -1,
+        },
     },
 
     data() {
@@ -434,6 +438,9 @@ export default {
          * @return {Array} objs objects retrieved
          */
         async loadRelatedObjects(filter = {}, force = false) {
+            if (this.preCount === 0) {
+                return [];
+            }
             this.loading = true;
 
             return this.getPaginatedObjects(true, filter)

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -67,7 +67,8 @@ export default {
         return {
             method: 'relatedJson',      // define AppController method to be used
             loading: false,
-            count: 0,                   // count number of related objects, on change triggers an event
+            objectsLoaded: false,       // objects loaded flag
+            positions: {},              // used in children relations
 
             removedRelationsData: [],   // hidden field containing serialized json passed on form submit
             addedRelationsData: [],     // array of serialized new relations
@@ -114,7 +115,10 @@ export default {
         PanelEvents.listen('upload-files:save', this, this.appendRelationsFromPanel);
         PanelEvents.listen('panel:closed', null, this.resetPanelRequester);
 
-        await this.loadOnMounted();
+        // if preCount is '-1' => no object count from API, force load
+        if (this.preCount === -1 || this.$parent.isOpen) {
+            await this.loadOnMounted();
+        }
 
         // check if relation is related to media objects
         if (this.relationTypes && this.relationTypes.right) {
@@ -196,7 +200,7 @@ export default {
          */
         onUpdatePageSize(pageSize) {
             this.setPageSize(pageSize);
-            this.loadRelatedObjects(this.activeFilter);
+            this.loadRelatedObjects(this.activeFilter, true);
         },
 
         /**
@@ -433,12 +437,12 @@ export default {
          * @emits Event#count count objects event
          *
          * @param {Object} filter object containing filters
-         * @param {Boolean} force force recount of related objects
+         * @param {Boolean} force force reload of related objects
          *
          * @return {Array} objs objects retrieved
          */
         async loadRelatedObjects(filter = {}, force = false) {
-            if (this.preCount === 0) {
+            if (this.preCount === 0 || (this.objectsLoaded && !force)) {
                 return [];
             }
             this.loading = true;
@@ -447,13 +451,14 @@ export default {
                 .then((objs) => {
                     this.$emit('count', this.pagination.count);
                     this.loading = false;
+                    this.objectsLoaded = true;
                     return objs;
                 })
                 .catch((error) => {
                     // code 20 is user aborted fetch which is ok
                     if (error.code !== 20) {
                         this.loading = false;
-                        console.error(error);s
+                        console.error(error);
                     }
                 });
         },


### PR DESCRIPTION
In this PR:

 * `count=all` query string added on object view
 * `preCount` prop in `property-view` and `-relation-view` with precalculated count
 * related objects are loaded when the tab is open when created or the first time the tab is opened
 * if `preCount` is 0 related objects are never loaded

Related objects are loaded only when necessary hence the number of API calls has been greatly reduced, 

