### PR TITLE
Date, default hours 12

### DIFF
--- a/src/Template/Element/Form/calendar.twig
+++ b/src/Template/Element/Form/calendar.twig
@@ -21,7 +21,7 @@
                                     :name="`date_ranges[${index}][start_date]`"
                                     v-model="dateRange.start_date"
                                     @change="onDateChanged(dateRange, $event)"
-                                    v-datepicker="true" date="true" :time="!dateRange.params.all_day"
+                                    v-datepicker="true" date="true" :time="!dateRange.params.all_day" daterange="true"
                                 />
                             </div>
                         </div>
@@ -32,7 +32,7 @@
                                     :name="`date_ranges[${index}][end_date]`"
                                     v-model="dateRange.end_date"
                                     @change="onDateChanged(dateRange, $event)"
-                                    v-datepicker="true" date="true" :time="!dateRange.params.all_day"
+                                    v-datepicker="true" date="true" :time="!dateRange.params.all_day" daterange="true"
                                 />
                             </div>
                         </div>

--- a/src/Template/Layout/js/app/components/date-input.js
+++ b/src/Template/Layout/js/app/components/date-input.js
@@ -104,6 +104,10 @@ export default {
             options.formatDate = (dateObj, format) => {
                 // this value goes to the hidden input which will be saved, needs to be a correct ISO8601
                 if (format === 'Z') {
+                    // date? force hours to 12. datetime handles hours directly
+                    if (!this.attrs.time) {
+                        dateObj.setHours(12);
+                    }
                     return dateObj.toISOString();
                 }
                 return Intl.DateTimeFormat(LOCALE, dateFormatOptions).format(dateObj);

--- a/src/Template/Layout/js/app/components/date-input.js
+++ b/src/Template/Layout/js/app/components/date-input.js
@@ -105,7 +105,7 @@ export default {
                 // this value goes to the hidden input which will be saved, needs to be a correct ISO8601
                 if (format === 'Z') {
                     // date? force hours to 12. datetime handles hours directly
-                    if (!this.attrs.time) {
+                    if (!this.attrs.time && !this.attrs.daterange) {
                         dateObj.setHours(12);
                     }
                     return dateObj.toISOString();

--- a/src/Template/Layout/js/app/components/date-input.js
+++ b/src/Template/Layout/js/app/components/date-input.js
@@ -106,7 +106,7 @@ export default {
                 if (format === 'Z') {
                     // date? force hours to 12. datetime handles hours directly
                     if (!this.attrs.time) {
-                        dateObj.setHours(12);
+                        return dateObj.toISOString().replaceAll('00:00:00.000Z', '12:00:00.000Z');
                     }
                     return dateObj.toISOString();
                 }

--- a/src/Template/Layout/js/app/components/date-input.js
+++ b/src/Template/Layout/js/app/components/date-input.js
@@ -106,7 +106,7 @@ export default {
                 if (format === 'Z') {
                     // date? force hours to 12. datetime handles hours directly
                     if (!element.attributes.time && !element.attributes.daterange) {
-                        const date = new Date(dateObj.getTime())
+                        const date = new Date(dateObj.getTime());
                         date.setHours(12);
 
                         return date.toISOString();

--- a/src/Template/Layout/js/app/components/date-input.js
+++ b/src/Template/Layout/js/app/components/date-input.js
@@ -105,9 +105,13 @@ export default {
                 // this value goes to the hidden input which will be saved, needs to be a correct ISO8601
                 if (format === 'Z') {
                     // date? force hours to 12. datetime handles hours directly
-                    if (!this.attrs.time && !this.attrs.daterange) {
-                        dateObj.setHours(12);
+                    if (!element.attributes.time && !element.attributes.daterange) {
+                        const date = new Date(dateObj.getTime())
+                        date.setHours(12);
+
+                        return date.toISOString();
                     }
+
                     return dateObj.toISOString();
                 }
                 return Intl.DateTimeFormat(LOCALE, dateFormatOptions).format(dateObj);

--- a/src/Template/Layout/js/app/components/date-input.js
+++ b/src/Template/Layout/js/app/components/date-input.js
@@ -106,7 +106,7 @@ export default {
                 if (format === 'Z') {
                     // date? force hours to 12. datetime handles hours directly
                     if (!this.attrs.time) {
-                        return dateObj.toISOString().replaceAll('00:00:00.000Z', '12:00:00.000Z');
+                        dateObj.setHours(12);
                     }
                     return dateObj.toISOString();
                 }


### PR DESCRIPTION
When handling date fields (not datetime fields!), this sets default hours to 12.
This way, date picker handles correctly date to show.
Otherwise: picker was showing a day before...

Rif: https://chialab.atlassian.net/browse/BEM-2