### PR TITLE
Concurrent editors in object's view page

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -756,4 +756,12 @@ return [
     //         ],
     //     ],
     // ],
+
+    /**
+     * Editors configuration.
+     * concurrentCheckTime: the time in milliseconds that a concurrent access is considered still active
+     */
+    // 'Editors' => [
+    //     'concurrentCheckTime' => 30000, // 30 seconds
+    // ],
 ];

--- a/src/Controller/Component/ObjectsEditorsComponent.php
+++ b/src/Controller/Component/ObjectsEditorsComponent.php
@@ -1,0 +1,131 @@
+<?php
+namespace App\Controller\Component;
+
+use Cake\Cache\Cache;
+use Cake\Controller\Component;
+use Cake\Core\Configure;
+
+/**
+ * ObjectsEditors component
+ */
+class ObjectsEditorsComponent extends Component
+{
+    /**
+     * Objects editors.
+     *
+     * @var array
+     */
+    public $objectsEditors;
+
+    /**
+     * Concurrent check time.
+     *
+     * @var integer
+     */
+    public $concurrentCheckTime = 20000;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize(array $config): void
+    {
+        // set concurrent check time by config, if any. default 20s
+        $concurrentCheckTime = Configure::read('Editors.concurrentCheckTime');
+        if (!empty($concurrentCheckTime)) {
+            $this->concurrentCheckTime = $concurrentCheckTime;
+        }
+        // get concurrent editors
+        $this->objectsEditors = $this->getEditors();
+        // remove expired data
+        $this->cleanup();
+
+        parent::initialize($config);
+    }
+
+    /**
+     * Update objects editors adding the user access to ID object
+     *
+     * @param string $id The object ID
+     * @return string
+     */
+    public function update(string $id): string
+    {
+        if (!array_key_exists($id, $this->objectsEditors)) {
+            $this->objectsEditors[$id] = [];
+        }
+        $found = false;
+        $editor = $this->editorName();
+        $now = time();
+        foreach ($this->objectsEditors[$id] as &$objectEditor) {
+            if ($found) {
+                continue;
+            }
+            if ($objectEditor['name'] === $editor) {
+                $found = true;
+                $objectEditor['timestamp'] = $now;
+            }
+        }
+        if (!$found) {
+            $this->objectsEditors[$id][] = [
+                'name' => $editor,
+                'timestamp' => $now,
+            ];
+        }
+        $encoded = json_encode($this->objectsEditors);
+        Cache::write('objects_editors', $encoded);
+
+        return $encoded;
+    }
+
+    /**
+     * Get editor name from authenticated user.
+     *
+     * @return string
+     */
+    public function editorName(): string
+    {
+        $user = $this->getController()->Auth->user();
+        if (empty($user['attributes']['name']) && empty($user['attributes']['name'])) {
+            return $user['attributes']['username'];
+        }
+
+        return sprintf('%s %s', $user['attributes']['name'], $user['attributes']['surname']);
+    }
+
+    /**
+     * Get all objects concurrent editors.
+     *
+     * @return array
+     */
+    public function getEditors(): array
+    {
+        $cached = (string)Cache::read('objects_editors', 'default');
+        if (empty($cached)) {
+            return [];
+        }
+
+        return json_decode($cached, true);
+    }
+
+    /**
+     * Remove expired concurrent editors
+     *
+     * @return void
+     */
+    public function cleanup(): void
+    {
+        if (empty($this->objectsEditors)) {
+            return;
+        }
+        $validity = $this->concurrentCheckTime / 1000;
+        $now = time();
+        foreach ($this->objectsEditors as $id => $objectEditors) {
+            foreach ($objectEditors as $key => $objectEditor) {
+                if ($objectEditor['timestamp'] + $validity < $now) {
+                    unset($this->objectsEditors[$id][$key]);
+                }
+            }
+        }
+        Cache::write('objects_editors', json_encode($this->objectsEditors));
+    }
+}

--- a/src/Controller/Component/ObjectsEditorsComponent.php
+++ b/src/Controller/Component/ObjectsEditorsComponent.php
@@ -80,16 +80,23 @@ class ObjectsEditorsComponent extends Component
     /**
      * Get editor name from authenticated user.
      *
-     * @return string
+     * @return string|null
      */
-    public function editorName(): string
+    public function editorName(): ?string
     {
         $user = $this->getController()->Auth->user();
-        if (empty($user['attributes']['name']) && empty($user['attributes']['name'])) {
+        if (empty($user)) {
+            return null;
+        }
+
+        if (!empty($user['attributes']['name']) && !empty($user['attributes']['name'])) {
+            return sprintf('%s %s', $user['attributes']['name'], $user['attributes']['surname']);
+        }
+        if (!empty($user['attributes']['username'])) {
             return $user['attributes']['username'];
         }
 
-        return sprintf('%s %s', $user['attributes']['name'], $user['attributes']['surname']);
+        return null;
     }
 
     /**

--- a/src/Controller/Component/ObjectsEditorsComponent.php
+++ b/src/Controller/Component/ObjectsEditorsComponent.php
@@ -57,12 +57,10 @@ class ObjectsEditorsComponent extends Component
         $editor = $this->editorName();
         $now = time();
         foreach ($this->objectsEditors[$id] as &$objectEditor) {
-            if ($found) {
-                continue;
-            }
             if ($objectEditor['name'] === $editor) {
                 $found = true;
                 $objectEditor['timestamp'] = $now;
+                break;
             }
         }
         if (!$found) {

--- a/src/Controller/Component/ObjectsEditorsComponent.php
+++ b/src/Controller/Component/ObjectsEditorsComponent.php
@@ -89,7 +89,7 @@ class ObjectsEditorsComponent extends Component
             return null;
         }
 
-        if (!empty($user['attributes']['name']) && !empty($user['attributes']['name'])) {
+        if (!empty($user['attributes']['name']) && !empty($user['attributes']['surname'])) {
             return sprintf('%s %s', $user['attributes']['name'], $user['attributes']['surname']);
         }
         if (!empty($user['attributes']['username'])) {

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -24,6 +24,7 @@ use Psr\Log\LogLevel;
  * Modules controller: list, add, edit, remove objects
  *
  * @property \App\Controller\Component\HistoryComponent $History
+ * @property \App\Controller\Component\ObjectsEditorsComponent $ObjectsEditors
  * @property \App\Controller\Component\ProjectConfigurationComponent $ProjectConfiguration
  * @property \App\Controller\Component\PropertiesComponent $Properties
  * @property \App\Controller\Component\QueryComponent $Query
@@ -47,6 +48,7 @@ class ModulesController extends AppController
         parent::initialize();
 
         $this->loadComponent('History');
+        $this->loadComponent('ObjectsEditors');
         $this->loadComponent('Properties');
         $this->loadComponent('ProjectConfiguration');
         $this->loadComponent('Query');
@@ -173,6 +175,8 @@ class ModulesController extends AppController
         // set objectNav
         $objectNav = $this->getObjectNav((string)$id);
         $this->set('objectNav', $objectNav);
+
+        $this->ObjectsEditors->update((string)$id);
 
         return null;
     }

--- a/src/Locale/en_US/default.po
+++ b/src/Locale/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-01-21 16:33:19 \n"
+"POT-Creation-Date: 2021-07-16 07:10:30 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -27,6 +27,9 @@ msgid "Add translation"
 msgstr ""
 
 msgid "Advanced"
+msgstr ""
+
+msgid "Alert!"
 msgstr ""
 
 msgid "All"
@@ -65,7 +68,10 @@ msgstr ""
 msgid "BEdita Web site"
 msgstr ""
 
-msgid "BEdita {0}"
+msgid "Back to login"
+msgstr ""
+
+msgid "Bad related data method"
 msgstr ""
 
 msgid "Bulk Action failed on: "
@@ -99,6 +105,9 @@ msgid "Clone"
 msgstr ""
 
 msgid "Close"
+msgstr ""
+
+msgid "Concurrent users"
 msgstr ""
 
 msgid "Confirm new password"
@@ -191,9 +200,6 @@ msgstr ""
 msgid "Export Filtered"
 msgstr ""
 
-msgid "Format choosen is not available"
-msgstr ""
-
 msgid "Failed to write file to disk"
 msgstr ""
 
@@ -219,6 +225,9 @@ msgid "Folders"
 msgstr ""
 
 msgid "Forgot your password?"
+msgstr ""
+
+msgid "Format choosen is not available"
 msgstr ""
 
 msgid "From"
@@ -264,6 +273,9 @@ msgid "Language"
 msgstr ""
 
 msgid "Language and translations"
+msgstr ""
+
+msgid "Left types"
 msgstr ""
 
 msgid "Locations"
@@ -383,9 +395,6 @@ msgstr ""
 msgid "Other"
 msgstr ""
 
-msgid "Password"
-msgstr ""
-
 msgid "Password reset"
 msgstr ""
 
@@ -402,6 +411,9 @@ msgid "Please check your mailbox and follow the instructions"
 msgstr ""
 
 msgid "Please provide a Mapbox access token in app configuration"
+msgstr ""
+
+msgid "Position"
 msgstr ""
 
 msgid "Preferences and Tools"
@@ -434,7 +446,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-msgid "Request password reset"
+msgid "Request password"
 msgstr ""
 
 msgid "Reset filters"
@@ -458,16 +470,19 @@ msgstr ""
 msgid "Retype password"
 msgstr ""
 
+msgid "Right types"
+msgstr ""
+
 msgid "Save"
 msgstr ""
 
 msgid "Search"
 msgstr ""
 
-msgid "Set selected"
+msgid "Select a project"
 msgstr ""
 
-msgid "Settings"
+msgid "Set selected"
 msgstr ""
 
 msgid "Sign in"
@@ -563,9 +578,6 @@ msgstr ""
 msgid "User profile saved"
 msgstr ""
 
-msgid "Username"
-msgstr ""
-
 msgid "Users"
 msgstr ""
 
@@ -590,10 +602,10 @@ msgstr ""
 msgid "Your recent items"
 msgstr ""
 
-msgid "add objects"
+msgid "add"
 msgstr ""
 
-msgid "add to"
+msgid "add objects"
 msgstr ""
 
 msgid "cancel"
@@ -617,6 +629,9 @@ msgstr ""
 msgid "current password"
 msgstr ""
 
+msgid "elements to"
+msgstr ""
+
 msgid "empty"
 msgstr ""
 
@@ -624,9 +639,6 @@ msgid "file name"
 msgstr ""
 
 msgid "id"
-msgstr ""
-
-msgid "language"
 msgstr ""
 
 msgid "modified"
@@ -642,6 +654,9 @@ msgid "objects to"
 msgstr ""
 
 msgid "original"
+msgstr ""
+
+msgid "related object"
 msgstr ""
 
 msgid "remove"
@@ -686,57 +701,61 @@ msgstr ""
 msgid "www.bedita.com"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:158
-#: src/Template/Layout/js/app/components/history/history.js:90
+#: src/Template/Layout/js/app/app.js:157
+#: src/Template/Layout/js/app/components/history/history.js:99
 #, javascript-format
 msgid "Please insert a new title on \"${ title }\" clone"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:159
-#: src/Template/Layout/js/app/components/history/history.js:91
+#: src/Template/Layout/js/app/app.js:158
+#: src/Template/Layout/js/app/components/history/history.js:100
 msgid "copy"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:481
+#: src/Template/Layout/js/app/app.js:477
 msgid "If you confirm, this data will be gone forever. Are you sure?"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:483
+#: src/Template/Layout/js/app/app.js:479
 msgid "Do you really want to trash the object?"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:492
-#: src/Template/Layout/js/app/components/history/history.js:82
-#: src/Template/Layout/js/app/pages/model/index.js:263
+#: src/Template/Layout/js/app/app.js:487
+#: src/Template/Layout/js/app/components/history/history.js:89
+#: src/Template/Layout/js/app/pages/model/index.js:262
 #: src/Template/Layout/js/app/pages/modules/index.js:144
-#: src/Template/Layout/js/app/pages/trash/index.js:42
+#: src/Template/Layout/js/app/pages/trash/index.js:43
 msgid "yes, proceed"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:501
+#: src/Template/Layout/js/app/app.js:496
 msgid "There are unsaved changes, are you sure you want to leave page?"
 msgstr ""
 
-#: src/Template/Layout/js/app/pages/trash/index.js:39
+#: src/Template/Layout/js/app/pages/trash/index.js:42
 #, javascript-format
 msgid "Do you confirm the deletion of ${ number } item from the trash?"
 msgstr ""
 
-#: src/Template/Layout/js/app/pages/modules/index.js:141
+#: src/Template/Layout/js/app/pages/modules/index.js:142
 #, javascript-format
 msgid "Moving ${ number } item(s) to trash. Are you sure?"
 msgstr ""
 
-#: src/Template/Layout/js/app/pages/model/index.js:261
+#: src/Template/Layout/js/app/pages/model/index.js:262
 #, javascript-format
 msgid "Do you really want to trash these property types? ${ types }"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:263
+#: src/Template/Layout/js/app/components/filter-box.js:214
+msgid "Search text too short. Minimum length is 3. Retry"
+msgstr ""
+
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:262
 msgid "Error while creating new object."
 msgstr ""
 
-#: src/Template/Layout/js/app/components/history/history.js:79
+#: src/Template/Layout/js/app/components/history/history.js:88
 msgid ""
 "Restored data will replace current data (you can still check the data before "
 "saving). Are you sure?"

--- a/src/Locale/it_IT/default.po
+++ b/src/Locale/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-01-21 16:33:19 \n"
+"POT-Creation-Date: 2021-07-16 07:10:30 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -28,6 +28,9 @@ msgstr "Aggiungi traduzione"
 
 msgid "Advanced"
 msgstr "Avanzate"
+
+msgid "Alert!"
+msgstr "Attenzione!"
 
 msgid "All"
 msgstr "Tutti"
@@ -65,7 +68,10 @@ msgstr "Traduci automaticamente tutti i campi"
 msgid "BEdita Web site"
 msgstr "Sito BEdita"
 
-msgid "BEdita {0}"
+msgid "Back to login"
+msgstr "Torna al login"
+
+msgid "Bad related data method"
 msgstr ""
 
 msgid "Bulk Action failed on: "
@@ -100,6 +106,9 @@ msgstr "Clona"
 
 msgid "Close"
 msgstr "Chiudi"
+
+msgid "Concurrent users"
+msgstr "Redattori concorrenti"
 
 msgid "Confirm new password"
 msgstr "Conferma nuova password"
@@ -182,9 +191,6 @@ msgstr "Errore nel caricamento del contenuto richiesto"
 msgid "Events"
 msgstr "Eventi"
 
-msgid "Competition Notices"
-msgstr "Bandi"
-
 msgid "Export"
 msgstr "Esporta"
 
@@ -193,9 +199,6 @@ msgstr "Esporta Tutti"
 
 msgid "Export Filtered"
 msgstr "Esporta Filtrati"
-
-msgid "Format choosen is not available"
-msgstr "Il formato selezionato non è disponibile"
 
 msgid "Failed to write file to disk"
 msgstr "Scrittura file su disco fallita"
@@ -223,6 +226,9 @@ msgstr "Cartelle"
 
 msgid "Forgot your password?"
 msgstr "Hai dimenticato la password?"
+
+msgid "Format choosen is not available"
+msgstr "Il formato selezionato non è disponibile"
 
 msgid "From"
 msgstr "Da"
@@ -269,26 +275,11 @@ msgstr "Lingua"
 msgid "Language and translations"
 msgstr "Lingua e traduzioni"
 
-msgid "Places"
-msgstr "Luoghi"
+msgid "Left types"
+msgstr ""
 
 msgid "Locations"
 msgstr "Posizioni"
-
-msgid "Libraries"
-msgstr "Biblioteche"
-
-msgid "Bibliographies"
-msgstr "Bibliografie"
-
-msgid "Books"
-msgstr "Libri"
-
-msgid "Lecture Groups"
-msgstr "Gruppi di lettura"
-
-msgid "Galleries"
-msgstr "Gallerie"
 
 msgid "Log out"
 msgstr "Esci"
@@ -298,9 +289,6 @@ msgstr "Accedi"
 
 msgid "Login required"
 msgstr "È richiesto il login"
-
-msgid "Back to login"
-msgstr "Torna al login"
 
 msgid "Long Lat Coordinates"
 msgstr ""
@@ -407,9 +395,6 @@ msgstr "Opzioni"
 msgid "Other"
 msgstr "Altro"
 
-msgid "Password"
-msgstr ""
-
 msgid "Password reset"
 msgstr "Reimposta password"
 
@@ -429,6 +414,9 @@ msgid "Please provide a Mapbox access token in app configuration"
 msgstr ""
 "Per visualizzare la mappa è necessario inserire un token di accesso a Mapbox "
 "in configurazione"
+
+msgid "Position"
+msgstr ""
 
 msgid "Preferences and Tools"
 msgstr "Preferenze e Strumenti"
@@ -484,17 +472,20 @@ msgstr "Risultato"
 msgid "Retype password"
 msgstr "Ridigita password"
 
+msgid "Right types"
+msgstr ""
+
 msgid "Save"
 msgstr "Salva"
 
 msgid "Search"
 msgstr "Cerca"
 
+msgid "Select a project"
+msgstr ""
+
 msgid "Set selected"
 msgstr "Applica a selezione"
-
-msgid "Settings"
-msgstr "Impostazioni"
 
 msgid "Sign in"
 msgstr "Accedi"
@@ -590,9 +581,6 @@ msgstr "Profilo Utente"
 msgid "User profile saved"
 msgstr "Profilo utente salvato"
 
-msgid "Username"
-msgstr "Nome utente"
-
 msgid "Users"
 msgstr "Utenti"
 
@@ -617,11 +605,11 @@ msgstr "Hai richiesto una modifica della password, fornisci una nuova password"
 msgid "Your recent items"
 msgstr "I tuoi elementi più recenti"
 
+msgid "add"
+msgstr ""
+
 msgid "add objects"
 msgstr "aggiungi oggetti"
-
-msgid "add to"
-msgstr "aggiungi a"
 
 msgid "cancel"
 msgstr "annulla"
@@ -644,6 +632,9 @@ msgstr "crea nuovo"
 msgid "current password"
 msgstr "password corrente"
 
+msgid "elements to"
+msgstr ""
+
 msgid "empty"
 msgstr "vuoto"
 
@@ -651,9 +642,6 @@ msgid "file name"
 msgstr "nome del file"
 
 msgid "id"
-msgstr ""
-
-msgid "language"
 msgstr ""
 
 msgid "modified"
@@ -670,6 +658,9 @@ msgstr "oggetti a"
 
 msgid "original"
 msgstr "originale"
+
+msgid "related object"
+msgstr ""
 
 msgid "remove"
 msgstr "rimuovi"
@@ -713,63 +704,97 @@ msgstr "attenzione"
 msgid "www.bedita.com"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:158
-#: src/Template/Layout/js/app/components/history/history.js:90
+#: src/Template/Layout/js/app/app.js:157
+#: src/Template/Layout/js/app/components/history/history.js:99
 #, javascript-format
 msgid "Please insert a new title on \"${ title }\" clone"
 msgstr "Inserisci un nuovo titolo per la copia di \"${ title }\""
 
-#: src/Template/Layout/js/app/app.js:159
-#: src/Template/Layout/js/app/components/history/history.js:91
+#: src/Template/Layout/js/app/app.js:158
+#: src/Template/Layout/js/app/components/history/history.js:100
 msgid "copy"
 msgstr "copia"
 
-#: src/Template/Layout/js/app/app.js:481
+#: src/Template/Layout/js/app/app.js:477
 msgid "If you confirm, this data will be gone forever. Are you sure?"
 msgstr "Questo dato verrà eliminato definitivamente. Vuoi proseguire?"
 
-#: src/Template/Layout/js/app/app.js:483
+#: src/Template/Layout/js/app/app.js:479
 msgid "Do you really want to trash the object?"
 msgstr "Vuoi davvero spostare l'oggetto nel cestino?"
 
-#: src/Template/Layout/js/app/app.js:492
-#: src/Template/Layout/js/app/components/history/history.js:82
-#: src/Template/Layout/js/app/pages/model/index.js:263
+#: src/Template/Layout/js/app/app.js:487
+#: src/Template/Layout/js/app/components/history/history.js:89
+#: src/Template/Layout/js/app/pages/model/index.js:262
 #: src/Template/Layout/js/app/pages/modules/index.js:144
-#: src/Template/Layout/js/app/pages/trash/index.js:42
+#: src/Template/Layout/js/app/pages/trash/index.js:43
 msgid "yes, proceed"
 msgstr "sì, prosegui"
 
-#: src/Template/Layout/js/app/app.js:501
+#: src/Template/Layout/js/app/app.js:496
 msgid "There are unsaved changes, are you sure you want to leave page?"
 msgstr "Ci sono delle modifiche non salvate, vuoi comunque lasciare la pagina?"
 
-#: src/Template/Layout/js/app/pages/trash/index.js:39
+#: src/Template/Layout/js/app/pages/trash/index.js:42
 #, javascript-format
 msgid "Do you confirm the deletion of ${ number } item from the trash?"
 msgstr "Confermi la cancellazione di ${ number } elementi dal cestino?"
 
-#: src/Template/Layout/js/app/pages/modules/index.js:141
+#: src/Template/Layout/js/app/pages/modules/index.js:142
 #, javascript-format
 msgid "Moving ${ number } item(s) to trash. Are you sure?"
 msgstr "Stai per spostare ${ number } elementi nel cestino. Vuoi procedere?"
 
-#: src/Template/Layout/js/app/pages/model/index.js:261
+#: src/Template/Layout/js/app/pages/model/index.js:262
 #, javascript-format
 msgid "Do you really want to trash these property types? ${ types }"
 msgstr "Vuoi davvero cancellare questi tipi di proprietà? ${ types }"
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:263
+#: src/Template/Layout/js/app/components/filter-box.js:214
+msgid "Search text too short. Minimum length is 3. Retry"
+msgstr ""
+
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:262
 msgid "Error while creating new object."
 msgstr "Si è verificato un errore durante la creazione del nuovo oggetto."
 
-#: src/Template/Layout/js/app/components/history/history.js:79
+#: src/Template/Layout/js/app/components/history/history.js:88
 msgid ""
 "Restored data will replace current data (you can still check the data before "
 "saving). Are you sure?"
 msgstr ""
 "I dati recuperati sostiruiranno quelli attuali (potrai comunque controllarli "
 "prima di salvare). Vuoi procedere?"
+
+#~ msgid "Competition Notices"
+#~ msgstr "Bandi"
+
+#~ msgid "Places"
+#~ msgstr "Luoghi"
+
+#~ msgid "Libraries"
+#~ msgstr "Biblioteche"
+
+#~ msgid "Bibliographies"
+#~ msgstr "Bibliografie"
+
+#~ msgid "Books"
+#~ msgstr "Libri"
+
+#~ msgid "Lecture Groups"
+#~ msgstr "Gruppi di lettura"
+
+#~ msgid "Galleries"
+#~ msgstr "Gallerie"
+
+#~ msgid "Settings"
+#~ msgstr "Impostazioni"
+
+#~ msgid "Username"
+#~ msgstr "Nome utente"
+
+#~ msgid "add to"
+#~ msgstr "aggiungi a"
 
 #~ msgid "Coordinates"
 #~ msgstr "Coordinate"

--- a/src/Locale/master.pot
+++ b/src/Locale/master.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-01-21 16:33:19 \n"
+"POT-Creation-Date: 2021-07-16 07:10:30 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -24,6 +24,9 @@ msgid "Add translation"
 msgstr ""
 
 msgid "Advanced"
+msgstr ""
+
+msgid "Alert!"
 msgstr ""
 
 msgid "All"
@@ -62,7 +65,10 @@ msgstr ""
 msgid "BEdita Web site"
 msgstr ""
 
-msgid "BEdita {0}"
+msgid "Back to login"
+msgstr ""
+
+msgid "Bad related data method"
 msgstr ""
 
 msgid "Bulk Action failed on: "
@@ -96,6 +102,9 @@ msgid "Clone"
 msgstr ""
 
 msgid "Close"
+msgstr ""
+
+msgid "Concurrent users"
 msgstr ""
 
 msgid "Confirm new password"
@@ -188,9 +197,6 @@ msgstr ""
 msgid "Export Filtered"
 msgstr ""
 
-msgid "Format choosen is not available"
-msgstr ""
-
 msgid "Failed to write file to disk"
 msgstr ""
 
@@ -216,6 +222,9 @@ msgid "Folders"
 msgstr ""
 
 msgid "Forgot your password?"
+msgstr ""
+
+msgid "Format choosen is not available"
 msgstr ""
 
 msgid "From"
@@ -261,6 +270,9 @@ msgid "Language"
 msgstr ""
 
 msgid "Language and translations"
+msgstr ""
+
+msgid "Left types"
 msgstr ""
 
 msgid "Locations"
@@ -380,9 +392,6 @@ msgstr ""
 msgid "Other"
 msgstr ""
 
-msgid "Password"
-msgstr ""
-
 msgid "Password reset"
 msgstr ""
 
@@ -399,6 +408,9 @@ msgid "Please check your mailbox and follow the instructions"
 msgstr ""
 
 msgid "Please provide a Mapbox access token in app configuration"
+msgstr ""
+
+msgid "Position"
 msgstr ""
 
 msgid "Preferences and Tools"
@@ -431,7 +443,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-msgid "Request password reset"
+msgid "Request password"
 msgstr ""
 
 msgid "Reset filters"
@@ -455,16 +467,19 @@ msgstr ""
 msgid "Retype password"
 msgstr ""
 
+msgid "Right types"
+msgstr ""
+
 msgid "Save"
 msgstr ""
 
 msgid "Search"
 msgstr ""
 
-msgid "Set selected"
+msgid "Select a project"
 msgstr ""
 
-msgid "Settings"
+msgid "Set selected"
 msgstr ""
 
 msgid "Sign in"
@@ -560,9 +575,6 @@ msgstr ""
 msgid "User profile saved"
 msgstr ""
 
-msgid "Username"
-msgstr ""
-
 msgid "Users"
 msgstr ""
 
@@ -587,10 +599,10 @@ msgstr ""
 msgid "Your recent items"
 msgstr ""
 
-msgid "add objects"
+msgid "add"
 msgstr ""
 
-msgid "add to"
+msgid "add objects"
 msgstr ""
 
 msgid "cancel"
@@ -614,6 +626,9 @@ msgstr ""
 msgid "current password"
 msgstr ""
 
+msgid "elements to"
+msgstr ""
+
 msgid "empty"
 msgstr ""
 
@@ -621,9 +636,6 @@ msgid "file name"
 msgstr ""
 
 msgid "id"
-msgstr ""
-
-msgid "language"
 msgstr ""
 
 msgid "modified"
@@ -639,6 +651,9 @@ msgid "objects to"
 msgstr ""
 
 msgid "original"
+msgstr ""
+
+msgid "related object"
 msgstr ""
 
 msgid "remove"
@@ -683,57 +698,61 @@ msgstr ""
 msgid "www.bedita.com"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:158
-#: src/Template/Layout/js/app/components/history/history.js:90
+#: src/Template/Layout/js/app/app.js:157
+#: src/Template/Layout/js/app/components/history/history.js:99
 #, javascript-format
 msgid "Please insert a new title on \"${ title }\" clone"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:159
-#: src/Template/Layout/js/app/components/history/history.js:91
+#: src/Template/Layout/js/app/app.js:158
+#: src/Template/Layout/js/app/components/history/history.js:100
 msgid "copy"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:481
+#: src/Template/Layout/js/app/app.js:477
 msgid "If you confirm, this data will be gone forever. Are you sure?"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:483
+#: src/Template/Layout/js/app/app.js:479
 msgid "Do you really want to trash the object?"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:492
-#: src/Template/Layout/js/app/components/history/history.js:82
-#: src/Template/Layout/js/app/pages/model/index.js:263
+#: src/Template/Layout/js/app/app.js:487
+#: src/Template/Layout/js/app/components/history/history.js:89
+#: src/Template/Layout/js/app/pages/model/index.js:262
 #: src/Template/Layout/js/app/pages/modules/index.js:144
-#: src/Template/Layout/js/app/pages/trash/index.js:42
+#: src/Template/Layout/js/app/pages/trash/index.js:43
 msgid "yes, proceed"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:501
+#: src/Template/Layout/js/app/app.js:496
 msgid "There are unsaved changes, are you sure you want to leave page?"
 msgstr ""
 
-#: src/Template/Layout/js/app/pages/trash/index.js:39
+#: src/Template/Layout/js/app/pages/trash/index.js:42
 #, javascript-format
 msgid "Do you confirm the deletion of ${ number } item from the trash?"
 msgstr ""
 
-#: src/Template/Layout/js/app/pages/modules/index.js:141
+#: src/Template/Layout/js/app/pages/modules/index.js:142
 #, javascript-format
 msgid "Moving ${ number } item(s) to trash. Are you sure?"
 msgstr ""
 
-#: src/Template/Layout/js/app/pages/model/index.js:261
+#: src/Template/Layout/js/app/pages/model/index.js:262
 #, javascript-format
 msgid "Do you really want to trash these property types? ${ types }"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:263
+#: src/Template/Layout/js/app/components/filter-box.js:214
+msgid "Search text too short. Minimum length is 3. Retry"
+msgstr ""
+
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:262
 msgid "Error while creating new object."
 msgstr ""
 
-#: src/Template/Layout/js/app/components/history/history.js:79
+#: src/Template/Layout/js/app/components/history/history.js:88
 msgid ""
 "Restored data will replace current data (you can still check the data before "
 "saving). Are you sure?"

--- a/src/Template/Element/Menu/sidebar.scss
+++ b/src/Template/Element/Menu/sidebar.scss
@@ -55,6 +55,14 @@
     }
 }
 
+ul.concurrent-editors {
+    margin:0; padding:0;
+    li {
+        padding: .5rem 0 .5rem 0;
+        border-bottom: 1px solid $gray-600; 
+    }
+}
+
 .project-title {
     width: 100%;
     // make whole area clickable

--- a/src/Template/Element/Menu/sidebar.scss
+++ b/src/Template/Element/Menu/sidebar.scss
@@ -25,6 +25,36 @@
     }
 }
 
+
+.module-box-concurrent-editors a {
+    position: relative;
+    display: flex;
+    height: $dashboard-item-height;
+    background-image: url('/svg/concurrent-editors.svg');
+    background-repeat:no-repeat;
+    background-position: center center;
+    font-size: $font-size-base;
+    padding: $gutter;
+    filter: brightness(1);
+    transition: filter .3s;
+
+    &:after {
+        content: '';
+        position: absolute;
+        bottom: 0; left: 0;
+        width: 100%; height: $gutter * 1.5;
+        background-color: $black;
+        opacity: .2;
+        transition: opacity .3s;
+    }
+
+    &:hover {
+        filter: brightness(1.2);
+        &:after { opacity: .5; }
+        &[class^="icon-"]:before, &[class*=" icon-"]:before { opacity: .8; }
+    }
+}
+
 .project-title {
     width: 100%;
     // make whole area clickable

--- a/src/Template/Element/Menu/sidebar.twig
+++ b/src/Template/Element/Menu/sidebar.twig
@@ -11,11 +11,22 @@
         <div class="sidebar-module-commands">
 
         {% if not Layout.isDashboard() %}
-            <div class="module-box">
+            {% set editors = Editors.list() %}
+            <div class="module-box{% if editors|length > 1 %}-concurrent-editors{% endif %}">
                 {{ Layout.moduleLink()|raw }}
             </div>
+            {% if editors|length > 1 %}
+            <div>
+                <b>{{ __('Alert!') }}</b>
+                <span>{{ __('Concurrent users') }}:</span>
+                {% for editor in editors %}
+                    <div style="border-bottom: 1px solid #f8f9fa; ">{{ editor.name }}</div>
+                {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
         {% endif %}
-        
+
             <div class="module-buttons">
                 {{ _view.fetch('module-buttons')|raw }}
                 {% if currentModule.hints.multiple_types and types.right is iterable %}
@@ -31,7 +42,7 @@
 
 
     <div class="sidebar-body">
-        
+
         {% if I18n.getLanguages|length > 1 %}
             <div>
                 <p class="has-text-size-smaller">

--- a/src/Template/Element/Menu/sidebar.twig
+++ b/src/Template/Element/Menu/sidebar.twig
@@ -16,14 +16,13 @@
                 {{ Layout.moduleLink()|raw }}
             </div>
             {% if editors|length > 1 %}
-            <div>
-                <b>{{ __('Alert!') }}</b>
+            <ul class="concurrent-editors">
+                <strong>{{ __('Alert!') }}</strong>
                 <span>{{ __('Concurrent users') }}:</span>
                 {% for editor in editors %}
-                    <div style="border-bottom: 1px solid #f8f9fa; ">{{ editor.name }}</div>
+                    <li>{{ editor.name }}</li>
                 {% endfor %}
-                </ul>
-            </div>
+            </ul>
             {% endif %}
         {% endif %}
 

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -38,6 +38,7 @@ class AppView extends TwigView
                 'inputContainer' => '<div class="input {{type}}{{required}} {{containerClass}}">{{content}}</div>',
             ],
         ]);
+        $this->loadHelper('Editors');
         $this->loadHelper('Layout');
         $this->loadHelper('Array');
         $this->loadHelper('Html');

--- a/src/View/Helper/EditorsHelper.php
+++ b/src/View/Helper/EditorsHelper.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\View\Helper;
+
+use Cake\Cache\Cache;
+use Cake\Utility\Hash;
+use Cake\View\Helper;
+
+/**
+ * Helper for editors
+ */
+class EditorsHelper extends Helper
+{
+    /**
+     * Get list of object editors.
+     *
+     * @return array
+     */
+    public function list(): array
+    {
+        $id = (string)Hash::get((array)$this->getView()->get('object'), 'id');
+        $cached = (string)Cache::read('objects_editors', 'default');
+        $objectsEditors = (array)json_decode($cached, true);
+        if (array_key_exists($id, $objectsEditors)) {
+            return $objectsEditors[$id];
+        }
+
+        return [];
+    }
+}

--- a/tests/TestCase/Controller/Component/ObjectsEditorsComponentTest.php
+++ b/tests/TestCase/Controller/Component/ObjectsEditorsComponentTest.php
@@ -103,6 +103,18 @@ class ObjectsEditorsComponentTest extends TestCase
      */
     public function testEditorName(): void
     {
+        // empty user
+        $expected = null;
+        $actual = $this->ObjectsEditors->editorName();
+        static::assertEquals($expected, $actual);
+
+        // no username, no name, no surname
+        $user = ['id' => 123];
+        $this->ObjectsEditors->getController()->Auth->setUser($user);
+        $expected = null;
+        $actual = $this->ObjectsEditors->editorName();
+        static::assertEquals($expected, $actual);
+
         // username
         $user = ['id' => 123, 'attributes' => ['username' => 'gustavo']];
         $this->ObjectsEditors->getController()->Auth->setUser($user);

--- a/tests/TestCase/Controller/Component/ObjectsEditorsComponentTest.php
+++ b/tests/TestCase/Controller/Component/ObjectsEditorsComponentTest.php
@@ -5,6 +5,7 @@ use App\Controller\Component\ObjectsEditorsComponent;
 use Cake\Cache\Cache;
 use Cake\Controller\Component\AuthComponent;
 use Cake\Controller\Controller;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -55,9 +56,17 @@ class ObjectsEditorsComponentTest extends TestCase
      */
     public function testInitialize(): void
     {
-        $this->ObjectsEditors->initialize([]);
         // verify concurrent check time is not empty
+        $this->ObjectsEditors->initialize([]);
         static::assertNotEmpty($this->ObjectsEditors->concurrentCheckTime);
+
+        // verify concurrent check time is read from config
+        $expected = 15000;
+        Configure::write('Editors.concurrentCheckTime', 15000); // 15 seconds
+        $this->ObjectsEditors->initialize([]);
+        $actual = $this->ObjectsEditors->concurrentCheckTime;
+        static::assertEquals($expected, $actual);
+
         // verify objectsEditors is an array
         $expected = true;
         $actual = is_array($this->ObjectsEditors->objectsEditors);

--- a/tests/TestCase/Controller/Component/ObjectsEditorsComponentTest.php
+++ b/tests/TestCase/Controller/Component/ObjectsEditorsComponentTest.php
@@ -1,0 +1,175 @@
+<?php
+namespace App\Test\TestCase\Controller\Component;
+
+use App\Controller\Component\ObjectsEditorsComponent;
+use Cake\Cache\Cache;
+use Cake\Controller\Component\AuthComponent;
+use Cake\Controller\Controller;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \App\Controller\Component\ObjectsEditorsComponent} Test Case
+ *
+ * @coversDefaultClass \App\Controller\Component\ObjectsEditorsComponent
+ */
+class ObjectsEditorsComponentTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \App\Controller\Component\ObjectsEditorsComponent
+     */
+    public $ObjectsEditors;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp(): void
+    {
+        Cache::enable();
+        parent::setUp();
+        $controller = new Controller();
+        $registry = $controller->components();
+        $registry->load('Auth');
+        $this->ObjectsEditors = $registry->load(ObjectsEditorsComponent::class);
+        $this->Auth = $registry->load(AuthComponent::class);
+        $controller->Auth = $this->Auth;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown(): void
+    {
+        unset($this->ObjectsEditors);
+        Cache::disable();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test initial setup
+     *
+     * @return void
+     * @covers ::initialize()
+     */
+    public function testInitialize(): void
+    {
+        $this->ObjectsEditors->initialize([]);
+        // verify concurrent check time is not empty
+        static::assertNotEmpty($this->ObjectsEditors->concurrentCheckTime);
+        // verify objectsEditors is an array
+        $expected = true;
+        $actual = is_array($this->ObjectsEditors->objectsEditors);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `update` method
+     *
+     * @return void
+     * @covers ::update()
+     */
+    public function testUpdate(): void
+    {
+        $time = time();
+        $this->ObjectsEditors->objectsEditors = [
+            '99999' => [
+                ['name' => 'gustavo', 'timestamp' => $time],
+                ['name' => 'john doe', 'timestamp' => $time],
+            ],
+        ];
+
+        // id not found in objectsEditors
+        $user = ['id' => 123, 'attributes' => ['name' => 'Gustavo', 'surname' => 'Support']];
+        $this->ObjectsEditors->getController()->Auth->setUser($user);
+        $this->ObjectsEditors->update('999');
+        $expected = 'Gustavo Support';
+        $actual = $this->ObjectsEditors->objectsEditors['999'][0]['name'];
+        static::assertEquals($expected, $actual);
+        $expected = [
+            ['name' => 'gustavo', 'timestamp' => $time],
+            ['name' => 'john doe', 'timestamp' => $time],
+        ];
+        $actual = $this->ObjectsEditors->objectsEditors['99999'];
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `editorName` method
+     *
+     * @return void
+     * @covers ::editorName()
+     */
+    public function testEditorName(): void
+    {
+        // username
+        $user = ['id' => 123, 'attributes' => ['username' => 'gustavo']];
+        $this->ObjectsEditors->getController()->Auth->setUser($user);
+        $expected = 'gustavo';
+        $actual = $this->ObjectsEditors->editorName();
+        static::assertEquals($expected, $actual);
+
+        // name + surname
+        $user = ['id' => 123, 'attributes' => ['name' => 'Gustavo', 'surname' => 'Support']];
+        $this->ObjectsEditors->getController()->Auth->setUser($user);
+        $expected = 'Gustavo Support';
+        $actual = $this->ObjectsEditors->editorName();
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `getEditors` method
+     *
+     * @return void
+     * @covers ::getEditors()
+     */
+    public function testGetEditors(): void
+    {
+        // empty cache
+        Cache::delete('objects_editors');
+        $expected = [];
+        $actual = $this->ObjectsEditors->getEditors();
+        static::assertEquals($expected, $actual);
+
+        // not empty cache
+        $user = ['id' => 123, 'attributes' => ['username' => 'gustavo']];
+        $this->ObjectsEditors->getController()->Auth->setUser($user);
+        $expected = $this->ObjectsEditors->update(999);
+        $expected = json_decode($expected, true);
+        $actual = $this->ObjectsEditors->getEditors();
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `cleanup` method
+     *
+     * @return void
+     * @covers ::cleanup()
+     */
+    public function testCleanup(): void
+    {
+        // empty object editors
+        $expected = [];
+        $this->ObjectsEditors->objectsEditors = $expected;
+        $this->ObjectsEditors->cleanup();
+        static::assertEquals($expected, $this->ObjectsEditors->objectsEditors);
+
+        // not empty, remove expired
+        $validity = $this->ObjectsEditors->concurrentCheckTime / 1000;
+        $time = time();
+        $this->ObjectsEditors->objectsEditors = [
+            '99999' => [
+                ['name' => 'gustavo', 'timestamp' => $time], // valid
+                ['name' => 'john doe', 'timestamp' => $time - $validity - 1], // expired
+            ],
+        ];
+        $this->ObjectsEditors->cleanup();
+        $expected = [
+            '99999' => [
+                ['name' => 'gustavo', 'timestamp' => $time], // valid
+            ],
+        ];
+        static::assertEquals($expected, $this->ObjectsEditors->objectsEditors);
+    }
+}

--- a/tests/TestCase/Controller/Component/ObjectsEditorsComponentTest.php
+++ b/tests/TestCase/Controller/Component/ObjectsEditorsComponentTest.php
@@ -86,6 +86,7 @@ class ObjectsEditorsComponentTest extends TestCase
             '99999' => [
                 ['name' => 'gustavo', 'timestamp' => $time],
                 ['name' => 'john doe', 'timestamp' => $time],
+                ['name' => 'jane doe', 'timestamp' => $time],
             ],
         ];
 
@@ -99,8 +100,20 @@ class ObjectsEditorsComponentTest extends TestCase
         $expected = [
             ['name' => 'gustavo', 'timestamp' => $time],
             ['name' => 'john doe', 'timestamp' => $time],
+            ['name' => 'jane doe', 'timestamp' => $time],
         ];
         $actual = $this->ObjectsEditors->objectsEditors['99999'];
+        static::assertEquals($expected, $actual);
+
+        // id found in objectsEditors
+        $user = ['id' => 12345, 'attributes' => ['name' => 'john', 'surname' => 'doe']];
+        $this->ObjectsEditors->getController()->Auth->setUser($user);
+        $this->ObjectsEditors->update('99999');
+        $expected = 'gustavo';
+        $actual = $this->ObjectsEditors->objectsEditors['99999'][0]['name'];
+        static::assertEquals($expected, $actual);
+        $expected = 'john doe';
+        $actual = $this->ObjectsEditors->objectsEditors['99999'][1]['name'];
         static::assertEquals($expected, $actual);
     }
 

--- a/tests/TestCase/View/Helper/EditorsHelperTest.php
+++ b/tests/TestCase/View/Helper/EditorsHelperTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\EditorsHelper;
+use Cake\Cache\Cache;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+/**
+ * {@see \App\View\Helper\EditorsHelper} Test Case
+ *
+ * @coversDefaultClass \App\View\Helper\EditorsHelper
+ */
+class EditorsHelperTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \App\View\Helper\EditorsHelper
+     */
+    public $EditorsHelper;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp(): void
+    {
+        Cache::enable();
+        parent::setUp();
+        $request = $response = $events = null;
+        $this->EditorsHelper = new EditorsHelper(new View($request, $response, $events, []));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown(): void
+    {
+        unset($this->EditorsHelper);
+        Cache::disable();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test `list` method
+     *
+     * @return void
+     * @covers ::list()
+     */
+    public function testlist(): void
+    {
+        // no objects in view
+        $actual = $this->EditorsHelper->list();
+        static::assertSame([], $actual);
+
+        // set something by ID in objects_editors cache
+        $time = time();
+        $expected = [
+            ['name' => 'gustavo', 'timestamp' => $time],
+            ['name' => 'john doe', 'timestamp' => $time],
+        ];
+        $data = [
+            '99' => $expected,
+        ];
+        Cache::write('objects_editors', json_encode($data));
+        $this->EditorsHelper->getView()->set('object', ['id' => '99']);
+        $actual = $this->EditorsHelper->list();
+        static::assertEquals($expected, $actual);
+    }
+}

--- a/webroot/svg/concurrent-editors.svg
+++ b/webroot/svg/concurrent-editors.svg
@@ -1,0 +1,9 @@
+<svg id="collaborate" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <path id="Tracciato_206" data-name="Tracciato 206" d="M6,21V20H4v1a7,7,0,0,0,7,7h3V26H11a5,5,0,0,1-5-5Z"/>
+  <path id="Tracciato_207" data-name="Tracciato 207" d="M24,11v1h2V11a7,7,0,0,0-7-7H16V6h3a5,5,0,0,1,5,5Z"/>
+  <path id="Tracciato_208" data-name="Tracciato 208" d="M11,11H5a3,3,0,0,0-3,3v2H4V14a1,1,0,0,1,1-1h6a1,1,0,0,1,1,1v2h2V14a3,3,0,0,0-3-3Z"/>
+  <path id="Tracciato_209" data-name="Tracciato 209" d="M8,10A4,4,0,1,0,4,6a4,4,0,0,0,4,4ZM8,4A2,2,0,1,1,6,6,2,2,0,0,1,8,4Z"/>
+  <path id="Tracciato_210" data-name="Tracciato 210" d="M27,25H21a3,3,0,0,0-3,3v2h2V28a1,1,0,0,1,1-1h6a1,1,0,0,1,1,1v2h2V28a3,3,0,0,0-3-3Z"/>
+  <path id="Tracciato_211" data-name="Tracciato 211" d="M20,20a4,4,0,1,0,4-4A4,4,0,0,0,20,20Zm6,0a2,2,0,1,1-2-2A2,2,0,0,1,26,20Z"/>
+  <rect id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" width="32" height="32" fill="none"/>
+</svg>


### PR DESCRIPTION
This provides a visible "Alert! Concurrent users: ..." in object view, when more than one user accesses an object view page.

How long a user is considered "active editor" on an object's view page? this is configurable with:

```
/**
 * Editors configuration.
 * concurrentCheckTime: the time in milliseconds that a concurrent access is considered still active
 */
'Editors' => [
     'concurrentCheckTime' => 30000, // 30 seconds
],
```

Default `concurrentCheckTime` is 20000 (20 seconds).

The system cleans up concurrent editors data, on each page access; expired users accesses are removed.

Note: we used `Cache` to save the `objects_editors` data: it is multi-user and it doesn't need database.

Rif: https://chialab.atlassian.net/browse/BEM-26