### PR TITLE
Module Data Modelling, page_size 500 in index pages

### DIFF
--- a/src/Controller/Model/ModelBaseController.php
+++ b/src/Controller/Model/ModelBaseController.php
@@ -70,11 +70,12 @@ abstract class ModelBaseController extends AppController
     public function index(): ?Response
     {
         $this->request->allowMethod(['get']);
+        $query = $this->request->getQueryParams() + ['page_size' => 500];
 
         try {
             $response = $this->apiClient->get(
                 sprintf('/model/%s', $this->resourceType),
-                $this->request->getQueryParams()
+                $query
             );
         } catch (BEditaClientException $e) {
             $this->log($e, LogLevel::ERROR);


### PR DESCRIPTION
In module "Data Modelling" (only admin users can view and access it), sometimes data is truncated to api default `page_size`.

This provides `page_size` 500 for calls in this module.

This affects the following pages:

 - /model/object_types
 - /model/relations
 - /model/property_types