### PR TITLE
refactor: rename methods and routes {action}Json to {action}

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -225,6 +225,6 @@ Type::build('timestamp')
  */
 Configure::write('CsrfExceptions', [
     'PropertyTypes' => ['save'],
-    'Modules' => ['saveJson'],
+    'Modules' => ['save'],
     'Translator' => ['translate'],
 ]);

--- a/config/routes.php
+++ b/config/routes.php
@@ -216,19 +216,19 @@ Router::scope('/', function (RouteBuilder $routes) {
     );
     // Relations ...
     $routes->connect(
-        '/:object_type/view/:id/relatedJson/:relation',
-        ['controller' => 'Modules', 'action' => 'relatedJson'],
-        ['pass' => ['id', 'relation'], '_name' => 'modules:relatedJson']
+        '/:object_type/view/:id/related/:relation',
+        ['controller' => 'Modules', 'action' => 'related'],
+        ['pass' => ['id', 'relation'], '_name' => 'modules:related']
     );
     $routes->connect(
-        '/:object_type/view/:id/relationshipsJson/:relation',
-        ['controller' => 'Modules', 'action' => 'relationshipsJson'],
-        ['pass' => ['id', 'relation'], '_name' => 'modules:relationshipsJson']
+        '/:object_type/view/:id/relationships/:relation',
+        ['controller' => 'Modules', 'action' => 'relationships'],
+        ['pass' => ['id', 'relation'], '_name' => 'modules:relationships']
     );
     $routes->connect(
-        '/:object_type/view/:id/resourcesJson/:relation',
-        ['controller' => 'Modules', 'action' => 'resourcesJson'],
-        ['pass' => ['id', 'relation'], '_name' => 'modules:resourcesJson']
+        '/:object_type/view/:id/resources/:relation',
+        ['controller' => 'Modules', 'action' => 'resources'],
+        ['pass' => ['id', 'relation'], '_name' => 'modules:resources']
     );
     $routes->connect(
         '/:object_type/view/:id/relationData/:relation',

--- a/config/routes.php
+++ b/config/routes.php
@@ -241,11 +241,6 @@ Router::scope('/', function (RouteBuilder $routes) {
         ['_name' => 'modules:save']
     );
     $routes->connect(
-        '/:object_type/saveJson',
-        ['controller' => 'Modules', 'action' => 'saveJson'],
-        ['_name' => 'modules:saveJson']
-    );
-    $routes->connect(
         '/:object_type/clone/:id',
         ['controller' => 'Modules', 'action' => 'clone'],
         ['pass' => ['id'], '_name' => 'modules:clone']

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -279,6 +279,9 @@ class ModulesController extends AppController
             $this->set(compact('error'));
             $this->set('_serialize', ['error']);
 
+            // set session data to recover form
+            $this->Modules->setDataFromFailedSave($this->objectType, $requestData);
+
             return;
         }
         if ($response['data']) {

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -374,7 +374,7 @@ class ModulesController extends AppController
      * @param string $relation The relation name.
      * @return void
      */
-    public function relatedJson($id, string $relation): void
+    public function related($id, string $relation): void
     {
         if ($id === 'new') {
             $this->set('data', []);
@@ -411,7 +411,7 @@ class ModulesController extends AppController
      * @param string $type the resource type name.
      * @return void
      */
-    public function resourcesJson($id, string $type): void
+    public function resources($id, string $type): void
     {
         $this->request->allowMethod(['get']);
         $query = $this->Query->prepare($this->request->getQueryParams());
@@ -438,7 +438,7 @@ class ModulesController extends AppController
      * @param string $relation The relation name.
      * @return void
      */
-    public function relationshipsJson($id, string $relation): void
+    public function relationships($id, string $relation): void
     {
         $this->request->allowMethod(['get']);
         $available = $this->availableRelationshipsUrl($relation);

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -61,7 +61,7 @@ class ModulesController extends AppController
             $this->Schema->setConfig('type', $this->objectType);
         }
 
-        $this->Security->setConfig('unlockedActions', ['saveJson']);
+        $this->Security->setConfig('unlockedActions', ['save']);
     }
 
     /**
@@ -252,57 +252,11 @@ class ModulesController extends AppController
     }
 
     /**
-     * Create or edit single resource.
-     *
-     * @return \Cake\Http\Response|null
-     */
-    public function save(): ?Response
-    {
-        $this->request->allowMethod(['post']);
-        $requestData = $this->prepareRequest($this->objectType);
-        // extract related objects data
-        $relatedData = (array)Hash::get($requestData, '_api');
-        unset($requestData['_api']);
-
-        try {
-            // upload file (if available)
-            $this->Modules->upload($requestData);
-
-            // save data
-            $response = $this->apiClient->save($this->objectType, $requestData);
-            $objectId = (string)Hash::get($response, 'data.id');
-            $this->Modules->saveRelated($objectId, $this->objectType, $relatedData);
-        } catch (InternalErrorException | BEditaClientException | UploadException $e) {
-            // Error! Back to object view or index.
-            $this->log($e, LogLevel::ERROR);
-            $this->Flash->error($e->getMessage(), ['params' => $e]);
-
-            // set session data to recover form
-            $this->Modules->setDataFromFailedSave($this->objectType, $requestData);
-
-            if ($this->request->getData('id')) {
-                return $this->redirect(['_name' => 'modules:view', 'object_type' => $this->objectType, 'id' => $this->request->getData('id')]);
-            }
-
-            return $this->redirect(['_name' => 'modules:list', 'object_type' => $this->objectType]);
-        }
-
-        // annoying message removed, restore with https://github.com/bedita/manager/issues/71
-        // $this->Flash->success(__('Object saved'));
-
-        return $this->redirect([
-            '_name' => 'modules:view',
-            'object_type' => $this->objectType,
-            'id' => $objectId,
-        ]);
-    }
-
-    /**
      * Create new object from ajax request.
      *
      * @return void
      */
-    public function saveJson(): void
+    public function save(): void
     {
         $this->viewBuilder()->setClassName('Json'); // force json response
         $this->request->allowMethod(['post']);

--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -125,6 +125,7 @@ class TranslationsController extends ModulesController
                     'id' => $objectId,
                     'lang' => $lang,
                 ]);
+
                 return;
             }
 
@@ -133,6 +134,7 @@ class TranslationsController extends ModulesController
                 'object_type' => $this->objectType,
                 'id' => $objectId,
             ]);
+
             return;
         }
 

--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -101,10 +101,8 @@ class TranslationsController extends ModulesController
 
     /**
      * Create or edit single translation.
-     *
-     * @return \Cake\Http\Response|null
      */
-    public function save(): ?Response
+    public function save(): void
     {
         $this->request->allowMethod(['post']);
         $requestData = $this->prepareRequest($this->objectType);
@@ -121,22 +119,24 @@ class TranslationsController extends ModulesController
             $this->Flash->error($e->getMessage(), ['params' => $e]);
 
             if ($this->request->getData('id')) {
-                return $this->redirect([
+                $this->redirect([
                     '_name' => 'translations:edit',
                     'object_type' => $this->objectType,
                     'id' => $objectId,
                     'lang' => $lang,
                 ]);
+                return;
             }
 
-            return $this->redirect([
+            $this->redirect([
                 '_name' => 'translations:add',
                 'object_type' => $this->objectType,
                 'id' => $objectId,
             ]);
+            return;
         }
 
-        return $this->redirect([
+        $this->redirect([
             '_name' => 'translations:edit',
             'object_type' => $this->objectType,
             'id' => $objectId,

--- a/src/Controller/UserProfileController.php
+++ b/src/Controller/UserProfileController.php
@@ -75,10 +75,8 @@ class UserProfileController extends AppController
 
     /**
      * Save user profile data
-     *
-     * @return \Cake\Http\Response|null
      */
-    public function save(): ?Response
+    public function save(): void
     {
         $data = $this->request->getData();
         try {
@@ -89,6 +87,6 @@ class UserProfileController extends AppController
             $this->Flash->error($e->getMessage(), ['params' => $e]);
         }
 
-        return $this->redirect(['_name' => 'user_profile:view']);
+        $this->redirect(['_name' => 'user_profile:view']);
     }
 }

--- a/src/Template/Layout/js/app/components/drop-upload.js
+++ b/src/Template/Layout/js/app/components/drop-upload.js
@@ -128,7 +128,7 @@ export default {
                 formData.append('file', file);
                 formData.append('model-type', objectType);
 
-            const url = `/${objectType}/saveJson`;
+            const url = `/${objectType}/save`;
 
             const CancelToken = this.getAxios().CancelToken;
             const source = CancelToken.source();

--- a/src/Template/Layout/js/app/components/locations-view/locations-view.js
+++ b/src/Template/Layout/js/app/components/locations-view/locations-view.js
@@ -44,7 +44,7 @@ export default {
     },
 
     async created() {
-        const requestUrl = `${window.location.href}/relatedJson/${this.relationName}`;
+        const requestUrl = `${window.location.href}/related/${this.relationName}`;
         this.locations = (await (await fetch(requestUrl, options)).json()).data;
 
         // add params for location that does not have them

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -65,7 +65,7 @@ export default {
 
     data() {
         return {
-            method: 'relatedJson',      // define AppController method to be used
+            method: 'related',      // define AppController method to be used
             loading: false,
             objectsLoaded: false,       // objects loaded flag
             positions: {},              // used in children relations

--- a/src/Template/Layout/js/app/components/relation-view/relations-add.js
+++ b/src/Template/Layout/js/app/components/relation-view/relations-add.js
@@ -55,7 +55,7 @@ export default {
 
     data() {
         return {
-            method: 'relationshipsJson',
+            method: 'relationships',
             endpoint: '',
             loading: false,
             selectedObjects: [],

--- a/src/Template/Layout/js/app/components/relation-view/relations-add.js
+++ b/src/Template/Layout/js/app/components/relation-view/relations-add.js
@@ -218,7 +218,7 @@ export default {
 
             // save object
             const baseUrl = window.location.origin;
-            const postUrl = `${baseUrl}/${this.object.type}/saveJson`;
+            const postUrl = `${baseUrl}/${this.object.type}/save`;
 
             const formData = new FormData();
             formData.append('model-type', this.object.type);

--- a/src/Template/Layout/js/app/components/relation-view/relationships-view/relationships-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relationships-view/relationships-view.js
@@ -44,7 +44,7 @@ export default {
 
     data() {
         return {
-            method: 'relationshipsJson',    // define AppController method to be used
+            method: 'relationships',    // define AppController method to be used
             loading: false,
             pendingRelations: [],           // pending elements to be added
             relationsData: [],              // hidden field containing serialized json passed on form submit

--- a/src/Template/Layout/js/app/components/relation-view/resource-relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/resource-relation-view.js
@@ -29,7 +29,7 @@ export default {
 
     data() {
         return {
-            method: 'relatedJson',                      // define AppController method to be used
+            method: 'related',                      // define AppController method to be used
             loading: false,
             count: 0,                                   // count number of related objects, on change triggers an event
         }

--- a/src/Template/Layout/js/app/components/relation-view/roles-list-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/roles-list-view.js
@@ -20,7 +20,7 @@ export default {
 
     data() {
         return {
-            method: 'resourcesJson',
+            method: 'resources',
             removedRelations: [],
         }
     },

--- a/src/Template/Layout/js/app/pages/modules/view.js
+++ b/src/Template/Layout/js/app/pages/modules/view.js
@@ -48,7 +48,11 @@ export default {
             event.stopPropagation();
             const form = new FormData(event.target);
             const action = event.target.getAttribute('action');
-            const response = await fetch(`${action}Json`, {
+            let endpoint = action;
+            if (!endpoint.endsWith('/save')) {
+                endpoint = `${action}Json`;
+            }
+            const response = await fetch(`${endpoint}`, {
                 method: 'POST',
                 headers: {
                     'Accept': 'application/json',

--- a/src/Template/Layout/js/app/pages/modules/view.js
+++ b/src/Template/Layout/js/app/pages/modules/view.js
@@ -48,11 +48,7 @@ export default {
             event.stopPropagation();
             const form = new FormData(event.target);
             const action = event.target.getAttribute('action');
-            let endpoint = action;
-            if (!endpoint.endsWith('/save')) {
-                endpoint = `${action}Json`;
-            }
-            const response = await fetch(`${endpoint}`, {
+            const response = await fetch(action, {
                 method: 'POST',
                 headers: {
                     'Accept': 'application/json',

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -531,7 +531,6 @@ class ModulesControllerTest extends TestCase
         $actual = get_class($error);
         $expected = get_class(new BEditaClientException(''));
         static::assertEquals($expected, $actual);
-
     }
 
     /**

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -487,11 +487,13 @@ class ModulesControllerTest extends TestCase
         $this->controller = new ModulesControllerSample($request);
 
         // do controller call
-        $response = $this->controller->save();
+        $this->controller->save();
 
-        // verify response status code and type
-        static::assertEquals(302, $response->getStatusCode());
-        static::assertEquals('text/html', $response->getType());
+        // verify BEditaClientException
+        $error = $this->controller->viewVars['error'];
+        $actual = get_class($error);
+        $expected = get_class(new BEditaClientException(''));
+        static::assertEquals($expected, $actual);
     }
 
     /**
@@ -522,11 +524,14 @@ class ModulesControllerTest extends TestCase
         $this->controller = new ModulesControllerSample($request);
 
         // do controller call
-        $response = $this->controller->save();
+        $this->controller->save();
 
-        // verify response status code and type
-        static::assertEquals(302, $response->getStatusCode());
-        static::assertEquals('text/html', $response->getType());
+        // verify BEditaClientException
+        $error = $this->controller->viewVars['error'];
+        $actual = get_class($error);
+        $expected = get_class(new BEditaClientException(''));
+        static::assertEquals($expected, $actual);
+
     }
 
     /**
@@ -737,13 +742,13 @@ class ModulesControllerTest extends TestCase
     }
 
     /**
-     * Test `relatedJson` method
+     * Test `related` method
      *
-     * @covers ::relatedJson()
+     * @covers ::related()
      *
      * @return void
      */
-    public function testRelatedJson(): void
+    public function testRelated(): void
     {
         // Setup controller for test
         $this->setupController();
@@ -752,57 +757,57 @@ class ModulesControllerTest extends TestCase
         $id = $this->getTestId();
 
         // do controller call
-        $this->controller->relatedJson($id, 'translations');
+        $this->controller->related($id, 'translations');
 
         // verify expected vars in view
         $this->assertExpectedViewVars(['_serialize', 'data']);
     }
 
     /**
-     * Test `relatedJson` method on `new` object
+     * Test `related` method on `new` object
      *
-     * @covers ::relatedJson()
+     * @covers ::related()
      *
      * @return void
      */
-    public function testRelatedJsonNew(): void
+    public function testRelatedNew(): void
     {
         // Setup controller for test
         $this->setupController();
 
         // do controller call
-        $this->controller->relatedJson('new', 'has_media');
+        $this->controller->related('new', 'has_media');
 
         static::assertEquals([], $this->controller->viewVars['data']);
     }
 
     /**
-     * Test `relatedJson` method, on error
+     * Test `related` method, on error
      *
-     * @covers ::relatedJson()
+     * @covers ::related()
      *
      * @return void
      */
-    public function testRelatedJsonError(): void
+    public function testRelatedError(): void
     {
         // Setup controller for test
         $this->setupController();
 
         // do controller call
-        $this->controller->relatedJson(12346789, 'translations');
+        $this->controller->related(12346789, 'translations');
 
         // verify expected vars in view
         $this->assertExpectedViewVars(['_serialize', 'error']);
     }
 
     /**
-     * Test `resourcesJson method
+     * Test `resources` method
      *
-     * @covers ::resourcesJson)
+     * @covers ::resources()
      *
      * @return void
      */
-    public function testResourcesJson(): void
+    public function testResources(): void
     {
         // Setup controller for test
         $this->setupController();
@@ -811,37 +816,37 @@ class ModulesControllerTest extends TestCase
         $id = $this->getTestId();
 
         // do controller call
-        $this->controller->resourcesJson($id, 'documents');
+        $this->controller->resources($id, 'documents');
 
         // verify expected vars in view
         $this->assertExpectedViewVars(['_serialize', 'data']);
     }
 
     /**
-     * Test `resourcesJson method
+     * Test `resources` method
      *
-     * @covers ::resourcesJson)
+     * @covers ::resources()
      *
      * @return void
      */
-    public function testResourcesJsonError(): void
+    public function testResourcesError(): void
     {
         // Setup controller for test
         $this->setupController();
 
         // do controller call
-        $this->controller->resourcesJson(123456789, 'dummies');
+        $this->controller->resources(123456789, 'dummies');
 
         // verify expected vars in view
         $this->assertExpectedViewVars(['_serialize', 'error']);
     }
 
     /**
-     * Data provider for `testRelationshipsJson` test case.
+     * Data provider for `testRelationships` test case.
      *
      * @return array
      */
-    public function relationshipsJsonProvider(): array
+    public function relationshipsProvider(): array
     {
         return [
             'children' => [
@@ -864,17 +869,17 @@ class ModulesControllerTest extends TestCase
     }
 
     /**
-     * Test `relationshipsJson` method
+     * Test `relationships` method
      *
      * @param string $relation The relation to test
      * @param string $objectType The object type / endpoint
      * @param array $expected The expected data
      *
-     * @covers ::relationshipsJson()
-     * @dataProvider relationshipsJsonProvider()
+     * @covers ::relationships()
+     * @dataProvider relationshipsProvider()
      * @return void
      */
-    public function testRelationshipsJson(string $relation, string $objectType): void
+    public function testRelationships(string $relation, string $objectType): void
     {
         // Setup controller for test
         $this->setupController([
@@ -891,7 +896,7 @@ class ModulesControllerTest extends TestCase
         $id = $this->getTestId();
 
         // do controller call
-        $this->controller->relationshipsJson($id, $relation);
+        $this->controller->relationships($id, $relation);
 
         // verify expected vars in view
         $this->assertExpectedViewVars(['_serialize']);

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -84,9 +84,9 @@ class ModulesControllerSample extends ModulesController
      *
      * @return void
      */
-    public function saveJson(): void
+    public function save(): void
     {
-        parent::saveJson();
+        parent::save();
     }
 }
 
@@ -463,43 +463,6 @@ class ModulesControllerTest extends TestCase
     }
 
     /**
-     * Test `save` method
-     *
-     * @covers ::save()
-     *
-     * @return void
-     */
-    public function testSave(): void
-    {
-        // Setup controller for test
-        $this->setupController();
-
-        // get object for test
-        $o = $this->getTestObject();
-        $config = [
-            'environment' => [
-                'REQUEST_METHOD' => 'POST',
-            ],
-            'post' => [
-                'id' => $o['id'],
-                'title' => $o['attributes']['title'],
-            ],
-            'params' => [
-                'object_type' => 'documents',
-            ],
-        ];
-        $request = new ServerRequest($config);
-        $this->controller = new ModulesControllerSample($request);
-
-        // do controller call
-        $result = $this->controller->save();
-
-        // verify response status code and type
-        static::assertEquals(302, $result->getStatusCode());
-        static::assertEquals('text/html', $result->getType());
-    }
-
-    /**
      * Test `save` method, on error
      *
      * @covers ::save()
@@ -568,10 +531,10 @@ class ModulesControllerTest extends TestCase
 
     /**
      *
-     * Data provider for `testSaveJson` test case.
+     * Data provider for `testSave` test case.
      *
      */
-    public function saveJsonProvider()
+    public function saveProvider()
     {
         return [
             'save' => [
@@ -606,14 +569,14 @@ class ModulesControllerTest extends TestCase
     }
 
     /**
-     * Test `saveJson` method
+     * Test `save` method
      *
-     * @dataProvider saveJsonProvider()
-     * @covers ::saveJson()
+     * @dataProvider saveProvider()
+     * @covers ::save()
      *
      * @return void
      */
-    public function testSaveJson($expected, $data): void
+    public function testSave($expected, $data): void
     {
         // Setup controller for test
         $this->setupController();
@@ -630,7 +593,7 @@ class ModulesControllerTest extends TestCase
         $this->controller = new ModulesControllerSample($request);
 
         // do controller call
-        $this->controller->saveJson();
+        $this->controller->save();
 
         // verify response status code and type
         $result = $this->controller->getApiClient();

--- a/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -180,11 +180,13 @@ class TranslationsControllerTest extends TestCase
         $this->controller = new TranslationsController($request);
 
         // do controller call
-        $result = $this->controller->save();
+        $this->controller->save();
+
+        $response = $this->controller->getResponse();
 
         // verify response status code and type
-        static::assertEquals(302, $result->getStatusCode());
-        static::assertEquals('text/html', $result->getType());
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('text/html', $response->getType());
     }
 
     /**

--- a/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -14,7 +14,6 @@
 namespace App\Test\TestCase\Controller;
 
 use App\Controller\TranslationsController;
-use BEdita\SDK\BEditaClient;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -116,6 +115,12 @@ class TranslationsControllerTest extends TestCase
 
         // verify expected vars in view
         $this->assertExpectedViewVars(['schema', 'object', 'translation']);
+
+        // on error
+        $result = $this->controller->add(123456789);
+        $expected = get_class(new \Cake\Http\Response());
+        $actual = get_class($result);
+        static::assertEquals($expected, $actual);
     }
 
     /**
@@ -144,6 +149,12 @@ class TranslationsControllerTest extends TestCase
 
         // verify expected vars in view
         $this->assertExpectedViewVars(['schema', 'object', 'translation']);
+
+        // on error
+        $result = $this->controller->edit(123456789, $lang);
+        $expected = get_class(new \Cake\Http\Response());
+        $actual = get_class($result);
+        static::assertEquals($expected, $actual);
     }
 
     /**

--- a/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -180,6 +180,64 @@ class TranslationsControllerTest extends TestCase
             'post' => [
                 'lang' => $lang,
                 'object_id' => $o['id'],
+                'status' => 'draft',
+                'translated_fields' => [
+                    'title' => sprintf('Titolo in italiano', $o['attributes']['title']),
+                ],
+            ],
+            'params' => [
+                'object_type' => 'documents',
+            ],
+        ];
+        $request = new ServerRequest($config);
+        $this->controller = new TranslationsController($request);
+
+        // do controller call
+        $this->controller->save();
+
+        $response = $this->controller->getResponse();
+
+        // verify response status code and type
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('text/html', $response->getType());
+
+        // error, with not empty request id
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [ // missing required 'status'
+                'lang' => $lang,
+                'id' => $o['id'],
+                'object_id' => $o['id'],
+                'translated_fields' => [
+                    'title' => sprintf('Una traduzione di esempio per "%s"', $o['attributes']['title']),
+                ],
+            ],
+            'params' => [
+                'object_type' => 'documents',
+            ],
+        ];
+        $request = new ServerRequest($config);
+        $this->controller = new TranslationsController($request);
+
+        // do controller call
+        $this->controller->save();
+
+        $response = $this->controller->getResponse();
+
+        // verify response status code and type
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('text/html', $response->getType());
+
+        // error, with empty request id
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [ // missing required 'status'
+                'lang' => $lang,
+                'object_id' => $o['id'],
                 'translated_fields' => [
                     'title' => sprintf('Una traduzione di esempio per "%s"', $o['attributes']['title']),
                 ],

--- a/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -15,6 +15,7 @@ namespace App\Test\TestCase\Controller;
 
 use App\Controller\TranslationsController;
 use BEdita\WebTools\ApiClientProvider;
+use Cake\Http\Exception\BadRequestException;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 
@@ -240,6 +241,89 @@ class TranslationsControllerTest extends TestCase
 
         // restore test object
         $this->restoreTestObject($objectId, 'documents');
+
+        // on missing post data
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [],
+            'params' => [
+                'object_type' => 'documents',
+            ],
+        ];
+        $request = new ServerRequest($config);
+        $this->controller = new TranslationsController($request);
+        try {
+            $this->controller->delete();
+        } catch (\Exception $e) {
+            $expected = get_class(new BadRequestException());
+            $actual = get_class($e);
+            static::assertEquals($expected, $actual);
+        }
+
+        // on missing post data id
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [
+                [],
+            ],
+            'params' => [
+                'object_type' => 'documents',
+            ],
+        ];
+        $request = new ServerRequest($config);
+        $this->controller = new TranslationsController($request);
+        try {
+            $this->controller->delete();
+        } catch (\Exception $e) {
+            $expected = get_class(new BadRequestException());
+            $actual = get_class($e);
+            static::assertEquals($expected, $actual);
+        }
+
+        // on missing post data object_id
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [
+                ['id' => 1234567789],
+            ],
+            'params' => [
+                'object_type' => 'documents',
+            ],
+        ];
+        $request = new ServerRequest($config);
+        $this->controller = new TranslationsController($request);
+        try {
+            $this->controller->delete();
+        } catch (\Exception $e) {
+            $expected = get_class(new BadRequestException());
+            $actual = get_class($e);
+            static::assertEquals($expected, $actual);
+        }
+
+        // on missing wrong payload
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [
+                ['id' => 1234567789, 'object_id' => 9999999999],
+            ],
+            'params' => [
+                'object_type' => 'documents',
+            ],
+        ];
+        $request = new ServerRequest($config);
+        $this->controller = new TranslationsController($request);
+        $response = $this->controller->delete();
+        $expected = get_class(new \Cake\Http\Response());
+        $actual = get_class($response);
+        static::assertEquals($expected, $actual);
     }
 
     /**

--- a/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -346,7 +346,7 @@ class TranslationsControllerTest extends TestCase
                 'REQUEST_METHOD' => 'POST',
             ],
             'post' => [
-                [],
+                ['object_id' => 1234567789],
             ],
             'params' => [
                 'object_type' => 'documents',

--- a/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -170,19 +170,39 @@ class TranslationsControllerTest extends TestCase
         // Setup controller for test
         $this->setupController();
 
-        // get object for test
+        // delete translation before starting test
         $lang = 'it';
-        $o = $this->getTestObject();
+        $objectId = $this->getTestId();
+        $id = $this->getTestTranslationId($objectId, 'documents', $lang);
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [
+                [
+                    'id' => $id,
+                    'object_id' => $objectId,
+                ],
+            ],
+            'params' => [
+                'object_type' => 'documents',
+            ],
+        ];
+        $request = new ServerRequest($config);
+        $this->controller = new TranslationsController($request);
+        $this->controller->delete();
+
+        // get object for test
         $config = [
             'environment' => [
                 'REQUEST_METHOD' => 'POST',
             ],
             'post' => [
                 'lang' => $lang,
-                'object_id' => $o['id'],
+                'object_id' => $objectId,
                 'status' => 'draft',
                 'translated_fields' => [
-                    'title' => sprintf('Titolo in italiano', $o['attributes']['title']),
+                    'title' => 'Titolo in italiano',
                 ],
             ],
             'params' => [
@@ -208,10 +228,10 @@ class TranslationsControllerTest extends TestCase
             ],
             'post' => [ // missing required 'status'
                 'lang' => $lang,
-                'id' => $o['id'],
-                'object_id' => $o['id'],
+                'id' => $id,
+                'object_id' => $objectId,
                 'translated_fields' => [
-                    'title' => sprintf('Una traduzione di esempio per "%s"', $o['attributes']['title']),
+                    'title' => 'Titolo in italiano',
                 ],
             ],
             'params' => [
@@ -237,9 +257,9 @@ class TranslationsControllerTest extends TestCase
             ],
             'post' => [ // missing required 'status'
                 'lang' => $lang,
-                'object_id' => $o['id'],
+                'object_id' => $objectId,
                 'translated_fields' => [
-                    'title' => sprintf('Una traduzione di esempio per "%s"', $o['attributes']['title']),
+                    'title' => 'Titolo in italiano',
                 ],
             ],
             'params' => [


### PR DESCRIPTION
After https://github.com/bedita/manager/pull/580 `ModulesController::save` was not used anymore.

This remove "old"  `ModulesController::save` and rename `saveJson` to `save`.

This renames routes and methods with `{action}Json` to `{action}`

Bonus: more coverage for `TranslationsControllerTest`.