### PR TITLE
Draft: filters __remove

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -382,9 +382,17 @@ class AppController extends Controller
         // write request query parameters (if any) in session
         $params = $this->queryParams();
         if (!empty($params)) {
+            if ($params === $session->read($sessionKey)) {
+                return null;
+            }
             $session->write($sessionKey, $params);
+            $query = http_build_query($session->read($sessionKey), null, '&', PHP_QUERY_RFC3986);
 
-            return null;
+            return $this->redirect((string)$this->request->getUri()->withQuery($query));
+        } elseif ($session->read($sessionKey) !== null) {
+            $session->delete($sessionKey);
+
+            return $this->redirect((string)$this->request->getUri()->withQuery(''));
         }
 
         // read request query parameters from session and redirect to proper page

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -28,7 +28,7 @@
     {# status if available #}
     <div class="filter-container radio" v-if="Object.keys(statusFilter).length !== 0">
         <label>
-            <input type="radio" :name="statusFilter.name" value="" v-model="queryFilter.filter['status']">{{ __('All') }}
+            <input type="radio" :name="statusFilter.name" value="__remove" v-model="queryFilter.filter['status']">{{ __('All') }}
         </label>
         <label v-for="s in statusFilter.options">
             <input type="radio" :name="statusFilter.name" :value="s.value" v-model="queryFilter.filter['status']"><: s.text :>
@@ -42,7 +42,7 @@
 
         <span v-if="filter.type === 'select' || filter.type === 'radio'">
             <select v-model="queryFilter.filter[filter.name]" :id="filter.name" class="{{ selectBaseClasses }}">
-                <option value="">
+                <option value="__remove">
                     {{ __('All') }}
                 </option>
                 <option v-for="option in filter.options" v-if="option.text" :name="option.name" :value="option.value">
@@ -53,7 +53,7 @@
 
         <span v-if="filter.type === 'checkbox'">
             <label>
-                <input type="radio" v-model="queryFilter.filter[filter.name]" value="">
+                <input type="radio" v-model="queryFilter.filter[filter.name]" value="__remove">
                 {{ __('Any') }}
             </label>
             <label>

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -748,15 +748,14 @@ class AppControllerTest extends TestCase
      * @return void
      */
     public function testApplySessionFilter(
-            array $requestConfig,
-            string $sessionKey,
-            string $action = null,
-            $sessionValue,
-            $expectedSessionValue,
-            string $expectedHttpStatusCode = null,
-            string $expectedResultType = null
-        ): void
-    {
+        array $requestConfig,
+        string $sessionKey,
+        string $action = null,
+        $sessionValue,
+        $expectedSessionValue,
+        string $expectedHttpStatusCode = null,
+        string $expectedResultType = null
+    ): void {
         // Setup controller for test
         $this->setupController($requestConfig);
 


### PR DESCRIPTION
This provides a way to set "clear filter" values for radios and combos.
I.e.:
```
<select v-model="queryFilter.filter['dummySelect']">
    <option value="__remove">{{ __('All') }}</option>
    <option value="1">{{ __('One')l }}</option>
    <option value="2">{{ __('Two')l }}</option>
    <option value="3">{{ __('Three')l }}</option>
</select>
[...]
<input type="radio" v-model="queryFilter.filter['dummyRadio']"  value="__remove">{{ __('All') }}
<input type="radio" v-model="queryFilter.filter['dummyRadio']" value="1">{{ __('One') }}
<input type="radio" v-model="queryFilter.filter['dummyRadio']" value="2">{{ __('Two') }}
<input type="radio" v-model="queryFilter.filter['dummyRadio']" value="3">{{ __('Three') }}
```
In this example, query filter will be cleared when selecting "All" (no `?filter[dummySelect]` nor `?filter[dummyRadio]`).