### PR TITLE
Refactor view URL helper methods

### DIFF
--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -722,18 +722,6 @@ export default {
         },
 
         /**
-         * helper function: build open view url
-         *
-         * @param {String} objectType
-         * @param {Number} objectId
-         *
-         * @return {String} url
-         */
-        buildViewUrl(objectType, objectId) {
-            return `${window.location.protocol}//${window.location.host}/${objectType}/view/${objectId}`;
-        },
-
-        /**
          * Object type available to view.
          *
          * @param {String} type

--- a/src/Template/Layout/js/app/components/relation-view/relations-add.js
+++ b/src/Template/Layout/js/app/components/relation-view/relations-add.js
@@ -404,18 +404,6 @@ export default {
         },
 
         /**
-         * helper function: build open view url
-         *
-         * @param {String} objectType
-         * @param {Number} objectId
-         *
-         * @return {String} url
-         */
-        buildViewUrl(objectType, objectId) {
-            return `${window.location.protocol}/${window.location.host}/${objectType}/view/${objectId}`;
-        },
-
-        /**
          * set file, object type and placeholder
          *
          * @param {Event} event input file change event

--- a/src/Template/Layout/js/app/helpers/view.js
+++ b/src/Template/Layout/js/app/helpers/view.js
@@ -3,16 +3,28 @@ import Vue from 'vue';
 export default {
     install (Vue, options) {
         Vue.prototype.$helpers = {
+
             /**
-            * helper function: build open view url
+            * Build view url using object ID
             *
-            * @param {String} objectType
             * @param {Number} objectId
             *
             * @return {String} url
             */
             buildViewUrl(objectId) {
                 return `${BEDITA.base}/view/${objectId}`;
+            },
+
+            /**
+            * Build view url usiong object type and ID
+            *
+            * @param {String} objectType
+            * @param {Number} objectId
+            *
+            * @return {String} url
+            */
+            buildViewUrlType(objectType, objectId) {
+                return `${BEDITA.base}/${objectType}/view/${objectId}`;
             },
 
             /**

--- a/src/Template/Layout/js/app/pages/modules/view.js
+++ b/src/Template/Layout/js/app/pages/modules/view.js
@@ -69,7 +69,7 @@ export default {
 
                 // clear form dirty state, to avoid alert message about unsaved changes before changing page
                 window._vueInstance.dataChanged.clear();
-                window.location = this.$helpers.buildViewUrl(json.data[0].id);
+                window.location = this.$helpers.buildViewUrlType(json.data[0].type, json.data[0].id);
 
                 return;
             }


### PR DESCRIPTION
In this PR

* a new `buildViewUrlType(objectType, objectId)` helper method has been introduced
* method is used to view object ID after save without redirect
* unused methods with same same have been removed
 