### PR TITLE
fix: restore previously sorted relation priority after changing page

### DIFF
--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -708,6 +708,17 @@ export default {
                     this.loading = false;
                     return objs;
                 })
+                .then(() => {
+                    // restore previously modified priorities
+                    this.objects.forEach((object) => {
+                        const modifiedObject = this.modifiedRelations.find((modified) => modified.id === object.id);
+                        if (modifiedObject) {
+                            object.meta.relation.priority = modifiedObject.meta.relation.priority;
+                        }
+                    });
+                    // sort by restored priorities
+                    this.objects.sort((a, b) => a.meta.relation.priority - b.meta.relation.priority);
+                })
                 .catch((error) => {
                     // code 20 is user aborted fetch which is ok
                     if (error.code !== 20) {


### PR DESCRIPTION
This PR fixes a UI/UX problem: if an user sorted objects in a relation view, changed relation page and then returned to the previous page, the objects seemed to have restored their previous order. This was not the case, but the graphical representation did not reflect the actual state of the data.