### PR TITLE
Invert relation call on children `folders`

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -281,7 +281,7 @@ class ModulesController extends AppController
             // save data
             $response = $this->apiClient->save($this->objectType, $requestData);
             $objectId = (string)Hash::get($response, 'data.id');
-            $this->saveRelated($relatedData, $objectId);
+            $this->Modules->saveRelated($objectId, $this->objectType, $relatedData);
         } catch (InternalErrorException | BEditaClientException | UploadException $e) {
             // Error! Back to object view or index.
             $this->log($e, LogLevel::ERROR);
@@ -305,29 +305,6 @@ class ModulesController extends AppController
             'object_type' => $this->objectType,
             'id' => $objectId,
         ]);
-    }
-
-    /**
-     * Save related objects reading from `_api` key in request data.
-     *
-     * @param array $relatedData Related objects data
-     * @param string $id Object ID
-     * @return void
-     */
-    protected function saveRelated(array $relatedData, string $id): void
-    {
-        if (empty($relatedData)) {
-            return;
-        }
-        foreach ($relatedData as $rel) {
-            $method = (string)Hash::get($rel, 'method');
-            $relation = (string)Hash::get($rel, 'relation');
-            $relatedObjects = (array)Hash::get($rel, 'relatedIds');
-            $this->Modules->saveObjects($relatedObjects);
-            if (in_array($method, ['addRelated', 'removeRelated', 'replaceRelated'])) {
-                $this->apiClient->{$method}($id, $this->objectType, $relation, $relatedObjects);
-            }
-        }
     }
 
     /**

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -23,6 +23,7 @@ use BEdita\WebTools\ApiClientProvider;
 use Cake\Controller\Component\AuthComponent;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -1384,5 +1385,128 @@ class ModulesComponentTest extends TestCase
             $expected['id'] = $object['id'];
         }
         static::assertEquals($expected, $object);
+    }
+
+    /**
+     * Data provider for `testSaveRelated`.
+     *
+     * @return array
+     */
+    public function saveRelatedProvider(): array
+    {
+        $dummy = ['id' => 123, 'type' => 'dummies'];
+
+        return [
+            'bad request exception' => [
+                111, // id
+                'dummies', // type
+                [
+                    [
+                        'method' => 'wrongMethod',
+                        'relation' => 'see_also',
+                        'relatedIds' => [$dummy],
+                    ],
+                ], // relatedData
+                new BadRequestException(__('Bad related data method')), // expected
+            ],
+            'addRelated see_also' => [
+                111, // id
+                'dummies', // type
+                [
+                    [
+                        'method' => 'addRelated',
+                        'relation' => 'see_also',
+                        'relatedIds' => [$dummy],
+                    ],
+                ], // relatedData
+                'addRelated', // expected
+            ],
+            'removeRelated see_also' => [
+                111, // id
+                'dummies', // type
+                [
+                    [
+                        'method' => 'removeRelated',
+                        'relation' => 'see_also',
+                        'relatedIds' => [$dummy],
+                    ],
+                ], // relatedData
+                'removeRelated', // expected
+            ],
+            'replaceRelated see_also' => [
+                111, // id
+                'dummies', // type
+                [
+                    [
+                        'method' => 'replaceRelated',
+                        'relation' => 'see_also',
+                        'relatedIds' => [$dummy],
+                    ],
+                ], // relatedData
+                'replaceRelated', // expected
+            ],
+            'folders children not folders' => [
+                111, // id
+                'folders', // type
+                [
+                    [
+                        'method' => 'addRelated',
+                        'relation' => 'children',
+                        'relatedIds' => [$dummy],
+                    ],
+                ], // relatedData
+                'addRelated', // expected
+            ],
+            'folders children folders' => [
+                222, // id
+                'folders', // type
+                [
+                    [
+                        'method' => 'addRelated',
+                        'relation' => 'children',
+                        'relatedIds' => [['id' => 123, 'type' => 'folders']],
+                    ],
+                ], // relatedData
+                'replaceRelated', // expected
+            ],
+        ];
+    }
+
+    /**
+     * Test `saveRelated`
+     *
+     * @param string $id Object ID
+     * @param string $type Object type
+     * @param array $relatedData Related objects data
+     * @param mixed $expected The expected result
+     * @return void
+     * @dataProvider saveRelatedProvider
+     * @covers ::saveRelated()
+     * @covers ::folderChildrenRelated()
+     */
+    public function testSaveRelated(string $id, string $type, array $relatedData, $expected): void
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionCode($expected->getCode());
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+        $actual = 'none';
+        // Setup mock API client.
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://media.example.org'])
+            ->getMock();
+        // $apiClient->method('save')
+        //     ->willReturn(['data' => ['id' => 1]]);
+        $apiClient->method('addRelated')
+            ->will($this->returnCallback(function() use (&$actual) { $actual = 'addRelated'; }));
+        $apiClient->method('removeRelated')
+            ->will($this->returnCallback(function() use (&$actual) { $actual = 'removeRelated'; }));
+        $apiClient->method('replaceRelated')
+            ->will($this->returnCallback(function() use (&$actual) { $actual = 'replaceRelated'; }));
+        ApiClientProvider::setApiClient($apiClient);
+
+        $this->Modules->saveRelated($id, $type, $relatedData);
+        static::assertEquals($expected, $actual);
     }
 }

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1499,11 +1499,17 @@ class ModulesComponentTest extends TestCase
         // $apiClient->method('save')
         //     ->willReturn(['data' => ['id' => 1]]);
         $apiClient->method('addRelated')
-            ->will($this->returnCallback(function() use (&$actual) { $actual = 'addRelated'; }));
+            ->will($this->returnCallback(function () use (&$actual) {
+                $actual = 'addRelated';
+            }));
         $apiClient->method('removeRelated')
-            ->will($this->returnCallback(function() use (&$actual) { $actual = 'removeRelated'; }));
+            ->will($this->returnCallback(function () use (&$actual) {
+                $actual = 'removeRelated';
+            }));
         $apiClient->method('replaceRelated')
-            ->will($this->returnCallback(function() use (&$actual) { $actual = 'replaceRelated'; }));
+            ->will($this->returnCallback(function () use (&$actual) {
+                $actual = 'replaceRelated';
+            }));
         ApiClientProvider::setApiClient($apiClient);
 
         $this->Modules->saveRelated($id, $type, $relatedData);

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1496,8 +1496,6 @@ class ModulesComponentTest extends TestCase
         $apiClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs(['https://media.example.org'])
             ->getMock();
-        // $apiClient->method('save')
-        //     ->willReturn(['data' => ['id' => 1]]);
         $apiClient->method('addRelated')
             ->will($this->returnCallback(function () use (&$actual) {
                 $actual = 'addRelated';

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -965,64 +965,6 @@ class ModulesControllerTest extends TestCase
     }
 
     /**
-     * Test `saveRelated` method
-     *
-     * @covers ::saveRelated()
-     *
-     * @return void
-     */
-    public function testSaveRelated()
-    {
-        $request = new ServerRequest([
-            'environment' => [
-                'REQUEST_METHOD' => 'POST',
-            ],
-            'params' => [
-                'object_type' => 'documents',
-            ],
-        ]);
-        $this->controller = new ModulesControllerSample($request);
-
-        $apiClient = $this->getMockBuilder(BEditaClient::class)
-            ->setConstructorArgs(['https://media.example.org'])
-            ->getMock();
-        $apiClient->method('save')
-            ->willReturn(['data' => ['id' => 1]]);
-        $apiClient->method('addRelated')
-            ->willReturn([]);
-
-        $this->controller->apiClient = $apiClient;
-
-        $result = $this->controller->save();
-        static::assertEquals(302, $result->getStatusCode());
-        static::assertEquals('/documents/view/1', $result->getHeaderLine('Location'));
-
-        $request = new ServerRequest([
-            'environment' => [
-                'REQUEST_METHOD' => 'POST',
-            ],
-            'post' => [
-                '_api' => [
-                    [
-                        'method' => 'addRelated',
-                        'relation' => '',
-                        'relatedIds' => [],
-                    ],
-                ],
-            ],
-            'params' => [
-                'object_type' => 'documents',
-            ],
-        ]);
-        $this->controller = new ModulesControllerSample($request);
-        $this->controller->apiClient = $apiClient;
-
-        $result = $this->controller->save();
-        static::assertEquals(302, $result->getStatusCode());
-        static::assertEquals('/documents/view/1', $result->getHeaderLine('Location'));
-    }
-
-    /**
      * Get test object id
      *
      * @return void


### PR DESCRIPTION
This PR solves a bug when adding a `folder` in a `children` relation of another folder.

In this case the usual `addRelated` call is replaced by a `replaceRelated` on the `parent` relation of the future child folder. 