### PR TITLE
fix: change / division with multiply *

### DIFF
--- a/src/Template/Element/Form/trees.scss
+++ b/src/Template/Element/Form/trees.scss
@@ -27,15 +27,15 @@
 
             > input[type='checkbox'],
             > input[type='radio'] {
-                margin-top: -$gutter / 8;
-                margin-right: $gutter / 2;
+                margin-top: -$gutter * .125;
+                margin-right: $gutter * .5;
                 vertical-align: middle;
             }
         }
 
         > a {
             display: inline-block;
-            padding: $gutter / 2 $gutter * 1.5;
+            padding: $gutter * .5 $gutter * 1.5;
             margin-left: $gutter;
             vertical-align: middle;
             text-transform: uppercase;
@@ -58,7 +58,7 @@
 
         .tree-param {
             position: relative;
-            margin: $gutter / 4 $gutter / 2 $gutter / 4 0;
+            margin: $gutter * .25 $gutter * .5 $gutter * .25 0;
 
             input {
                 position: absolute;
@@ -116,9 +116,9 @@
     .node-element ~ .node-children {
         &:not(:empty) {
             margin-top: -$gutter;
-            margin-left: 3 * $gutter / 8;
+            margin-left: 3 * $gutter * .125;
             padding-top: $gutter;
-            padding-left: $gutter / 2;
+            padding-left: $gutter * .5;
             border-left: solid 1px rgba(255, 255, 255, 0.25);
         }
     }

--- a/src/Template/Element/Menu/sidebar.scss
+++ b/src/Template/Element/Menu/sidebar.scss
@@ -54,7 +54,7 @@
     // > *:not(:last-child) { margin-bottom: $gutter;}
 
     button, .button {
-        width: $dashboard-item-width / 2;
+        width: $dashboard-item-width * .5;
     }
 
     &-bedita-logo {

--- a/src/Template/Pages/Login/login.scss
+++ b/src/Template/Pages/Login/login.scss
@@ -50,7 +50,7 @@ body.view-login {
                     label {
                         color: $white;
                         font-weight: normal;
-                        margin: $gutter 0 $gutter/4 0;
+                        margin: $gutter 0 $gutter * .25 0;
                     }
 
                     label, input {

--- a/src/Template/Pages/Model/_model-index.scss
+++ b/src/Template/Pages/Model/_model-index.scss
@@ -54,7 +54,7 @@ body.view-model {
                 }
 
                 div {
-                    padding: $gutter/4 $gutter/2;
+                    padding: $gutter * .25 $gutter * .5;
                     vertical-align: middle;
 
                     &.first-cell, &.action-cell {


### PR DESCRIPTION
Since deprecation in SCSS compile plugin all occurrences of / divisions were changed in multiply for 1/n

e.g.:
`margin-right: $gutter / 2;`
became
`margin-right: $gutter * .5;`