### PR TITLE
Load a content css for tinymce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ bundle-report.*.html
 # bundle directories
 /webroot/bundle-report
 /webroot/css/app*
+/webroot/css/*.lazy.css
 /webroot/css/vendors*
 /webroot/css/**/*.map
 /webroot/css/vendors/async

--- a/src/Template/Layout/js/app/directives/richeditor.js
+++ b/src/Template/Layout/js/app/directives/richeditor.js
@@ -70,10 +70,11 @@ export default {
                     items = DEFAULT_TOOLBAR;
                 }
 
+                const { default: contentCSS } = await import('../../../richeditor.lazy.scss');
                 const [editor] = await tinymce.init({
                     target: element,
                     skin: false,
-                    content_css: false,
+                    content_css: contentCSS,
                     menubar: false,
                     branding: false,
                     max_height: 500,

--- a/src/Template/Layout/richeditor.lazy.scss
+++ b/src/Template/Layout/richeditor.lazy.scss
@@ -1,0 +1,25 @@
+/*
+██████╗ ███████╗██████╗ ██╗████████╗ █████╗     ██╗  ██╗
+██╔══██╗██╔════╝██╔══██╗██║╚══██╔══╝██╔══██╗    ██║  ██║
+██████╔╝█████╗  ██║  ██║██║   ██║   ███████║    ███████║
+██╔══██╗██╔══╝  ██║  ██║██║   ██║   ██╔══██║    ╚════██║
+██████╔╝███████╗██████╔╝██║   ██║   ██║  ██║         ██║
+╚═════╝ ╚══════╝╚═════╝ ╚═╝   ╚═╝   ╚═╝  ╚═╝         ╚═╝
+BEdita 4 ~ @ 2018 from ChannelWeb & Chialab with love
+*/
+@import './styles/variables';   // common variables used for color, margins, typography, media breakpoints, tag collections
+@import './styles/mixins';
+
+// general
+@import './styles/base';
+
+body {
+    padding: 1em !important;
+    color: unset;
+    background: unset;
+}
+
+.mce-offscreen-selection {
+    position: absolute;
+    left: -9999999999999px;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -225,9 +225,33 @@ module.exports = {
                 ]
             },
             {
+                test: /\.lazy\.(scss|css)$/,
+                include: [
+                    path.resolve(__dirname, BUNDLE.templateRoot),
+                ],
+
+                use: [
+                    {
+                        loader: 'file-loader',
+                        options: {
+                            name: `${BUNDLE.cssDir}/[name].css`,
+                        },
+                    },
+                    {
+                        loader: 'sass-loader',
+                        options: {
+                            sourceMap: devMode,
+                        }
+                    },
+                ]
+            },
+            {
                 test: /\.(scss|css)$/,
                 include: [
                     path.resolve(__dirname, BUNDLE.templateRoot),
+                ],
+                exclude: [
+                    /\.lazy\.(scss|css)$/,
                 ],
 
                 use: [


### PR DESCRIPTION
This PR introduces a webpack rule for css lazy loading in order to correctly load a style file in the TinyMCE editor.