### PR TITLE
Handle `date_ranges` sort

### DIFF
--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -206,6 +206,10 @@ class SchemaHelper extends Helper
      */
     public function sortable(string $field): bool
     {
+        // exception 'date_ranges' default sortable
+        if ($field === 'date_ranges') {
+            return true;
+        }
         $schema = (array)$this->_View->get('schema');
         $schema = Hash::get($schema, sprintf('properties.%s', $field), []);
 

--- a/tests/TestCase/View/Helper/LinkHelperTest.php
+++ b/tests/TestCase/View/Helper/LinkHelperTest.php
@@ -108,6 +108,12 @@ class LinkHelperTest extends TestCase
                 true, // reset page
                 'http://localhost/?page=1&sort=title', // expected
             ],
+            'date ranges' => [
+                $request->withQueryParams(['page' => 1]), // request
+                'date_ranges', // field
+                false, // reset page
+                'http://localhost/?page=1&sort=date_ranges_min_start_date', // expected
+            ],
         ];
     }
 
@@ -121,6 +127,8 @@ class LinkHelperTest extends TestCase
      * @return void
      * @dataProvider sortUrlProvider()
      * @covers ::sortUrl
+     * @covers ::sortValue
+     * @covers ::sortField
      * @covers ::replaceQueryParams
      */
     public function testSortUrl(ServerRequest $request, string $field, bool $resetPage, string $expected): void

--- a/tests/TestCase/View/Helper/LinkHelperTest.php
+++ b/tests/TestCase/View/Helper/LinkHelperTest.php
@@ -108,6 +108,12 @@ class LinkHelperTest extends TestCase
                 true, // reset page
                 'http://localhost/?page=1&sort=title', // expected
             ],
+            'revert sort' => [
+                $request->withQueryParams(['sort' => 'title']), // request
+                'title', // field
+                false, // reset page
+                'http://localhost/?sort=-title', // expected
+            ],
             'date ranges' => [
                 $request->withQueryParams(['page' => 1]), // request
                 'date_ranges', // field

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -654,6 +654,11 @@ class SchemaHelperTest extends TestCase
                 ['oneOf' => [['type' => 'null'], ['type' => 'object']]],
                 false,
             ],
+            'date_ranges' => [
+                'date_ranges',
+                [],
+                true,
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR introduces sort actions on `date_ranges` fields in objects index using special sort field `date_ranges_min_start_date` added to BEdita API in bedita/bedita#1759 