### PR TITLE
fix: date empty, return empty string

### DIFF
--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -130,6 +130,9 @@ class SchemaHelper extends Helper
      */
     protected function formatDate($value): string
     {
+        if (empty($value)) {
+            return '';
+        }
         return (string)$this->Time->format($value);
     }
 
@@ -141,6 +144,9 @@ class SchemaHelper extends Helper
      */
     protected function formatDateTime($value): string
     {
+        if (empty($value)) {
+            return '';
+        }
         return (string)$this->Time->format($value);
     }
 

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -133,6 +133,7 @@ class SchemaHelper extends Helper
         if (empty($value)) {
             return '';
         }
+
         return (string)$this->Time->format($value);
     }
 
@@ -147,6 +148,7 @@ class SchemaHelper extends Helper
         if (empty($value)) {
             return '';
         }
+
         return (string)$this->Time->format($value);
     }
 

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -512,7 +512,7 @@ class SchemaHelperTest extends TestCase
     public function formatProvider(): array
     {
         return [
-            'dumy' => [
+            'dummy' => [
                 'dummy',
                 'dummy',
                 [
@@ -549,9 +549,25 @@ class SchemaHelperTest extends TestCase
                     'format' => 'date',
                 ],
             ],
+            'empty date' => [
+                '',
+                '',
+                [
+                    'type' => 'string',
+                    'format' => 'date',
+                ],
+            ],
             'date time' => [
                 '9/8/19, 4:35 PM',
                 '2019-09-08T16:35:15+00',
+                [
+                    'type' => 'string',
+                    'format' => 'date-time',
+                ],
+            ],
+            'empty date time' => [
+                '',
+                '',
                 [
                     'type' => 'string',
                     'format' => 'date-time',


### PR DESCRIPTION
This fixes a bug.

Actual behaviour:

`formatDate($value)` and `formatDateTime($value)` return today date on empty $value.

Expected behaviour:

`formatDate($value)` and `formatDateTime($value)` return empty string on empty $value.
