### PR TITLE
fix: render flash messages even when using AJAX save

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -75,6 +75,11 @@ Router::scope('/', function (RouteBuilder $routes) {
         ['controller' => 'Dashboard', 'action' => 'index'],
         ['_name' => 'dashboard']
     );
+    $routes->connect(
+        '/dashboard/messages',
+        ['controller' => 'Dashboard', 'action' => 'messages'],
+        ['_name' => 'dashboard:messages']
+    );
 
     // Profile.
     $routes->connect(

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -42,6 +42,18 @@ class DashboardController extends AppController
     }
 
     /**
+     * Render flash messages without layout for fetch requests.
+     *
+     * @retrun void
+     */
+    public function messages(): void
+    {
+        $this->request->allowMethod('get');
+        $this->viewBuilder()->disableAutoLayout();
+        $this->render('/Element/Dashboard/messages');
+    }
+
+    /**
      * Load 20 most recent items modified by authenticated user.
      *
      * @return array

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -44,11 +44,11 @@ class DashboardController extends AppController
     /**
      * Render flash messages without layout for fetch requests.
      *
-     * @retrun void
+     * @return void
      */
     public function messages(): void
     {
-        $this->request->allowMethod('get');
+        $this->request->allowMethod(['get']);
         $this->viewBuilder()->disableAutoLayout();
         $this->render('/Element/Dashboard/messages');
     }

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -320,10 +320,10 @@ class ModulesController extends AppController
             $objectId = (string)Hash::get($response, 'data.id');
             $this->Modules->saveRelated($objectId, $this->objectType, $relatedData);
         } catch (BEditaClientException $error) {
-            $this->log($error, LogLevel::ERROR);
+            $this->log($error->getMessage(), LogLevel::ERROR);
             $this->Flash->error($error->getMessage(), ['params' => $error]);
 
-            $this->set(['error' => $error->getMessage()]);
+            $this->set(['error' => $error->getAttributes()]);
             $this->set('_serialize', ['error']);
 
             return;

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -321,8 +321,9 @@ class ModulesController extends AppController
             $this->Modules->saveRelated($objectId, $this->objectType, $relatedData);
         } catch (BEditaClientException $error) {
             $this->log($error, LogLevel::ERROR);
+            $this->Flash->error($error->getMessage(), ['params' => $error]);
 
-            $this->set(compact('error'));
+            $this->set(['error' => $error->getMessage()]);
             $this->set('_serialize', ['error']);
 
             return;

--- a/src/Template/Element/Dashboard/messages.twig
+++ b/src/Template/Element/Dashboard/messages.twig
@@ -1,0 +1,1 @@
+{{ Flash.render()|raw }}

--- a/src/Template/Layout/js/app/components/flash-message.js
+++ b/src/Template/Layout/js/app/components/flash-message.js
@@ -44,6 +44,7 @@ export default {
             this.isVisible = !this.isVisible;
             setTimeout(() => {
                 this.$refs.flashMessagesContainer.remove();
+                window._vueInstance.$emit('flash-message:closed');
             }, this.waitPanelAnimation * 1000);
         },
     },

--- a/src/Template/Layout/js/app/pages/modules/view.js
+++ b/src/Template/Layout/js/app/pages/modules/view.js
@@ -1,4 +1,5 @@
 import { AjaxLogin } from '../../components/ajax-login/ajax-login.js';
+import Vue from 'vue';
 
 /**
  * Templates that uses this component (directly or indirectly):
@@ -62,7 +63,7 @@ export default {
             if (response.ok) {
                 const json = await response.json();
                 if (json.error) {
-                    console.error('server responded with an error', json.error);
+                    await this.showFlashMessages();
 
                     return;
                 }
@@ -95,6 +96,28 @@ export default {
             });
             iframe.$mount();
             document.body.appendChild(iframe.$el);
+        },
+
+        async showFlashMessages() {
+            // fetch flash messages template
+            const messages = await fetch('/dashboard/messages');
+            const html = await messages.text();
+            // create new element and append to DOM
+            const element = document.createElement('div');
+            element.innerHTML = html.trim();
+            this.$root.$el.appendChild(element);
+            // create new Vue instance to handle flash messages template
+            const flashInstance = new Vue({
+                el: element.firstElementChild,
+                components: {
+                    FlashMessage: () => import(/* webpackChunkName: "flash-message" */'app/components/flash-message'),
+                },
+            });
+            // cleanup on flash message close
+            window._vueInstance.$once('flash-message:closed', () => {
+                flashInstance.$destroy();
+                element.remove();
+            });
         },
 
         async translateAll(data, e) {

--- a/tests/TestCase/Controller/DashboardControllerTest.php
+++ b/tests/TestCase/Controller/DashboardControllerTest.php
@@ -127,6 +127,46 @@ class DashboardControllerTest extends TestCase
     }
 
     /**
+     * Test `messages` method
+     *
+     * @covers ::messages()
+     *
+     * @return void
+     */
+    public function testMessages(): void
+    {
+        $this->setupController([
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+        ]);
+        $this->Dashboard->messages();
+        $response = $this->Dashboard->response;
+        static::assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Test `messages` method for "MethodNotAllowed" case
+     *
+     * @covers ::messages()
+     *
+     * @return void
+     */
+    public function testMessagesMethodNotAllowed(): void
+    {
+        $notallowed = ['POST', 'DELETE', 'PATCH'];
+        foreach ($notallowed as $method) {
+            static::expectException('Cake\Http\Exception\MethodNotAllowedException');
+            $this->setupController([
+                'environment' => [
+                    'REQUEST_METHOD' => $method,
+                ],
+            ]);
+            $this->Dashboard->messages();
+        }
+    }
+
+    /**
      * Test `recentItems` method
      *
      * @covers ::recentItems()

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -489,11 +489,8 @@ class ModulesControllerTest extends TestCase
         // do controller call
         $this->controller->save();
 
-        // verify BEditaClientException
-        $error = $this->controller->viewVars['error'];
-        $actual = get_class($error);
-        $expected = get_class(new BEditaClientException(''));
-        static::assertEquals($expected, $actual);
+        // verify page has error key
+        static::assertArrayHasKey('error', $this->controller->viewVars);
     }
 
     /**
@@ -526,11 +523,8 @@ class ModulesControllerTest extends TestCase
         // do controller call
         $this->controller->save();
 
-        // verify BEditaClientException
-        $error = $this->controller->viewVars['error'];
-        $actual = get_class($error);
-        $expected = get_class(new BEditaClientException(''));
-        static::assertEquals($expected, $actual);
+        // verify page has error key
+        static::assertArrayHasKey('error', $this->controller->viewVars);
     }
 
     /**


### PR DESCRIPTION
This PR adds rendering of flash messages when saving an object with ajax request returns an error:
- action in `DashboardController` to return the template for flash messages
- element to render only flash messages template
- method in `view.js` to dynamically render flash messages with a child Vue instance