### PR TITLE
Search section in dashboard

### DIFF
--- a/src/Template/Pages/Dashboard/index.twig
+++ b/src/Template/Pages/Dashboard/index.twig
@@ -96,6 +96,18 @@
             </div>
         </section>
 
+        <section class="dashboard-section">
+            <header>
+                <h2>{{ __('Search') }}</h2>
+            </header>
+
+            <nav role="search">
+                <input type="text" v-model="searchString" v-on:keydown.stop="captureKeys">
+                <button ref="searchSubmit" :disabled="!searchString || searchString.length < 3" v-on:click="searchObjects">{{ __('Search') }}</button>
+            </nav>
+
+        </section>
+
         <div class="dashboard-area">
 
             <section class="dashboard-section">
@@ -117,18 +129,6 @@
                         {{ __('No items found') }}
                     {% endfor %}
                 </div>
-            </section>
-
-            <section class="dashboard-section">
-                <header>
-                    <h2>{{ __('Search') }}</h2>
-                </header>
-
-                <nav role="search">
-                    <input type="text" v-model="searchString" v-on:keydown.stop="captureKeys">
-                    <button ref="searchSubmit" :disabled="!searchString || searchString.length < 3" v-on:click="searchObjects">{{ __('Search') }}</button>
-                </nav>
-
             </section>
 
         </div>


### PR DESCRIPTION
This fixes the odd position of "search section" in dashboard.

Before this patch
----------------------

![search-before](https://user-images.githubusercontent.com/2227145/137683531-d2b75197-b10a-4a4b-b9ef-32f8e910fb49.png)

After this patch
--------------------

![search-after](https://user-images.githubusercontent.com/2227145/137683554-c4295457-e93b-4959-bcc7-16c891f4fafd.png)

