### PR TITLE
Fix: redirect URL after object save

### DIFF
--- a/src/Template/Layout/js/app/pages/modules/view.js
+++ b/src/Template/Layout/js/app/pages/modules/view.js
@@ -61,10 +61,15 @@ export default {
 
             if (response.ok) {
                 const json = await response.json();
-                // clear form dirty state, to avoid alert message about unsaved changes when changing page
+                if (json.error) {
+                    console.error('server responded with an error', json.error);
+
+                    return;
+                }
+
+                // clear form dirty state, to avoid alert message about unsaved changes before changing page
                 window._vueInstance.dataChanged.clear();
-                window.location.pathname = window.location.pathname.replace('/new', `/${json.data[0].id}`);
-                window.location.pathname = window.location.pathname.replace('/clone', `/view`);
+                window.location = this.$helpers.buildViewUrl(json.data[0].id);
 
                 return;
             }


### PR DESCRIPTION
This PR fixes a bug introduced with #580 and #583, where using `String.replace` could lead to unexpected URLs for object type names that conflicted with the strings used for comparison. For example, creating a new object of type `news` from URL `/news/view/new` redirected to `/<object id>s/view/<object id>`.

Here is used the utility function `buildViewUrl(<object id>)` to generate the correct URL to the `/view` action for the new (or cloned) object.