### PR TITLE
Perms helper

### DIFF
--- a/src/Template/Element/Form/related_item.twig
+++ b/src/Template/Element/Form/related_item.twig
@@ -143,7 +143,7 @@
                 v-html="containsId(removedRelated, related.id)? '{{__('undo remove') }}' : '{{ __('remove') }}'"></a>
 
         {% else %}
-            <a class="button button-outlined-white is-small mr-1" :href="$helpers.buildViewUrl(related.id)" target="_blank">{{ __('Edit') }}</a>
+            <a class="button button-outlined-white is-small mr-1" :href="$helpers.buildViewUrl(related.id)" target="_blank" v-show="moduleAvailable(related.type)">{{ __('Edit') }}</a>
             <a class="button button-text is-small" @click.prevent="relationToggle(related)" :class="containsId(removedRelated, related.id) ? 'icon-cw-2' : 'icon-unlink'"
                 v-html="containsId(removedRelated, related.id) ? '{{__('undo') }}' : '{{ __('remove') }}'">
             </a>

--- a/src/Template/Element/Form/relation.twig
+++ b/src/Template/Element/Form/relation.twig
@@ -73,6 +73,7 @@
 
         </div>
 
+        {% if Perms.canSave() %}
         <div class="mt-5">
             {# DROP FILES #}
             {% set acceptedTypes = uploadable | filter((item) => item in relationSchema.right) | join(', ') %}
@@ -99,6 +100,7 @@
                     })">{{ __('add objects') }}</button>
             </div>
         </div>
+        {% endif %} {# Perms #}
 
         {# End relation custom or default view #}
         {% endif %}

--- a/src/Template/Element/Modules/index_bulk.twig
+++ b/src/Template/Element/Modules/index_bulk.twig
@@ -44,7 +44,7 @@
         {{ Form.end()|raw }}
 
         {# trash #}
-        {% if (objects) and in_array('DELETE', currentModule.hints.allow) %}
+        {% if (objects) and Perms.canDelete() %}
             {{ Form.create(null, {'id': 'form-delete', 'url': {'_name': 'modules:delete', 'object_type': objectType}})|raw }}
                 <input type="hidden" name="ids" v-bind:value="selectedRows">
                 {{ Form.unlockField('ids') }}

--- a/src/Template/Element/Modules/index_table_row.twig
+++ b/src/Template/Element/Modules/index_table_row.twig
@@ -50,7 +50,7 @@
         <div class="buttons-cell narrow">
         {% if isTrash %}
 
-            {% if Perms.canSave() %}
+            {% if Perms.canSave(object.type) %}
                 {{ Form.postButton(__('Restore'),
                     {'_name': 'trash:restore'},
                     {
@@ -61,7 +61,7 @@
                 )|raw }}
             {% endif %}
 
-            {% if Perms.canDelete() %}
+            {% if Perms.canDelete(object.type) %}
                 {{ Form.postButton(__('Delete'),
                     {'_name': 'trash:delete'},
                     {

--- a/src/Template/Element/Modules/index_table_row.twig
+++ b/src/Template/Element/Modules/index_table_row.twig
@@ -10,7 +10,7 @@
 
         <div class="select-cell narrow" @click="selectRow">
             {{ Form.unlockField('oneItem') }}
-            <input type="checkbox" name="oneItem" value="{{ object.id }}" v-model="selectedRows">
+            <input type="checkbox" name="oneItem" value="{{ object.id }}" v-model="selectedRows" {% if not Perms.canRead(object.type) %}disabled="disabled"{% endif %}>
         </div>
 
         <div class="thumb-cell narrow">

--- a/src/Template/Element/Modules/index_table_row.twig
+++ b/src/Template/Element/Modules/index_table_row.twig
@@ -5,7 +5,7 @@
 
 {% set buttonClasses = 'button button-text-white is-width-auto' %}
 
-<a href="{{ Url.build({'_name': routeName, 'object_type': object.type, 'id': object.id}) }}"
+<a {% if Perms.canRead(object.type) %}href="{{ Url.build({'_name': routeName, 'object_type': object.type, 'id': object.id}) }}"{% endif %}
     class="table-row object-status-{{ object.attributes.status }}">
 
         <div class="select-cell narrow" @click="selectRow">
@@ -50,7 +50,7 @@
         <div class="buttons-cell narrow">
         {% if isTrash %}
 
-            {% if in_array('PATCH', currentModule.hints.allow) %}
+            {% if Perms.canSave() %}
                 {{ Form.postButton(__('Restore'),
                     {'_name': 'trash:restore'},
                     {
@@ -61,23 +61,27 @@
                 )|raw }}
             {% endif %}
 
-            {{ Form.postButton(__('Delete'),
-                {'_name': 'trash:delete'},
-                {
-                    'data': {'ids': object.id, 'query': q},
-                    'class': buttonClasses,
-                    'title': __('Permanently delete') ~ ' ' ~ object.attributes.title|escape,
-                    'onclick': confirm,
-                }
-            )|raw }}
+            {% if Perms.canDelete() %}
+                {{ Form.postButton(__('Delete'),
+                    {'_name': 'trash:delete'},
+                    {
+                        'data': {'ids': object.id, 'query': q},
+                        'class': buttonClasses,
+                        'title': __('Permanently delete') ~ ' ' ~ object.attributes.title|escape,
+                        'onclick': confirm,
+                    }
+                )|raw }}
+            {% endif %}
 
         {% else %}
 
+            {% if Perms.canRead(object.type) %}
             <button
                 title="{{ __('Edit') }} {{ object.attributes.title }}"
                 class="{{ buttonClasses }}">{{ __('Edit') }}</button>
+            {% endif %}
 
-            {% if in_array('DELETE', currentModule.hints.allow) %}
+            {% if Perms.canDelete(object.type) %}
                 {{ Form.postButton(__('Trash-verb'),
                     {'_name': 'modules:delete', 'object_type': object.type},
                     {

--- a/src/Template/Element/json_meta_config.ctp
+++ b/src/Template/Element/json_meta_config.ctp
@@ -24,9 +24,7 @@
         'currentModule': <?php if (!empty($currentModule)): ?> <?= json_encode($currentModule, true) ?> <?php else: ?>{ name: 'home' }<?php endif; ?>,
         'template': '<?= $this->template ?>',
         'relations': {},
-        <?php if (!empty($modules)): ?>
-        'modules': <?= json_encode(array_keys((array)$modules), true) ?>,
-        <?php endif; ?>
+        'modules': <?php if (!empty($modules)): ?><?= json_encode(array_keys((array)$modules), true) ?><?php else: ?>[]<?php endif; ?>,
         'plugins': '<?= json_encode(\App\Plugin::loadedAppPlugins()) ?>',
         'locale': locale,
         <?php if (!empty($uploadable)): ?>

--- a/src/Template/Element/json_meta_config.ctp
+++ b/src/Template/Element/json_meta_config.ctp
@@ -24,6 +24,9 @@
         'currentModule': <?php if (!empty($currentModule)): ?> <?= json_encode($currentModule, true) ?> <?php else: ?>{ name: 'home' }<?php endif; ?>,
         'template': '<?= $this->template ?>',
         'relations': {},
+        <?php if (!empty($modules)): ?>
+        'modules': <?= json_encode(array_keys((array)$modules), true) ?>,
+        <?php endif; ?>
         'plugins': '<?= json_encode(\App\Plugin::loadedAppPlugins()) ?>',
         'locale': locale,
         <?php if (!empty($uploadable)): ?>

--- a/src/Template/Element/json_meta_config.ctp
+++ b/src/Template/Element/json_meta_config.ctp
@@ -24,7 +24,7 @@
         'currentModule': <?php if (!empty($currentModule)): ?> <?= json_encode($currentModule, true) ?> <?php else: ?>{ name: 'home' }<?php endif; ?>,
         'template': '<?= $this->template ?>',
         'relations': {},
-        'modules': <?php if (!empty($modules)): ?><?= json_encode(array_keys((array)$modules), true) ?><?php else: ?>[]<?php endif; ?>,
+        'modules': <?= (!empty($modules)) ? json_encode(array_keys((array)$modules), true) : [] ?>,
         'plugins': '<?= json_encode(\App\Plugin::loadedAppPlugins()) ?>',
         'locale': locale,
         <?php if (!empty($uploadable)): ?>

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -721,6 +721,17 @@ export default {
         buildViewUrl(objectType, objectId) {
             return `${window.location.protocol}//${window.location.host}/${objectType}/view/${objectId}`;
         },
+
+        /**
+         * Object type available to view.
+         *
+         * @param {String} type
+         *
+         * @return {Boolean} true if module is available
+         */
+        moduleAvailable(type) {
+            return (BEDITA.modules.indexOf(type) !== -1);
+        },
     }
 
 }

--- a/src/Template/Pages/Modules/index.twig
+++ b/src/Template/Pages/Modules/index.twig
@@ -39,7 +39,7 @@
 
 
         {# commands to append in side bar (commands menu) #}
-        {% if in_array('POST', currentModule.hints.allow) %}
+        {% if Perms.canCreate() %}
             {% do _view.append('module-buttons',
                 Html.link(__('Create new'),
                     {'_name': 'modules:create', 'object_type': objectType},

--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -93,15 +93,17 @@
 
             {# append buttons to sidebar #}
             {# Append "Save" #}
-            {% do _view.append('module-buttons', Form.button( __('Save'),
-                {
-                    'form': 'form-main',
-                    'class': 'button button-primary button-primary-hover-module-' ~ currentModule.name
-                })
-            ) %}
+            {% if Perms.canSave() %}
+                {% do _view.append('module-buttons', Form.button( __('Save'),
+                    {
+                        'form': 'form-main',
+                        'class': 'button button-primary button-primary-hover-module-' ~ currentModule.name
+                    })
+                ) %}
+            {% endif %}
 
             {# Append "Clone" #}
-            {% if object.id %}
+            {% if object.id and Perms.canCreate() %}
                 {% do _view.append('module-buttons', Html.link(
                     __('Clone'),
                     {'_name': 'modules:clone', 'object_type': objectType, 'id': object.id},
@@ -110,13 +112,15 @@
             {% endif %}
 
             {# Append "Trash (move to)" #}
-            {% do _view.append('module-buttons',
-                Form.postButton(
-                    __('Trash-verb'),
-                    {'_name': 'modules:delete', 'object_type': objectType},
-                    {'data': {'id': object.id}, 'class': 'button button-outlined button-outlined-hover-module-' ~ currentModule.name }
-                )
-            ) %}
+            {% if Perms.canDelete() %}
+                {% do _view.append('module-buttons',
+                    Form.postButton(
+                        __('Trash-verb'),
+                        {'_name': 'modules:delete', 'object_type': objectType},
+                        {'data': {'id': object.id}, 'class': 'button button-outlined button-outlined-hover-module-' ~ currentModule.name }
+                    )
+                ) %}
+            {% endif %}
 
             {# Append "Prev" and "Next" #}
             {% if object.id and objectNav %}

--- a/src/Template/Pages/Trash/index.twig
+++ b/src/Template/Pages/Trash/index.twig
@@ -27,14 +27,14 @@
                     <p>{{ __('Actions on selected items') }}</p>
                 </header>
                 <nav>
-                    {% if (objects) and in_array('PATCH', currentModule.hints.allow) %}
+                    {% if (objects) and Perms.canSave() %}
                         {{ Form.create(null, {'id': 'form-restore', 'url': {'_name': 'trash:restore', 'object_type': objectType}})|raw }}
                             <input type="hidden" name="ids" v-bind:value="selectedRows">
                             {{ Form.unlockField('ids') }}
                             <button @click.prevent="restoreItem" :disabled="!selectedRows.length">{{ __('Restore') }}</button>
                         {{ Form.end()|raw }}
                     {% endif %}
-                    {% if (objects) and in_array('DELETE', currentModule.hints.allow) %}
+                    {% if (objects) and Perms.canDelete() %}
                         {{ Form.create(null, {'id': 'form-delete', 'url': {'_name': 'trash:delete', 'object_type': objectType}})|raw }}
                             <input type="hidden" name="ids" v-bind:value="selectedRows">
                             {{ Form.unlockField('ids') }}

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -44,6 +44,7 @@ class AppView extends TwigView
         $this->loadHelper('Link');
         $this->loadHelper('Property');
         $this->loadHelper('Time', ['outputTimezone' => Configure::read('I18n.timezone', 'UTC')]);
+        $this->loadHelper('Perms');
         $this->loadHelper('Schema');
         $this->loadHelper('Text');
         $this->loadHelper('BEdita/WebTools.Thumb');

--- a/src/View/Helper/PermsHelper.php
+++ b/src/View/Helper/PermsHelper.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\View\Helper;
+
+use Cake\Utility\Hash;
+use Cake\View\Helper;
+
+/**
+ * Helper class to handle permissions on modules.
+ *
+ */
+class PermsHelper extends Helper
+{
+    /**
+     * API methods allowed in current module
+     *
+     * @var array
+     */
+    protected $current = [];
+
+    /**
+     * API methods allowed in all modules
+     *
+     * @var array
+     */
+    protected $allowed = [];
+
+    /**
+     * {@inheritDoc}
+     *
+     * Init API and WebAPP base URL
+     *
+     * @return  void
+     */
+    public function initialize(array $config): void
+    {
+        $modules = (array)$this->_View->get('modules');
+        $this->allowed = Hash::combine($modules, '{s}.name', '{s}.hints.allow');
+        $currentModule = (array)$this->_View->get('currentModule');
+        $this->current = (array)Hash::get($currentModule, 'hints.allow');
+    }
+
+    /**
+     * Check create permission.
+     *
+     * @param string $module Module name
+     * @return bool
+     */
+    public function canCreate(string $module = null): bool
+    {
+        return $this->isAllowed('POST', $module);
+    }
+
+    /**
+     * Check delete permission.
+     *
+     * @param string $module Module name
+     * @return bool
+     */
+    public function canDelete(string $module = null): bool
+    {
+        return $this->isAllowed('DELETE', $module);
+    }
+
+    /**
+     * Check save permission.
+     *
+     * @param string $module Module name
+     * @return bool
+     */
+    public function canSave(string $module = null): bool
+    {
+        return $this->isAllowed('PATCH', $module);
+    }
+
+    /**
+     * Check read permission.
+     *
+     * @param string $module Module name
+     * @return bool
+     */
+    public function canRead(string $module = null): bool
+    {
+        return $this->isAllowed('GET', $module);
+    }
+
+    /**
+     * Check if a method is allowed on a module.
+     *
+     * @param string $method Method to check
+     * @param string $module Module name, if missing or null current module is used.
+     * @return bool
+     */
+    protected function isAllowed(string $method, string $module = null): bool
+    {
+        if (empty($module)) {
+            if (empty($this->current)) {
+                return true;
+            }
+
+            return in_array($method, $this->current);
+        }
+
+        $allowed = (array)Hash::get($this->allowed, $module);
+
+        return in_array($method, $allowed);
+    }
+}

--- a/tests/TestCase/View/Helper/PermsHelperTest.php
+++ b/tests/TestCase/View/Helper/PermsHelperTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\PermsHelper;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+/**
+ * {@see \App\View\Helper\ArrayHelper} Test Case
+ *
+ * @coversDefaultClass \App\View\Helper\PermsHelper
+ */
+class PermsHelperTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \App\View\Helper\PermsHelper
+     */
+    public $Perms;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp(): void
+    {
+        $view = new View(null, null, null, []);
+        $view->set('modules', [
+            'documents' => [
+                'name' => 'documents',
+                'hints' => ['allow' => ['GET', 'POST', 'PATCH', 'DELETE']],
+            ],
+            'profiles' => [
+                'name' => 'profiles',
+                'hints' => ['allow' => ['GET']],
+            ],
+        ]);
+        $view->set('currentModule', [
+            'name' => 'profiles',
+            'hints' => ['allow' => ['GET']],
+        ]);
+        $this->Perms = new PermsHelper($view);
+        $this->Perms->initialize([]);
+    }
+
+    /**
+     * Data provider for `testIsAllowed` test case
+     *
+     * @return array
+     */
+    public function isAllowedProvider(): array
+    {
+        return [
+            [
+                false,
+                'canDelete',
+            ],
+            [
+                true,
+                'canRead',
+            ],
+            [
+                true,
+                'canCreate',
+                'documents',
+            ],
+            [
+                false,
+                'canSave',
+                'events',
+            ],
+        ];
+    }
+
+    /**
+     * Test main `isAllowed` method logic
+     *
+     * @param bool $expected Expected result
+     * @param string $method Helper method
+     * @param string $module Mdule tested
+     * @return void
+     *
+     * @dataProvider isAllowedProvider()
+     * @covers ::isAllowed()
+     * @covers ::initialize()
+     */
+    public function testIsAllowed(bool $expected, string $method, string $module = null): void
+    {
+        $result = $this->Perms->{$method}($module);
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test `isAllowed` method with no current module perms.
+     *
+     * @return void
+     * @covers ::isAllowed()
+     */
+    public function testIsAllowedNoCurrent(): void
+    {
+        $this->Perms->getView()->set('currentModule', null);
+        $this->Perms->initialize([]);
+        $result = $this->Perms->canSave();
+        static::assertTrue($result);
+    }
+
+    /**
+     * Test `canCreate` method
+     *
+     * @return void
+     */
+    public function testCanCreate(): void
+    {
+        $result = $this->Perms->canCreate();
+        static::assertFalse($result);
+    }
+
+    /**
+     * Test `canRead` method
+     *
+     * @return void
+     */
+    public function testCanRead(): void
+    {
+        $result = $this->Perms->canRead();
+        static::assertTrue($result);
+    }
+
+    /**
+     * Test `canSave` method
+     *
+     * @return void
+     */
+    public function testCanSave(): void
+    {
+        $result = $this->Perms->canSave();
+        static::assertFalse($result);
+    }
+    /**
+     * Test `canDelete` method
+     *
+     * @return void
+     */
+    public function testCanDelete(): void
+    {
+        $result = $this->Perms->canDelete();
+        static::assertFalse($result);
+    }
+}

--- a/tests/TestCase/View/Helper/PermsHelperTest.php
+++ b/tests/TestCase/View/Helper/PermsHelperTest.php
@@ -89,7 +89,7 @@ class PermsHelperTest extends TestCase
      *
      * @param bool $expected Expected result
      * @param string $method Helper method
-     * @param string $module Mdule tested
+     * @param string $module Module tested
      * @return void
      *
      * @dataProvider isAllowedProvider()

--- a/tests/TestCase/View/Helper/PermsHelperTest.php
+++ b/tests/TestCase/View/Helper/PermsHelperTest.php
@@ -148,6 +148,7 @@ class PermsHelperTest extends TestCase
         $result = $this->Perms->canSave();
         static::assertFalse($result);
     }
+
     /**
      * Test `canDelete` method
      *


### PR DESCRIPTION
This PR introduces a new `PermsHelper` to hide or show controls or link depending on module permissions.
A set of methods like `canRead()` or `canSave()` may be used in twig views to hide or show edit or save buttons or view links for an object type or generic module.

Related objects cases and `delete` cases are now correctly handled.
