### PR TITLE
Fix filter in paginated-content

### DIFF
--- a/src/Template/Layout/js/app/components/filter-box.js
+++ b/src/Template/Layout/js/app/components/filter-box.js
@@ -40,7 +40,7 @@ export default {
         },
         initFilter: {
             type: Object,
-            default: DEFAULT_FILTER,
+            default: () => DEFAULT_FILTER,
         },
         objectsLabel: {
             type: String,

--- a/src/Template/Layout/js/app/mixins/paginated-content.js
+++ b/src/Template/Layout/js/app/mixins/paginated-content.js
@@ -190,7 +190,7 @@ export const PaginatedContentMixin = {
                 const query = this.query[key];
 
                 if (key !== 'filter') {
-                    if (query) {
+                    if (query && typeof query !== 'object') {
                         urlSearchParams.append(key, query);
                     }
 

--- a/src/Template/Layout/js/app/mixins/paginated-content.js
+++ b/src/Template/Layout/js/app/mixins/paginated-content.js
@@ -189,28 +189,34 @@ export const PaginatedContentMixin = {
             Object.keys(this.query).forEach((key, index) => {
                 const query = this.query[key];
 
+                if (key !== 'filter') {
+                    if (query) {
+                        urlSearchParams.append(key, query);
+                    }
+
+                    return;
+                }
+
                 // parse filter property
-                if (key === 'filter') {
-                    Object.keys(query).forEach((filterKey) => {
-                        let filterVal = query[filterKey];
-                        if (filterVal) {
-                            if (typeof filterVal === 'object' || typeof filterVal === 'array') {
-                                if (filterVal.length > 0) {
-                                    filterVal = filterVal.join(',');
-                                    urlSearchParams.append(`filter[${filterKey}]`, filterVal);
-                                }
-                            } else {
+                Object.keys(query).forEach((filterKey) => {
+                    let filterVal = query[filterKey];
+                    if (filterVal) {
+                        if (typeof filterVal === 'object') {
+                            return;
+                        }
+                        if (typeof filterVal === 'array') {
+                            if (filterVal.length > 0) {
+                                filterVal = filterVal.join(',');
                                 urlSearchParams.append(`filter[${filterKey}]`, filterVal);
                             }
+                            return;
                         }
-                    });
-                } else {
-                    urlSearchParams.append(key, query);
-                }
+                        urlSearchParams.append(`filter[${filterKey}]`, filterVal);
+                    }
+                });
             });
 
-            let hasQueryIdentifier = url.indexOf(qi) === -1;
-            if (!hasQueryIdentifier) {
+            if (url.indexOf(qi) > 0) {
                 qi = '&';
             }
 

--- a/src/Template/Layout/js/app/mixins/paginated-content.js
+++ b/src/Template/Layout/js/app/mixins/paginated-content.js
@@ -180,50 +180,41 @@ export const PaginatedContentMixin = {
          * @return {String} The formatted url
          */
         getUrlWithPaginationAndQuery(url) {
-            let queryString = '';
+            const urlSearchParams = new URLSearchParams('');
             let qi = '?';
-            const separator = '&';
 
             Object.keys(this.pagination).forEach((key, index) => {
-                queryString += `${index ? separator : ''}${key}=${this.pagination[key]}`;
+                urlSearchParams.append(key, this.pagination[key]);
             });
-            if (queryString.length > 1) {
-                queryString += separator;
-            }
             Object.keys(this.query).forEach((key, index) => {
                 const query = this.query[key];
-                let entry = `${key}=${query}`;
 
                 // parse filter property
                 if (key === 'filter') {
-                    let filter = '';
-                    let i = 0;
                     Object.keys(query).forEach((filterKey) => {
-                        if (query[filterKey] !== '') {
-                            if (i > 0) {
-                                filter += separator;
-                            }
-                            let filterVal = query[filterKey];
+                        let filterVal = query[filterKey];
+                        if (filterVal) {
                             if (typeof filterVal === 'object' || typeof filterVal === 'array') {
                                 if (filterVal.length > 0) {
                                     filterVal = filterVal.join(',');
+                                    urlSearchParams.append(`filter[${filterKey}]`, filterVal);
                                 }
+                            } else {
+                                urlSearchParams.append(`filter[${filterKey}]`, filterVal);
                             }
-                            filter += `filter[${filterKey}]=${filterVal}`;
                         }
-                        i++;
                     });
-
-                    entry = filter;
+                } else {
+                    urlSearchParams.append(key, query);
                 }
-                queryString += `${index ? separator : ''}${entry}`;
             });
 
             let hasQueryIdentifier = url.indexOf(qi) === -1;
             if (!hasQueryIdentifier) {
                 qi = '&';
             }
-            return `${url}${qi}${queryString}`;
+
+            return `${url}${qi}${urlSearchParams.toString()}`;
         },
 
         /**

--- a/src/Template/Layout/js/app/mixins/paginated-content.js
+++ b/src/Template/Layout/js/app/mixins/paginated-content.js
@@ -204,12 +204,6 @@ export const PaginatedContentMixin = {
                         if (typeof filterVal === 'object') {
                             return;
                         }
-                        if (typeof filterVal === 'array') {
-                            if (filterVal.length > 0) {
-                                urlSearchParams.append(`filter[${filterKey}]`, filterVal);
-                            }
-                            return;
-                        }
                         urlSearchParams.append(`filter[${filterKey}]`, filterVal);
                     }
                 });

--- a/src/Template/Layout/js/app/mixins/paginated-content.js
+++ b/src/Template/Layout/js/app/mixins/paginated-content.js
@@ -200,10 +200,7 @@ export const PaginatedContentMixin = {
                 // parse filter property
                 Object.keys(query).forEach((filterKey) => {
                     let filterVal = query[filterKey];
-                    if (filterVal) {
-                        if (typeof filterVal === 'object') {
-                            return;
-                        }
+                    if (filterVal && typeof filterVal !== 'object') {
                         urlSearchParams.append(`filter[${filterKey}]`, filterVal);
                     }
                 });

--- a/src/Template/Layout/js/app/mixins/paginated-content.js
+++ b/src/Template/Layout/js/app/mixins/paginated-content.js
@@ -197,10 +197,21 @@ export const PaginatedContentMixin = {
                 // parse filter property
                 if (key === 'filter') {
                     let filter = '';
+                    let i = 0;
                     Object.keys(query).forEach((filterKey) => {
                         if (query[filterKey] !== '') {
-                            filter += `filter[${filterKey}]=${query[filterKey]}`;
+                            if (i > 0) {
+                                filter += separator;
+                            }
+                            let filterVal = query[filterKey];
+                            if (typeof filterVal === 'object' || typeof filterVal === 'array') {
+                                if (filterVal.length > 0) {
+                                    filterVal = filterVal.join(',');
+                                }
+                            }
+                            filter += `filter[${filterKey}]=${filterVal}`;
                         }
+                        i++;
                     });
 
                     entry = filter;

--- a/src/Template/Layout/js/app/mixins/paginated-content.js
+++ b/src/Template/Layout/js/app/mixins/paginated-content.js
@@ -183,12 +183,10 @@ export const PaginatedContentMixin = {
             const urlSearchParams = new URLSearchParams('');
             let qi = '?';
 
-            Object.keys(this.pagination).forEach((key, index) => {
+            Object.keys(this.pagination).forEach((key) => {
                 urlSearchParams.append(key, this.pagination[key]);
             });
-            Object.keys(this.query).forEach((key, index) => {
-                const query = this.query[key];
-
+            Object.entries(this.query).forEach(([key, query]) => {
                 if (key !== 'filter') {
                     if (query && typeof query !== 'object') {
                         urlSearchParams.append(key, query);
@@ -198,8 +196,7 @@ export const PaginatedContentMixin = {
                 }
 
                 // parse filter property
-                Object.keys(query).forEach((filterKey) => {
-                    let filterVal = query[filterKey];
+                Object.entries(query).forEach(([filterKey, filterVal]) => {
                     if (filterVal && typeof filterVal !== 'object') {
                         urlSearchParams.append(`filter[${filterKey}]`, filterVal);
                     }

--- a/src/Template/Layout/js/app/mixins/paginated-content.js
+++ b/src/Template/Layout/js/app/mixins/paginated-content.js
@@ -206,7 +206,6 @@ export const PaginatedContentMixin = {
                         }
                         if (typeof filterVal === 'array') {
                             if (filterVal.length > 0) {
-                                filterVal = filterVal.join(',');
                                 urlSearchParams.append(`filter[${filterKey}]`, filterVal);
                             }
                             return;


### PR DESCRIPTION
This resolves a bug in filtering data by type in "add objects to relation" panel.

After https://github.com/bedita/manager/pull/612/ filter box contains more filters.

Bug reason was filter badly built (missing a `&` in the api call url).