### PR TITLE
view annotations when available

### DIFF
--- a/src/Template/Element/Form/resource_relations.twig
+++ b/src/Template/Element/Form/resource_relations.twig
@@ -13,18 +13,17 @@
                 </h2>
             </header>
 
-            {# TODO: review, commented out, v-show is always false!!! #}
-            {# <div v-show="false" class="tab-container">
+            <div class="tab-container">
                 <resource-relation-view inline-template
                     relation-name={{ resourceName }}
                     ref="relation"
-
                     @loading="onToggleLoading"
                     @count="onCount">
-
-                    <div class="resource-relation-view"></div>
+                    <div class="resource-relation-view">
+                        <div v-for="(note, index) in annotations" :key="index"><: index + 1 :>: <: note.attributes.description :></div>
+                    </div>
                 </resource-relation-view>
-            </div> #}
+            </div>
 
         </section>
     </property-view>

--- a/src/Template/Layout/js/app/components/relation-view/resource-relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/resource-relation-view.js
@@ -6,14 +6,13 @@
  *
  * <relation-view> component used for ModulesPage -> View
  *
- * @property {String} relationName name of the relation used by the PaginatiedContentMixin
+ * @property {String} relationName name of the relation used by the PaginatedContentMixin
 
  * @requires
  *
  */
 
 import { PaginatedContentMixin } from 'app/mixins/paginated-content';
-import sleep from 'sleep-promise';
 
 export default {
     mixins: [
@@ -32,6 +31,7 @@ export default {
             method: 'relatedJson',                      // define AppController method to be used
             loading: false,
             count: 0,                                   // count number of related objects, on change triggers an event
+            annotations: []
         }
     },
 
@@ -96,6 +96,7 @@ export default {
                 .then((objs) => {
                     this.$emit('count', this.pagination.count);
                     this.loading = false;
+                    this.annotations = objs;
                     return objs;
                 })
                 .catch((error) => {


### PR DESCRIPTION
In object view, in a module, annotations are not properly shown (in master branch).
This provides a fix to see:

 - annotations count
 - list of annotations (first 20, no pagination)

Future desired features:

- better css
- pagination
- edit annotation (modify / delete)
- add annotation