### PR TITLE
Make text/plain fields translatable

### DIFF
--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -44,7 +44,7 @@ class SchemaHelper extends Helper
     public const DEFAULT_TRANSLATABLE = ['title', 'description', 'body'];
 
     /**
-     * Default translatable fields to be prepended in translations
+     * Translatable media types
      *
      * @var array
      */

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -44,6 +44,13 @@ class SchemaHelper extends Helper
     public const DEFAULT_TRANSLATABLE = ['title', 'description', 'body'];
 
     /**
+     * Default translatable fields to be prepended in translations
+     *
+     * @var array
+     */
+    public const TRANSLATABLE_MEDIATYPES = ['text/html', 'text/plain'];
+
+    /**
      * Get control options for a property schema.
      *
      * @param string $name Property name.
@@ -225,11 +232,12 @@ class SchemaHelper extends Helper
                 }
             );
         }
-        // accept as translatable 'string' type with any not empty 'contentMediaType'
+        // accept as translatable 'string' type having text/html or tex/plain 'contentMediaType'
         $type = (string)Hash::get($schema, 'type');
         $contentMediaType = Hash::get($schema, 'contentMediaType');
 
-        return $type === 'string' && !empty($contentMediaType);
+        return $type === 'string' &&
+            in_array($contentMediaType, static::TRANSLATABLE_MEDIATYPES);
     }
 
     /**

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -37,6 +37,13 @@ class SchemaHelper extends Helper
     public $helpers = ['Time'];
 
     /**
+     * Default translatable fields to be prepended in translations
+     *
+     * @var array
+     */
+    public const DEFAULT_TRANSLATABLE = ['title', 'description', 'body'];
+
+    /**
      * Get control options for a property schema.
      *
      * @param string $name Property name.
@@ -182,25 +189,13 @@ class SchemaHelper extends Helper
 
         $fields = [];
         foreach ($properties as $name => $property) {
-            if (!empty($property['oneOf'])) {
-                foreach ($property['oneOf'] as $one) {
-                    if (!empty($one['type']) && $one['type'] === 'null') {
-                        continue;
-                    }
-
-                    if (!empty($one['type']) && !empty($one['contentMediaType']) && $one['type'] === 'string' && $one['contentMediaType'] === 'text/html') {
-                        $fields[] = $name;
-                    }
-                }
-            } elseif (!empty($property['type']) && $property['type'] === 'string') {
-                if (!empty($property['contentMediaType']) && $property['contentMediaType'] === 'text/html') { // textarea
-                    $fields[] = $name;
-                }
+            if ($this->translatableType($property)) {
+                $fields[] = $name;
             }
         }
+
         // put specific fields at the beginning of the fields array
-        $prefields = array_reverse(['title', 'description']);
-        foreach ($prefields as $field) {
+        foreach (array_reverse(static::DEFAULT_TRANSLATABLE) as $field) {
             if (in_array($field, $fields)) {
                 unset($fields[array_search($field, $fields)]);
                 array_unshift($fields, $field);
@@ -208,6 +203,33 @@ class SchemaHelper extends Helper
         }
 
         return $fields;
+    }
+
+    /**
+     * Helper recursive method to check if a property is translatable checking its JSON SCHEMA
+     *
+     * @param array $schema Property schema
+     * @return bool
+     */
+    protected function translatableType(array $schema): bool
+    {
+        if (!empty($schema['oneOf'])) {
+            return array_reduce(
+                (array)$schema['oneOf'],
+                function ($carry, $item) {
+                    if ($carry) {
+                        return true;
+                    }
+
+                    return $this->translatableType((array)$item);
+                }
+            );
+        }
+        // accept as translatable 'string' type with any not empty 'contentMediaType'
+        $type = (string)Hash::get($schema, 'type');
+        $contentMediaType = Hash::get($schema, 'contentMediaType');
+
+        return $type === 'string' && !empty($contentMediaType);
     }
 
     /**

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -437,7 +437,7 @@ class SchemaHelperTest extends TestCase
                             ],
                             [
                                 'type' => 'string',
-                                'contentMediaType' => 'text/html',
+                                'contentMediaType' => 'text/plain',
                             ],
                         ],
                     ],
@@ -468,6 +468,7 @@ class SchemaHelperTest extends TestCase
      *
      * @dataProvider translatableFieldsProvider()
      * @covers ::translatableFields()
+     * @covers ::translatableType()
      */
     public function testTranslatableFields(array $properties, array $expected)
     {

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -428,6 +428,18 @@ class SchemaHelperTest extends TestCase
                 [],
                 [],
             ],
+            'not translatable' => [
+                [
+                    'field1' => [
+                        'type' => 'string',
+                    ],
+                    'field2' => [
+                        'type' => 'string',
+                        'contentMediaType' => 'text/css',
+                    ],
+                ],
+                [],
+            ],
             'properties' => [
                 [
                     'dummy' => [

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -428,6 +428,22 @@ class SchemaHelperTest extends TestCase
                 [],
                 [],
             ],
+            'simple' => [
+                [
+                    'field' => [
+                        'oneOf' => [
+                            [
+                                'type' => 'string',
+                                'contentMediaType' => 'text/plain',
+                            ],
+                            [
+                                'type' => 'null',
+                            ],
+                        ],
+                    ],
+                ],
+                ['field'],
+            ],
             'not translatable' => [
                 [
                     'field1' => [


### PR DESCRIPTION
This PR enables `text/plain` fields as translatable. 
Currently only `text/html` are considered translatable.
