### PR TITLE
Review `json_meta_config`

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -28,7 +28,7 @@ class Plugin extends CakePlugin
      *
      * @return array
      */
-    public static function loadedAppPlugins()
+    public static function loadedAppPlugins(): array
     {
         $sysPlugins = ['Bake', 'DebugKit', 'BEdita/WebTools', 'BEdita/I18n', 'Migrations', 'WyriHaximus/TwigView'];
 

--- a/src/Template/Element/json_meta_config.ctp
+++ b/src/Template/Element/json_meta_config.ctp
@@ -5,19 +5,30 @@
     } elseif (!empty($this->request->getData('_csrfToken'))) {
         $csrfToken = json_encode($this->request->getData('_csrfToken'));
     }
+    if (!isset($modules)) {
+        $modules = [];
+    }
+    if (!isset($uploadable)) {
+        $uploadable = [];
+    }
+    if (!isset($currentModule)) {
+        $currentModule = ['name' => 'home'];
+    }
+
+    $conf = [
+        'base' => \Cake\Routing\Router::fullBaseUrl(),
+        'currentModule' => $currentModule,
+        'template' => $this->template,
+        'modules' => array_keys($modules),
+        'plugins' => \App\Plugin::loadedAppPlugins(),
+        'uploadable' => $uploadable,
+        'locale' => \Cake\I18n\I18n::getLocale(),
+        'csrfToken' => $csrfToken,
+    ];
 ?>
 
 <script type="text/javascript">
 
-    const BEDITA = {
-        'base': '<?= \Cake\Routing\Router::fullBaseUrl() ?>',
-        'currentModule': <?= !empty($currentModule) ? json_encode($currentModule, true) : '{ name: "home" }' ?>,
-        'template': '<?= $this->template ?>',
-        'modules': <?= !empty($modules) ? json_encode(array_keys((array)$modules), true) : '[]' ?>,
-        'plugins': <?= json_encode(\App\Plugin::loadedAppPlugins()) ?>,
-        'locale': '<?= \Cake\I18n\I18n::getLocale() ?>',
-        'uploadable': <?= !empty($uploadable) ? json_encode((array)$uploadable, true) : '[]' ?>,
-        'csrfToken': <?= $csrfToken ?>
-    };
+    const BEDITA = <?= json_encode($conf) ?>;
 
 </script>

--- a/src/Template/Element/json_meta_config.ctp
+++ b/src/Template/Element/json_meta_config.ctp
@@ -5,43 +5,24 @@
     } elseif (!empty($this->request->getData('_csrfToken'))) {
         $csrfToken = json_encode($this->request->getData('_csrfToken'));
     }
+    $lang = \Cake\Core\Configure::read('I18n.lang', 'en');
 ?>
 
-<meta name="BEDITA.currLang" content="eng" />
-<meta name="BEDITA.currLang2" content="en" />
+<meta name="BEDITA.currLang" content="<?= $lang ?>" />
 <meta name="BEdita.base" content="<?= \Cake\Routing\Router::fullBaseUrl() ?>" />
 
 <script type="text/javascript">
 
-    var locale = '<?= \Cake\I18n\I18n::getLocale() ?>';
-
-    // global JSON BEDITA config
-    var BEDITA = {
-        'currLang': 'eng',
-        'currLang2': 'en',
+    const BEDITA = {
+        'currLang': '<?= $lang ?>',
         'base': '<?= \Cake\Routing\Router::fullBaseUrl() ?>',
-        <?php if (!empty($object['id'])): ?>'id': <?= $object['id'] ?>,<?php endif; ?>
-        'currentModule': <?php if (!empty($currentModule)): ?> <?= json_encode($currentModule, true) ?> <?php else: ?>{ name: 'home' }<?php endif; ?>,
+        'currentModule': <?= !empty($currentModule) ? json_encode($currentModule, true) : '{ name: "home" }' ?>,
         'template': '<?= $this->template ?>',
-        'relations': {},
-        'modules': <?= (!empty($modules)) ? json_encode(array_keys((array)$modules), true) : [] ?>,
+        'modules': <?= !empty($modules) ? json_encode(array_keys((array)$modules), true) : '[]' ?>,
         'plugins': <?= json_encode(\App\Plugin::loadedAppPlugins()) ?>,
-        'locale': locale,
-        <?php if (!empty($uploadable)): ?>
-        // types having files to upload
-        'uploadable': <?= json_encode((array)$uploadable, true) ?>,
-        <?php endif; ?>
+        'locale': '<?= \Cake\I18n\I18n::getLocale() ?>',
+        'uploadable': <?= !empty($uploadable) ? json_encode((array)$uploadable, true) : '[]' ?>,
         'csrfToken': <?= $csrfToken ?>
     };
-
-    if (BEDITA.plugins) {
-        try {
-            BEDITA.plugins = JSON.parse(BEDITA.plugins);
-        } catch(e) {
-            console.err(e);
-        }
-    } else {
-        BEDITA.plugins = [];
-    }
 
 </script>

--- a/src/Template/Element/json_meta_config.ctp
+++ b/src/Template/Element/json_meta_config.ctp
@@ -5,16 +5,11 @@
     } elseif (!empty($this->request->getData('_csrfToken'))) {
         $csrfToken = json_encode($this->request->getData('_csrfToken'));
     }
-    $lang = \Cake\Core\Configure::read('I18n.lang', 'en');
 ?>
-
-<meta name="BEDITA.currLang" content="<?= $lang ?>" />
-<meta name="BEdita.base" content="<?= \Cake\Routing\Router::fullBaseUrl() ?>" />
 
 <script type="text/javascript">
 
     const BEDITA = {
-        'currLang': '<?= $lang ?>',
         'base': '<?= \Cake\Routing\Router::fullBaseUrl() ?>',
         'currentModule': <?= !empty($currentModule) ? json_encode($currentModule, true) : '{ name: "home" }' ?>,
         'template': '<?= $this->template ?>',

--- a/src/Template/Element/json_meta_config.ctp
+++ b/src/Template/Element/json_meta_config.ctp
@@ -25,7 +25,7 @@
         'template': '<?= $this->template ?>',
         'relations': {},
         'modules': <?= (!empty($modules)) ? json_encode(array_keys((array)$modules), true) : [] ?>,
-        'plugins': '<?= json_encode(\App\Plugin::loadedAppPlugins()) ?>',
+        'plugins': <?= json_encode(\App\Plugin::loadedAppPlugins()) ?>,
         'locale': locale,
         <?php if (!empty($uploadable)): ?>
         // types having files to upload

--- a/src/Template/Layout/default.twig
+++ b/src/Template/Layout/default.twig
@@ -11,7 +11,7 @@
 BEdita 4 ~ @ 2018 from ChannelWeb & Chialab with love
 -->
 
-<html>
+<html lang="{{ config('I18n.lang', 'en')}}">
 <head>
     {{ Html.charset()|raw }}
     {% element 'meta' %}


### PR DESCRIPTION
In this PR a refactor and cleanup of `json_meta_config` template has been done.

* some elements inherited from BEdita3 apparently not used now have been removed (ma be reintroduced later, if needed)
* BEDITA object definition done in PHP, more readable 

Elements removed:

1. unused tags
```html
<meta name="BEDITA.currLang" content="eng" />	    
<meta name="BEDITA.currLang2" content="en" />	       
<meta name="BEdita.base" content="<?= \Cake\Routing\Router::fullBaseUrl() ?>" />
```

2. unused `BEDITA` attributes

- currLang	
- currLang2
- id
- relations
 