### PR TITLE
Fix: sort relation object

### DIFF
--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -255,36 +255,24 @@ export default {
         // common relations priorities
         updatePriorities(movedObject, newIndex) {
             const oldIndex = this.objects.findIndex((object) => movedObject.id === object.id);
-            let priority = this.objects[newIndex].meta.relation.priority;
+            let priority = (oldIndex - newIndex > 0) ? this.objects[newIndex].meta.relation.priority : this.objects[oldIndex].meta.relation.priority;
+            const startIndex = Math.min(oldIndex, newIndex);
+            const endIndex = Math.max(oldIndex, newIndex);
 
             // moves the object in the objects array from the old index to the new index
             this.objects.splice(newIndex, 0, this.objects.splice(oldIndex, 1)[0]);
 
             // update priorities
-            if (oldIndex - newIndex > 0) {
-                for (let i = newIndex; i <= oldIndex; i++) {
-                    if (i === newIndex || this.objects[i].meta.relation.priority < priority) {
-                        this.objects[i].meta.relation.priority = priority;
-                        this.modifyRelation(this.objects[i]);
-                        priority++;
+            for (let i = startIndex; i <= endIndex; i++) {
+                if (i === startIndex || this.objects[i].meta.relation.priority < priority || this.objects[i].meta.relation.priority >= this.objects[endIndex].meta.relation.priority) {
+                    this.objects[i].meta.relation.priority = priority;
+                    this.modifyRelation(this.objects[i]);
+                    priority++;
 
-                        continue;
-                    }
-
-                    priority = this.objects[i].meta.relation.priority;
+                    continue;
                 }
-            } else {
-                for (let i = newIndex; i >= oldIndex; i--) {
-                    if (i === newIndex || this.objects[i].meta.relation.priority > priority) {
-                        this.objects[i].meta.relation.priority = priority;
-                        this.modifyRelation(this.objects[i]);
-                        priority--;
 
-                        continue;
-                    }
-
-                    priority = this.objects[i].meta.relation.priority;
-                }
+                priority = this.objects[i].meta.relation.priority;
             }
         },
 

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -80,8 +80,6 @@ export default {
 
             relationsData: [],          // hidden field containing serialized json passed on form submit
             activeFilter: {},           // current active filter for objects list
-
-            positions: {},              // used in children relations
         }
     },
 

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -255,15 +255,37 @@ export default {
         // common relations priorities
         updatePriorities(movedObject, newIndex) {
             const oldIndex = this.objects.findIndex((object) => movedObject.id === object.id);
+            let priority = this.objects[newIndex].meta.relation.priority;
 
             // moves the object in the objects array from the old index to the new index
             this.objects.splice(newIndex, 0, this.objects.splice(oldIndex, 1)[0]);
 
-            this.objects = this.objects.map((object, index) => {
-                object.meta.relation.priority = index + 1;
-                this.modifyRelation(object);
-                return object;
-            });
+            // update priorities
+            if (oldIndex - newIndex > 0) {
+                for (let i = newIndex; i <= oldIndex; i++) {
+                    if (i === newIndex || this.objects[i].meta.relation.priority < priority) {
+                        this.objects[i].meta.relation.priority = priority;
+                        this.modifyRelation(this.objects[i]);
+                        priority++;
+
+                        continue;
+                    }
+
+                    priority = this.objects[i].meta.relation.priority;
+                }
+            } else {
+                for (let i = newIndex; i >= oldIndex; i--) {
+                    if (i === newIndex || this.objects[i].meta.relation.priority > priority) {
+                        this.objects[i].meta.relation.priority = priority;
+                        this.modifyRelation(this.objects[i]);
+                        priority--;
+
+                        continue;
+                    }
+
+                    priority = this.objects[i].meta.relation.priority;
+                }
+            }
         },
 
         // children position


### PR DESCRIPTION
This PR fixes the update of priorities when sorting objects in a relationship view.

Previously, the behavior was to reassign priorities to all related objects starting from 1, which didn't play good with the pagination of related items.

Now the behavior is to reassign priorities to objects in the modified range, accounting for the previous priority numbers and changing only those needed.