### PR TITLE
Fast create form(s)

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -507,6 +507,7 @@ return [
      *
      *  - 'filter' filters to display
      *  - 'bulk' bulk actions list
+     *  - 'fastCreate' fields for fast creation forms, by type
      *
      * A special custom element 'Form/empty' can be used to hide a property group or relation via `_element`
      */
@@ -554,6 +555,10 @@ return [
         //     'bulk' => [
         //         'status',
         //         'other_field',
+        //     ],
+        //     'fastCreate' => [
+        //         'required' => ['status', 'title'],
+        //         'all' => ['status', 'title', 'description'],
         //     ],
         // ],
     // ],

--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -92,6 +92,22 @@ class SchemaComponent extends Component
     }
 
     /**
+     * Get schemas by types and return them group by type
+     *
+     * @param array $types The types
+     * @return array
+     */
+    public function getSchemasByType(array $types): array
+    {
+        $schemas = [];
+        foreach ($types as $type) {
+            $schemas[$type] = $this->getSchema($type);
+        }
+
+        return $schemas;
+    }
+
+    /**
      * Load schema from cache with revision check.
      * If cached revision don't match cache is removed.
      *

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -170,6 +170,14 @@ class ModulesController extends AppController
             $this->Properties->relationsList($this->objectType)
         );
 
+        // set schemas for relations right types
+        $schemasByType = $this->Schema->getSchemasByType(
+            \App\Utility\Schema::rightTypes(
+                $this->viewVars['relationsSchema']
+            )
+        );
+        $this->set('schemasByType', $schemasByType);
+
         // set objectNav
         $objectNav = $this->getObjectNav((string)$id);
         $this->set('objectNav', $objectNav);

--- a/src/Locale/en_US/default.po
+++ b/src/Locale/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-10-12 07:11:46 \n"
+"POT-Creation-Date: 2021-10-12 07:30:56 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -836,7 +836,12 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:298
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:246
+#, javascript-format
+msgid "Missing required data \"${ required }\". Retry"
+msgstr ""
+
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:300
 msgid "Error while creating new object."
 msgstr ""
 

--- a/src/Locale/en_US/default.po
+++ b/src/Locale/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-10-08 10:23:50 \n"
+"POT-Creation-Date: 2021-10-12 07:11:46 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -99,6 +99,9 @@ msgid "Change password"
 msgstr ""
 
 msgid "Children"
+msgstr ""
+
+msgid "Choose a type"
 msgstr ""
 
 msgid "Click or drop new files here"
@@ -765,7 +768,7 @@ msgstr ""
 #: src/Template/Layout/js/app/app.js:494
 #: src/Template/Layout/js/app/components/history/history.js:89
 #: src/Template/Layout/js/app/pages/model/index.js:262
-#: src/Template/Layout/js/app/pages/modules/index.js:151
+#: src/Template/Layout/js/app/pages/modules/index.js:156
 #: src/Template/Layout/js/app/pages/trash/index.js:43
 msgid "yes, proceed"
 msgstr ""
@@ -779,7 +782,7 @@ msgstr ""
 msgid "Do you confirm the deletion of ${ number } item from the trash?"
 msgstr ""
 
-#: src/Template/Layout/js/app/pages/modules/index.js:149
+#: src/Template/Layout/js/app/pages/modules/index.js:154
 #, javascript-format
 msgid "Moving ${ number } item(s) to trash. Are you sure?"
 msgstr ""
@@ -833,7 +836,7 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:262
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:298
 msgid "Error while creating new object."
 msgstr ""
 

--- a/src/Locale/it_IT/default.po
+++ b/src/Locale/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-10-12 07:11:46 \n"
+"POT-Creation-Date: 2021-10-12 07:30:56 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -839,7 +839,12 @@ msgstr "modifica"
 msgid "Menu"
 msgstr "Menù"
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:298
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:246
+#, javascript-format
+msgid "Missing required data \"${ required }\". Retry"
+msgstr "Dato obbligatorio mancante \"${ required }\". Riprovare"
+
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:300
 msgid "Error while creating new object."
 msgstr "Si è verificato un errore durante la creazione del nuovo oggetto."
 

--- a/src/Locale/it_IT/default.po
+++ b/src/Locale/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-10-08 10:40:02 \n"
+"POT-Creation-Date: 2021-10-12 07:11:46 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -100,6 +100,9 @@ msgstr "Cambia password"
 
 msgid "Children"
 msgstr "Contenuti"
+
+msgid "Choose a type"
+msgstr "Selezionare un tipo"
 
 msgid "Click or drop new files here"
 msgstr "Clicca o trascina qui i nuovi file"
@@ -768,7 +771,7 @@ msgstr "Vuoi davvero spostare l'oggetto nel cestino?"
 #: src/Template/Layout/js/app/app.js:494
 #: src/Template/Layout/js/app/components/history/history.js:89
 #: src/Template/Layout/js/app/pages/model/index.js:262
-#: src/Template/Layout/js/app/pages/modules/index.js:151
+#: src/Template/Layout/js/app/pages/modules/index.js:156
 #: src/Template/Layout/js/app/pages/trash/index.js:43
 msgid "yes, proceed"
 msgstr "sì, prosegui"
@@ -782,7 +785,7 @@ msgstr "Ci sono delle modifiche non salvate, vuoi comunque lasciare la pagina?"
 msgid "Do you confirm the deletion of ${ number } item from the trash?"
 msgstr "Confermi la cancellazione di ${ number } elementi dal cestino?"
 
-#: src/Template/Layout/js/app/pages/modules/index.js:149
+#: src/Template/Layout/js/app/pages/modules/index.js:154
 #, javascript-format
 msgid "Moving ${ number } item(s) to trash. Are you sure?"
 msgstr "Stai per spostare ${ number } elementi nel cestino. Vuoi procedere?"
@@ -836,7 +839,7 @@ msgstr "modifica"
 msgid "Menu"
 msgstr "Menù"
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:262
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:298
 msgid "Error while creating new object."
 msgstr "Si è verificato un errore durante la creazione del nuovo oggetto."
 
@@ -844,7 +847,7 @@ msgstr "Si è verificato un errore durante la creazione del nuovo oggetto."
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.  
+#.
 #: src/Template/Layout/js/app/components/locations-view/location-view.js:51
 msgid "Title"
 msgstr "Titolo"
@@ -853,7 +856,7 @@ msgstr "Titolo"
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.  
+#.
 #: src/Template/Layout/js/app/components/locations-view/location-view.js:70
 msgid "Address"
 msgstr "Indirizzo"
@@ -862,7 +865,7 @@ msgstr "Indirizzo"
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.  
+#.
 #: src/Template/Layout/js/app/components/locations-view/location-view.js:95
 msgid "GET"
 msgstr ""
@@ -874,7 +877,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.  
+#.
 #: src/Template/Layout/js/app/components/locations-view/locations-view.js:30
 msgid "add new"
 msgstr "aggiungi nuovo"
@@ -889,14 +892,14 @@ msgstr "data"
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.  
+#.
 #: src/Template/Layout/js/app/components/history/history.js:19
 msgid "by"
 msgstr "di"
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.  
+#.
 #: src/Template/Layout/js/app/components/history/history.js:29
 msgid "No History data found"
 msgstr "Nessun dato di Cronologia"

--- a/src/Locale/master.pot
+++ b/src/Locale/master.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-10-08 10:40:02 \n"
+"POT-Creation-Date: 2021-10-12 07:11:46 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -96,6 +96,9 @@ msgid "Change password"
 msgstr ""
 
 msgid "Children"
+msgstr ""
+
+msgid "Choose a type"
 msgstr ""
 
 msgid "Click or drop new files here"
@@ -762,7 +765,7 @@ msgstr ""
 #: src/Template/Layout/js/app/app.js:494
 #: src/Template/Layout/js/app/components/history/history.js:89
 #: src/Template/Layout/js/app/pages/model/index.js:262
-#: src/Template/Layout/js/app/pages/modules/index.js:151
+#: src/Template/Layout/js/app/pages/modules/index.js:156
 #: src/Template/Layout/js/app/pages/trash/index.js:43
 msgid "yes, proceed"
 msgstr ""
@@ -776,7 +779,7 @@ msgstr ""
 msgid "Do you confirm the deletion of ${ number } item from the trash?"
 msgstr ""
 
-#: src/Template/Layout/js/app/pages/modules/index.js:149
+#: src/Template/Layout/js/app/pages/modules/index.js:154
 #, javascript-format
 msgid "Moving ${ number } item(s) to trash. Are you sure?"
 msgstr ""
@@ -830,7 +833,7 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:262
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:298
 msgid "Error while creating new object."
 msgstr ""
 

--- a/src/Locale/master.pot
+++ b/src/Locale/master.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-10-12 07:11:46 \n"
+"POT-Creation-Date: 2021-10-12 07:30:56 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -833,7 +833,12 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:298
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:246
+#, javascript-format
+msgid "Missing required data \"${ required }\". Retry"
+msgstr ""
+
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:300
 msgid "Error while creating new object."
 msgstr ""
 

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -55,7 +55,7 @@
                                     {% if field == 'status' %}
                                         {% set fieldOptions =  fieldOptions|merge({'v-model': 'object.attributes.status'}) %}
                                     {% endif %}
-                                    {{ Property.control(field, '', fieldOptions)|raw }}
+                                    {{ Property.control(field, '', fieldOptions, type)|raw }}
                                 {% endfor %}
                             </fieldset>
 

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -49,7 +49,8 @@
                                     {% set fieldOptions = {
                                         'id': prefix ~ field,
                                         'class': fieldClass,
-                                        'data-name': field
+                                        'data-name': field,
+                                        'key': type ~ '-' ~ field
                                     } %}
                                     {% if field == 'status' %}
                                         {% set fieldOptions =  fieldOptions|merge({'v-model': 'object.attributes.status'}) %}

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -10,72 +10,74 @@
         </header>
 
         <div class="create-new-object mt-1 mx-1" v-if="showCreateObjectForm">
+
             <div class="select">
                 <label for="related_object_type">{{ __('Type') }}</label>
                 <select id="related_object_type"
                     name="related_object_type"
                     class="{{ selectBaseClasses }}"
-                    @click="updateForms"
                     v-if="relationTypes"
                     v-model="object.type">
                     <option value="_choose">{{ __('Choose a type') }}</option>
                     <option v-for="type in relationTypes.right"><: t(type) :></option>
                 </select>
             </div>
-        {% for type in Schema.rightTypes() %}
-            {% set prefix = '_fast_create_' ~ type ~ '_' %}
-            <form name="create-object" class="object-form fast-create" :disabled="saving" id="{{ type }}-form" style="display:none">
-                {{ Form.control('upload_behavior', {
-                    'id': 'url_behavior',
-                    'type': 'hidden',
-                    'v-bind:value': 'url'
-                }) | raw }}
-                {{ Form.control('upload_behavior', {
-                    'id': 'file_behavior',
-                    'type': 'hidden',
-                    'v-bind:value': 'file'
-                }) | raw }}
-                {{ Form.unlockField('upload_behavior')}}
 
-                <section class="fieldset mb-1">
-                    <div class="container">
+            {% for type in Schema.rightTypes() %}
+                {% set prefix = '_fast_create_' ~ type ~ '_' %}
+                <form name="create-object" class="object-form fast-create" :disabled="saving" id="{{ type }}-form" v-if="object.type == '{{ type }}'">
+                    {{ Form.control('upload_behavior', {
+                        'id': 'url_behavior',
+                        'type': 'hidden',
+                        'v-bind:value': 'url'
+                    }) | raw }}
+                    {{ Form.control('upload_behavior', {
+                        'id': 'file_behavior',
+                        'type': 'hidden',
+                        'v-bind:value': 'file'
+                    }) | raw }}
+                    {{ Form.unlockField('upload_behavior')}}
 
-                        <fieldset id="{{ type }}-form-fields">
-                            {% set fields = config('Properties.' ~ type ~ '.fast_create.all')|default(['status', 'title', 'description']) %}
-                            {% set required = config('Properties.' ~ type ~ '.fast_create.required')|default(['status', 'title']) %}
-                            {% for field in fields %}
-                                {% set fieldClass = field not in required ? 'fastCreateField' : 'fastCreateField required' %}
-                                {{ Property.control(field, '', {
-                                    'id': prefix ~ field,
-                                    'class': fieldClass,
-                                    'data-name': field
-                                })|raw }}
-                            {% endfor %}
-                        </fieldset>
+                    <section class="fieldset mb-1">
+                        <div class="container">
 
-                        <div class="input text" v-if="isMedia">
-                            <label for="{{ prefix }}file">{{ __('File') }}</label>
-                            <input type="file" name="file" v-on:change="processFile" id="{{ prefix }}file" class="drop-file" />
+                            <fieldset id="{{ type }}-form-fields">
+                                {% set fields = config('Properties.' ~ type ~ '.fast_create.all')|default(['status', 'title', 'description']) %}
+                                {% set required = config('Properties.' ~ type ~ '.fast_create.required')|default(['status', 'title']) %}
+                                {% for field in fields %}
+                                    {% set fieldClass = field not in required ? 'fastCreateField' : 'fastCreateField required' %}
+                                    {{ Property.control(field, '', {
+                                        'id': prefix ~ field,
+                                        'class': fieldClass,
+                                        'data-name': field
+                                    })|raw }}
+                                {% endfor %}
+                            </fieldset>
+
+                            <div class="input text" v-if="isMedia">
+                                <label for="{{ prefix }}file">{{ __('File') }}</label>
+                                <input type="file" name="file" v-on:change="processFile" id="{{ prefix }}file" class="drop-file" />
+                            </div>
+
+                            <div class="input text" v-if="isMedia">
+                                <label for="{{ prefix }}remote_url">{{ __('Url') }}</label>
+                                {{ Form.text('remote_url', {
+                                    'id': prefix ~ 'remote_url',
+                                    'v-model': 'url',
+                                    'type': 'text',
+                                    'autocomplete': 'off',
+                                    'autocorrect': 'off',
+                                    'autocapitalize': 'off',
+                                    'spellcheck': 'false',
+                                    'placeholder': __('Remote URL') }) | raw
+                                }}
+                            </div>
                         </div>
-
-                        <div class="input text" v-if="isMedia">
-                            <label for="{{ prefix }}remote_url">{{ __('Url') }}</label>
-                            {{ Form.text('remote_url', {
-                                'id': prefix ~ 'remote_url',
-                                'v-model': 'url',
-                                'type': 'text',
-                                'autocomplete': 'off',
-                                'autocorrect': 'off',
-                                'autocapitalize': 'off',
-                                'spellcheck': 'false',
-                                'placeholder': __('Remote URL') }) | raw }}
-                        </div>
-                    </div>
-                </section>
-                <button @click="createObject" type="button">{{ __('create') }}</button>
-                <button @click="resetForm">{{ __('reset') }}</button>
-            </form>
-        {% endfor %}
+                    </section>
+                    <button @click="createObject" type="button">{{ __('create') }}</button>
+                    <button @click="resetForm">{{ __('reset') }}</button>
+                </form>
+            {% endfor %}
         </div>
     </section>
 

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -46,11 +46,15 @@
                                 {% set required = config('Properties.' ~ type ~ '.fast_create.required')|default(['status', 'title']) %}
                                 {% for field in fields %}
                                     {% set fieldClass = field not in required ? 'fastCreateField' : 'fastCreateField required' %}
-                                    {{ Property.control(field, '', {
+                                    {% set fieldOptions = {
                                         'id': prefix ~ field,
                                         'class': fieldClass,
                                         'data-name': field
-                                    })|raw }}
+                                    } %}
+                                    {% if field == 'status' %}
+                                        {% set fieldOptions =  fieldOptions|merge({'v-model': 'object.attributes.status'}) %}
+                                    {% endif %}
+                                    {{ Property.control(field, '', fieldOptions)|raw }}
                                 {% endfor %}
                             </fieldset>
 

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -42,8 +42,8 @@
                         <div class="container">
 
                             <fieldset id="{{ type }}-form-fields">
-                                {% set fields = config('Properties.' ~ type ~ '.fast_create.all')|default(['status', 'title', 'description']) %}
-                                {% set required = config('Properties.' ~ type ~ '.fast_create.required')|default(['status', 'title']) %}
+                                {% set fields = config('Properties.' ~ type ~ '.fastCreate.all')|default(['status', 'title', 'description']) %}
+                                {% set required = config('Properties.' ~ type ~ '.fastCreate.required')|default(['status', 'title']) %}
                                 {% for field in fields %}
                                     {% set fieldClass = field not in required ? 'fastCreateField' : 'fastCreateField required' %}
                                     {% set fieldOptions = {

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -1,17 +1,30 @@
 {% set selectBaseClasses = "has-background-gray-700 has-border-gray-700 has-font-weight-light has-text-gray-200 has-text-size-smallest" %}
-{% set prefix = '_fast_create_' %}
 
 <div class="relations-add">
     <section class="fieldset mb-1">
         <header class="mx-1 tab unselectable"
             :class="showCreateObjectForm ? 'open' : ''"
             :disabled="saving"
-            @click="showCreateObjectForm = !showCreateObjectForm">
+            @click="resetForms">
             <h2><span v-show="relationName"><strong>{{ __('create new') }}</strong> "<: relationName | humanize :></span>" {{ __('related object') }}&nbsp;</h2>
         </header>
 
         <div class="create-new-object mt-1 mx-1" v-if="showCreateObjectForm">
-            <form name="create-object" class="object-form" :disabled="saving">
+            <div class="select">
+                <label for="related_object_type">{{ __('Type') }}</label>
+                <select id="related_object_type"
+                    name="related_object_type"
+                    class="{{ selectBaseClasses }}"
+                    @click="updateForms"
+                    v-if="relationTypes"
+                    v-model="object.type">
+                    <option value="_choose">{{ __('Choose a type') }}</option>
+                    <option v-for="type in relationTypes.right"><: t(type) :></option>
+                </select>
+            </div>
+        {% for type in Schema.rightTypes() %}
+            {% set prefix = '_fast_create_' ~ type ~ '_' %}
+            <form name="create-object" class="object-form fast-create" :disabled="saving" id="{{ type }}-form" style="display:none">
                 {{ Form.control('upload_behavior', {
                     'id': 'url_behavior',
                     'type': 'hidden',
@@ -26,27 +39,25 @@
 
                 <section class="fieldset mb-1">
                     <div class="container">
-                        <div class="select">
-                            <label for="related_object_type">{{ __('Type') }}</label>
-                            <select id="related_object_type"
-                                name="related_object_type"
-                                class="{{ selectBaseClasses }}"
-                                v-if="relationTypes"
-                                v-model="object.type">
-                                <option v-for="type in relationTypes.right"><: t(type) :></option>
-                            </select>
-                        </div>
 
-                        {{ Property.control('status', object.attributes.status|default('draft'), {'id': prefix ~ 'status' , 'v-model': 'object.attributes.status'})|raw }}
-
-                        {{ Property.control('title', '', {'id': prefix ~ 'title' ,'v-model': 'object.attributes.title'})|raw }}
-
-                        {{ Property.control('description', '', {'id': prefix ~ 'description' ,'v-model': 'object.attributes.description'})|raw }}
+                        <fieldset id="{{ type }}-form-fields">
+                            {% set fields = config('Properties.' ~ type ~ '.fast_create.all')|default(['status', 'title', 'description']) %}
+                            {% set required = config('Properties.' ~ type ~ '.fast_create.required')|default(['status', 'title']) %}
+                            {% for field in fields %}
+                                {% set fieldClass = field not in required ? 'fastCreateField' : 'fastCreateField required' %}
+                                {{ Property.control(field, '', {
+                                    'id': prefix ~ field,
+                                    'class': fieldClass,
+                                    'data-name': field
+                                })|raw }}
+                            {% endfor %}
+                        </fieldset>
 
                         <div class="input text" v-if="isMedia">
                             <label for="{{ prefix }}file">{{ __('File') }}</label>
                             <input type="file" name="file" v-on:change="processFile" id="{{ prefix }}file" class="drop-file" />
                         </div>
+
                         <div class="input text" v-if="isMedia">
                             <label for="{{ prefix }}remote_url">{{ __('Url') }}</label>
                             {{ Form.text('remote_url', {
@@ -61,9 +72,10 @@
                         </div>
                     </div>
                 </section>
-                <button :disabled="!object.attributes.title && !object.attributes.description && !file && !url" @click="createObject" type="button">{{ __('create') }}</button>
-                <button :disabled="!object.attributes.title && !object.attributes.description && !file && !url" @click="resetForm">{{ __('reset') }}</button>
+                <button @click="createObject" type="button">{{ __('create') }}</button>
+                <button @click="resetForm">{{ __('reset') }}</button>
             </form>
+        {% endfor %}
         </div>
     </section>
 

--- a/src/Template/Layout/js/app/components/dialog/dialog.scss
+++ b/src/Template/Layout/js/app/components/dialog/dialog.scss
@@ -27,7 +27,7 @@
     .dialog {
         position: fixed;
         width: 600px;
-        z-index: 2;
+        z-index: 1002;
         min-height: 200px;
         top: 0;
         left: calc(50vw - 300px);

--- a/src/Template/Layout/js/app/components/filter-box.js
+++ b/src/Template/Layout/js/app/components/filter-box.js
@@ -40,7 +40,7 @@ export default {
         },
         initFilter: {
             type: Object,
-            default: DEFAULT_FILTER,
+            default: () => DEFAULT_FILTER,
         },
         objectsLabel: {
             type: String,

--- a/src/Template/Layout/js/app/components/relation-view/relations-add.js
+++ b/src/Template/Layout/js/app/components/relation-view/relations-add.js
@@ -23,6 +23,7 @@ import { warning } from 'app/components/dialog/dialog';
 const createData = (type = '') => ({
     type,
     attributes: {
+
         status: 'draft',
     },
 });
@@ -203,19 +204,7 @@ export default {
 
         resetForms() {
             this.showCreateObjectForm = !this.showCreateObjectForm;
-            this.updateForms();
             this.object.type = '_choose';
-        },
-
-        updateForms() {
-            const forms = document.getElementsByClassName('fast-create');
-            for (let i = 0; i < forms.length; i++) {
-                if (forms[i].id === `${this.object.type}-form`) {
-                    forms[i].style.display = 'block';
-                } else {
-                    forms[i].style.display = 'none';
-                }
-            };
         },
 
         formCheck() {

--- a/src/Template/Layout/js/app/components/relation-view/relations-add.js
+++ b/src/Template/Layout/js/app/components/relation-view/relations-add.js
@@ -18,6 +18,7 @@ import { DragdropMixin } from 'app/mixins/dragdrop';
 import { error as showError } from 'app/components/dialog/dialog';
 import sleep from 'sleep-promise';
 import { t } from 'ttag';
+import { warning } from 'app/components/dialog/dialog';
 
 const createData = (type = '') => ({
     type,
@@ -240,9 +241,10 @@ export default {
                 // form element might be tempered
                 return;
             }
-            const check = this.formCheck();
-            if (check !== true) {
-                alert(`Fill required data: "${check}"`);
+            const required = this.formCheck();
+            if (required !== true) {
+                const msg = t`Missing required data "${required}". Retry`;
+                warning(msg);
 
                 return;
             }

--- a/src/Template/Layout/js/app/components/relation-view/relations-add.js
+++ b/src/Template/Layout/js/app/components/relation-view/relations-add.js
@@ -210,7 +210,11 @@ export default {
         formCheck() {
             const fields = document.getElementById(`${this.object.type}-form-fields`).querySelectorAll('.required');
             for (let i = 0; i < fields.length; i++) {
-                if (fields[i].value == '') {
+                if (fields[i].dataset.name === 'status') {
+                    if (this.object.attributes.status == '') {
+                        return fields[i].dataset.name;
+                    }
+                } else if (fields[i].value == '') {
                     return fields[i].dataset.name;
                 }
             }
@@ -247,13 +251,9 @@ export default {
             const baseUrl = window.location.origin;
             const postUrl = `${baseUrl}/${type}/save`;
 
-            // only desired form fields
-            const fields = document.getElementById(`${type}-form-fields`).querySelectorAll('.fastCreateField');
-            const formData = new FormData();
-            formData.append('model-type', type);
-            for (let i = 0; i < fields.length; i++) {
-                formData.set(fields[i].dataset.name, fields[i].value);
-            }
+            // set form data
+            const formData = new FormData(document.getElementById(`${type}-form`));
+            formData.set('status', this.object.attributes.status);
 
             if (this.file) {
                 formData.set('file', this.file);

--- a/src/Template/Layout/js/app/components/relation-view/relations-add.js
+++ b/src/Template/Layout/js/app/components/relation-view/relations-add.js
@@ -204,7 +204,7 @@ export default {
 
         resetForms() {
             this.showCreateObjectForm = !this.showCreateObjectForm;
-            this.object.type = '_choose';
+            this.resetType();
         },
 
         formCheck() {
@@ -241,14 +241,16 @@ export default {
             this.saving = true;
             this.loading = true;
 
+            const type = this.object.type;
+
             // save object
             const baseUrl = window.location.origin;
-            const postUrl = `${baseUrl}/${this.object.type}/save`;
+            const postUrl = `${baseUrl}/${type}/save`;
 
             // only desired form fields
-            const fields = document.getElementById(`${this.object.type}-form-fields`).querySelectorAll('.fastCreateField');
+            const fields = document.getElementById(`${type}-form-fields`).querySelectorAll('.fastCreateField');
             const formData = new FormData();
-            formData.append('model-type', this.object.type);
+            formData.append('model-type', type);
             for (let i = 0; i < fields.length; i++) {
                 formData.set(fields[i].dataset.name, fields[i].value);
             }
@@ -280,7 +282,6 @@ export default {
                 // add newly added object to list / selected
                 this.objects = createdObjects.concat(this.objects);
                 this.selectedObjects = createdObjects.concat(this.selectedObjects);
-                this.resetForm(event);
             } catch (error) {
                 if (error.code === 20) {
                     throw error;
@@ -288,9 +289,9 @@ export default {
 
                 showError(t`Error while creating new object.`);
                 console.error(error);
-
-                this.resetForm(event);
             } finally {
+                this.resetForm(event, type);
+                this.resetType(type);
                 this.saving = false;
                 this.loading = false;
             }
@@ -344,12 +345,30 @@ export default {
          * clear form
          * @return {void}
          */
-        resetForm(event) {
+        resetForm(event, type) {
             event.preventDefault();
 
             this.file = null;
             this.url = null;
-            this.object = createData(this.relationTypes && this.relationTypes.right[0]);
+            let t = type ? type : this.relationTypes.right[0];
+            this.object = createData(this.relationTypes && t);
+            const fields = document.querySelectorAll('.fastCreateField');
+            for (let i = 0; i < fields.length; i++) {
+                fields[i].value = '';
+            }
+        },
+
+        resetType(type) {
+            if (type) {
+                this.object.type = type;
+
+                return;
+            }
+            if (this.relationTypes.right.length === 1) {
+                this.object.type = this.relationTypes.right[0];
+            } else {
+                this.object.type = '_choose';
+            }
         },
 
         /**

--- a/src/Template/Layout/js/app/components/relation-view/relations-add.js
+++ b/src/Template/Layout/js/app/components/relation-view/relations-add.js
@@ -67,7 +67,7 @@ export default {
             file: null,
             url: null,
             showCreateObjectForm: false,
-            object: createData(),
+            object: createData('_choose'),
         };
     },
 
@@ -200,6 +200,34 @@ export default {
             PanelEvents.closePanel();
         },
 
+        resetForms() {
+            this.showCreateObjectForm = !this.showCreateObjectForm;
+            this.updateForms();
+            this.object.type = '_choose';
+        },
+
+        updateForms() {
+            const forms = document.getElementsByClassName('fast-create');
+            for (let i = 0; i < forms.length; i++) {
+                if (forms[i].id === `${this.object.type}-form`) {
+                    forms[i].style.display = 'block';
+                } else {
+                    forms[i].style.display = 'none';
+                }
+            };
+        },
+
+        formCheck() {
+            const fields = document.getElementById(`${this.object.type}-form-fields`).querySelectorAll('.required');
+            for (let i = 0; i < fields.length; i++) {
+                if (fields[i].value == '') {
+                    return fields[i].dataset.name;
+                }
+            }
+
+            return true;
+        },
+
         /**
          * create new object
          *
@@ -212,6 +240,12 @@ export default {
                 // form element might be tempered
                 return;
             }
+            const check = this.formCheck();
+            if (check !== true) {
+                alert(`Fill required data: "${check}"`);
+
+                return;
+            }
 
             this.saving = true;
             this.loading = true;
@@ -220,10 +254,12 @@ export default {
             const baseUrl = window.location.origin;
             const postUrl = `${baseUrl}/${this.object.type}/save`;
 
+            // only desired form fields
+            const fields = document.getElementById(`${this.object.type}-form-fields`).querySelectorAll('.fastCreateField');
             const formData = new FormData();
             formData.append('model-type', this.object.type);
-            for (let attr in this.object.attributes) {
-                formData.set(attr, this.object.attributes[attr]);
+            for (let i = 0; i < fields.length; i++) {
+                formData.set(fields[i].dataset.name, fields[i].value);
             }
 
             if (this.file) {

--- a/src/Template/Layout/js/app/directives/richeditor.js
+++ b/src/Template/Layout/js/app/directives/richeditor.js
@@ -58,6 +58,10 @@ export default {
                 });
             },
 
+            unbind(element) {
+                tinymce.remove();
+            },
+
             /**
              * dynamic load richtext-editor-input component and mount it
              *

--- a/src/Utility/Schema.php
+++ b/src/Utility/Schema.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Utility;
+
+use Cake\Utility\Hash;
+
+/**
+ * Utility class to get schema data
+ */
+class Schema
+{
+    /**
+     * Return unique alphabetically ordered right types from schema $schema
+     *
+     * @return array
+     */
+    public static function rightTypes(array $schema): array
+    {
+        $relationsRightTypes = (array)Hash::extract($schema, '{s}.right');
+        $types = [];
+        foreach ($relationsRightTypes as $rightTypes) {
+            $types = array_unique(array_merge($types, $rightTypes));
+        }
+        sort($types);
+
+        return $types;
+    }
+}

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -62,11 +62,12 @@ class PropertyHelper extends Helper
      * @param string $name The property name
      * @param mixed|null $value The property value
      * @param array $options The form element options, if any
+     * @param string|null $type The type, for others schemas
      * @return string
      */
-    public function control(string $name, $value, array $options = []): string
+    public function control(string $name, $value, array $options = [], ?string $type = null): string
     {
-        $controlOptions = $this->Schema->controlOptions($name, $value, $this->schema($name));
+        $controlOptions = $this->Schema->controlOptions($name, $value, $this->schema($name, $type));
         if (Hash::get($controlOptions, 'class') === 'json') {
             $jsonKeys = (array)Configure::read('_jsonKeys');
             Configure::write('_jsonKeys', array_merge($jsonKeys, [$name]));
@@ -82,11 +83,16 @@ class PropertyHelper extends Helper
      * JSON Schema array of property name
      *
      * @param string $name The property name
+     * @param string|null $type The type, for others schemas
      * @return array
      */
-    public function schema(string $name): array
+    public function schema(string $name, ?string $type = null): array
     {
         $schema = (array)$this->_View->get('schema');
+        if (!empty($type)) {
+            $schemas = (array)$this->_View->get('schemasByType');
+            $schema = (array)$schemas[$type];
+        }
         $res = (array)Hash::get($schema, sprintf('properties.%s', $name));
         $default = array_filter([
             'type' => Hash::get(self::SPECIAL_PROPS_TYPE, $name),

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -277,4 +277,22 @@ class SchemaHelper extends Helper
 
         return true;
     }
+
+    /**
+     * Return unique right types from schema "relationsSchema".
+     *
+     * @return array
+     */
+    public function rightTypes(): array
+    {
+        $relationsSchema = (array)$this->_View->get('relationsSchema');
+        $rightTypes = (array)Hash::extract($relationsSchema, '{s}.right');
+        $resultTypes = [];
+        foreach ($rightTypes as $types) {
+            $resultTypes = array_unique(array_merge($resultTypes, $types));
+        }
+        sort($resultTypes);
+
+        return $resultTypes;
+    }
 }

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -286,13 +286,7 @@ class SchemaHelper extends Helper
     public function rightTypes(): array
     {
         $relationsSchema = (array)$this->_View->get('relationsSchema');
-        $rightTypes = (array)Hash::extract($relationsSchema, '{s}.right');
-        $resultTypes = [];
-        foreach ($rightTypes as $types) {
-            $resultTypes = array_unique(array_merge($resultTypes, $types));
-        }
-        sort($resultTypes);
 
-        return $resultTypes;
+        return \App\Utility\Schema::rightTypes($relationsSchema);
     }
 }

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -172,6 +172,56 @@ class SchemaComponentTest extends TestCase
     }
 
     /**
+     * Data provider for `testGetSchemasByType`.
+     *
+     * @return array
+     */
+    public function getSchemasByTypeProvider(): array
+    {
+        return [
+            'empty' => [
+                [],
+                [],
+            ],
+            'documents' => [
+                [
+                    'documents',
+                    'users',
+                ],
+                [
+                    'documents' => [
+                        'definitions', '$id', '$schema', 'type', 'properties', 'required', 'associations', 'relations', 'revision',
+                    ],
+                    'users' => [
+                        'definitions', '$id', '$schema', 'type', 'properties', 'required', 'associations', 'relations', 'revision',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `getSchemasByType`.
+     *
+     * @return void
+     * @dataProvider getSchemasByTypeProvider()
+     * @covers ::getSchemasByType()
+     */
+    public function testGetSchemasByType(array $types, array $expected): void
+    {
+        $schemasByType = $this->Schema->getSchemasByType($types);
+        if (empty($expected)) {
+            static::assertEquals($expected, $schemasByType);
+        } else {
+            foreach ($expected as $type => $keys) {
+                $actual = array_keys($schemasByType[$type]);
+                static::assertEquals($actual, $keys);
+            }
+        }
+
+    }
+
+    /**
      * Test `loadWithRevision`
      *
      * @return void

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -218,7 +218,6 @@ class SchemaComponentTest extends TestCase
                 static::assertEquals($actual, $keys);
             }
         }
-
     }
 
     /**

--- a/tests/TestCase/Utility/SchemaTest.php
+++ b/tests/TestCase/Utility/SchemaTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Test\TestCase;
+
+use App\Utility\Schema;
+use Cake\TestSuite\TestCase;
+
+/**
+ * App\Utility\Schema Test Case
+ *
+ * @coversDefaultClass App\Utility\Schema
+ */
+class SchemaTest extends TestCase
+{
+    /**
+     * Test `rightTypes` method
+     *
+     * @return void
+     * @covers ::rightTypes()
+     */
+    public function testRightTypes(): void
+    {
+        $schema = [
+            'dummy_relation_1' => [
+                'right' => [
+                    'dummy_type_1',
+                ],
+            ],
+            'dummy_relation_2' => [
+                'right' => [
+                    'dummy_type_2',
+                    'dummy_type_3',
+                ],
+            ],
+            'dummy_relation_3' => [
+                'right' => [
+                    'dummy_type_1',
+                    'dummy_type_4',
+                    'dummy_type_5',
+                ],
+            ],
+        ];
+        $expected = [
+            'dummy_type_1',
+            'dummy_type_2',
+            'dummy_type_3',
+            'dummy_type_4',
+            'dummy_type_5',
+        ];
+        $actual = Schema::rightTypes($schema);
+        static::assertEquals($expected, $actual);
+    }
+}

--- a/tests/TestCase/View/Helper/PropertyHelperTest.php
+++ b/tests/TestCase/View/Helper/PropertyHelperTest.php
@@ -166,6 +166,43 @@ class PropertyHelperTest extends TestCase
     }
 
     /**
+     * Test `control` with parameter type, for "other" types schema controls
+     *
+     * @return void
+     *
+     * @covers ::control()
+     * @covers ::schema()
+     */
+    public function testControlOtherType(): void
+    {
+        $key = 'title';
+        $value = 'something';
+        $options = [];
+        $type = 'documents';
+        $schema = [];
+        $schemasByType = [
+            'documents' => [
+                'oneOf' => [
+                    ['type' => null],
+                    ['type' => 'string', 'contentMediaType' => 'text/html'],
+                ],
+                '$id' => '/properties/title',
+                'title' => 'Title',
+                'description' => null,
+            ],
+        ];
+        $expected = '<div class="input title text"><label for="title">Title</label><input type="text" name="title" class="title" id="title" value="something"/></div>';
+        $view = new View(null, null, null, []);
+        $schema = ['properties' => [$key => $schema]];
+        $view->set('schema', $schema);
+        $view->set('schemasByType', $schemasByType);
+        $view->set('objectType', 'dummies');
+        $property = new PropertyHelper($view);
+        $actual = $property->control($key, $value, $options, $type);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
      * Data provider for `testValue` test case.
      *
      * @return array

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -737,4 +737,65 @@ class SchemaHelperTest extends TestCase
         $actual = $this->Schema->sortable($field);
         static::assertSame($expected, $actual);
     }
+
+    /**
+     * Data provider for `rightTypes`
+     *
+     * @return array
+     */
+    public function rightTypesProvider(): array
+    {
+        return [
+            'empty relationsSchema' => [
+                [],
+                [],
+            ],
+            'some right types' => [
+                [
+                    'dummyRelation1' => [
+                        'left' => [
+                            'l1dummies',
+                        ],
+                        'right' => [
+                            'r1dummies',
+                            'r2dummies',
+                            'r3dummies',
+                        ],
+                    ],
+                    'dummyRelation2' => [
+                        'left' => [
+                            'l2dummies',
+                        ],
+                        'right' => [
+                            'r1dummies',
+                            'r4dummies',
+                            'r5dummies',
+                        ],
+                    ],
+                ],
+                [
+                    'r1dummies',
+                    'r2dummies',
+                    'r3dummies',
+                    'r4dummies',
+                    'r5dummies',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `rightTypes`
+     *
+     * @return void
+     * @dataProvider rightTypesProvider()
+     * @covers ::rightTypes()
+     */
+    public function testRightTypes($relationsSchema, $expected): void
+    {
+        $view = $this->Schema->getView();
+        $view->set('relationsSchema', $relationsSchema);
+        $actual = $this->Schema->rightTypes();
+        static::assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
This provides in panel view the possibility to switch among different forms to fast create objects [#619].

Fast creation config example:
```
'Properties' => [
    // ...
    'links' => [
        'fastCreate' => [
            'required' => ['status', 'url'],
            'all' => ['status', 'url', 'title', 'description'],
        ],
    ],
    // ...
], 
```

Rif: https://chialab.atlassian.net/browse/BEM-41