### PR TITLE
Avoid empty password always

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -160,7 +160,7 @@ class AppController extends Controller
     {
         $data = (array)$this->request->getData();
 
-        $this->specialAttributes($type, $data);
+        $this->specialAttributes($data);
         $this->setupParentsRelation($type, $data);
         $this->prepareRelations($data);
         $this->changedAttributes($data);
@@ -176,14 +176,13 @@ class AppController extends Controller
     /**
      * Setup special attributes to be saved.
      *
-     * @param string $type Object or resource type
      * @param array $data Request data
      * @return void
      */
-    protected function specialAttributes(string $type, array &$data): void
+    protected function specialAttributes(array &$data): void
     {
-        // when saving users, if password is empty, unset it
-        if ($type === 'users' && array_key_exists('password', $data) && empty($data['password'])) {
+        // if password is empty, unset it
+        if (array_key_exists('password', $data) && empty($data['password'])) {
             unset($data['password']);
             unset($data['confirm-password']);
         }

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -339,6 +339,18 @@ class AppControllerTest extends TestCase
                     'confirm-password' => '',
                 ],
             ],
+            'supporters' => [
+                'supporters',
+                [
+                    'id' => '9',
+                    'username' => 'gustavo'
+                ],
+                [
+                    'id' => '9',
+                    'username' => 'gustavo',
+                    'password' => '',
+                ],
+            ],
             'date ranges' => [ // test date_ranges array
                 'events', // object_type
                 [ // expected

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -343,7 +343,7 @@ class AppControllerTest extends TestCase
                 'supporters',
                 [
                     'id' => '9',
-                    'username' => 'gustavo'
+                    'username' => 'gustavo',
                 ],
                 [
                     'id' => '9',


### PR DESCRIPTION
This PR avoids empty `password` save when we are using object types != `users` but having `users` attributes like `username`, `password`. 
Typical use case: object types that are siblings of `users`
