### PR TITLE
Fix: locations remove

### DIFF
--- a/src/Template/Element/Form/locations.twig
+++ b/src/Template/Element/Form/locations.twig
@@ -1,8 +1,7 @@
 {# Locations: show add relation form if the relation is set #}
 <locations-view
-    apikey="{{ config('Location.google.key') }}"
-    apiurl="{{ config('Location.google.url') }}"
+    api-key="{{ config('Location.google.key') }}"
+    api-url="{{ config('Location.google.url') }}"
     relation-name="{{ relationName }}"
-    :object="{{ object|json_encode }}"
 ></locations-view>
 {{ Form.unlockField('relations.' ~ relationName ~ '.replaceRelated')}}

--- a/src/Template/Element/Form/relations.scss
+++ b/src/Template/Element/Form/relations.scss
@@ -156,7 +156,7 @@
             position: absolute;
             top: $gutter * .5;
             left: $gutter * .5;
-            z-index: 10;
+            z-index: 2;
         }
 
         .thumbnail {
@@ -204,7 +204,7 @@
                 position: absolute;
                 top: $gutter * .5;
                 right: -$gutter * .5;
-                z-index: 10;
+                z-index: 2;
                 display: block;
                 color: #fff;
                 background-color: #000;

--- a/src/Template/Layout/js/app/components/locations-view/location-view.js
+++ b/src/Template/Layout/js/app/components/locations-view/location-view.js
@@ -22,6 +22,10 @@ function convertToPoint(input) {
     if (!input) {
         return;
     }
+    if (input.match(/point\(([^)]*)\)/i)) {
+        return input;
+    }
+
     let [lon, lat] = input.split(/\s*,\s*/);
     return `POINT(${lon} ${lat})`;
 }
@@ -49,11 +53,11 @@ export default {
                             autocomplete="none"
                             ref="title"
                             class="autocomplete-title"
-                            :default-value="getDefaultTitle()"
+                            :default-value="title"
                             :search="searchTitle"
                             base-class="autocomplete-title"
-                            :get-result-value="getTitle"
-                            @submit="onSubmitTitle"
+                            :get-result-value="getResultTitle"
+                            @submit="onAutocompleteSubmit"
                             @input="onInputTitle"
                             @change="onChange"
                             :debounce-time="500"
@@ -68,11 +72,11 @@ export default {
                             autocomplete="none"
                             ref="address"
                             class="autocomplete-address"
-                            :default-value="getDefaultAddress()"
+                            :default-value="address"
                             :search="searchAddress"
                             base-class="autocomplete-address"
-                            :get-result-value="getAddress"
-                            @submit="onSubmitAddress"
+                            :get-result-value="getResultAddress"
+                            @submit="onAutocompleteSubmit"
                             @input="onInputAddress"
                             @change="onChange"
                             :debounce-time="500"
@@ -86,8 +90,8 @@ export default {
                     <label>
                         <: t('Long Lat Coordinates') :>
                         <div class="is-flex">
-                            <input class="coordinates" type="text" :value="coordinates" @change="onCoordsChange" />
-                            <button class="get-coordinates icon-globe" @click.prevent="geocode" :disabled="!apiKey || !location.attributes.address">
+                            <input class="coordinates" type="text" v-model="coordinates" @change="onChange" />
+                            <button class="get-coordinates icon-globe" @click.prevent="geocode" :disabled="!apiKey || !address">
                                 <: t('GET') :>
                             </button>
                         </div>
@@ -96,24 +100,24 @@ export default {
                 <div class="is-flex-column">
                     <label>
                         Zoom
-                        <input @change="onRelationDataChange" :value="zoom" data-name="zoom" type="number" min="2" max="20"/>
+                        <input @change="onChange" v-model.number="zoom" type="number" min="2" max="20"/>
                     </label>
                 </div>
                 <div class="is-flex-column">
                     <label>
                         Pitch°
-                        <input @change="onRelationDataChange" :value="pitch" data-name="pitch" type="number" min="0" max="60"/>
+                        <input @change="onChange" v-model.number="pitch" type="number" min="0" max="60"/>
                     </label>
                 </div>
                 <div class="is-flex-column">
                     <label>
                         Bearing°
-                        <input @change="onRelationDataChange" :value="bearing" data-name="bearing" type="number" min="-180" max="180"/>
+                        <input @change="onChange" v-model.number="bearing" type="number" min="-180" max="180"/>
                     </label>
                 </div>
             </div>
             <div class="location-buttons">
-                <button @click.prevent @click="onRemove" class="icon-unlink remove"><: t("remove") :></button>
+                <button @click.prevent="onRemove" class="icon-unlink remove"><: t("remove") :></button>
             </div>
         </div>
     </div>`,
@@ -130,6 +134,7 @@ export default {
         return {
             location: this.locationData,
             title: this.locationData.attributes.title,
+            address: this.locationData.attributes.address,
             coordinates: convertFromPoint(this.locationData.attributes.coords),
             zoom: parseInt(this.locationData.meta &&
                 this.locationData.meta.relation &&
@@ -147,6 +152,44 @@ export default {
     },
 
     methods: {
+        onChange() {
+            this.location.attributes.title = this.title;
+            this.location.attributes.address = this.address;
+            this.location.attributes.status = 'on';
+            this.location.attributes.coords = convertToPoint(this.coordinates);
+            this.location.meta.relation = this.location.meta.relation || { params: {} }; // ensure relation object
+            this.location.meta.relation.params.zoom = `${this.zoom}`;
+            this.location.meta.relation.params.pitch = `${this.pitch}`;
+            this.location.meta.relation.params.bearing = `${this.bearing}`;
+
+            this.$parent.$emit('updated', this.index, this.location);
+        },
+        onAutocompleteSubmit(result) {
+            if (!result) {
+                return;
+            }
+
+            // use original fetched location instead of the "potentially" edited one (see `searchAddress` method)
+            const location = this.fetchedLocations.find((item) => item.id == result.id);
+            if (!location) {
+                return;
+            }
+
+            this.location = location;
+            this.title = this.location.attributes.title;
+            this.address = this.location.attributes.address;
+            this.coordinates = convertFromPoint(this.location.attributes.coords);
+            this.onChange();
+        },
+        onInputTitle(event) {
+            this.title = event.target.value;
+        },
+        onInputAddress(event) {
+            this.address = this.cleanAddress(event.target.value);
+        },
+        onRemove() {
+            this.$parent.$emit('removed', this.index);
+        },
         /**
          * Check if a location's `attrName` already appears between a list of locations.
          * In that case append its `suffixAttr` as suffix to be more distinguishable.
@@ -178,49 +221,6 @@ export default {
 
             // if `suffixAttr` is set, append the value also for the duplicate
             locations[duplicateValueIdx].attributes[attrName] = stripHtml(`${duplicateValue.attributes[attrName]} (${duplicateValue.attributes[suffixAttr]})`);
-        },
-        onChange() {
-            let location = {
-                id: this.location && this.location.id,
-                type: 'locations',
-                attributes: {
-                    status: 'on',
-                    ...(this.location && this.location.attributes || {}),
-                    coords: convertToPoint(this.coordinates),
-                },
-                meta: {
-                    relation: {
-                        params: {
-                            zoom: `${this.zoom}`,
-                            pitch: `${this.pitch}`,
-                            bearing: `${this.bearing}`,
-                        },
-                    },
-                },
-            };
-            this.$parent.$emit('updated', this.index, location);
-        },
-        onSubmitTitle(result) {
-            // use original fetched location instead of the "potentially" edited one (see `searchAddress` method)
-            let location = this.fetchedLocations.find((item) => item.id == result.id);
-            this.location = location; // set the retrieved location as model
-            this.coordinates = convertFromPoint(this.location.attributes.coords);
-            this.$parent.$emit('updated', this.index, this.location);
-        },
-        onSubmitAddress(result) {
-            // use original fetched location instead of the "potentially" edited one (see `searchAddress` method)
-            let location = this.fetchedLocations.find((item) => item.id == result.id);
-            this.location = location; // set the retrieved location as model
-            this.coordinates = convertFromPoint(this.location.attributes.coords);
-            this.$parent.$emit('updated', this.index, this.location);
-        },
-        onInputTitle(event) {
-            const title = event.target.value;
-            this.location.attributes.title = title;
-        },
-        onInputAddress(event) {
-            const address = event.target.value;
-            this.location.attributes.address = address;
         },
         searchTitle(input) {
             const requestUrl = `${BEDITA.base}/api/locations?filter[query]=${input}&sort=title`;
@@ -269,7 +269,7 @@ export default {
 
                         // only pick locations that include input string in the address
                         results = results.filter((location) => {
-                            const address = this.address(location);
+                            const address = location && location.attributes && this.cleanAddress(location.attributes.address);
                             return address && address.toLowerCase().indexOf(input.toLowerCase()) !== -1;
                         });
                         // store raw fetched data
@@ -281,24 +281,28 @@ export default {
                     });
             });
         },
-        getTitle(model) {
-            return model.attributes && model.attributes.title;
+        /**
+         * Title to show in the autocomplete component.
+         * @param {Object} model Autocomplete result object
+         * @returns {String}
+         */
+        getResultTitle(model) {
+            return (model && model.attributes && model.attributes.title) || '';
         },
-        getAddress(model) {
-            return this.address(model);
+        /**
+         * Address to show in the autocomplete component.
+         * @param {Object} model Autocomplete result object
+         * @returns {String}
+         */
+        getResultAddress(model) {
+            return (model && model.attributes && this.cleanAddress(model.attributes.address)) || '';
         },
-        getDefaultTitle() {
-            return this.location && this.location.attributes && this.location.attributes.title;
-        },
-        getDefaultAddress() {
-            return this.address(this.location);
-        },
-        address(model) {
-            if (!model || !model.attributes || !model.attributes.address) {
+        cleanAddress(address) {
+            if (!address) {
                 return '';
             }
 
-            return stripHtml(`${model.attributes.address}`);
+            return stripHtml(`${address}`);
         },
         async geocode() {
             const retrieveGeocode = () => {
@@ -307,18 +311,17 @@ export default {
                 }
 
                 const geocoder = new window.google.maps.Geocoder();
-                geocoder.geocode({ address: this.address(this.location) }, (results, status) => {
+                geocoder.geocode({ address: this.address }, (results, status) => {
                     if (status === "OK" && results.length) {
                         const result = results[0];
 
                         // Longitude, Latitude format: see https://docs.mapbox.com/api/#coordinate-format
                         this.coordinates = `${result.geometry.location.lng()}, ${result.geometry.location.lat()}`;
-                        this.location.attributes.coords = convertToPoint(this.coordinates);
-                        this.$parent.$emit('updated', this.index, this.location);
                     } else {
                         this.coordinates = '';
                         console.error("Error in geocoding address");
                     }
+                    this.onChange();
                 });
             };
 
@@ -336,24 +339,6 @@ export default {
                 retrieveGeocode();
             };
             document.head.appendChild(script);
-        },
-        onCoordsChange(event) {
-            this.location.attributes.coords = convertToPoint(event.target.value);
-            this.onChange();
-        },
-        onRelationDataChange(event) {
-            const target = event.target;
-            const value = target.value;
-            const attributeName = target.dataset['name'];
-            this[attributeName] = parseInt(value);
-
-            this.location.meta.relation.params.zoom = `${this.zoom}`;
-            this.location.meta.relation.params.pitch = `${this.pitch}`;
-            this.location.meta.relation.params.bearing = `${this.bearing}`;
-            this.$parent.$emit('updated', this.index, this.location);
-        },
-        onRemove() {
-            this.$parent.$emit('removed', this.index);
         },
     }
 }

--- a/src/Template/Layout/js/app/components/locations-view/location-view.js
+++ b/src/Template/Layout/js/app/components/locations-view/location-view.js
@@ -37,7 +37,6 @@ function stripHtml(str) {
  */
 export default {
     template: `<div class="location mb-2 is-flex">
-        <input type="hidden" :name="'relations[' + relationName + '][replaceRelated][]'" :value="locationValue" />
         <div class="order mr-1 p-1 has-background-white is-flex align-center has-text-black">
             <: index + 1 :>
         </div>
@@ -88,7 +87,7 @@ export default {
                         <: t('Long Lat Coordinates') :>
                         <div class="is-flex">
                             <input class="coordinates" type="text" :value="coordinates" @change="onCoordsChange" />
-                            <button class="get-coordinates icon-globe" @click.prevent="geocode" :disabled="!apikey || !location.attributes.address">
+                            <button class="get-coordinates icon-globe" @click.prevent="geocode" :disabled="!apiKey || !location.attributes.address">
                                 <: t('GET') :>
                             </button>
                         </div>
@@ -121,53 +120,30 @@ export default {
 
     props: {
         index: Number,
-        apikey: String,
-        apiurl: String,
-        locationdata: Object,
+        apiKey: String,
+        apiUrl: String,
+        locationData: Object,
         relationName: String,
     },
 
     data() {
         return {
-            location: this.locationdata,
-            title: this.locationdata.attributes.title,
-            coordinates: convertFromPoint(this.locationdata.attributes.coords),
-            zoom: parseInt(this.locationdata.meta &&
-                this.locationdata.meta.relation &&
-                this.locationdata.meta.relation.params &&
-                this.locationdata.meta.relation.params.zoom) || 2,
-            pitch: parseInt(this.locationdata.meta &&
-                this.locationdata.meta.relation &&
-                this.locationdata.meta.relation.params &&
-                this.locationdata.meta.relation.params.pitch) || 0,
-            bearing: parseInt(this.locationdata.meta &&
-                this.locationdata.meta.relation &&
-                this.locationdata.meta.relation.params &&
-                this.locationdata.meta.relation.params.bearing) || 0,
+            location: this.locationData,
+            title: this.locationData.attributes.title,
+            coordinates: convertFromPoint(this.locationData.attributes.coords),
+            zoom: parseInt(this.locationData.meta &&
+                this.locationData.meta.relation &&
+                this.locationData.meta.relation.params &&
+                this.locationData.meta.relation.params.zoom) || 2,
+            pitch: parseInt(this.locationData.meta &&
+                this.locationData.meta.relation &&
+                this.locationData.meta.relation.params &&
+                this.locationData.meta.relation.params.pitch) || 0,
+            bearing: parseInt(this.locationData.meta &&
+                this.locationData.meta.relation &&
+                this.locationData.meta.relation.params &&
+                this.locationData.meta.relation.params.bearing) || 0,
         }
-    },
-
-    computed: {
-        locationValue() {
-            return JSON.stringify({
-                id: this.location && this.location.id,
-                type: 'locations',
-                attributes: {
-                    status: 'on',
-                    ...(this.location && this.location.attributes || {}),
-                    coords: convertToPoint(this.coordinates),
-                },
-                meta: {
-                    relation: {
-                        params: {
-                            zoom: `${this.zoom}`,
-                            pitch: `${this.pitch}`,
-                            bearing: `${this.bearing}`,
-                        },
-                    },
-                },
-            });
-        },
     },
 
     methods: {
@@ -204,7 +180,25 @@ export default {
             locations[duplicateValueIdx].attributes[attrName] = stripHtml(`${duplicateValue.attributes[attrName]} (${duplicateValue.attributes[suffixAttr]})`);
         },
         onChange() {
-            this.$parent.$emit('updated', this.index, this.location);
+            let location = {
+                id: this.location && this.location.id,
+                type: 'locations',
+                attributes: {
+                    status: 'on',
+                    ...(this.location && this.location.attributes || {}),
+                    coords: convertToPoint(this.coordinates),
+                },
+                meta: {
+                    relation: {
+                        params: {
+                            zoom: `${this.zoom}`,
+                            pitch: `${this.pitch}`,
+                            bearing: `${this.bearing}`,
+                        },
+                    },
+                },
+            };
+            this.$parent.$emit('updated', this.index, location);
         },
         onSubmitTitle(result) {
             // use original fetched location instead of the "potentially" edited one (see `searchAddress` method)
@@ -334,7 +328,7 @@ export default {
 
             // init script
             var script = document.createElement('script');
-            script.src = `${this.apiurl}js?key=${this.apikey}&callback=initMap`;
+            script.src = `${this.apiUrl}js?key=${this.apiKey}&callback=initMap`;
             script.defer = true;
             script.id = 'googleapi';
 

--- a/src/Template/Layout/js/app/components/locations-view/locations-view.js
+++ b/src/Template/Layout/js/app/components/locations-view/locations-view.js
@@ -21,9 +21,10 @@ export default {
     },
 
     template: `<div class="locations">
+        <input type="hidden" :name="'relations[' + relationName + '][replaceRelated]'" :value="locationsData" />
         <div v-if="!locations" class="is-loading-spinner"></div>
-        <div v-if="locations" v-for="(location, index) in locations">
-            <location-view :key="locationSymbol(location)" :index="index" :locationdata="location" :apikey="apikey" :apiurl="apiurl" :relation-name="relationName" />
+        <div v-else v-for="(location, index) in locations">
+            <location-view :key="locationSymbol(location)" :index="index" :location-data="location" :api-key="apiKey" :api-url="apiUrl" :relation-name="relationName" />
         </div>
         <div v-if="locations" class="is-flex mt-1">
             <button @click.prevent @click="onAddNew"><: t('add new') :></button>
@@ -31,10 +32,9 @@ export default {
     </div>`,
 
     props: {
-        apikey: String,
-        apiurl: String,
+        apiKey: String,
+        apiUrl: String,
         relationName: String,
-        object: Object,
     },
 
     data() {
@@ -62,6 +62,7 @@ export default {
     async mounted() {
         this.$on('removed', (index) => {
             this.locations.splice(index, 1);
+            this.markChanged();
         });
         this.$on('updated', (index, location) => {
             if (!location.meta || !location.meta.relation || !location.meta.relation.params) {
@@ -72,6 +73,7 @@ export default {
                 };
             }
             this.locations.splice(index, 1, location);
+            this.markChanged();
         });
     },
 
@@ -98,6 +100,25 @@ export default {
          */
         locationSymbol(location) {
             return Symbol(location);
+        },
+        /**
+         * Let the app know that something has changed here.
+         * @return {void}
+         */
+        markChanged() {
+            this.$el.dispatchEvent(new CustomEvent('change', {
+                bubbles: true,
+                detail: {
+                    id: this.$vnode.tag,
+                    isChanged: true,
+                }
+            }));
         }
     },
+
+    computed: {
+        locationsData() {
+            return JSON.stringify(this.locations);
+        }
+    }
 }

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -507,9 +507,9 @@ export default {
         },
 
         /**
-         * remove related object: adding it to removedRelated Array
+         * remove related object adding it to removedRelated Array
          *
-         * @param {String} type
+         * @param {Object} related Related object
          *
          * @returns {void}
          */
@@ -527,8 +527,7 @@ export default {
         /**
          * re-add removed related object: removing it from removedRelated Array
          *
-         * @param {Number} id
-         * @param {String} type
+         * @param {Object} related Related object
          *
          * @returns {void}
          */
@@ -719,7 +718,7 @@ export default {
          * @return {Boolean} true if id is in Array relations
          */
         containsId(relations, id) {
-            return relations.filter((rel) => rel.id === id).length;
+            return !!relations.find((rel) => rel.id === id);
         },
 
         /**

--- a/src/Template/Layout/styles/_non-production.scss
+++ b/src/Template/Layout/styles/_non-production.scss
@@ -31,7 +31,7 @@ body[alert-message] {
         display: flex;
         justify-content: center;
         align-items: center;
-        z-index: 1;
+        z-index: 2;
     }
 
     main.layout > .layout-sidebar > .sidebar {


### PR DESCRIPTION
This PR fixes a bug that causes the inability to remove all the related locations. That happened because the edit of locations data was handled by some hidden inputs with `name="relations[has_location][replaceRelated][]"`, one for each `location-view`. When removing some location leaving some others in relation, everything works fine, but once ALL `location-view` are removed, so are the `replaceRelated` inputs, so to the form there's no change. 

The solution was to move the `replaceRelated` input to `locations-view` component.

Other small enhancements are:
- now removing or adding locations marks the form as changed, so the warning appears before leaving the page
- props name consistency
- some `relations-view`'s methods doc
- fix relations priority z-index to prevent the number overlaps other things
- environment alert bar z-index