### PR TITLE
fix: BEDITA.csrfToken

### DIFF
--- a/src/Template/Element/json_meta_config.ctp
+++ b/src/Template/Element/json_meta_config.ctp
@@ -1,9 +1,9 @@
 <?php
     $csrfToken = null;
     if (!empty($this->request->getParam('_csrfToken'))) {
-        $csrfToken = json_encode($this->request->getParam('_csrfToken'));
+        $csrfToken = $this->request->getParam('_csrfToken');
     } elseif (!empty($this->request->getData('_csrfToken'))) {
-        $csrfToken = json_encode($this->request->getData('_csrfToken'));
+        $csrfToken = $this->request->getData('_csrfToken');
     }
     if (!isset($modules)) {
         $modules = [];


### PR DESCRIPTION
This fixes a problem with certain ajax calls that uses in their header `this.getCSRFToken()`.

Basically: `json_encode` is performed once on `$conf` array, not necessary perform `json_encode` for `csrfToken`.