### PR TITLE
filter layout on no results

### DIFF
--- a/src/Template/Element/FilterBox/filter_box.twig
+++ b/src/Template/Element/FilterBox/filter_box.twig
@@ -3,9 +3,11 @@
         {% element 'FilterBox/filter_box_common' %}
     </div>
 
+    <div>
     {% if not hidePagination %}
         <div v-if="pagination.count">
             {% element 'FilterBox/filter_box_page_toolbar' %}
         </div>
     {% endif %}
+    </div>
 </div>

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -96,7 +96,9 @@
 </div>
 
 {% if filterActive %}
+<div>
     <p class="is-expanded tag" style="margin-top: 1rem;">
         {{ __('Data is filtered') }}
     </p>
+</div>
 {% endif %}


### PR DESCRIPTION
Actual behaviour: filter layout not well aligned, when search returns no result.

Expected Behavior, provided by this PR: filter layout ok, on no results.