### PR TITLE
Status and modified columns when available, in index

### DIFF
--- a/src/Template/Element/Modules/index_table_header.twig
+++ b/src/Template/Element/Modules/index_table_header.twig
@@ -19,7 +19,7 @@
         <div>{{ __('type') }}</div>
     {% endif %}
 
-    {% if object.attributes.status %}
+    {% if refObject.attributes.status %}
         <div class="narrow {{ Link.sortClass('status') }}">
             {% if Schema.sortable('status') %}
                 <a href="{{ Link.sortUrl('status') }}">{{ __('status') }}</a>
@@ -29,7 +29,7 @@
         </div>
     {% endif %}
 
-    {% if object.meta.modified %}
+    {% if refObject.meta.modified %}
         <div class="{{ Link.sortClass('modified') }}">
             {% if Schema.sortable('modified') %}
                 <a href="{{ Link.sortUrl('modified') }}">{{ __('modified') }}</a>

--- a/src/Template/Element/Modules/index_table_header.twig
+++ b/src/Template/Element/Modules/index_table_header.twig
@@ -19,21 +19,25 @@
         <div>{{ __('type') }}</div>
     {% endif %}
 
-    <div class="narrow {{ Link.sortClass('status') }}">
-        {% if Schema.sortable('status') %}
-            <a href="{{ Link.sortUrl('status') }}">{{ __('status') }}</a>
-        {% else %}
-            {{ __('status') }}
-        {% endif %}
-    </div>
+    {% if object.attributes.status %}
+        <div class="narrow {{ Link.sortClass('status') }}">
+            {% if Schema.sortable('status') %}
+                <a href="{{ Link.sortUrl('status') }}">{{ __('status') }}</a>
+            {% else %}
+                {{ __('status') }}
+            {% endif %}
+        </div>
+    {% endif %}
 
-    <div class="{{ Link.sortClass('modified') }}">
-        {% if Schema.sortable('modified') %}
-            <a href="{{ Link.sortUrl('modified') }}">{{ __('modified') }}</a>
-        {% else %}
-            {{ __('modified') }}
-        {% endif %}
-    </div>
+    {% if object.meta.modified %}
+        <div class="{{ Link.sortClass('modified') }}">
+            {% if Schema.sortable('modified') %}
+                <a href="{{ Link.sortUrl('modified') }}">{{ __('modified') }}</a>
+            {% else %}
+                {{ __('modified') }}
+            {% endif %}
+        </div>
+    {% endif %}
 
     <div class="narrow {{ Link.sortClass('id') }}">
         {% if Schema.sortable('id') %}

--- a/src/Template/Element/Modules/index_table_row.twig
+++ b/src/Template/Element/Modules/index_table_row.twig
@@ -36,9 +36,13 @@
             <div class="type-cell"><span class="tag has-background-module-{{ object.type }}">{{ __(object.type) }}</span></div>
         {% endif %}
 
-        <div class="narrow">{{ __(object.attributes.status) }}</div>
+        {% if object.attributes.status %}
+            <div class="narrow">{{ __(object.attributes.status) }}</div>
+        {% endif %}
 
-        <div class="narrow">{{ Time.format(object.meta.modified, 'd MMM YYYY') }} &nbsp; {{ Time.format(object.meta.modified, 'HH:mm') }}</div>
+        {% if object.meta.modified %}
+            <div class="narrow">{{ Time.format(object.meta.modified, 'd MMM YYYY') }} &nbsp; {{ Time.format(object.meta.modified, 'HH:mm') }}</div>
+        {% endif %}
 
         <div class="narrow">{{ object.id }}</div>
 

--- a/src/Template/Pages/Modules/index.twig
+++ b/src/Template/Pages/Modules/index.twig
@@ -20,7 +20,7 @@
 
             <div class="list-objects">
                 {% if objects %}
-                    {% element 'Modules/index_table_header' { 'object': objects[0] } %}
+                    {% element 'Modules/index_table_header' { 'refObject': objects[0] } %}
                 {% endif %}
 
                 {% for object in objects %}

--- a/src/Template/Pages/Modules/index.twig
+++ b/src/Template/Pages/Modules/index.twig
@@ -20,7 +20,7 @@
 
             <div class="list-objects">
                 {% if objects %}
-                    {% element 'Modules/index_table_header' %}
+                    {% element 'Modules/index_table_header' { 'object': objects[0] } %}
                 {% endif %}
 
                 {% for object in objects %}

--- a/src/Template/Pages/Trash/index.twig
+++ b/src/Template/Pages/Trash/index.twig
@@ -11,7 +11,7 @@
         <div class="module-index">
             <div class="list-objects">
                 {% if objects %}
-                    {% element 'Modules/index_table_header' { 'object': objects[0] } %}
+                    {% element 'Modules/index_table_header' { 'refObject': objects[0] } %}
                 {% endif %}
 
                 {% for object in objects %}

--- a/src/Template/Pages/Trash/index.twig
+++ b/src/Template/Pages/Trash/index.twig
@@ -11,7 +11,7 @@
         <div class="module-index">
             <div class="list-objects">
                 {% if objects %}
-                    {% element 'Modules/index_table_header' %}
+                    {% element 'Modules/index_table_header' { 'object': objects[0] } %}
                 {% endif %}
 
                 {% for object in objects %}


### PR DESCRIPTION
In modules index "status" and "modified" column are shown only when data contain them.

Scenario: custom module could load a list of objects without "attributes.status" and|or "meta.modified": with this fix, that module index would hide columns without relative data.