### PR TITLE
Enhance index filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         {
             "name": "Chia Lab s.r.l.",
             "email": "dev@chialab.it",
-            "homepage": "http://www.chialab.it"
+            "homepage": "https://www.chialab.it"
         }
     ],
     "require": {

--- a/src/Controller/BulkController.php
+++ b/src/Controller/BulkController.php
@@ -87,7 +87,7 @@ class BulkController extends AppController
         $this->request->allowMethod(['post']);
         $requestData = $this->request->getData();
         $this->ids = explode(',', (string)Hash::get($requestData, 'ids'));
-        $this->categories = (string)Hash::get($requestData, 'categoriesSelected');
+        $this->categories = (string)Hash::get($requestData, 'categories');
         $this->loadCategories();
         $this->saveCategories();
         $this->errors();

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -60,9 +60,7 @@ class PropertiesComponent extends Component
         ],
 
         'filter' => [
-            'status',
-            'lang',
-            'categories'
+            'status'
         ],
         'bulk' => [
             'status',

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -60,7 +60,7 @@ class PropertiesComponent extends Component
         ],
 
         'filter' => [
-            'status'
+            'status',
         ],
         'bulk' => [
             'status',

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -61,6 +61,8 @@ class PropertiesComponent extends Component
 
         'filter' => [
             'status',
+            'lang',
+            'categories'
         ],
         'bulk' => [
             'status',

--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -58,14 +58,15 @@ class Options
 
     /**
      * Options for lang, using configuration loaded from API
-     * If available, use config `I18n.languages`
+     * If available, use config `Project.config.I18n.languages`.
      *
      * @param mixed|null $value The field value.
      * @return array
      */
     public static function lang($value): array
     {
-        $languages = Configure::read('I18n.languages');
+        // $languages = Configure::read('I18n.languages');
+        $languages = Configure::read('Project.config.I18n.languages');
         if (empty($languages)) {
             return compact('value') + ['type' => 'text'];
         }

--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -58,14 +58,14 @@ class Options
 
     /**
      * Options for lang, using configuration loaded from API
-     * If available, use config `Project.config.I18n.languages`
+     * If available, use config `I18n.languages`
      *
      * @param mixed|null $value The field value.
      * @return array
      */
     public static function lang($value): array
     {
-        $languages = Configure::read('Project.config.I18n.languages');
+        $languages = Configure::read('I18n.languages');
         if (empty($languages)) {
             return compact('value') + ['type' => 'text'];
         }

--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -65,7 +65,6 @@ class Options
      */
     public static function lang($value): array
     {
-        // $languages = Configure::read('I18n.languages');
         $languages = Configure::read('Project.config.I18n.languages');
         if (empty($languages)) {
             return compact('value') + ['type' => 'text'];

--- a/src/Locale/en_US/default.po
+++ b/src/Locale/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-10-06 09:51:37 \n"
+"POT-Creation-Date: 2021-10-08 10:23:50 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -152,6 +152,9 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
+msgid "Descendants"
+msgstr ""
+
 msgid "Description"
 msgstr ""
 
@@ -231,6 +234,9 @@ msgid "File type"
 msgstr ""
 
 msgid "Files"
+msgstr ""
+
+msgid "Folder"
 msgstr ""
 
 msgid "Folders"
@@ -759,7 +765,7 @@ msgstr ""
 #: src/Template/Layout/js/app/app.js:494
 #: src/Template/Layout/js/app/components/history/history.js:89
 #: src/Template/Layout/js/app/pages/model/index.js:262
-#: src/Template/Layout/js/app/pages/modules/index.js:152
+#: src/Template/Layout/js/app/pages/modules/index.js:151
 #: src/Template/Layout/js/app/pages/trash/index.js:43
 msgid "yes, proceed"
 msgstr ""
@@ -773,7 +779,7 @@ msgstr ""
 msgid "Do you confirm the deletion of ${ number } item from the trash?"
 msgstr ""
 
-#: src/Template/Layout/js/app/pages/modules/index.js:150
+#: src/Template/Layout/js/app/pages/modules/index.js:149
 #, javascript-format
 msgid "Moving ${ number } item(s) to trash. Are you sure?"
 msgstr ""
@@ -811,11 +817,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/filter-box.js:177
+#: src/Template/Layout/js/app/components/filter-box.js:194
 msgid "Items"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/filter-box.js:237
+#: src/Template/Layout/js/app/components/filter-box.js:253
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr ""
 
@@ -896,8 +902,4 @@ msgstr ""
 msgid ""
 "Restored data will replace current data (you can still check the data before "
 "saving). Are you sure?"
-msgstr ""
-
-#: src/Template/Layout/js/app/components/folder-picker/folder-picker.js:21
-msgid "Folder"
 msgstr ""

--- a/src/Locale/en_US/default.po
+++ b/src/Locale/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-09-30 06:28:47 \n"
+"POT-Creation-Date: 2021-10-06 09:51:37 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -99,9 +99,6 @@ msgid "Change password"
 msgstr ""
 
 msgid "Children"
-msgstr ""
-
-msgid "Choose"
 msgstr ""
 
 msgid "Click or drop new files here"
@@ -293,6 +290,9 @@ msgstr ""
 msgid "Left types"
 msgstr ""
 
+msgid "Less filters"
+msgstr ""
+
 msgid "Locations"
 msgstr ""
 
@@ -333,6 +333,9 @@ msgid "Module access not authorized"
 msgstr ""
 
 msgid "More"
+msgstr ""
+
+msgid "More filters"
 msgstr ""
 
 msgid "Move to"
@@ -808,11 +811,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/filter-box.js:168
+#: src/Template/Layout/js/app/components/filter-box.js:177
 msgid "Items"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/filter-box.js:228
+#: src/Template/Layout/js/app/components/filter-box.js:237
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr ""
 

--- a/src/Locale/it_IT/default.po
+++ b/src/Locale/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-10-06 09:51:37 \n"
+"POT-Creation-Date: 2021-10-08 10:40:02 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -152,6 +152,9 @@ msgstr "Modellazione"
 msgid "Delete"
 msgstr "Elimina"
 
+msgid "Descendants"
+msgstr "Discendenti"
+
 msgid "Description"
 msgstr "Descrizione"
 
@@ -232,6 +235,9 @@ msgstr "Tipo di file"
 
 msgid "Files"
 msgstr "File"
+
+msgid "Folder"
+msgstr "Cartella"
 
 msgid "Folders"
 msgstr "Cartelle"
@@ -762,7 +768,7 @@ msgstr "Vuoi davvero spostare l'oggetto nel cestino?"
 #: src/Template/Layout/js/app/app.js:494
 #: src/Template/Layout/js/app/components/history/history.js:89
 #: src/Template/Layout/js/app/pages/model/index.js:262
-#: src/Template/Layout/js/app/pages/modules/index.js:152
+#: src/Template/Layout/js/app/pages/modules/index.js:151
 #: src/Template/Layout/js/app/pages/trash/index.js:43
 msgid "yes, proceed"
 msgstr "sì, prosegui"
@@ -776,7 +782,7 @@ msgstr "Ci sono delle modifiche non salvate, vuoi comunque lasciare la pagina?"
 msgid "Do you confirm the deletion of ${ number } item from the trash?"
 msgstr "Confermi la cancellazione di ${ number } elementi dal cestino?"
 
-#: src/Template/Layout/js/app/pages/modules/index.js:150
+#: src/Template/Layout/js/app/pages/modules/index.js:149
 #, javascript-format
 msgid "Moving ${ number } item(s) to trash. Are you sure?"
 msgstr "Stai per spostare ${ number } elementi nel cestino. Vuoi procedere?"
@@ -814,11 +820,11 @@ msgstr "Priorità"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/Template/Layout/js/app/components/filter-box.js:177
+#: src/Template/Layout/js/app/components/filter-box.js:194
 msgid "Items"
 msgstr "Elementi"
 
-#: src/Template/Layout/js/app/components/filter-box.js:237
+#: src/Template/Layout/js/app/components/filter-box.js:253
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr "Testo troppo breve. Lunghezza minima 3 caratteri. Riprova"
 
@@ -838,7 +844,7 @@ msgstr "Si è verificato un errore durante la creazione del nuovo oggetto."
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 #: src/Template/Layout/js/app/components/locations-view/location-view.js:51
 msgid "Title"
 msgstr "Titolo"
@@ -847,7 +853,7 @@ msgstr "Titolo"
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 #: src/Template/Layout/js/app/components/locations-view/location-view.js:70
 msgid "Address"
 msgstr "Indirizzo"
@@ -856,7 +862,7 @@ msgstr "Indirizzo"
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 #: src/Template/Layout/js/app/components/locations-view/location-view.js:95
 msgid "GET"
 msgstr ""
@@ -868,7 +874,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 #: src/Template/Layout/js/app/components/locations-view/locations-view.js:30
 msgid "add new"
 msgstr "aggiungi nuovo"
@@ -883,14 +889,14 @@ msgstr "data"
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 #: src/Template/Layout/js/app/components/history/history.js:19
 msgid "by"
 msgstr "di"
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 #: src/Template/Layout/js/app/components/history/history.js:29
 msgid "No History data found"
 msgstr "Nessun dato di Cronologia"
@@ -902,10 +908,6 @@ msgid ""
 msgstr ""
 "I dati recuperati sostiruiranno quelli attuali (potrai comunque controllarli "
 "prima di salvare). Vuoi procedere?"
-
-#: src/Template/Layout/js/app/components/folder-picker/folder-picker.js:21
-msgid "Folder"
-msgstr "Cartella"
 
 #~ msgid "Choose"
 #~ msgstr "Seleziona"

--- a/src/Locale/it_IT/default.po
+++ b/src/Locale/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-09-30 06:28:47 \n"
+"POT-Creation-Date: 2021-10-06 09:51:37 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -100,9 +100,6 @@ msgstr "Cambia password"
 
 msgid "Children"
 msgstr "Contenuti"
-
-msgid "Choose"
-msgstr "Seleziona"
 
 msgid "Click or drop new files here"
 msgstr "Clicca o trascina qui i nuovi file"
@@ -293,6 +290,9 @@ msgstr "Lingua e traduzioni"
 msgid "Left types"
 msgstr "Tipi di sinistra"
 
+msgid "Less filters"
+msgstr "Meno filtri"
+
 msgid "Locations"
 msgstr "Posizioni"
 
@@ -334,6 +334,9 @@ msgstr "Accesso al modulo non autorizzato"
 
 msgid "More"
 msgstr "Altro"
+
+msgid "More filters"
+msgstr "Più filtri"
 
 msgid "Move to"
 msgstr "Sposta in"
@@ -811,11 +814,11 @@ msgstr "Priorità"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/Template/Layout/js/app/components/filter-box.js:168
+#: src/Template/Layout/js/app/components/filter-box.js:177
 msgid "Items"
 msgstr "Elementi"
 
-#: src/Template/Layout/js/app/components/filter-box.js:228
+#: src/Template/Layout/js/app/components/filter-box.js:237
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr "Testo troppo breve. Lunghezza minima 3 caratteri. Riprova"
 
@@ -903,6 +906,9 @@ msgstr ""
 #: src/Template/Layout/js/app/components/folder-picker/folder-picker.js:21
 msgid "Folder"
 msgstr "Cartella"
+
+#~ msgid "Choose"
+#~ msgstr "Seleziona"
 
 #~ msgid "Set selected"
 #~ msgstr "Applica a selezione"

--- a/src/Locale/master.pot
+++ b/src/Locale/master.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-10-06 09:51:37 \n"
+"POT-Creation-Date: 2021-10-08 10:40:02 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -149,6 +149,9 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
+msgid "Descendants"
+msgstr ""
+
 msgid "Description"
 msgstr ""
 
@@ -228,6 +231,9 @@ msgid "File type"
 msgstr ""
 
 msgid "Files"
+msgstr ""
+
+msgid "Folder"
 msgstr ""
 
 msgid "Folders"
@@ -756,7 +762,7 @@ msgstr ""
 #: src/Template/Layout/js/app/app.js:494
 #: src/Template/Layout/js/app/components/history/history.js:89
 #: src/Template/Layout/js/app/pages/model/index.js:262
-#: src/Template/Layout/js/app/pages/modules/index.js:152
+#: src/Template/Layout/js/app/pages/modules/index.js:151
 #: src/Template/Layout/js/app/pages/trash/index.js:43
 msgid "yes, proceed"
 msgstr ""
@@ -770,7 +776,7 @@ msgstr ""
 msgid "Do you confirm the deletion of ${ number } item from the trash?"
 msgstr ""
 
-#: src/Template/Layout/js/app/pages/modules/index.js:150
+#: src/Template/Layout/js/app/pages/modules/index.js:149
 #, javascript-format
 msgid "Moving ${ number } item(s) to trash. Are you sure?"
 msgstr ""
@@ -808,11 +814,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/filter-box.js:177
+#: src/Template/Layout/js/app/components/filter-box.js:194
 msgid "Items"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/filter-box.js:237
+#: src/Template/Layout/js/app/components/filter-box.js:253
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr ""
 
@@ -893,8 +899,4 @@ msgstr ""
 msgid ""
 "Restored data will replace current data (you can still check the data before "
 "saving). Are you sure?"
-msgstr ""
-
-#: src/Template/Layout/js/app/components/folder-picker/folder-picker.js:21
-msgid "Folder"
 msgstr ""

--- a/src/Locale/master.pot
+++ b/src/Locale/master.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-09-30 06:28:47 \n"
+"POT-Creation-Date: 2021-10-06 09:51:37 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -96,9 +96,6 @@ msgid "Change password"
 msgstr ""
 
 msgid "Children"
-msgstr ""
-
-msgid "Choose"
 msgstr ""
 
 msgid "Click or drop new files here"
@@ -290,6 +287,9 @@ msgstr ""
 msgid "Left types"
 msgstr ""
 
+msgid "Less filters"
+msgstr ""
+
 msgid "Locations"
 msgstr ""
 
@@ -330,6 +330,9 @@ msgid "Module access not authorized"
 msgstr ""
 
 msgid "More"
+msgstr ""
+
+msgid "More filters"
 msgstr ""
 
 msgid "Move to"
@@ -805,11 +808,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/filter-box.js:168
+#: src/Template/Layout/js/app/components/filter-box.js:177
 msgid "Items"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/filter-box.js:228
+#: src/Template/Layout/js/app/components/filter-box.js:237
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr ""
 

--- a/src/Template/Element/FilterBox/filter_box.scss
+++ b/src/Template/Element/FilterBox/filter_box.scss
@@ -1,23 +1,15 @@
 .filter-box {
-    > div {
-        flex: 1 1 0;
-        &:first-child {
-            flex: none;
-            // flex-grow: 1;
-            max-width: 100%;
-        }
-        &:last-child {
-            margin-top: $gutter;
-        }
-    }
+    display: flex;
+    flex-direction: column;
 
     @media screen and (min-width: 1024px) {
+        flex-direction: row;
+    }
+
+    .pagination {
         display: flex;
-        > div:last-child {
-            display: flex;
-            justify-content: flex-end;
-            margin-top: 0;
-        }
+        justify-content: flex-end;
+        margin-left: auto;
     }
 }
 
@@ -32,7 +24,7 @@
         flex-wrap: wrap;
 
         > * {
-            margin-bottom: $gutter * .5;
+            margin-bottom: $gutter;
         }
 
         > *:not(:last-child) {

--- a/src/Template/Element/FilterBox/filter_box.scss
+++ b/src/Template/Element/FilterBox/filter_box.scss
@@ -57,13 +57,22 @@
             }
         }
 
+        > * {
+            display: inline-flex;
+            align-items: center;
+        }
+
         label {
+            display: inline-flex;
+            align-items: center;
+            margin-right: $gutter * .5;
+
             &:first-letter {
                 text-transform: uppercase;
             }
 
-            &:not(:last-child) {
-                margin-right: $gutter * .5;
+            &:last-child {
+                margin-right: 0;
             }
         }
 
@@ -76,21 +85,21 @@
             }
         }
 
+        &.parent .filter-label,
+        &.categories .filter-label {
+            display: none;
+        }
+
         .category-picker,
         .folder-picker {
             display: flex;
             align-items: center;
         }
 
-        .position-filter {
+        .descendants-filter {
             display: flex;
             align-items: center;
-
-            .position-filter {
-                display: flex;
-                align-items: center;
-                margin-left: $gutter;
-            }
+            margin-left: $gutter;
         }
     }
 }

--- a/src/Template/Element/FilterBox/filter_box.scss
+++ b/src/Template/Element/FilterBox/filter_box.scss
@@ -57,19 +57,7 @@
             }
         }
 
-        // TODO: non mi piace, da rivedere il componente input date picker
-        &.date {
-            > span {
-                display: flex;
-
-                input {
-                    margin: 0;
-                    width: 100%;
-                }
-            }
-        }
-
-        & > label {
+        label {
             &:first-letter {
                 text-transform: uppercase;
             }
@@ -79,10 +67,30 @@
             }
         }
 
+        .date-filter {
+            display: flex;
+
+            input {
+                margin: 0;
+                width: 100%;
+            }
+        }
+
         .category-picker,
         .folder-picker {
             display: flex;
             align-items: center;
+        }
+
+        .position-filter {
+            display: flex;
+            align-items: center;
+
+            .position-filter {
+                display: flex;
+                align-items: center;
+                margin-left: $gutter;
+            }
         }
     }
 }

--- a/src/Template/Element/FilterBox/filter_box.scss
+++ b/src/Template/Element/FilterBox/filter_box.scss
@@ -21,9 +21,26 @@
     }
 }
 
-
 .filters-container {
-    .filter-container, .filter-buttons {
+    display: flex;
+    flex-direction: column;
+
+    .basic-filters,
+    .more-filters {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+
+        > * {
+            margin-bottom: $gutter * .5;
+        }
+
+        > *:not(:last-child) {
+            margin-right: $gutter;
+        }
+    }
+
+    .more-filters {
         margin-top: $gutter;
     }
 
@@ -32,51 +49,41 @@
         flex-wrap: wrap;
         align-items: center;
 
-        &:first-child { margin-top: 0; }
         &.filter-search {
             display: flex;
-            input[type="text"] { 
+            input[type="text"] {
                 width: 100%;
-                min-width: $gutter * 12; 
+                min-width: $gutter * 12;
             }
         }
+
         // TODO: non mi piace, da rivedere il componente input date picker
         &.date {
             > span {
                 display: flex;
-                input { margin: 0; width: 100%; }
+
+                input {
+                    margin: 0;
+                    width: 100%;
+                }
             }
         }
 
-        .filter-status-select { margin-left: $gutter * .5; }
-        .filter-label:first-letter { text-transform: uppercase; }
+        & > label {
+            &:first-letter {
+                text-transform: uppercase;
+            }
 
-        label, .filter-label {
-            cursor: pointer;
-            display: inline-block;
-            // flex-grow: 1;
-            &:not(:last-child) { margin-right: $gutter; }
+            &:not(:last-child) {
+                margin-right: $gutter * .5;
+            }
         }
-    }
 
-    .filter-buttons {
-        display: flex;
-        > *:not(:last-child) { margin-right: $gutter * .5; }
-    }
-}
-
-
-.filters-container.basic-filters-only {
-    display: flex;
-    .filter-container {
-        margin-top: 0;
-        margin-right: $gutter * .5;
-        .filter-label { display: none; }
-    }
-    .filter-buttons {
-        margin-top: 0;
-        margin-left: $gutter * .5;
-        margin-right: $gutter * .5;
+        .category-picker,
+        .folder-picker {
+            display: flex;
+            align-items: center;
+        }
     }
 }
 

--- a/src/Template/Element/FilterBox/filter_box.twig
+++ b/src/Template/Element/FilterBox/filter_box.twig
@@ -5,7 +5,7 @@
     </div>
     {% endif %}
 
-    <div>
+    <div class="pagination">
     {% if not hidePagination %}
         <div v-if="pagination.count">
             {% element 'FilterBox/filter_box_page_toolbar' %}

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -56,20 +56,25 @@
             <span v-if="filter.name === 'categories'">
                 <category-picker
                     :categories="{{ schema.categories|json_encode }}"
-                    :selected-categories="Object.values(initFilter.filter.categories)"
+                    :initial-categories="initCategories"
                     id="category-filter"
                     label=""
                     @change="onCategoryChange"
-                />
+                ></category-picker>
                 {{ Form.unlockField('categories') }}
             </span>
 
-            <span v-else-if="filter.name === 'parent'">
-                <folder-picker label="" />
+            <span v-else-if="filter.name === 'parent'" class="position-filter">
+                <folder-picker label="" :initial-folder="initFolder" @change="onFolderChange"></folder-picker>
                 {{ Form.unlockField('folderSelected') }}
+
+                <span class="position-filter">
+                    <label for="descendants">{{ __('Descendants') }}</label>
+                    <input id="descendants" type="checkbox" v-model="filterByDescendants" @change="onPositionFilterChange" />
+                </span>
             </span>
 
-            <span v-else-if="filter.name === 'date_ranges'">
+            <span v-else-if="filter.name === 'date_ranges'" class="date-filter">
                 <label>{{ __('From date') }}
                     <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['from_date']" :attrs="filter" />
                 </label>

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -1,111 +1,129 @@
-{% set selectBaseClasses = "has-background-gray-700 has-border-gray-700 has-font-weight-light has-text-gray-200 has-text-size-smallest" %}
-{% set containerClass = 'filters-container' %}
 {% set filterActive = (_view.request.getQuery('filter') or _view.request.getQuery('q')) %}
-{% if filterActive %}
-    {% set containerClass = 'filters-container filters-container-active' %}
-{% endif %}
 
-<div class="{{ containerClass }}" :class="filterList.length > 1? '' : 'basic-filters-only'">
-    {# dynamic filter object types #}
-    <div class="filter-container search-types" v-if="rightTypes.length > 1">
-        <select class="{{ selectBaseClasses }}"
-            v-model="queryFilter.filter.type"
-            @change="onOtherFiltersChange">
+<div class="filters-container{{ filterActive ? ' filters-container-active' : '' }}">
+    <div class="basic-filters">
+        {# search #}
+        <div class="filter-container filter-search input">
+            <input type="text"
+                :placeholder="placeholder"
+                v-model="queryFilter.q"
+                @keyup.prevent.stop="onQueryStringKeyup"
+                @change="onQueryStringChange"
+                @keyup.enter.prevent.stop="applyFilter" />
+        </div>
+
+        <button class="button button-secondary button-primary-hover-module-{{ currentModule.name }}"
+            @click.prevent="applyFilter()"
+        >
+            {{ __('Search') }}
+        </button>
+
+        <button class="toggle-filters button button-outlined" @click="moreFilters = !moreFilters">
+            <span v-if="!moreFilters">{{ __('More filters') }}</span>
+            <span v-else>{{ __('Less filters') }}</span>
+        </button>
+
+        {# Checkbox my contents #}
+        <div class="filter-container checkbox">
+            <label>
+                <input type="checkbox" v-model="queryFilter.filter['history_editor']">{{ __('Only my contents') }}</input>
+            </label>
+        </div>
+
+        <button class="button button-outlined" @click.prevent="resetFilter()">{{ __('Reset filters') }}</button>
+    </div>
+
+    <div class="more-filters" v-show="moreFilters">
+        {# status filter #}
+        <div class="filter-container" v-if="statusFilter.options">
+            <label v-for="s in statusFilter.options">
+                <input type="checkbox" :id="s.value" :name="statusFilter.name" :value="s.value" v-model="selectedStatuses">
+                <: s.text :>
+            </label>
+        </div>
+
+        {# dynamic filter object types #}
+        <div class="filter-container search-types" v-if="rightTypes.length > 1">
+            <select v-model="queryFilter.filter.type" @change="onOtherFiltersChange">
                 <option value="" label="{{ __('All Types') }}"></option>
                 <option v-for="type in rightTypes"><: t(type) :></option>
-        </select>
-    </div>
-
-    {# search #}
-    <div class="filter-container filter-search input">
-        <input type="text"
-            :placeholder="placeholder"
-            v-model="queryFilter.q"
-            @keyup.prevent.stop="onQueryStringKeyup"
-            @change="onQueryStringChange"
-            @keyup.enter.prevent.stop="applyFilter" />
-    </div>
-
-    {# status if available #}
-    <div class="filter-container radio" v-if="Object.keys(statusFilter).length !== 0">
-        <label>
-            <input type="radio" :name="statusFilter.name" value="" v-model="queryFilter.filter['status']">{{ __('All') }}
-        </label>
-        <label v-for="s in statusFilter.options">
-            <input type="radio" :name="statusFilter.name" :value="s.value" v-model="queryFilter.filter['status']"><: s.text :>
-        </label>
-    </div>
-
-    {# other dynamic filters #}
-    <div v-for="filter in dynamicFilters" class="filter-container" :class="[filter.name, filter.type, filter.date? 'date' : '' ]">
-        <input type="hidden" :name="filter.name" :value="filter.value">
-        <div class="filter-label"><: filter.name | humanize :></div>
-
-        <span v-if="filter.type === 'select' || filter.type === 'radio'">
-            <select v-model="queryFilter.filter[filter.name]" :id="filter.name" class="{{ selectBaseClasses }}">
-                <option value="">
-                    {{ __('All') }}
-                </option>
-                <option v-for="option in filter.options" v-if="option.text" :name="option.name" :value="option.value">
-                    <: option.text :>
-                </option>
             </select>
-        </span>
+        </div>
 
-        <span v-if="filter.type === 'checkbox'">
-            <label>
-                <input type="radio" v-model="queryFilter.filter[filter.name]" value="">
-                {{ __('Any') }}
-            </label>
-            <label>
-                <input type="radio" v-model="queryFilter.filter[filter.name]" value="true">
-                {{ __('Yes') }}
-            </label>
-            <label>
-                <input type="radio" v-model="queryFilter.filter[filter.name]" value="false">
-                {{ __('No') }}
-            </label>
-        </span>
+        {# other dynamic filters #}
+        <div v-for="filter in dynamicFilters" class="filter-container" :class="[filter.name, filter.type, filter.date ? 'date' : '']">
+            <input type="hidden" :name="filter.name" :value="filter.value">
+            <label><: filter.name | humanize :></label>
 
-        <span v-if="filter.name === 'date_ranges'">
-            <label>{{ __('From date') }}
-            <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['from_date']" :attrs="filter" />
-            </label>
-            <label>{{ __('To date') }}
-            <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['to_date']" :attrs="filter" />
-            </label>
-        </span>
+            <span v-if="filter.type === 'select' || filter.type === 'radio'">
+                <select v-model="queryFilter.filter[filter.name]" :id="filter.name">
+                    <option value="">
+                        {{ __('All') }}
+                    </option>
+                    <option v-for="option in filter.options" v-if="option.text" :name="option.name" :value="option.value">
+                        <: option.text :>
+                    </option>
+                </select>
+            </span>
 
-        <span v-else-if="filter.date">
-            <label>{{ __('From') }}
-            <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]['gte']" :attrs="filter" />
-            </label>
-            <label>{{ __('To') }}
-            <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]['lte']" :attrs="filter" />
-            </label>
-        </span>
+            <span v-else-if="filter.type === 'checkbox'">
+                <label>
+                    <input type="radio" v-model="queryFilter.filter[filter.name]" value="">
+                    {{ __('Any') }}
+                </label>
+                <label>
+                    <input type="radio" v-model="queryFilter.filter[filter.name]" value="true">
+                    {{ __('Yes') }}
+                </label>
+                <label>
+                    <input type="radio" v-model="queryFilter.filter[filter.name]" value="false">
+                    {{ __('No') }}
+                </label>
+            </span>
 
-        <span v-else-if="filter.type === 'text' || filter.type === 'number'">
-            <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]" :attrs="filter"/>
-        </span>
-    </div>
+            <span v-if="filter.name === 'date_ranges'">
+                <label>{{ __('From date') }}
+                    <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['from_date']" :attrs="filter" />
+                </label>
+                <label>{{ __('To date') }}
+                    <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['to_date']" :attrs="filter" />
+                </label>
+            </span>
 
-    <div class="filter-buttons">
-        <button v-show="showFilterButtons" class="button button-secondary" @click.prevent="applyFilter()">{{ __('Search') }}</button>
-        <button v-show="showFilterButtons" class="button button-secondary" @click.prevent="resetFilter()">{{ __('Reset filters') }}</button>
-    </div>
+            <span v-else-if="filter.date">
+                <label>{{ __('From') }}
+                    <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]['gte']" :attrs="filter" />
+                </label>
+                <label>{{ __('To') }}
+                    <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]['lte']" :attrs="filter" />
+                </label>
+            </span>
 
-    {# Checkbox my contents #}
-    <div class="filter-container checkbox">
-        <label>
-            <input type="checkbox" v-model="queryFilter.filter['history_editor']">{{ __('Only my contents') }}</input>
-        </label>
+            <span v-else-if="filter.type === 'text' || filter.type === 'number'">
+                <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]" :attrs="filter"/>
+            </span>
+        </div>
+
+        {% if schema.categories|length > 0 %}
+        <div class="filter-container" v-if="filterList.some(f => f.name === 'categories')">
+            <category-picker
+                :categories="{{ schema.categories|json_encode }}"
+                id="category-filter"
+            />
+            {{ Form.unlockField('categoriesSelected') }}
+        </div>
+        {% endif %}
+
+        <div class="filter-container">
+            <folder-picker />
+            {{ Form.unlockField('folderSelected') }}
+        </div>
     </div>
 </div>
 
 {% if filterActive %}
 <div>
-    <p class="is-expanded tag" style="margin-top: 1rem;">
+    <p class="is-expanded tag mt-1">
         {{ __('Data is filtered') }}
     </p>
 </div>

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -1,6 +1,4 @@
-{% set filterActive = (_view.request.getQuery('filter') or _view.request.getQuery('q')) %}
-
-<div class="filters-container{{ filterActive ? ' filters-container-active' : '' }}">
+<div class="filters-container" :class="{ 'filters-container-active': filterActive }">
     <div class="basic-filters">
         {# search #}
         <div class="filter-container filter-search input">
@@ -58,8 +56,10 @@
             <span v-if="filter.name === 'categories'">
                 <category-picker
                     :categories="{{ schema.categories|json_encode }}"
+                    :selected-categories="Object.values(initFilter.filter.categories)"
                     id="category-filter"
                     label=""
+                    @change="onCategoryChange"
                 />
                 {{ Form.unlockField('categories') }}
             </span>
@@ -120,10 +120,8 @@
     </div>
 </div>
 
-{% if filterActive %}
-<div>
+<div v-if="filterActive">
     <p class="is-expanded tag mt-1">
         {{ __('Data is filtered') }}
     </p>
 </div>
-{% endif %}

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -55,7 +55,30 @@
             <input type="hidden" :name="filter.name" :value="filter.value">
             <label><: filter.name | humanize :></label>
 
-            <span v-if="filter.type === 'select' || filter.type === 'radio'">
+            <span v-if="filter.name === 'categories'">
+                <category-picker
+                    :categories="{{ schema.categories|json_encode }}"
+                    id="category-filter"
+                    label=""
+                />
+                {{ Form.unlockField('categories') }}
+            </span>
+
+            <span v-else-if="filter.name === 'parent'">
+                <folder-picker label="" />
+                {{ Form.unlockField('folderSelected') }}
+            </span>
+
+            <span v-else-if="filter.name === 'date_ranges'">
+                <label>{{ __('From date') }}
+                    <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['from_date']" :attrs="filter" />
+                </label>
+                <label>{{ __('To date') }}
+                    <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['to_date']" :attrs="filter" />
+                </label>
+            </span>
+
+            <span v-else-if="filter.type === 'select' || filter.type === 'radio'">
                 <select v-model="queryFilter.filter[filter.name]" :id="filter.name">
                     <option value="">
                         {{ __('All') }}
@@ -81,15 +104,6 @@
                 </label>
             </span>
 
-            <span v-if="filter.name === 'date_ranges'">
-                <label>{{ __('From date') }}
-                    <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['from_date']" :attrs="filter" />
-                </label>
-                <label>{{ __('To date') }}
-                    <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['to_date']" :attrs="filter" />
-                </label>
-            </span>
-
             <span v-else-if="filter.date">
                 <label>{{ __('From') }}
                     <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]['gte']" :attrs="filter" />
@@ -102,21 +116,6 @@
             <span v-else-if="filter.type === 'text' || filter.type === 'number'">
                 <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]" :attrs="filter"/>
             </span>
-        </div>
-
-        {% if schema.categories|length > 0 %}
-        <div class="filter-container" v-if="filterList.some(f => f.name === 'categories')">
-            <category-picker
-                :categories="{{ schema.categories|json_encode }}"
-                id="category-filter"
-            />
-            {{ Form.unlockField('categories') }}
-        </div>
-        {% endif %}
-
-        <div class="filter-container">
-            <folder-picker />
-            {{ Form.unlockField('folderSelected') }}
         </div>
     </div>
 </div>

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -34,6 +34,7 @@
     <div class="more-filters" v-show="moreFilters">
         {# status filter #}
         <div class="filter-container" v-if="statusFilter.options">
+            <label>{{ __('Status') }}</label>
             <label v-for="s in statusFilter.options">
                 <input type="checkbox" :id="s.value" :name="statusFilter.name" :value="s.value" v-model="selectedStatuses">
                 <: s.text :>
@@ -51,9 +52,11 @@
         {# other dynamic filters #}
         <div v-for="filter in dynamicFilters" class="filter-container" :class="[filter.name, filter.type, filter.date ? 'date' : '']">
             <input type="hidden" :name="filter.name" :value="filter.value">
-            <label><: filter.name | humanize :></label>
+            <label class="filter-label"><: filter.name | humanize :></label>
 
             <span v-if="filter.name === 'categories'">
+                <label>{{ __('Categories') }}</label>
+
                 <category-picker
                     :categories="{{ schema.categories|json_encode }}"
                     :initial-categories="initCategories"
@@ -65,10 +68,12 @@
             </span>
 
             <span v-else-if="filter.name === 'parent'" class="position-filter">
+                <label>{{ __('Folder') }}</label>
+
                 <folder-picker label="" :initial-folder="initFolder" @change="onFolderChange"></folder-picker>
                 {{ Form.unlockField('folderSelected') }}
 
-                <span class="position-filter">
+                <span class="descendants-filter">
                     <label for="descendants">{{ __('Descendants') }}</label>
                     <input id="descendants" type="checkbox" v-model="filterByDescendants" @change="onPositionFilterChange" />
                 </span>

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -110,7 +110,7 @@
                 :categories="{{ schema.categories|json_encode }}"
                 id="category-filter"
             />
-            {{ Form.unlockField('categoriesSelected') }}
+            {{ Form.unlockField('categories') }}
         </div>
         {% endif %}
 

--- a/src/Template/Element/Form/bulk_category.twig
+++ b/src/Template/Element/Form/bulk_category.twig
@@ -6,7 +6,7 @@
 })|raw }}
     <div class="fieldset bulk-categories">
         <div class="input">
-            <category-picker :categories="{{ schema.categories|json_encode }}" :disabled="!selectedRows.length" />
+            <category-picker label="{{ __('Categories') }}" :categories="{{ schema.categories|json_encode }}" :disabled="!selectedRows.length" />
             {{ Form.unlockField('categories') }}
         </div>
 

--- a/src/Template/Element/Form/bulk_category.twig
+++ b/src/Template/Element/Form/bulk_category.twig
@@ -7,7 +7,7 @@
     <div class="fieldset bulk-categories">
         <div class="input">
             <category-picker :categories="{{ schema.categories|json_encode }}" :disabled="!selectedRows.length" />
-            {{ Form.unlockField('categoriesSelected') }}
+            {{ Form.unlockField('categories') }}
         </div>
 
         <input type="hidden" name="ids" :value="selectedRows">

--- a/src/Template/Element/Form/bulk_category.twig
+++ b/src/Template/Element/Form/bulk_category.twig
@@ -1,21 +1,16 @@
 {% if schema.categories|length > 0 %}
 {{ Form.create(null, {
     'id': 'bulk-categories',
-    'class': 'bulk-actions',
     'url': {'_name': 'modules:bulkCategories', 'object_type': objectType, '?': _view.request.getQuery()},
 })|raw }}
     <div class="fieldset bulk-categories">
-        <div class="input">
-            <category-picker label="{{ __('Categories') }}" :categories="{{ schema.categories|json_encode }}" :disabled="!selectedRows.length" />
-            {{ Form.unlockField('categories') }}
-        </div>
+        <category-picker label="{{ __('Categories') }}" :categories="{{ schema.categories|json_encode }}" :disabled="!selectedRows.length"></category-picker>
+        {{ Form.unlockField('categories') }}
 
-        <input type="hidden" name="ids" :value="selectedRows">
+        <input type="hidden" name="ids" :value="selectedRows"/>
         {{ Form.unlockField('ids') }}
 
-        <div class="input">
-            <button class="button button-outlined" @click.prevent="bulkActions('bulk-categories')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
-        </div>
+        <button class="button button-outlined" @click.prevent="bulkActions('bulk-categories')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
     </div>
 {{ Form.end()|raw }}
 {% endif %}

--- a/src/Template/Element/Form/bulk_category.twig
+++ b/src/Template/Element/Form/bulk_category.twig
@@ -4,22 +4,18 @@
     'class': 'bulk-actions',
     'url': {'_name': 'modules:bulkCategories', 'object_type': objectType, '?': _view.request.getQuery()},
 })|raw }}
-
-    <div class="fieldset bulk-categories" :disabled="!selectedRows.length">
-
+    <div class="fieldset bulk-categories">
         <div class="input">
             <category-picker :categories="{{ schema.categories|json_encode }}" :disabled="!selectedRows.length" />
             {{ Form.unlockField('categoriesSelected') }}
         </div>
 
-        <input type="hidden" name="ids" v-bind:value="selectedRows">
+        <input type="hidden" name="ids" :value="selectedRows">
         {{ Form.unlockField('ids') }}
 
         <div class="input">
             <button class="button button-outlined" @click.prevent="bulkActions('bulk-categories')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
         </div>
-
     </div>
-
 {{ Form.end()|raw }}
 {% endif %}

--- a/src/Template/Element/Form/bulk_export.twig
+++ b/src/Template/Element/Form/bulk_export.twig
@@ -36,7 +36,7 @@
                 {% set exportLabel = __('Export Filtered') %}
             {% endif %}
 
-            <button class="button button-outlined" @click.prevent="exportAll" :disabled="!selectedRows.length">{{ exportLabel }}</button>
+            <button class="button button-outlined" @click.prevent="exportAll">{{ exportLabel }}</button>
         </div>
     {{ Form.end()|raw }}
 {% endif %}

--- a/src/Template/Element/Form/bulk_export.twig
+++ b/src/Template/Element/Form/bulk_export.twig
@@ -11,7 +11,7 @@
             }) %}
             {% set defaultFormat = config('Export.default', 'xslx') %}
 
-            <select name="format" id="exportformat" :disabled="!selectedRows.length">
+            <select name="format" id="exportformat">
             {% for label,format in formats %}
                 <option value="{{ format }}" {% if format == defaultFormat %}selected="selected"{% endif %}>{{ label }}</option>
             {% endfor %}

--- a/src/Template/Element/Form/bulk_export.twig
+++ b/src/Template/Element/Form/bulk_export.twig
@@ -1,8 +1,9 @@
 {% if not currentModule.hints.multiple_types %}
-    {{ Form.create(null, {'id': 'form-export', 'class': 'bulk-actions', 'url': {'_name': 'export:export', 'object_type': objectType}})|raw }}
-
+    {{ Form.create(null, {
+        'id': 'form-export',
+        'url': {'_name': 'export:export', 'object_type': objectType}
+    })|raw }}
         <div class="fieldset">
-
             {% set formats = config('Export.formats', {
                 'CSV': 'csv',
                 'Open Document': 'ods',
@@ -10,13 +11,11 @@
             }) %}
             {% set defaultFormat = config('Export.default', 'xslx') %}
 
-            <div class="input select">
-                <select name="format" id="exportformat" :disabled="!selectedRows.length">
-                {% for label,format in formats %}
-                    <option value="{{ format }}" {% if format == defaultFormat %}selected="selected"{% endif %}>{{ label }}</option>
-                {% endfor %}
-                </select>
-            </div>
+            <select name="format" id="exportformat" :disabled="!selectedRows.length">
+            {% for label,format in formats %}
+                <option value="{{ format }}" {% if format == defaultFormat %}selected="selected"{% endif %}>{{ label }}</option>
+            {% endfor %}
+            </select>
 
             {{ Form.unlockField('format') }}
 
@@ -24,9 +23,7 @@
             {{ Form.unlockField('ids') }}
             {{ Form.hidden('objectType', {'value': objectType})|raw }}
 
-            <div class="input">
-                <button class="button button-outlined" @click.prevent="exportSelected" :disabled="!selectedRows.length">{{ __('Export') }}</button>
-            </div>
+            <button class="button button-outlined" @click.prevent="exportSelected" :disabled="!selectedRows.length">{{ __('Export') }}</button>
 
             {# Export all or filtered #}
             {% if _view.request.getQuery('filter') %}
@@ -39,11 +36,7 @@
                 {% set exportLabel = __('Export Filtered') %}
             {% endif %}
 
-            <div class="input">
-                <button class="button button-outlined" @click.prevent="exportAll" :disabled="!selectedRows.length">{{ exportLabel }}</button>
-            </div>
-
+            <button class="button button-outlined" @click.prevent="exportAll" :disabled="!selectedRows.length">{{ exportLabel }}</button>
         </div>
-
     {{ Form.end()|raw }}
 {% endif %}

--- a/src/Template/Element/Form/bulk_export.twig
+++ b/src/Template/Element/Form/bulk_export.twig
@@ -11,7 +11,7 @@
             {% set defaultFormat = config('Export.default', 'xslx') %}
 
             <div class="input select">
-                <select name="format" id="exportformat">
+                <select name="format" id="exportformat" :disabled="!selectedRows.length">
                 {% for label,format in formats %}
                     <option value="{{ format }}" {% if format == defaultFormat %}selected="selected"{% endif %}>{{ label }}</option>
                 {% endfor %}
@@ -40,7 +40,7 @@
             {% endif %}
 
             <div class="input">
-                <button class="button button-outlined" @click.prevent="exportAll">{{ exportLabel }}</button>
+                <button class="button button-outlined" @click.prevent="exportAll" :disabled="!selectedRows.length">{{ exportLabel }}</button>
             </div>
 
         </div>

--- a/src/Template/Element/Form/bulk_position.twig
+++ b/src/Template/Element/Form/bulk_position.twig
@@ -16,7 +16,7 @@
         </div>
 
         <div class="input">
-            <folder-picker :disabled="!selectedRows.length" />
+            <folder-picker label="{{ __('Folder') }}" :disabled="!selectedRows.length" />
             {{ Form.unlockField('folderSelected') }}
         </div>
 

--- a/src/Template/Element/Form/bulk_position.twig
+++ b/src/Template/Element/Form/bulk_position.twig
@@ -16,7 +16,7 @@
         </div>
 
         <div class="input">
-            <folder-picker/>
+            <folder-picker :disabled="!selectedRows.length" />
             {{ Form.unlockField('folderSelected') }}
         </div>
 

--- a/src/Template/Element/Form/bulk_position.twig
+++ b/src/Template/Element/Form/bulk_position.twig
@@ -5,7 +5,7 @@
     'url': {'_name': 'modules:bulkPosition', 'object_type': objectType, '?': _view.request.getQuery()},
 })|raw }}
 
-    <div class="fieldset bulk-folders" :disabled="!selectedRows.length">
+    <div class="fieldset bulk-folders">
 
         <div class="input select">
             <label for="bulk-copy">{{ __('Copy to') }}</label>

--- a/src/Template/Element/Form/bulk_position.twig
+++ b/src/Template/Element/Form/bulk_position.twig
@@ -1,33 +1,28 @@
 {% if modules.folders %}
 {{ Form.create(null, {
     'id': 'bulk-folder',
-    'class': 'bulk-actions',
     'url': {'_name': 'modules:bulkPosition', 'object_type': objectType, '?': _view.request.getQuery()},
 })|raw }}
 
     <div class="fieldset bulk-folders">
-
-        <div class="input select">
+        <div>
             <label for="bulk-copy">{{ __('Copy to') }}</label>
-            <input id="bulk-move" @click="folderPickerInit()" :disabled="!selectedRows.length" name="action" v-model="bulkAction" type="radio" value="copy"/>
+            <input id="bulk-move" :disabled="!selectedRows.length" name="action" v-model="bulkAction" type="radio" value="copy"/>
+        </div>
+
+        <div>
             <label for="bulk-move">{{ __('Move to') }}</label>
-            <input id="bulk-copy" @click="folderPickerInit()" :disabled="!selectedRows.length" name="action" v-model="bulkAction" type="radio" value="move"/>
-            {{ Form.unlockField('action') }}
+            <input id="bulk-copy" :disabled="!selectedRows.length" name="action" v-model="bulkAction" type="radio" value="move"/>
         </div>
+        {{ Form.unlockField('action') }}
 
-        <div class="input">
-            <folder-picker label="{{ __('Folder') }}" :disabled="!selectedRows.length" />
-            {{ Form.unlockField('folderSelected') }}
-        </div>
+        <folder-picker label="{{ __('Folder') }}" :disabled="!selectedRows.length || !bulkAction"></folder-picker>
+        {{ Form.unlockField('folderSelected') }}
 
-        <input type="hidden" name="ids" v-bind:value="selectedRows">
+        <input type="hidden" name="ids" :value="selectedRows"/>
         {{ Form.unlockField('ids') }}
 
-        <div class="input">
-            <button class="button button-outlined" @click.prevent="bulkActions('bulk-folder')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
-        </div>
-
+        <button class="button button-outlined" @click.prevent="bulkActions('bulk-folder')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
     </div>
-
 {{ Form.end()|raw }}
 {% endif %}

--- a/src/Template/Element/Form/bulk_position.twig
+++ b/src/Template/Element/Form/bulk_position.twig
@@ -16,13 +16,23 @@
         </div>
         {{ Form.unlockField('action') }}
 
-        <folder-picker label="{{ __('Folder') }}" :disabled="!selectedRows.length || !bulkAction"></folder-picker>
+        <folder-picker
+            label="{{ __('Folder') }}"
+            :disabled="!selectedRows.length || !bulkAction"
+            @change="bulkFolder = $event?.id"
+        ></folder-picker>
         {{ Form.unlockField('folderSelected') }}
 
         <input type="hidden" name="ids" :value="selectedRows"/>
         {{ Form.unlockField('ids') }}
 
-        <button class="button button-outlined" @click.prevent="bulkActions('bulk-folder')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
+        <button
+            class="button button-outlined"
+            @click.prevent="bulkActions('bulk-folder')"
+            :disabled="!selectedRows.length || !bulkAction || !bulkFolder"
+        >
+            {{ __('Ok') }}
+        </button>
     </div>
 {{ Form.end()|raw }}
 {% endif %}

--- a/src/Template/Element/Form/bulk_properties.twig
+++ b/src/Template/Element/Form/bulk_properties.twig
@@ -2,12 +2,9 @@
 {% for label, key in bulkActions %}
     {{ Form.create(null, {
         'id': 'bulk-' ~ key,
-        'class': 'bulk-actions',
         'url': {'_name': 'modules:bulkAttribute', 'object_type': objectType, '?': _view.request.getQuery()},
     })|raw }}
-
         <div class="fieldset" :disabled="!selectedRows.length">
-
             <input type="hidden" name="ids" v-bind:value="selectedRows">
             {{ Form.unlockField('ids') }}
 
@@ -41,11 +38,7 @@
                 {{ write_config('_jsonKeys', config('_jsonKeys', [])|merge([key])) }}
             {% endif %}
 
-            <div class="input">
-                <button class="button button-outlined" @click.prevent="bulkActions('bulk-{{ key }}')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
-            </div>
-
+            <button class="button button-outlined" @click.prevent="bulkActions('bulk-{{ key }}')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
         </div>
-
     {{ Form.end()|raw }}
 {% endfor %}

--- a/src/Template/Element/Form/bulk_properties.twig
+++ b/src/Template/Element/Form/bulk_properties.twig
@@ -12,25 +12,27 @@
             {{ Form.unlockField('ids') }}
 
             {% set options = Schema.controlOptions(key, null, schema.properties[key]) %}
-            {% set options = options|merge({ 'name': 'attributes[' ~ key ~ ']' }) %}
-            {% set options = options|merge({ 'v-model': 'bulkValue' }) %}
+            {% set options = options|merge({
+                'name': 'attributes[' ~ key ~ ']',
+                'v-model': 'bulkValue',
+                ':disabled': '!selectedRows.length'
+            }) %}
             {% if label %}
                 {% set options = options|merge({'label': __(label)}) %}
             {% endif %}
 
             {% if options.type == 'checkbox' %}
                 {# custom radio input for type checkbox #}
-                {% set radio =  {
+                {% set radio = {
                     "type":"radio",
-                    "options":
-                        [
-                            { "value": 1, "text": __("Yes") },
-                            { "value": 0, "text": __("No") }
-                        ],
+                    "options": [
+                        { "value": 1, "text": __("Yes") },
+                        { "value": 0, "text": __("No") },
+                        { ':disabled': '!selectedRows.length' }
+                    ],
                     "name": "attributes[" ~ key ~ "]"
                 } %}
                 {{ Form.control(key, radio)|raw }}
-
             {% else %}
                 {{ Form.control(key, options)|raw }}
             {% endif %}

--- a/src/Template/Element/Form/bulk_trash.twig
+++ b/src/Template/Element/Form/bulk_trash.twig
@@ -1,21 +1,19 @@
 {% if (objects) and Perms.canDelete({type: objectType}) %}
+{{ Form.create(null, {
+    'id': 'form-delete',
+    'url': {'_name': 'modules:delete', 'object_type': objectType}
+})|raw}}
+    <input type="hidden" name="ids" v-bind:value="selectedRows">
+    {{ Form.unlockField('ids') }}
 
-    {{ Form.create(null, {'id': 'form-delete', 'class': 'bulk-actions', 'url': {'_name': 'modules:delete', 'object_type': objectType}})|raw }}
-
-        <input type="hidden" name="ids" v-bind:value="selectedRows">
-
-        {{ Form.unlockField('ids') }}
-
-        <div class="fieldset">
-
-            <div class="input">
-
-                <button class="button button-outlined" @click.prevent="trash" :disabled="!selectedRows.length">{{ __('Move to trash') }}</button>
-
-            </div>
-
-        </div>
-
-    {{ Form.end()|raw }}
-
+    <div class="fieldset">
+        <button
+            class="button button-outlined"
+            @click.prevent="trash"
+            :disabled="!selectedRows.length"
+        >
+            {{ __('Move to trash') }}
+        </button>
+    </div>
+{{ Form.end()|raw }}
 {% endif %}

--- a/src/Template/Element/Form/bulk_trash.twig
+++ b/src/Template/Element/Form/bulk_trash.twig
@@ -6,7 +6,7 @@
 
         {{ Form.unlockField('ids') }}
 
-        <div class="fieldset" :disabled="!selectedRows.length">
+        <div class="fieldset">
 
             <div class="input">
 

--- a/src/Template/Element/Modules/index_bulk.twig
+++ b/src/Template/Element/Modules/index_bulk.twig
@@ -1,11 +1,11 @@
-<div class="bulk-actions" :class="!selectedRows.length ? 'disabled' : ''">
-    <nav>
+<div class="bulk-actions" :class="{ disabled: !selectedRows.length }">
+    <div>
         {% element 'Form/bulk_export' %}
-    </nav>
-    <header>
-        <h3>{{ __('Actions on selected items') }}</h3>
-    </header>
-    <nav>
+    </div>
+
+    <h3 class="bulk-header">{{ __('Actions on selected items') }}</h3>
+
+    <div>
         {% element 'Form/bulk_properties' %}
 
         {% element 'Form/bulk_category' %}
@@ -13,5 +13,5 @@
         {% element 'Form/bulk_position' %}
 
         {% element 'Form/bulk_trash' %}
-    </nav>
+    </div>
 </div>

--- a/src/Template/Element/Modules/index_bulk.twig
+++ b/src/Template/Element/Modules/index_bulk.twig
@@ -1,11 +1,11 @@
-<div class="bulk-actions" :class="{ disabled: !selectedRows.length }">
+<div class="bulk-actions">
     <div>
         {% element 'Form/bulk_export' %}
     </div>
 
     <h3 class="bulk-header">{{ __('Actions on selected items') }}</h3>
 
-    <div>
+    <div :class="{ disabled: !selectedRows.length }">
         {% element 'Form/bulk_properties' %}
 
         {% element 'Form/bulk_category' %}

--- a/src/Template/Element/Modules/index_bulk.twig
+++ b/src/Template/Element/Modules/index_bulk.twig
@@ -1,4 +1,4 @@
-<div class="bulk-actions" :class="!selectedRows.length? '' : 'enabled'">
+<div class="bulk-actions" :class="!selectedRows.length ? 'disabled' : ''">
     <nav>
         {% element 'Form/bulk_export' %}
     </nav>

--- a/src/Template/Element/Modules/index_header.twig
+++ b/src/Template/Element/Modules/index_header.twig
@@ -1,4 +1,5 @@
 <div class="module-header">
+    {% set filterActive = (_view.request.getQuery('filter') or _view.request.getQuery('q')) %}
     {% set list = [] %}
     {% for f in filter %}
         {% set options = Schema.controlOptions(f, null, schema.properties[f]) %}
@@ -10,7 +11,8 @@
         :pagination={{ meta.pagination|json_encode|raw }}
         :init-filter="urlFilterQuery"
         :selected-types='selectedTypes'
-        :filter-list='{{ list|json_encode|raw}}'
+        :filter-list='{{ list|json_encode|raw }}'
+        :filter-active="{{ filterActive|json_encode }}"
 
         config-paginate-sizes={{ config('Pagination.sizeAvailable')|json_encode()|raw }}
         placeholder="{{ __('Search') }}"

--- a/src/Template/Element/Modules/index_header.twig
+++ b/src/Template/Element/Modules/index_header.twig
@@ -12,7 +12,7 @@
         :init-filter="urlFilterQuery"
         :selected-types='selectedTypes'
         :filter-list='{{ list|json_encode|raw }}'
-        :filter-active="{{ filterActive|json_encode }}"
+        :filter-active="{{ filterActive|json_encode|raw }}"
 
         config-paginate-sizes={{ config('Pagination.sizeAvailable')|json_encode()|raw }}
         placeholder="{{ __('Search') }}"

--- a/src/Template/Element/Modules/index_header.twig
+++ b/src/Template/Element/Modules/index_header.twig
@@ -3,7 +3,7 @@
     {% for f in filter %}
         {% set options = Schema.controlOptions(f, null, schema.properties[f]) %}
         {% set options = options|merge({ 'name': f }) %}
-        {% set list = list|merge({ (loop.index0): options}) %}
+        {% set list = list|merge({ (loop.index0): options }) %}
     {% endfor %}
 
     <filter-box-view

--- a/src/Template/Layout/js/app/app.js
+++ b/src/Template/Layout/js/app/app.js
@@ -173,17 +173,17 @@ const _vueInstance = new Vue({
         /**
          * listen to FilterBoxView event filter-objects
          *
-         * @param {Object} filter
+         * @param {Object} query
          *
          * @return {void}
          */
-        onFilterObjects(filter) {
+        onFilterObjects(query) {
             // remove from query string filter `history_editor` if false
-            if (!filter.filter.history_editor) {
-                delete filter.filter.history_editor;
+            if (!query.filter.history_editor) {
+                delete query.filter.history_editor;
             }
 
-            this.urlFilterQuery = filter;
+            this.urlFilterQuery = query;
             this.page = '';
 
             this.applyFilters(this.urlFilterQuery);

--- a/src/Template/Layout/js/app/components/category-picker/category-picker.js
+++ b/src/Template/Layout/js/app/components/category-picker/category-picker.js
@@ -9,8 +9,16 @@ export default {
     template: `
         <div class="category-picker">
             <label v-if="label" :for="id"><: label :></label>
-            <Treeselect placeholder :options="categoriesOptions" :disabled="disabled" :disable-branch-nodes="true" :multiple="true" v-model="value" />
-            <input type="hidden" :id="id" name="categories" :value="value" />
+            <Treeselect
+                placeholder
+                :options="categoriesOptions"
+                :disabled="disabled"
+                :disable-branch-nodes="true"
+                :multiple="true"
+                v-model="selectedIds"
+                @input="onChange"
+            />
+            <input type="hidden" :id="id" name="categories" :value="selectedIds" />
         </div>
     `,
 
@@ -19,22 +27,28 @@ export default {
         categories: Array,
         disabled: Boolean,
         label: String,
+        selectedCategories: Array,
     },
 
     data() {
         return {
             categoriesOptions: [],
-            value: null,
+            selectedIds: null,
         };
     },
 
     mounted() {
-        this.loadCategories();
+        this.categoriesOptions = this.categories?.map((category) => ({ id: category.id, label: category.label }));
+        this.selectedIds = this.selectedCategories?.map(selected => this.categories.find(cat => cat.name == selected)?.id);
     },
 
     methods: {
-        loadCategories() {
-            this.categoriesOptions = this.categories?.map((category) => ({ id: category.id, label: category.label }));
-        },
+        /**
+         * Emits currently selected categories on selection change.
+         */
+        onChange() {
+            const selectedCategories = this.categories.filter((cat) => this.selectedIds.includes(cat.id));
+            this.$emit('change', selectedCategories);
+        }
     },
 }

--- a/src/Template/Layout/js/app/components/category-picker/category-picker.js
+++ b/src/Template/Layout/js/app/components/category-picker/category-picker.js
@@ -27,7 +27,7 @@ export default {
         categories: Array,
         disabled: Boolean,
         label: String,
-        selectedCategories: Array,
+        initialCategories: Array,
     },
 
     data() {
@@ -39,7 +39,7 @@ export default {
 
     mounted() {
         this.categoriesOptions = this.categories?.map((category) => ({ id: category.id, label: category.label }));
-        this.selectedIds = this.selectedCategories?.map(selected => this.categories.find(cat => cat.name == selected)?.id);
+        this.selectedIds = this.initialCategories?.map(selected => this.categories.find(cat => cat.name == selected)?.id);
     },
 
     methods: {

--- a/src/Template/Layout/js/app/components/category-picker/category-picker.js
+++ b/src/Template/Layout/js/app/components/category-picker/category-picker.js
@@ -1,6 +1,5 @@
 import { Treeselect } from '@riophae/vue-treeselect'
 import '@riophae/vue-treeselect/dist/vue-treeselect.css'
-import { t } from 'ttag';
 
 export default {
     components: {
@@ -9,7 +8,7 @@ export default {
 
     template: `
         <div class="category-picker">
-            <label :for="id">${t`Categories`}</label>
+            <label v-if="label" :for="id"><: label :></label>
             <Treeselect placeholder :options="categoriesOptions" :disabled="disabled" :disable-branch-nodes="true" :multiple="true" v-model="value" />
             <input type="hidden" :id="id" name="categories" :value="value" />
         </div>
@@ -19,6 +18,7 @@ export default {
         id: String,
         categories: Array,
         disabled: Boolean,
+        label: String,
     },
 
     data() {

--- a/src/Template/Layout/js/app/components/category-picker/category-picker.js
+++ b/src/Template/Layout/js/app/components/category-picker/category-picker.js
@@ -11,7 +11,7 @@ export default {
         <div class="category-picker">
             <label :for="id">${t`Categories`}</label>
             <Treeselect placeholder :options="categoriesOptions" :disabled="disabled" :disable-branch-nodes="true" :multiple="true" v-model="value" />
-            <input type="hidden" :id="id" name="categoriesSelected" :value="value" />
+            <input type="hidden" :id="id" name="categories" :value="value" />
         </div>
     `,
 

--- a/src/Template/Layout/js/app/components/category-picker/category-picker.js
+++ b/src/Template/Layout/js/app/components/category-picker/category-picker.js
@@ -3,21 +3,22 @@ import '@riophae/vue-treeselect/dist/vue-treeselect.css'
 import { t } from 'ttag';
 
 export default {
-
     components: {
         Treeselect,
     },
 
     template: `
-    <div>
-        <label for="bulk-categories">${t`Categories`}</label>
-        <Treeselect placeholder :options="categoriesOptions" :disable-branch-nodes="true" :multiple="true" v-model="value" />
-        <input type="hidden" id="bulk-categories" name="categoriesSelected" :value="value" />
-    </div>`,
+        <div class="category-picker">
+            <label :for="id">${t`Categories`}</label>
+            <Treeselect placeholder :options="categoriesOptions" :disabled="disabled" :disable-branch-nodes="true" :multiple="true" v-model="value" />
+            <input type="hidden" :id="id" name="categoriesSelected" :value="value" />
+        </div>
+    `,
 
     props: {
         id: String,
         categories: Array,
+        disabled: Boolean,
     },
 
     data() {
@@ -33,7 +34,7 @@ export default {
 
     methods: {
         loadCategories() {
-            this.categoriesOptions = this.categories.map((category) => ({ id: category.id, label: category.label }));
+            this.categoriesOptions = this.categories?.map((category) => ({ id: category.id, label: category.label }));
         },
     },
 }

--- a/src/Template/Layout/js/app/components/filter-box.js
+++ b/src/Template/Layout/js/app/components/filter-box.js
@@ -20,6 +20,10 @@ import merge from 'deepmerge';
 import { t } from 'ttag';
 import { warning } from 'app/components/dialog/dialog';
 
+/**
+ * Filters that are rendered with custom forms.
+ * Needed to skip generic form controls.
+ */
 const CUSTOM_RENDER_FILTERS = ['status', 'categories'];
 
 export default {
@@ -92,6 +96,7 @@ export default {
             this.initFilter
         ]);
 
+        // remove default filters with custom render from the list of dynamic filters
         this.dynamicFilters = this.filterList.filter(f => {
             if (CUSTOM_RENDER_FILTERS.includes(f.name)) {
                 if (f.name == 'status') {
@@ -125,10 +130,7 @@ export default {
          * @return {void}
          */
         isFullPaginationLayout() {
-            return (
-                this.pagination.page_count > 1 &&
-                this.pagination.page_count <= 7
-            );
+            return this.pagination.page_count > 1 && this.pagination.page_count <= 7;
         }
     },
 

--- a/src/Template/Layout/js/app/components/filter-box.js
+++ b/src/Template/Layout/js/app/components/filter-box.js
@@ -24,7 +24,7 @@ import { warning } from 'app/components/dialog/dialog';
  * Filters that are rendered with custom forms.
  * Needed to skip generic form controls.
  */
-const CUSTOM_RENDER_FILTERS = ['status', 'categories'];
+const CUSTOM_RENDER_FILTERS = [];
 
 export default {
     components: {

--- a/src/Template/Layout/js/app/components/folder-picker/folder-picker.js
+++ b/src/Template/Layout/js/app/components/folder-picker/folder-picker.js
@@ -1,5 +1,5 @@
-import { Treeselect, LOAD_ROOT_OPTIONS, LOAD_CHILDREN_OPTIONS } from '@riophae/vue-treeselect'
-import '@riophae/vue-treeselect/dist/vue-treeselect.css'
+import { Treeselect, LOAD_ROOT_OPTIONS, LOAD_CHILDREN_OPTIONS } from '@riophae/vue-treeselect';
+import '@riophae/vue-treeselect/dist/vue-treeselect.css';
 import { t } from 'ttag';
 import { EventBus } from '../../directives/eventbus.js';
 
@@ -17,7 +17,7 @@ export default {
         Treeselect,
     },
 
-    template: `<div>
+    template: `<div class="folder-picker">
         <label for="bulk-folders">${t`Folder`}</label>
         <Treeselect placeholder="" :options="options" :load-options="loadOptions" v-model="value" :disabled="disabled" />
         <input id="bulk-folders" type="hidden" name="folderSelected" :value="value" />

--- a/src/Template/Layout/js/app/components/folder-picker/folder-picker.js
+++ b/src/Template/Layout/js/app/components/folder-picker/folder-picker.js
@@ -1,7 +1,5 @@
 import { Treeselect, LOAD_ROOT_OPTIONS, LOAD_CHILDREN_OPTIONS } from '@riophae/vue-treeselect';
 import '@riophae/vue-treeselect/dist/vue-treeselect.css';
-import { t } from 'ttag';
-import { EventBus } from '../../directives/eventbus.js';
 
 const API_URL = new URL(BEDITA.base).pathname;
 const API_OPTIONS = {
@@ -11,71 +9,86 @@ const API_OPTIONS = {
     }
 };
 
+/**
+ * Folder picker component.
+ * Displays a tree-view folders list and allows to pick one.
+ *
+ * @prop {Boolean} disabled Enable/disable the select
+ * @prop {String} initialFolder Id of the folder to pre-select
+ * @prop {String} label Label to show before the select
+ */
 export default {
     components: {
         Treeselect,
     },
 
     template: `<div class="folder-picker">
-        <label v-if="label" for="bulk-folders"><: label :></label>
+        <label v-if="label"><: label :></label>
         <Treeselect
             placeholder=""
+            loading-text=""
+            v-model="selectedFolder"
+            :default-options="initialOptions"
+            :disabled="disabled"
             :options="options"
             :load-options="loadOptions"
             :auto-load-root-options="false"
-            v-model="value"
-            :disabled="disabled"
+            value-format="object"
+            @input="onChange"
         />
-        <input id="bulk-folders" type="hidden" name="folderSelected" :value="value" />
+        <input type="hidden" name="folderSelected" :value="selectedFolder?.id" />
     </div>`,
 
     props: {
         disabled: Boolean,
+        initialFolder: String,
         label: String,
     },
 
+    /**
+     * @property {Array} initialOptions Initial options used to pre-select the initial folder
+     * @property {Array} options The list of folder to show in the select
+     * @property {Object} options Currently selected folder (an object in the format {id: ..., label: ...})
+     */
     data() {
         return {
+            initialOptions: null,
             options: null,
-            value: null,
+            selectedFolder: null,
         };
     },
 
-    created() {
-        EventBus.$on('folder-picker-init', this.initOptions);
-    },
-
-    beforeDestroy() {
-        EventBus.$off('folder-picker-init', this.initOptions);
+    async created() {
+        if (this.initialFolder) {
+            const response = await fetch(`${API_URL}api/folders/${this.initialFolder}`);
+            const json = await response.json();
+            const data = json.data;
+            const folder = { id: data.id, label: data.attributes.title };
+            this.initialOptions = [folder];
+            this.selectedFolder = folder;
+        }
     },
 
     methods: {
         async fetchFolders(parent) {
             const pageSize = 100;
-            const folders = [];
             const filter = !parent ? 'filter[roots]' : `filter[parent]=${parent.id}`;
             const firstResponse = await fetch(`${API_URL}api/folders?${filter}&page=1&page_size=${pageSize}`, API_OPTIONS);
-            const pageCount = await this.updateFolders(firstResponse, folders);
+            const json = await firstResponse.json();
+            const folders = [...(json.data || [])];
+            const pageCount = json.meta.pagination.page_count;
+
             const deferred = [];
             for (let page = 2; page <= pageCount; page++) {
                 deferred.push(fetch(`${API_URL}api/folders?${filter}&page=${page}&page_size=${pageSize}`, API_OPTIONS));
             }
             const responses = await Promise.all(deferred);
             responses.forEach(async (response) => {
-                await this.updateFolders(response, folders);
+                const json = await response.json();
+                folders.push(...(json.data || []));
             });
 
-            return folders;
-        },
-
-        async updateFolders(response, folders) {
-            let json = await response.json();
-            if (json.data) {
-                const newFolders = json.data.map((folder) => ({id: folder.id, label: folder.attributes.title, children: null}));
-                folders.push(...newFolders);
-            }
-
-            return json.meta.pagination.page_count;
+            return folders.map((folder) => ({ id: folder.id, label: folder.attributes.title }));
         },
 
         async loadOptions({ action, parentNode, callback }) {
@@ -84,13 +97,11 @@ export default {
             } else if (action === LOAD_CHILDREN_OPTIONS) {
                 parentNode.children = await this.fetchFolders(parentNode);
             }
+            callback();
         },
 
-        async initOptions() {
-            if (this.options.length > 0) {
-                return;
-            }
-            this.options = await this.fetchFolders();
-        },
+        onChange() {
+            this.$emit('change', this.selectedFolder);
+        }
     },
 }

--- a/src/Template/Layout/js/app/components/folder-picker/folder-picker.js
+++ b/src/Template/Layout/js/app/components/folder-picker/folder-picker.js
@@ -88,7 +88,7 @@ export default {
                 folders.push(...(json.data || []));
             });
 
-            return folders.map((folder) => ({ id: folder.id, label: folder.attributes.title }));
+            return folders.map((folder) => ({ id: folder.id, label: folder.attributes.title, children: null }));
         },
 
         async loadOptions({ action, parentNode, callback }) {

--- a/src/Template/Layout/js/app/components/folder-picker/folder-picker.js
+++ b/src/Template/Layout/js/app/components/folder-picker/folder-picker.js
@@ -17,7 +17,7 @@ export default {
     },
 
     template: `<div class="folder-picker">
-        <label for="bulk-folders">${t`Folder`}</label>
+        <label v-if="label" for="bulk-folders"><: label :></label>
         <Treeselect
             placeholder=""
             :options="options"
@@ -31,6 +31,7 @@ export default {
 
     props: {
         disabled: Boolean,
+        label: String,
     },
 
     data() {

--- a/src/Template/Layout/js/app/components/tree-view/tree-view.js
+++ b/src/Template/Layout/js/app/components/tree-view/tree-view.js
@@ -175,17 +175,14 @@ export default {
          *
          * @return {boolean}
          */
-         isMenu() {
+        isMenu() {
             if (!this.isParent) {
                 return false;
             }
-            if (!this.node.meta.relation) {
-                return true;
-            }
-            return !!this.node.meta.relation.menu;
+            return !!this.node.meta?.relation?.menu;
         },
 
-         /**
+        /**
          * Check if this is the primary position.
          *
          * @return {boolean}
@@ -194,10 +191,7 @@ export default {
             if (!this.isParent) {
                 return false;
             }
-            if (!this.node.meta.relation) {
-                return false;
-            }
-            return !!this.node.meta.relation.canonical;
+            return !!this.node.meta?.relation?.canonical;
         },
 
         /**

--- a/src/Template/Layout/js/app/directives/eventbus.js
+++ b/src/Template/Layout/js/app/directives/eventbus.js
@@ -1,2 +1,0 @@
-import Vue from 'vue';
-export const EventBus = new Vue();

--- a/src/Template/Layout/js/app/pages/modules/index.js
+++ b/src/Template/Layout/js/app/pages/modules/index.js
@@ -1,6 +1,5 @@
 import { confirm } from 'app/components/dialog/dialog';
 import { t } from 'ttag';
-import { EventBus } from 'app/directives/eventbus.js';
 
 /**
  * Templates that uses this component (directly or indirectly)
@@ -40,7 +39,7 @@ export default {
             selectedRows: [],
             bulkField: null,
             bulkValue: null,
-            bulkAction: 'choose',
+            bulkAction: null,
             selectedIds: null,
         };
     },
@@ -168,13 +167,6 @@ export default {
                     this.selectedRows.push(cb.value);
                 }
             }
-        },
-
-        /**
-         * Emit event to init folder picker
-         */
-        folderPickerInit() {
-            EventBus.$emit('folder-picker-init', true);
         },
     }
 }

--- a/src/Template/Layout/js/app/pages/modules/index.js
+++ b/src/Template/Layout/js/app/pages/modules/index.js
@@ -41,6 +41,11 @@ export default {
             bulkValue: null,
             bulkAction: null,
             selectedIds: null,
+            /**
+             * Selected folder for bulk copy or move.
+             * Used to enable/disable confirmation button.
+             */
+            bulkFolder: null,
         };
     },
 

--- a/src/Template/Layout/styles/_forms.scss
+++ b/src/Template/Layout/styles/_forms.scss
@@ -217,7 +217,7 @@ form {
 
 // Treeselect
 .vue-treeselect {
-    min-width: 4rem !important;
+    min-width: 6rem !important;
 }
 
 .vue-treeselect--disabled {
@@ -225,9 +225,13 @@ form {
 }
 
 .vue-treeselect__control {
-    height: $gutter * 2 !important;
-    padding: 0 .5em !important;
+    display: inline-flex;
+    align-items: center;
     width: auto !important;
+    height: auto !important;
+    max-width: 15rem;
+    min-height: $gutter * 2;
+    padding: 0 .5em !important;
     color: #000 !important;
     border-radius: 2px !important;
     border: none !important;
@@ -254,6 +258,11 @@ form {
 
 .vue-treeselect__input-container input {
     height: 100%;
+}
+
+.vue-treeselect__multi-value {
+    max-height: 5rem;
+    overflow: auto;
 }
 
 .vue-treeselect__multi-value-item {

--- a/src/Template/Layout/styles/_forms.scss
+++ b/src/Template/Layout/styles/_forms.scss
@@ -36,6 +36,9 @@ textarea {
 
 select {
     height: $gutter * 2;
+    border-radius: 2px;
+    border: none;
+    font-family: $font-family-sans-serif;
 }
 
 label {
@@ -210,4 +213,84 @@ form {
             color: $gray-900;
         }
     }
+}
+
+// Treeselect
+.vue-treeselect {
+    min-width: 4rem !important;
+}
+
+.vue-treeselect--disabled {
+    opacity: .6;
+}
+
+.vue-treeselect__control {
+    height: $gutter * 2 !important;
+    padding: 0 .5em !important;
+    width: auto !important;
+    color: #000 !important;
+    border-radius: 2px !important;
+    border: none !important;
+
+    .vue-treeselect__value-container {
+        max-width: 100%;
+    }
+}
+
+.vue-treeselect__input {
+    box-shadow: none !important;
+    background: transparent !important;
+}
+
+.vue-treeselect__menu-container,
+.vue-treeselect__input-container,
+.vue-treeselect__placeholder {
+    color: #000 !important;
+}
+
+.vue-treeselect__placeholder {
+    padding: 0 !important;
+}
+
+.vue-treeselect__input-container input {
+    height: 100%;
+}
+
+.vue-treeselect__multi-value-item {
+    background: transparent !important;
+    border: 1px solid #000 !important;
+
+    .vue-treeselect__multi-value-label {
+        background: transparent !important;
+        color: #000 !important;
+    }
+
+    .vue-treeselect__icon.vue-treeselect__value-remove {
+        color: #000 !important;
+    }
+}
+
+.vue-treeselect__x-container,
+.vue-treeselect__control-arrow-container {
+    width: auto !important;
+    padding: 0 4px;
+}
+
+.vue-treeselect__menu {
+    border: none !important;
+    border-top: 1px solid $gray-200 !important;
+    border-bottom-left-radius: 2px !important;
+    border-bottom-right-radius: 2px !important;
+}
+
+.vue-treeselect--open-below .vue-treeselect__menu {
+    margin-top: -2px !important;
+}
+
+.vue-treeselect__checkbox {
+    border-color: $gray-600 !important;
+}
+
+.vue-treeselect__checkbox--checked {
+    background-color: $gray-600 !important;
 }

--- a/src/Template/Layout/styles/_forms.scss
+++ b/src/Template/Layout/styles/_forms.scss
@@ -278,13 +278,20 @@ form {
 
 .vue-treeselect__menu {
     border: none !important;
+}
+
+.vue-treeselect--open-below .vue-treeselect__menu {
+    margin-top: -2px !important;
     border-top: 1px solid $gray-200 !important;
     border-bottom-left-radius: 2px !important;
     border-bottom-right-radius: 2px !important;
 }
 
-.vue-treeselect--open-below .vue-treeselect__menu {
-    margin-top: -2px !important;
+.vue-treeselect--open-above .vue-treeselect__menu {
+    margin-bottom: -2px !important;
+    border-bottom: 1px solid $gray-200 !important;
+    border-top-left-radius: 2px !important;
+    border-top-right-radius: 2px !important;
 }
 
 .vue-treeselect__checkbox {

--- a/src/Template/Layout/styles/_layout.scss
+++ b/src/Template/Layout/styles/_layout.scss
@@ -12,7 +12,6 @@ main.layout {
         grid-template-areas: "sidebar content-header"
                              "sidebar content-body"
                              "sidebar footer";
-        grid-template-rows: ($dashboard-item-height + $gutter) auto;
         grid-template-columns: $dashboard-item-width auto;
 
         .view-dashboard & {
@@ -20,6 +19,10 @@ main.layout {
         }
 
         > .layout-footer { display: none; }
+    }
+
+    @media (min-width: 1024px) {
+        grid-template-rows: ($dashboard-item-height + $gutter) auto;
     }
 
     > .layout-sidebar { grid-area: sidebar; }
@@ -32,6 +35,13 @@ main.layout {
 
     > .layout-sidebar, > .layout-footer { max-width: 100%; overflow-x: hidden; }
     > .layout-content { max-width: 100%; overflow-x: hidden; }
+    > .layout-header + .layout-content {
+        margin-top: $gutter;
+
+        @media screen and (min-width: 1024px) {
+            margin-top: 0;
+        }
+    }
 }
 
 

--- a/src/Template/Pages/Modules/_modules-index.scss
+++ b/src/Template/Pages/Modules/_modules-index.scss
@@ -1,12 +1,10 @@
 body.view-module {
-
     .module-header {
         min-height: $dashboard-item-height - ($gutter * 3.25) - $gutter; // minus table header and margin
         margin-bottom: $gutter;
     }
 
     .module-index {
-
         .list-objects {
             display: table;
             border-collapse: collapse;
@@ -131,69 +129,65 @@ body.view-module {
         }
 
         .bulk-actions {
-            margin-top: $gutter * .5;
+            margin-top: $gutter;
 
             &.disabled {
                 opacity: .3;
             }
 
-            header {
-                margin: $gutter 0 $gutter * .5;
+            .bulk-header {
+                margin-top: $gutter;
             }
 
-            .bulk-categories, .bulk-folders {
-                display: flex;
-
-                .input > div {
-                    display: flex;
-                    align-items: center;
-                }
-            }
-
-            .bulk-folders {
-                .input {
-                    display: flex !important;
-                    align-items: center;
-
-                    label {
-                        margin-right: calc($gutter * 0.5);
-                    }
-
-                    input[type='radio'] {
-                        margin-right: $gutter;
-                    }
-                }
-            }
-
-            nav {
+            > * {
                 display: flex;
                 flex-direction: column;
 
                 form {
                     .fieldset {
-                        input, .input {
-                            display: inline-block;
-                            vertical-align: middle;
-                        }
-                    }
+                        display: inline-flex;
+                        align-items: center;
+                        margin-bottom: $gutter;
 
-                    .fieldset[disabled] {
-                        .clear-button {
-                            display: none;
+                        & > *:not([type='hidden']) ~ *:not([type='hidden']) {
+                            margin-left: $gutter * .5;
                         }
 
-                        .input.textarea {
-                            border-color: #adb5bd !important;
-                        }
-                    }
+                        &[disabled] {
+                            .clear-button {
+                                display: none;
+                            }
 
-                    .input {
-                        margin: $gutter * .5;
-                        margin-left: 0;
+                            .input.textarea {
+                                border-color: #adb5bd !important;
+                            }
+                        }
+
+                        .input,
+                        .input > * {
+                            display: inline-flex;
+                            align-items: center;
+                        }
+
+                        .input label:first-of-type {
+                            margin-right: $gutter;
+                        }
 
                         label {
                             margin-right: $gutter * .5;
                         }
+                    }
+
+                    .bulk-categories,
+                    .bulk-folders {
+                        & > * {
+                            display: inline-flex;
+                            align-items: center;
+                        }
+                    }
+
+                    .bulk-folders .folder-picker {
+                        margin-left: $gutter !important;
                     }
                 }
             }

--- a/src/Template/Pages/Modules/_modules-index.scss
+++ b/src/Template/Pages/Modules/_modules-index.scss
@@ -131,12 +131,12 @@ body.view-module {
         .bulk-actions {
             margin-top: $gutter;
 
-            &.disabled {
-                opacity: .3;
-            }
-
             .bulk-header {
                 margin-top: $gutter;
+            }
+
+            > .disabled {
+                opacity: .3;
             }
 
             > * {

--- a/src/Template/Pages/Modules/_modules-index.scss
+++ b/src/Template/Pages/Modules/_modules-index.scss
@@ -130,18 +130,15 @@ body.view-module {
             }
         }
 
-
         .bulk-actions {
             margin-top: $gutter * .5;
 
-            header {
-                margin: $gutter 0 $gutter * .5;
-                width: 100%;
+            &.disabled {
                 opacity: .3;
             }
 
-            &.enabled {
-                header { opacity: 1; }
+            header {
+                margin: $gutter 0 $gutter * .5;
             }
 
             .bulk-categories, .bulk-folders {
@@ -168,73 +165,21 @@ body.view-module {
                 }
             }
 
-            .vue-treeselect__input {
-                background-color: transparent;
-            }
-
             nav {
                 display: flex;
-                flex-wrap: wrap;
-                form {
-                    flex-basis: 100%;
-                    margin-right: $gutter;
-                    &:last-of-type {
-                        margin-right: 0;
-                        margin-left: auto;
-                    }
+                flex-direction: column;
 
+                form {
                     .fieldset {
                         input, .input {
                             display: inline-block;
                             vertical-align: middle;
-                        }
-                        .vue-treeselect {
-                            min-width: 20vw;
-                        }
-                        .vue-treeselect__control {
-                            width: auto;
-                            color: #000;
-                            border-radius: 2px !important;
-                        }
-                        .vue-treeselect__menu-container {
-                            color: #000;
-                        }
-                        .vue-treeselect__input-container {
-                            color: #000;
-
-                            input {
-                                min-width: 20vw !important;
-                                height: 100%;
-                            }
-                        }
-                        .vue-treeselect--disabled {
-                            opacity: .6;
-                        }
-                        .vue-treeselect__placeholder {
-                            color: #000;
-                        }
-                        .vue-treeselect__multi-value-item {
-                            background: transparent;
-                            border: 1px solid black;
-
-                            .vue-treeselect__multi-value-label {
-                                background: transparent;
-                                color: #000;
-                            }
-
-                            .vue-treeselect__icon.vue-treeselect__value-remove {
-                                color: #000;
-                            }
                         }
                     }
 
                     .fieldset[disabled] {
                         .clear-button {
                             display: none;
-                        }
-
-                        button, h2, input, label, select, .vue-treeselect__control {
-                            opacity: .3;
                         }
 
                         .input.textarea {
@@ -244,6 +189,7 @@ body.view-module {
 
                     .input {
                         margin: $gutter * .5;
+                        margin-left: 0;
 
                         label {
                             margin-right: $gutter * .5;
@@ -256,8 +202,8 @@ body.view-module {
 
     // TODO: da fare meglio
     &.module-media, &.module-images, &.module-video, &.module-audio, &.module-objects {
-       .module-index .list-objects > a div.title-cell {
-           max-width: 210px;
-       }
+        .module-index .list-objects > a div.title-cell {
+            max-width: 210px;
+        }
     }
 }


### PR DESCRIPTION
Some new filters and enhancements in modules index page:
- "More filters" toggle
- filter by categories
- filter by position, with additional "descendants" switch to change between api filters `parent` and `ancestor`
- multiple status filter
- filters initial values

Other things:
- changed to `false` the default value of the "menu" toggle in view's `Position` section

this filters can be enabled by object properties configuration, setting the right values for the property `filter`.
E.g.

```php
'Properties' => [
  'events' => [
    'filter' => [
      'status',
      'lang',
      'categories'
      'parent'
    ]
  ]
]
```