### PR TITLE
fix: filter_options of selected filter in form

### DIFF
--- a/src/Template/Pages/Import/index.twig
+++ b/src/Template/Pages/Import/index.twig
@@ -35,11 +35,12 @@
                     </header>
                     <div class="tab-container">
                         {% for index, datum in filters %}
-                            <div id="filter-{{ datum.value|lower }}-options" v-show="currentFilterId == {{ index }}">
+                            <div id="filter-{{ datum.value|lower }}-options" v-if="currentFilterId == {{ index }}">
                             {% if datum.options %}
                                 {% for optionName,optionData in datum.options %}
                                 <div>
                                     <label>{{ optionData.label }}</label>
+                                    {{ Form.unlockField(optionName) }}
                                     {% if optionData.dataType == 'boolean' %}
                                         {{ Form.control(optionName, {
                                             'type': 'checkbox',


### PR DESCRIPTION
This fixes an unexpected behavior in import page.

When selecting a filter with empty options, on import the system uses another filter options (non-empty).
This happens because filter options were always on page (hidden, but in form).

This let in page only options for selected filter.