### PR TITLE
Add scroll with new `table-container` class

### DIFF
--- a/src/Template/Layout/styles/_elements.scss
+++ b/src/Template/Layout/styles/_elements.scss
@@ -247,6 +247,11 @@ nav.pagination {
     margin: 1.5rem 0;
 }
 
+// overflow tables
+.table-container {
+    width: 100%;
+    overflow-x: auto;
+}
 
 // drop and upload
 .drop-area {

--- a/src/Template/Layout/styles/_layout.scss
+++ b/src/Template/Layout/styles/_layout.scss
@@ -31,7 +31,7 @@ main.layout {
     > .layout-footer { padding: $gutter 0; }
 
     > .layout-sidebar, > .layout-footer { max-width: 100%; overflow-x: hidden; }
-    > .layout-content { max-width: 100%; }
+    > .layout-content { max-width: 100%; overflow-x: hidden; }
 }
 
 

--- a/src/Template/Pages/Modules/index.twig
+++ b/src/Template/Pages/Modules/index.twig
@@ -18,6 +18,8 @@
 
         {% else %}
 
+        <div class="table-container">
+
             <div class="list-objects">
                 {% if objects %}
                     {% element 'Modules/index_table_header' { 'refObject': objects[0] } %}
@@ -29,6 +31,7 @@
                     {{ __('No items found') }}
                 {% endfor %}
             </div>
+        </div>
 
             {# bulk actions #}
             {% if objects %}

--- a/src/Template/Pages/Trash/index.twig
+++ b/src/Template/Pages/Trash/index.twig
@@ -9,6 +9,9 @@
 <trash-index inline-template ids='{{ ids|json_encode }}'>
     <div>
         <div class="module-index">
+
+          <div class="table-container">
+
             <div class="list-objects">
                 {% if objects %}
                     {% element 'Modules/index_table_header' { 'refObject': objects[0] } %}
@@ -20,6 +23,8 @@
                     {{ __('No items found') }}
                 {% endfor %}
             </div>
+
+          </div>
 
             {% if objects %}
             <div class="bulk-actions has-border-module-{{ currentModule.name }}">


### PR DESCRIPTION
This PR fixes #456 - temporary solution, could be improved. 

An horizontal scrollbar is displayed when objects index is too long for the current resolution.
