### PR TITLE
FIX: save changed order of children folders

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -670,6 +670,9 @@ class ModulesComponent extends Component
             }
             // invert relation call => use 'parent' relation on children folder
             $data = compact('id') + ['type' => 'folders'];
+            if (Hash::check($item, 'meta')) {
+                $data += ['meta' => Hash::check($item, 'meta')];
+            }
             $apiClient->replaceRelated($relId, 'folders', 'parent', $data);
         }
 

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -671,7 +671,7 @@ class ModulesComponent extends Component
             // invert relation call => use 'parent' relation on children folder
             $data = compact('id') + ['type' => 'folders'];
             if (Hash::check($item, 'meta')) {
-                $data += ['meta' => Hash::check($item, 'meta')];
+                $data += ['meta' => Hash::get($item, 'meta')];
             }
             $apiClient->replaceRelated($relId, 'folders', 'parent', $data);
         }

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -670,8 +670,8 @@ class ModulesComponent extends Component
             }
             // invert relation call => use 'parent' relation on children folder
             $data = compact('id') + ['type' => 'folders'];
-            if (Hash::check($item, 'meta')) {
-                $data += ['meta' => Hash::get($item, 'meta')];
+            if (Hash::check((array)$item, 'meta')) {
+                $data += ['meta' => Hash::get((array)$item, 'meta')];
             }
             $apiClient->replaceRelated($relId, 'folders', 'parent', $data);
         }

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1457,6 +1457,29 @@ class ModulesComponentTest extends TestCase
                 ], // relatedData
                 'addRelated', // expected
             ],
+            'folders children position' => [
+                111, // id
+                'folders', // type
+                [
+                    [
+                        'method' => 'addRelated',
+                        'relation' => 'children',
+                        'relatedIds' => [
+                            [
+                                'id' => 123,
+                                'type' => 'folders',
+                                'meta' => ['relation' => ['position' => 1]],
+                            ],
+                            [
+                                'id' => 124,
+                                'type' => 'folders',
+                                'meta' => ['relation' => ['position' => 2]],
+                            ],
+                        ],
+                    ],
+                ], // relatedData
+                'replaceRelated', // expected
+            ],
             'folders children folders' => [
                 222, // id
                 'folders', // type


### PR DESCRIPTION
This PR fixes a problem when changing order of children folders from within a folder in the Manager UI. The new order was not saved because the parameter `meta` of the relation wasn't sent to the APIs.