### PR TITLE
index pages: striptags and truncate 100 columns values

### DIFF
--- a/src/Template/Element/Modules/index_table_row.twig
+++ b/src/Template/Element/Modules/index_table_row.twig
@@ -26,7 +26,7 @@
                 </div>
             {% else %}
                 <div class="{{ prop }}-cell" untitled-label="{{ __('Untitled') }}">
-                    {{ Schema.format(object.attributes[prop], schema.properties[prop]) }}
+                    {{ Schema.format(object.attributes[prop], schema.properties[prop])|striptags|truncate(100) }}
                 </div>
             {% endif %}
         {% endfor %}


### PR DESCRIPTION
This provides 2 filters on columns in "index" pages:

 - striptags: remove html tags and show only text
 - truncate 100: truncate text to maximum of 100 characters and show `...` at the end

Benefits:

 - in the most part of scenarios this avoids an issue of horizontal space overflow and impossibility to scroll to the right
 - unuseful html tags are not shown