### PR TITLE
ExportController refactor: new methods + simpler fields extraction

### DIFF
--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -96,7 +96,7 @@ class ExportController extends AppController
             return $this->rowsAll($objectType);
         }
 
-        $response = $this->apiClient->get($this->apiUrl(), ['filter' => ['id' => $ids]]);
+        $response = $this->apiClient->get($this->apiPath(), ['filter' => ['id' => $ids]]);
         $fields = $this->getFieldNames($response);
         $data = [$fields];
         $this->fillDataFromResponse($data, $response, $fields);
@@ -105,11 +105,11 @@ class ExportController extends AppController
     }
 
     /**
-     * Get API Url
+     * Get API path.
      *
      * @return string
      */
-    protected function apiUrl(): string
+    protected function apiPath(): string
     {
         return sprintf('/%s', $this->request->getData('objectType'));
     }
@@ -128,7 +128,7 @@ class ExportController extends AppController
         $total = 0;
         $query = ['page_size' => self::DEFAULT_PAGE_SIZE] + $this->prepareQuery();
         while ($total < $limit && $page <= $pageCount) {
-            $response = (array)$this->apiClient->get($this->apiUrl(), $query + compact('page'));
+            $response = (array)$this->apiClient->get($this->apiPath(), $query + compact('page'));
             $pageCount = (int)Hash::get($response, 'meta.pagination.page_count');
             $total += (int)Hash::get($response, 'meta.pagination.page_items');
             $page++;

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -70,7 +70,7 @@ class ExportController extends AppController
         $rows = $this->rows($data['objectType'], $ids);
 
         // create spreadsheet and return as download
-        $filename = sprintf('%s_%s.%s', $data['objectType'], date('Ymd-His'), $format);
+        $filename = $this->getFileName($data['objectType'], $format);
         $data = $this->Export->format($format, $rows, $filename);
 
         // output
@@ -115,6 +115,18 @@ class ExportController extends AppController
     }
 
     /**
+     * Get exported file name.
+     *
+     * @param string $type Object or resource type.
+     * @param string $format The format.
+     * @return string
+     */
+    protected function getFileName(string $type, string $format): string
+    {
+        return sprintf('%s_%s.%s', $type, date('Ymd-His'), $format);
+    }
+
+    /**
      * Load all data for a given type using limit and query filters.
      *
      * @param string $objectType Object type
@@ -131,14 +143,14 @@ class ExportController extends AppController
             $response = (array)$this->apiClient->get($this->apiPath(), $query + compact('page'));
             $pageCount = (int)Hash::get($response, 'meta.pagination.page_count');
             $total += (int)Hash::get($response, 'meta.pagination.page_items');
-            $page++;
 
-            if (empty($fields)) {
+            if ($page === 1) {
                 $fields = $this->getFieldNames($response);
                 $data = [$fields];
             }
 
             $this->fillDataFromResponse($data, $response, $fields);
+            $page++;
         }
 
         return $data;

--- a/tests/TestCase/Controller/ExportControllerTest.php
+++ b/tests/TestCase/Controller/ExportControllerTest.php
@@ -18,6 +18,7 @@ use BEdita\SDK\BEditaClient;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * {@see \App\Controller\ExportController} Test Case
@@ -103,6 +104,7 @@ class ExportControllerTest extends TestCase
      * test 'export'.
      *
      * @covers ::export()
+     * @covers ::getFileName()
      *
      * @return void
      */
@@ -147,6 +149,11 @@ class ExportControllerTest extends TestCase
         $content = $response->getBody()->__toString();
         static::assertInstanceOf('Cake\Http\Response', $response);
         static::assertEquals($expected, $content);
+        // check 'Content-Disposition' header containing filename
+        $download = $response->getHeader('Content-Disposition');
+        $download = (string)Hash::get($download, '0');
+        static::assertEquals('attachment; filename="users_', substr($download, 0, 28));
+        static::assertEquals('.csv"', substr($download, strlen($download) - 5));
     }
 
     /**

--- a/tests/TestCase/Controller/ExportControllerTest.php
+++ b/tests/TestCase/Controller/ExportControllerTest.php
@@ -50,12 +50,12 @@ class ExportControllerTest extends TestCase
             'gustavo' => [
                 'id' => 999,
                 'attributes' => ['name' => 'gustavo', 'skills' => ['smart', 'rich', 'beautiful']],
-                'meta' => ['category' => 'developer'],
+                'meta' => ['category' => 'developer', 'extra' => ['prop' => 2]],
             ],
             'johndoe' => [
                 'id' => 888,
                 'attributes' => ['name' => 'john doe', 'skills' => ['humble', 'poor', 'ugly']],
-                'meta' => ['category' => 'poet'],
+                'meta' => ['category' => 'poet', 'extra' => ['prop' => null]],
             ],
         ],
         'expected' => [
@@ -64,12 +64,14 @@ class ExportControllerTest extends TestCase
                 'name' => 'gustavo',
                 'skills' => '["smart","rich","beautiful"]',
                 'category' => 'developer',
+                'prop' => 2,
             ],
             'johndoe' => [
                 'id' => 888,
                 'name' => 'john doe',
                 'skills' => '["humble","poor","ugly"]',
                 'category' => 'poet',
+                'prop' => null,
             ],
         ],
     ];
@@ -135,9 +137,9 @@ class ExportControllerTest extends TestCase
         $this->Export->apiClient = $apiClient;
 
         // expected csv.
-        $fields = '"id","name","skills","category"';
-        $row1 = '"999","gustavo","[""smart"",""rich"",""beautiful""]","developer"';
-        $row2 = '"888","john doe","[""humble"",""poor"",""ugly""]","poet"';
+        $fields = '"id","name","skills","category","prop"';
+        $row1 = '"999","gustavo","[""smart"",""rich"",""beautiful""]","developer","2"';
+        $row2 = '"888","john doe","[""humble"",""poor"",""ugly""]","poet",""';
         $expected = sprintf('%s%s%s%s%s%s', $fields, "\n", $row1, "\n", $row2, "\n");
 
         // call export.
@@ -157,7 +159,7 @@ class ExportControllerTest extends TestCase
         return [
             'documents, all' => [
                 [
-                    ['id', 'name', 'skills', 'category'],
+                    ['id', 'name', 'skills', 'category', 'prop'],
                     $this->testdata['expected']['gustavo'],
                     $this->testdata['expected']['johndoe'],
                 ],
@@ -179,7 +181,7 @@ class ExportControllerTest extends TestCase
             ],
             'documents with ids' => [
                 [
-                    ['id', 'name', 'skills', 'category'],
+                    ['id', 'name', 'skills', 'category', 'prop'],
                     $this->testdata['expected']['gustavo'],
                 ],
                 [
@@ -200,7 +202,7 @@ class ExportControllerTest extends TestCase
             ],
             'query' => [
                 [
-                    ['id', 'name', 'skills', 'category'],
+                    ['id', 'name', 'skills', 'category', 'prop'],
                     $this->testdata['expected']['gustavo'],
                 ],
                 [
@@ -289,7 +291,7 @@ class ExportControllerTest extends TestCase
             ],
             'some data' => [
                 [
-                    'fields' => ['id', 'name', 'skills', 'category'],
+                    'fields' => ['id', 'name', 'skills', 'category', 'prop'],
                     'response' => [
                         'data' => [
                             0 => $this->testdata['input']['gustavo'],
@@ -321,7 +323,7 @@ class ExportControllerTest extends TestCase
         $method->setAccessible(true);
         extract($input); // => $fields, $response
         $data = [];
-        $actual = $method->invokeArgs($this->Export, [&$data, $response, $fields]);
+        $method->invokeArgs($this->Export, [&$data, $response, $fields]);
         static::assertEquals($expected, $data);
     }
 
@@ -344,6 +346,7 @@ class ExportControllerTest extends TestCase
                     'name',
                     'skills',
                     'category',
+                    'prop',
                 ], // expected
             ],
             'full data by custom key' => [
@@ -417,6 +420,7 @@ class ExportControllerTest extends TestCase
                         'name',
                         'category',
                         'skills',
+                        'prop',
                     ],
                 ], // input
                 [
@@ -424,6 +428,7 @@ class ExportControllerTest extends TestCase
                     'name' => 'gustavo',
                     'category' => 'developer',
                     'skills' => '["smart","rich","beautiful"]',
+                    'prop' => 2,
                 ], // expected
             ],
         ];


### PR DESCRIPTION
In this PR `ExportController` class has been refactored allowing e better extensibility via plugins to modify some behaviors. 

* some methods moved from `private` to `protected` visibility
* `apiPath()` and `getFileName()` methods that can be overridden to modify API path and exported file name
* simpler extraction logic: all properties in `attributes`, `meta` and `meta.extra` (if any) will be extracted as default 
* new `getFieldNames()` method to extract field names only
* `fillDataFromResponse()` will just insert new rows without extracting field names
* unit tests have been changed accordingly
 