### PR TITLE
feat - Relations filters

### DIFF
--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -185,8 +185,9 @@ class PropertiesComponent extends Component
         return array_filter(
             array_reduce(
                 $types,
-                function(array $accumulator, string $type) {
+                function (array $accumulator, string $type) {
                     $accumulator[$type] = $this->filterList($type);
+
                     return $accumulator;
                 },
                 []

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -170,6 +170,31 @@ class PropertiesComponent extends Component
     }
 
     /**
+     * List of all filters, grouped by type, for passed `$types` list
+     *
+     * @param string[] $types List of types to get filters of
+     *
+     * @return array
+     */
+    public function filtersByType(array $types): array
+    {
+        if (empty($types)) {
+            return [];
+        }
+
+        return array_filter(
+            array_reduce(
+                $types,
+                function(array $accumulator, string $type) {
+                    $accumulator[$type] = $this->filterList($type);
+                    return $accumulator;
+                },
+                []
+            )
+        );
+    }
+
+    /**
      * List of bulk actions to display in `index` view
      *
      * @param string $type Object type name

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -170,13 +170,13 @@ class ModulesController extends AppController
             $this->Properties->relationsList($this->objectType)
         );
 
+        $rightTypes = \App\Utility\Schema::rightTypes($this->viewVars['relationsSchema']);
+
         // set schemas for relations right types
-        $schemasByType = $this->Schema->getSchemasByType(
-            \App\Utility\Schema::rightTypes(
-                $this->viewVars['relationsSchema']
-            )
-        );
+        $schemasByType = $this->Schema->getSchemasByType($rightTypes);
         $this->set('schemasByType', $schemasByType);
+
+        $this->set('filtersByType', $this->Properties->filtersByType($rightTypes));
 
         // set objectNav
         $objectNav = $this->getObjectNav((string)$id);

--- a/src/Template/Element/FilterBox/filter_box.scss
+++ b/src/Template/Element/FilterBox/filter_box.scss
@@ -68,8 +68,16 @@
             }
         }
 
+        &.date_ranges .filter-label {
+            margin-top: 1rem;
+        }
+
         .date-filter {
             display: flex;
+
+            > * + * {
+                margin-left: $gutter * .5;
+            }
 
             input {
                 margin: 0;

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -4,34 +4,47 @@
         <div class="filter-container filter-search input">
             <input type="text"
                 :placeholder="placeholder"
-                v-model="queryFilter.q"
-                @keyup.prevent.stop="onQueryStringKeyup"
-                @change="onQueryStringChange"
-                @keyup.enter.prevent.stop="applyFilter" />
+                v-model.trim="queryFilter.q"
+            />
         </div>
 
         <button class="button button-secondary button-primary-hover-module-{{ currentModule.name }}"
-            @click.prevent="applyFilter()"
+            @click.prevent="applyFilter"
         >
             {{ __('Search') }}
         </button>
 
-        <button class="toggle-filters button button-outlined" @click="moreFilters = !moreFilters">
-            <span v-if="!moreFilters">{{ __('More filters') }}</span>
-            <span v-else>{{ __('Less filters') }}</span>
+        <button class="toggle-filters button button-outlined"
+            type="button"
+            @click="moreFilters = !moreFilters"
+            v-if="canShowAdvanced"
+        >
+            <span v-show="!moreFilters">{{ __('More filters') }}</span>
+            <span v-show="moreFilters">{{ __('Less filters') }}</span>
         </button>
 
         {# Checkbox my contents #}
-        <div class="filter-container checkbox">
+        <div class="filter-container checkbox" v-if="showAdvanced">
             <label>
                 <input type="checkbox" v-model="queryFilter.filter['history_editor']">{{ __('Only my contents') }}</input>
             </label>
         </div>
 
-        <button class="button button-outlined" @click.prevent="resetFilter()">{{ __('Reset filters') }}</button>
+        <button class="button button-outlined" type="button" @click="resetFilter">{{ __('Reset filters') }}</button>
     </div>
 
     <div class="more-filters" v-show="moreFilters">
+        {# object type filter #}
+        <div class="filter-container search-types" v-if="rightTypes.length > 1">
+            <label>{{ __('Type') }}</label>
+            <select v-model="selectedType"
+                class="has-background-gray-700 has-border-gray-700 has-font-weight-light has-text-gray-200 has-text-size-smallest"
+            >
+                <option selected value="" label="{{ __('All Types') }}"></option>
+                <option v-for="type in rightTypes" :value="type"><: type | capitalize | translate :></option>
+            </select>
+        </div>
+
         {# status filter #}
         <div class="filter-container" v-if="statusFilter.options">
             <label>{{ __('Status') }}</label>
@@ -39,14 +52,6 @@
                 <input type="checkbox" :id="s.value" :name="statusFilter.name" :value="s.value" v-model="selectedStatuses">
                 <: s.text :>
             </label>
-        </div>
-
-        {# dynamic filter object types #}
-        <div class="filter-container search-types" v-if="rightTypes.length > 1">
-            <select v-model="queryFilter.filter.type" @change="onOtherFiltersChange">
-                <option value="" label="{{ __('All Types') }}"></option>
-                <option v-for="type in rightTypes"><: t(type) :></option>
-            </select>
         </div>
 
         {# other dynamic filters #}
@@ -57,14 +62,28 @@
             <span v-if="filter.name === 'categories'">
                 <label>{{ __('Categories') }}</label>
 
-                <category-picker
-                    :categories="{{ schema.categories|json_encode }}"
-                    :initial-categories="initCategories"
-                    id="category-filter"
-                    label=""
-                    @change="onCategoryChange"
-                ></category-picker>
-                {{ Form.unlockField('categories') }}
+                {% if schemasByType %}
+                    {% for type, typeSchema in schemasByType %}
+                        <category-picker
+                            v-if="queryFilter.filter.type == '{{ type }}'"
+                            :categories="{{ typeSchema.categories|json_encode }}"
+                            :initial-categories="initCategories"
+                            id="category-filter"
+                            label=""
+                            @change="onCategoryChange"
+                        ></category-picker>
+                        {{ Form.unlockField('categories') }}
+                    {% endfor %}
+                {% elseif schema %}
+                    <category-picker
+                        :categories="{{ schema.categories|json_encode }}"
+                        :initial-categories="initCategories"
+                        id="category-filter"
+                        label=""
+                        @change="onCategoryChange"
+                    ></category-picker>
+                    {{ Form.unlockField('categories') }}
+                {% endif %}
             </span>
 
             <span v-else-if="filter.name === 'parent'" class="position-filter">
@@ -75,17 +94,24 @@
 
                 <span class="descendants-filter">
                     <label for="descendants">{{ __('Descendants') }}</label>
-                    <input id="descendants" type="checkbox" v-model="filterByDescendants" @change="onPositionFilterChange" />
+                    <input
+                        id="descendants"
+                        type="checkbox"
+                        v-model="filterByDescendants"
+                        @change="onPositionFilterChange"
+                    />
                 </span>
             </span>
 
-            <span v-else-if="filter.name === 'date_ranges'" class="date-filter">
-                <label>{{ __('From date') }}
+            <span v-else-if="filter.name === 'date_ranges'" class="date-filter date-ranges-item">
+                <div>
+                    <label>{{ __('From date') }}</label>
                     <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['from_date']" :attrs="filter" />
-                </label>
-                <label>{{ __('To date') }}
+                </div>
+                <div>
+                    <label>{{ __('To date') }}</label>
                     <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['to_date']" :attrs="filter" />
-                </label>
+                </div>
             </span>
 
             <span v-else-if="filter.type === 'select' || filter.type === 'radio'">
@@ -94,7 +120,7 @@
                         {{ __('All') }}
                     </option>
                     <option v-for="option in filter.options" v-if="option.text" :name="option.name" :value="option.value">
-                        <: option.text :>
+                        <: option.text | translate :>
                     </option>
                 </select>
             </span>

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -41,7 +41,7 @@
                 class="has-background-gray-700 has-border-gray-700 has-font-weight-light has-text-gray-200 has-text-size-smallest"
             >
                 <option selected value="" label="{{ __('All Types') }}"></option>
-                <option v-for="type in rightTypes" :value="type"><: type | capitalize | translate :></option>
+                <option v-for="type in rightTypes" :value="type"><: t(capitalize(type)) :></option>
             </select>
         </div>
 
@@ -120,7 +120,7 @@
                         {{ __('All') }}
                     </option>
                     <option v-for="option in filter.options" v-if="option.text" :name="option.name" :value="option.value">
-                        <: option.text | translate :>
+                        <: t(option.text) :>
                     </option>
                 </select>
             </span>

--- a/src/Template/Element/FilterBox/filter_box_page_toolbar.twig
+++ b/src/Template/Element/FilterBox/filter_box_page_toolbar.twig
@@ -1,8 +1,8 @@
 {% set selectBaseClasses = "has-background-gray-700 has-border-gray-700 has-font-weight-light has-text-gray-200 has-text-size-smallest" %}
 
 <nav class="pagination has-text-size-smallest">
-    <div class="count-items " v-if="pagination.count">
-        <span class="has-font-weight-bold"><: pagination.count :></span> <span><: label() :></span>
+    <div class="count-items" v-if="pagination.count">
+        <span class="has-font-weight-bold"><: pagination.count :></span> <span><: label :></span>
     </div>
 
     <div class="page-size" v-show="pagination.count > paginateSizes[0]">
@@ -16,7 +16,7 @@
         <div v-if="isFullPaginationLayout">
             <button
                 v-for="i in pagination.page_count" :key="i"
-                v-bind:class="pagination.page == i? 'current-page' : 'button-outlined button-outlined-hover-module-{{currentModule.name }}'"
+                :class="pagination.page == i ? 'current-page' : 'button-outlined button-outlined-hover-module-{{currentModule.name }}'"
                 class="button is-width-auto has-text-size-smallest" @click.prevent="onChangePage(i)"><: i :>
             </button>
         </div>

--- a/src/Template/Element/Form/relation.twig
+++ b/src/Template/Element/Form/relation.twig
@@ -1,17 +1,17 @@
 <relation-view inline-template
-    :relation-data='{{ relationSchema|json_encode|raw }}'
-    :data-list=dataList
-    relation-name={{ relationName }}
-    :pre-count={{ preCount }}
-    config-paginate-sizes={{ config('Pagination.sizeAvailable')|json_encode()|raw }}
+    :relation-data="{{ relationSchema|json_encode|escape('html_attr') }}"
+    :data-list="dataList"
+    relation-name="{{ relationName }}"
+    :pre-count="{{ preCount }}"
+    config-paginate-sizes="{{ config('Pagination.sizeAvailable')|json_encode|escape('html_attr') }}"
     ref="relation"
-    @loading="onToggleLoading" @count="onCount">
-
+    @loading="onToggleLoading"
+    @count="onCount"
+>
     <div class="relation-view">
-
         {# Lookup in properties configuration if a custom element for this relation is set
-           in `Properties.{moduleName}.relations._element.{relationName}`.
-           Then load custom element or use default relation view #}
+        in `Properties.{moduleName}.relations._element.{relationName}`.
+        Then load custom element or use default relation view #}
         {% set customElement = Layout.customElement(relationName) %}
         {% if customElement %}
             {% element customElement {
@@ -21,23 +21,22 @@
         {% else %}
 
         <div class="related-list-container">
-
             {# FilterBoxView #}
             <div class="mb-1" v-show="showFilter">
                 <filter-box-view
                     :config-paginate-sizes="configPaginateSizes"
                     :pagination.sync="pagination"
-                    :show-filter-buttons="false"
+                    :show-advanced="false"
                     :relation-types="relationTypes"
                     :init-filter="activeFilter"
                     objects-label="{{ __('objects') }}"
                     @filter-update-current-page="onUpdateCurrentPage"
                     @filter-update-page-size="onUpdatePageSize"
-                    @filter-objects-submit="onFilterObjects"
-                    inline-template>
-
-                        {% element 'FilterBox/filter_box' %}
-
+                    @filter-objects="onFilterObjects"
+                    @filter-reset="reloadObjects"
+                    inline-template
+                >
+                    {% element 'FilterBox/filter_box' %}
                 </filter-box-view>
             </div>
 
@@ -53,7 +52,7 @@
                         :drag-data="JSON.stringify(related)">
 
                         {% if relationName == 'children' %}
-                            {% element 'Form/related_item' { 'children': true  } %}
+                            {% element 'Form/related_item' { 'children': true } %}
                         {% else %}
                             {% element 'Form/related_item' { 'common': true } %}
                         {% endif %}
@@ -85,7 +84,7 @@
             {% endif %}
 
             <div>
-                <button v-if="isPanelOpen({{object.id|json_encode}})" class="icon-coffee"
+                <button v-if="isPanelOpen({{object.id|json_encode}})" class="icon-cancel"
                     @click.prevent.stop="closePanel()">{{ __('cancel') }}</button>
 
                 <button v-else

--- a/src/Template/Element/Modules/index_header.twig
+++ b/src/Template/Element/Modules/index_header.twig
@@ -8,24 +8,23 @@
     {% endfor %}
 
     <filter-box-view
-        :pagination={{ meta.pagination|json_encode|raw }}
+        :pagination="{{ meta.pagination|json_encode|escape('html_attr') }}"
         :init-filter="urlFilterQuery"
         :selected-types='selectedTypes'
-        :filter-list='{{ list|json_encode|raw }}'
-        :filter-active="{{ filterActive|json_encode|raw }}"
+        :filter-list="{{ list|json_encode|escape('html_attr') }}"
+        :filter-active="{{ filterActive|json_encode|escape('html_attr') }}"
 
-        config-paginate-sizes={{ config('Pagination.sizeAvailable')|json_encode()|raw }}
+        config-paginate-sizes="{{ config('Pagination.sizeAvailable')|json_encode|escape('html_attr') }}"
         placeholder="{{ __('Search') }}"
         objects-label="{{ resourceType ?? __(currentModule.name) }}"
-        page-size={{ meta.pagination.page_size }}
+        page-size="{{ meta.pagination.page_size }}"
 
-        @filter-objects-submit="onFilterObjects"
+        @filter-objects="onFilterObjects"
         @filter-reset="resetFilters"
         @filter-update-current-page="onUpdateCurrentPage"
         @filter-update-page-size="onUpdatePageSize"
-        inline-template>
-
-            {% element 'FilterBox/filter_box' { 'meta': meta, 'hideFilter': hideFilter, 'hidePagination': hidePagination } %}
-
+        inline-template
+    >
+        {% element 'FilterBox/filter_box' { 'meta': meta, 'hideFilter': hideFilter, 'hidePagination': hidePagination } %}
     </filter-box-view>
 </div>

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -10,7 +10,6 @@
         </header>
 
         <div class="create-new-object mt-1 mx-1" v-if="showCreateObjectForm">
-
             <div class="select">
                 <label for="related_object_type">{{ __('Type') }}</label>
                 <select id="related_object_type"
@@ -19,7 +18,7 @@
                     v-if="relationTypes"
                     v-model="object.type">
                     <option value="_choose">{{ __('Choose a type') }}</option>
-                    <option v-for="type in relationTypes.right"><: t(type) :></option>
+                    <option v-for="type in relationTypes.right"><: type | capitalize | translate :></option>
                 </select>
             </div>
 
@@ -40,7 +39,6 @@
 
                     <section class="fieldset mb-1">
                         <div class="container">
-
                             <fieldset id="{{ type }}-form-fields">
                                 {% set fields = config('Properties.' ~ type ~ '.fastCreate.all')|default(['status', 'title', 'description']) %}
                                 {% set required = config('Properties.' ~ type ~ '.fastCreate.required')|default(['status', 'title']) %}
@@ -53,7 +51,7 @@
                                         'key': type ~ '-' ~ field
                                     } %}
                                     {% if field == 'status' %}
-                                        {% set fieldOptions =  fieldOptions|merge({'v-model': 'object.attributes.status'}) %}
+                                        {% set fieldOptions = fieldOptions|merge({'v-model': 'object.attributes.status'}) %}
                                     {% endif %}
                                     {{ Property.control(field, '', fieldOptions, type)|raw }}
                                 {% endfor %}
@@ -92,20 +90,30 @@
         </header>
 
         <div class="px-1 my-1">
+            {% set list = {} %}
+            {% for type, filters in filtersByType %}
+                {% set options = [] %}
+                {% for f in filters %}
+                    {% set o = Schema.controlOptions(f, null, schema.properties[f]) %}
+                    {% set options = options|merge([o|merge({ 'name': f })]) %}
+                {% endfor %}
+                {% set list = list|merge({ (type): options }) %}
+            {% endfor %}
             <filter-box-view
-                config-paginate-sizes={{ config('Pagination.sizeAvailable')|json_encode()|raw }}
+                config-paginate-sizes={{ config('Pagination.sizeAvailable')|json_encode|escape('html_attr') }}
                 :pagination.sync="pagination"
-                :show-filter-buttons="false"
                 :relation-types="relationTypes"
+                :filters-by-type="{{ list|json_encode|escape('html_attr') }}"
                 objects-label="{{ __('objects') }}"
 
                 @filter-update-current-page="onUpdateCurrentPage"
                 @filter-update-page-size="onUpdatePageSize"
-                @filter-objects-submit="onFilterObjects"
-                inline-template>
+                @filter-objects="onFilterObjects"
+                @filter-reset="onFilterObjects"
 
-                    {% element 'FilterBox/filter_box' %}
-
+                inline-template
+            >
+                {% element 'FilterBox/filter_box' %}
             </filter-box-view>
         </div>
 
@@ -118,14 +126,16 @@
         </div>
 
         <footer class="p-1">
-            <button class="has-background-info has-text-white" :disabled="!selectedObjects.length"
+            <button class="has-background-info has-text-white"
+                :disabled="!selectedObjects.length"
                 @click.prevent="addRelationsToObject({
                     relationName: relationName,
                     objects: selectedObjects,
-                })">
-                    {{ __('Add') }}
-                    <span v-if="selectedObjects.length" class="mx-025 has-font-weight-bold"><: selectedObjects.length :></span>
-                    {{ __('objects to') }} <: relationName | humanize :>
+                })"
+            >
+                {{ __('Add') }}
+                <span v-if="selectedObjects.length" class="mx-025 has-font-weight-bold"><: selectedObjects.length :></span>
+                {{ __('objects to') }} <: relationName | humanize :>
             </button>
 
             <button class="mx-1" href="#" :disabled="saving" @click.prevent="closePanel()">{{ __('Close') }}</button>

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -3,7 +3,7 @@
 <div class="relations-add">
     <section class="fieldset mb-1">
         <header class="mx-1 tab unselectable"
-            :class="showCreateObjectForm ? 'open' : ''"
+            :class="{ open: showCreateObjectForm }"
             :disabled="saving"
             @click="resetForms">
             <h2><span v-show="relationName"><strong>{{ __('create new') }}</strong> "<: relationName | humanize :></span>" {{ __('related object') }}&nbsp;</h2>
@@ -18,7 +18,7 @@
                     v-if="relationTypes"
                     v-model="object.type">
                     <option value="_choose">{{ __('Choose a type') }}</option>
-                    <option v-for="type in relationTypes.right"><: type | capitalize | translate :></option>
+                    <option v-for="type in relationTypes.right"><: t(capitalize(type)) :></option>
                 </select>
             </div>
 
@@ -94,7 +94,7 @@
             {% for type, filters in filtersByType %}
                 {% set options = [] %}
                 {% for f in filters %}
-                    {% set o = Schema.controlOptions(f, null, schema.properties[f]) %}
+                    {% set o = Schema.controlOptions(f, null, schemasByType[type].properties[f]) %}
                     {% set options = options|merge([o|merge({ 'name': f })]) %}
                 {% endfor %}
                 {% set list = list|merge({ (type): options }) %}

--- a/src/Template/Layout/js/app/app.js
+++ b/src/Template/Layout/js/app/app.js
@@ -19,6 +19,7 @@ import Autocomplete from '@trevoreyre/autocomplete-vue';
 
 import merge from 'deepmerge';
 import { t } from 'ttag';
+import { buildSearchParams } from '../libs/urlUtils.js';
 
 const _vueInstance = new Vue({
     el: 'main',
@@ -296,7 +297,6 @@ const _vueInstance = new Vue({
             }
         },
 
-
         /**
          * build coherent url based on these params:
          * - q=_string_
@@ -306,47 +306,11 @@ const _vueInstance = new Vue({
          * @param {Object} params
          * @returns {String} url
          */
-        buildUrlParams(params) {
-            let url = `${window.location.origin}${window.location.pathname}`;
-            const queryId = '?';
-            const separator = '&';
-            const paramsKeys = Object.keys(params);
+        buildUrlWithParams(params) {
+            let url = new URL(`${window.location.origin}${window.location.pathname}`);
+            url.search = buildSearchParams(params, url.searchParams).toString();
 
-            if (paramsKeys && paramsKeys.length) {
-                let fields = [];
-
-                paramsKeys.forEach((key) =>  {
-                    if (params[key]) {
-                        const query = params[key];
-
-                        // parse filter property
-                        if (key === 'filter') {
-                            Object.keys(query).forEach((filterKey) => {
-                                if (typeof query[filterKey] === 'object') {
-                                    const filter = query[filterKey];
-                                    Object.keys(filter).forEach((modifier) => {
-                                        if (filter[modifier] !== '') {
-                                            // look up for param modifier (i.e dates)
-                                            const encoded = encodeURIComponent(filter[modifier]);
-                                            fields.push(`filter[${filterKey}][${modifier}]=${encoded}`);
-                                        }
-                                    });
-                                } else if (query[filterKey] !== '') {
-                                    const encoded = encodeURIComponent(query[filterKey]);
-                                    fields.push(`filter[${filterKey}]=${encoded}`);
-                                }
-                            });
-                        } else {
-                            const encoded = encodeURIComponent(query);
-                            fields.push(`${key}=${encoded}`);
-                        }
-                    }
-                });
-                url += fields.length ? queryId : '';
-                url += fields.join(separator);
-            }
-
-            return url;
+            return url.href;
         },
 
         /**
@@ -355,7 +319,7 @@ const _vueInstance = new Vue({
          * @returns {void}
          */
         resetFilters() {
-            window.location.replace(this.buildUrlParams({ reset: 1 }));
+            window.location.replace(this.buildUrlWithParams({ reset: 1 }));
         },
 
         /**
@@ -366,7 +330,7 @@ const _vueInstance = new Vue({
          * @returns {void}
          */
         applyFilters(filters) {
-            let url = this.buildUrlParams({
+            const url = this.buildUrlWithParams({
                 q: filters.q,
                 filter: filters.filter,
                 page_size: this.pageSize,

--- a/src/Template/Layout/js/app/app.js
+++ b/src/Template/Layout/js/app/app.js
@@ -307,7 +307,7 @@ const _vueInstance = new Vue({
          * @returns {String} url
          */
         buildUrlWithParams(params) {
-            let url = new URL(`${window.location.origin}${window.location.pathname}`);
+            const url = new URL(`${window.location.origin}${window.location.pathname}`);
             url.search = buildSearchParams(params, url.searchParams).toString();
 
             return url.href;

--- a/src/Template/Layout/js/app/components/filter-box.js
+++ b/src/Template/Layout/js/app/components/filter-box.js
@@ -154,7 +154,7 @@ export default {
         },
 
         /**
-         * Capitalize `objectsLabel` and translate it.
+         * Capitalize `objectsLabel`.
          * Fallback to the translation of "Items".
          *
          * @returns {String}
@@ -164,7 +164,7 @@ export default {
                 return t`Items`;
             }
 
-            return t`${(this.objectsLabel.charAt(0) + this.objectsLabel.slice(1))}`;
+            return this.objectsLabel.charAt(0) + this.objectsLabel.slice(1);
         },
 
         positionFilterName() {

--- a/src/Template/Layout/js/app/components/filter-box.js
+++ b/src/Template/Layout/js/app/components/filter-box.js
@@ -8,15 +8,16 @@
  * @prop {String} configPaginateSizes
  * @prop {Boolean} filterActive Some filter is active on currently displayed data
  * @prop {Array} filterList custom filters to show
- * @prop {Object} initFilter
+ * @prop {Array} filtersByType Map of available filters grouped by object type
+ * @prop {Object} initFilter Initial filter
  * @prop {String} objectsLabel
  * @prop {Object} pagination
  * @prop {String} placeholder
  * @prop {Object} relationTypes relation types available for relation (left/right)
- * @prop {Array} selectedTypes Types selected
+ * @prop {Boolean} showAdvanced Flag to enable advanced filters. default: true
  */
 
-import { DEFAULT_PAGINATION, DEFAULT_FILTER } from 'app/mixins/paginated-content';
+import { DEFAULT_PAGINATION, getDefaultFilter } from 'app/mixins/paginated-content';
 import merge from 'deepmerge';
 import { t } from 'ttag';
 import { warning } from 'app/components/dialog/dialog';
@@ -38,9 +39,12 @@ export default {
             type: Array,
             default: () => [],
         },
+        filtersByType: {
+            type: Object,
+        },
         initFilter: {
             type: Object,
-            default: () => DEFAULT_FILTER,
+            default: getDefaultFilter,
         },
         objectsLabel: {
             type: String,
@@ -57,53 +61,45 @@ export default {
         relationTypes: {
             type: Object
         },
-        selectedTypes: {
-            type: Array,
-            default: () => [],
+        showAdvanced: {
+            type: Boolean,
+            default: true
         },
     },
 
     data() {
         return {
-            dynamicFilters: {},
+            availableFilters: [],
+            dynamicFilters: [],
             /**
              * Enable position filter by descendants.
              * When disabled, only direct children are fetched.
-             * This will switch the filter between `parent` and `ancestor`.
+             * This will switch the API filter between `parent` and `ancestor`.
              */
             filterByDescendants: false,
             moreFilters: this.filterActive,
             pageSize: this.pagination.page_size,
             queryFilter: {},
             selectedStatuses: [],
+            selectedType: '',
             statusFilter: {},
             timer: null,
         };
     },
 
     created() {
-        // merge default filters with initFilter
-        let mergeFilters = this.formatFilters();
         this.queryFilter = merge.all([
-            DEFAULT_FILTER,
-            this.queryFilter,
-            mergeFilters,
-            this.initFilter
+            this.getCleanQuery(this.filterList),
+            this.initFilter,
         ]);
 
-        // remove custom filters from the list of dynamic filters
-        this.dynamicFilters = this.filterList.filter(f => {
-            if (f.name == 'status') {
-                this.statusFilter = f;
-
-                return false;
-            }
-
-            return true;
-        });
-
+        if (this.filterList.length) {
+            this.availableFilters = this.filterList;
+        } else if (this.rightTypes.length == 1 && this.filtersByType) {
+            this.availableFilters = this.filtersByType[this.rightTypes[0]];
+        }
         this.selectedStatuses = Object.values(this.initFilter?.filter?.status || {});
-        this.filterByDescendants = !!this.initFilter.filter?.ancestor;
+        this.filterByDescendants = !!this.initFilter?.filter?.ancestor;
     },
 
     computed: {
@@ -117,7 +113,22 @@ export default {
          * @returns {Array} array of object types
          */
         rightTypes() {
-            return (this.relationTypes && this.relationTypes.right) || [];
+            return this.relationTypes?.right || [];
+        },
+
+        canShowAdvanced() {
+            return (this.availableFilters?.length && this.showAdvanced) || this.rightTypes.length > 1;
+        },
+
+        /**
+         * Check if the value of the search input is valid to perform a search.
+         * It has to be empty or longer than 2 characters.
+         *
+         * @returns {boolean}
+         */
+        isSearchFieldValid() {
+            const length = this.queryFilter?.q?.length;
+            return length === 0 || length > 2;
         },
 
         /**
@@ -139,7 +150,21 @@ export default {
         },
 
         initFolder() {
-            return this.initFilter.filter[this.positionFilterName];
+            return this.initFilter?.filter[this.positionFilterName];
+        },
+
+        /**
+         * Capitalize `objectsLabel` and translate it.
+         * Fallback to the translation of "Items".
+         *
+         * @returns {String}
+         */
+        label() {
+            if (!this.objectsLabel) {
+                return t`Items`;
+            }
+
+            return t`${(this.objectsLabel.charAt(0) + this.objectsLabel.slice(1))}`;
         },
 
         positionFilterName() {
@@ -149,14 +174,19 @@ export default {
 
     watch: {
         /**
-         * watch initFilter and assign it to queryFilter
-         *
-         * @param {Object} value filter object
-         *
-         * @returns {void}
+         * Normalize query filter and remove custom filters from the list of dynamic filters when `availableFilters` is updated.
          */
-        initFilter(value) {
-            this.queryFilter = merge(this.queryFilter, value);
+        availableFilters() {
+            this.normalizeQueryFilter();
+            this.dynamicFilters = this.availableFilters.filter(f => {
+                if (f.name == 'status') {
+                    this.statusFilter = f;
+
+                    return false;
+                }
+
+                return true;
+            });
         },
 
         /**
@@ -170,10 +200,6 @@ export default {
             this.$emit("filter-update-page-size", this.pageSize);
         },
 
-        selectedTypes(value) {
-            this.queryFilter.filter.type = value;
-        },
-
         /**
          * Add selected statuses to the query filters.
          * @param {String[]} value Selected statuses list
@@ -181,116 +207,129 @@ export default {
         selectedStatuses(value) {
             this.queryFilter.filter.status = value;
         },
+
+        /**
+         * Process dynamic filters list when selected object type changes.
+         * Then apply the current filter.
+         * @param {String} type Selected object type
+         */
+        selectedType(type) {
+            this.availableFilters = this.filtersByType[type] || [];
+            const query = this.getCleanQuery();
+            // persist old compatible filter values
+            query.q = this.queryFilter.q;
+            Object.keys(query.filter).forEach(f => {
+                const oldFilter = this.queryFilter.filter[f];
+                if (oldFilter) {
+                    query.filter[f] = oldFilter;
+                }
+            });
+            query.filter.type = type;
+            this.queryFilter = query;
+            this.applyFilter();
+        }
     },
 
     methods: {
         /**
-         * Return translation of ucfirst label objectsLabel.
+         * Build clean query filter object initializing all filters from `availableFilters`.
          *
-         * @returns {String}
+         * @returns {Object} clean query object
          */
-        label() {
-            if (!this.objectsLabel) {
-                return t`Items`;
+        getCleanQuery() {
+            const query = getDefaultFilter();
+            this.availableFilters.forEach(f => {
+                const defaultValue = f.date ? {} : '';
+                query.filter[f.name] = defaultValue;
+            });
+
+            return query;
+        },
+
+        /**
+         * Normalize query filter object initializing all filters from `availableFilters` and persisting already set values.
+         */
+        normalizeQueryFilter() {
+            const filterObj = this.getCleanQuery().filter;
+            this.availableFilters.forEach(f => {
+                const defaultValue = f.date ? {} : '';
+                const currentValue = this.queryFilter.filter[f.name];
+                filterObj[f.name] = currentValue || defaultValue;
+            });
+            this.queryFilter.filter = filterObj;
+        },
+
+        /**
+         * Check if filter value is empty.
+         * @param {*} filterVal Value to check
+         * @returns {Boolean}
+         */
+        isFilterValueEmpty(filterVal) {
+            if (typeof filterVal === 'object') {
+                return Object.values(filterVal).every((prop) => !prop);
             }
 
-            return this.ucfirst(this.objectsLabel);
-        },
-
-        /**
-         * First char upper case for string.
-         * @param {String} str The string
-         * @return {String}
-         */
-        ucfirst(str) {
-            return str.charAt(0).toUpperCase() + str.slice(1);
-        },
-
-        /**
-         * trigger filter-objects event when query string has 3 or more carachter
-         *
-         * @emits Event#filter-objects
-         */
-        onQueryStringKeyup() {
-            const queryString = this.queryFilter.q || "";
-
-            clearTimeout(this.timer);
-            if (queryString.trim().length >= 3 || queryString.trim().length === 0) {
-                this.timer = setTimeout(() => {
-                    this.$emit("filter-objects", this.queryFilter);
-                }, 300);
+            if (Array.isArray(filterVal)) {
+                return !filterVal.length;
             }
+
+            return !filterVal;
         },
 
         /**
-         * Handle Search input when value changes
-         * If search text is empty or at least 3 characters long, ok.
-         * Otherwise, warn that search text is too short.
-         */
-        onQueryStringChange() {
-            if (!this.searchFieldValid()) {
-                this.searchFieldDialog();
-            }
-        },
-
-        /**
-         * Verify search text.
-         * If is empty or more than 2 characters long, return true.
-         * Return false otherwise.
-         */
-        searchFieldValid() {
-            this.queryFilter.q = this.queryFilter.q.trim();
-
-            return (this.queryFilter.q.length === 0 || this.queryFilter.q.length > 2);
-        },
-
-        /**
-         * Verify search text.
-         * If is empty or more than 2 characters long, ok.
-         * Show prompt dialog otherwise.
-         */
-        searchFieldDialog() {
-            warning(t`Search text too short. Minimum length is 3. Retry`);
-        },
-
-        onOtherFiltersChange() {
-            this.$emit("filter-objects", this.queryFilter);
-        },
-
-        /**
-         * load custom filters property names
+         * Prepare filter object to perform a filter action.
+         * Clean the filter object removing empty properties and
+         * filters not available for the current object type.
          *
-         * @returns {Object} filters' name
+         * @returns {Object} filter object ready for the search
          */
-        formatFilters() {
-            let filter = {};
-            this.filterList.forEach (
-                f => (filter[f.name] = f.date ? {} : "")
-            );
+        prepareFilters() {
+            const filter = { ...this.queryFilter.filter };
 
-            return { filter };
+            Object.entries(filter).forEach(([key, filterValue]) => {
+                // do nothing for status or type filter, if value is set
+                if ((key === 'status' || key === 'type') && filterValue) {
+                    return;
+                }
+
+                // remove the filter if it doesn't appear in the list of available filters
+                if (!this.dynamicFilters.find(f => f.name == key)) {
+                    delete filter[key];
+                    return;
+                }
+
+                // reset the filter if it's an object or array and it only contains empty properties
+                if (this.isFilterValueEmpty(filterValue)) {
+                    delete filter[key];
+                }
+            });
+
+            return filter;
         },
 
         /**
          * apply filters
          *
-         * @emits Event#filter-objects-submit
+         * @emits Event#filter-objects
          */
         applyFilter() {
-            if (this.searchFieldValid()) {
-                this.$emit("filter-objects-submit", this.queryFilter);
-
-                return;
+            if (!this.isSearchFieldValid) {
+                return warning(t`Search text too short. Minimum length is 3. Retry`);
             }
-            this.searchFieldDialog();
+
+            const filter = this.prepareFilters();
+            this.$emit("filter-objects", { ...this.queryFilter, filter });
         },
 
         /**
-         * reset filters
+         * Reset filters
          *
          * @emits Event#filter-reset
          */
         resetFilter() {
+            this.selectedStatuses = [];
+            this.selectedType = '';
+            this.queryFilter = this.getCleanQuery();
             this.$emit("filter-reset");
         },
 
@@ -324,6 +363,6 @@ export default {
 
             this.queryFilter.filter[newFilter] = this.queryFilter.filter[oldFilter];
             delete this.queryFilter.filter[oldFilter];
-        }
+        },
     }
 };

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -98,9 +98,8 @@ export default {
          */
         showFilter() {
             return this.activeFilter.q ||
-                this.pagination.page > 1 ||
-                this.objects.length >= this.pagination.page_size ||
-                this.addedRelations.length >= this.pagination.page_size;
+                this.pagination.page_count > 1 ||
+                this.alreadyInView.length > this.pagination.page_size;
         },
     },
 
@@ -127,7 +126,7 @@ export default {
 
         // if preCount is '-1' => no object count from API, force load
         if (this.preCount === -1 || this.$parent.isOpen) {
-            await this.loadOnMounted();
+            await this.loadRelatedObjects();
         }
 
         // check if relation is related to media objects
@@ -442,16 +441,6 @@ export default {
         },
 
         /**
-         * load content if flag set to true
-         *
-         * @return {void}
-         */
-        async loadOnMounted() {
-            await this.loadRelatedObjects();
-            return Promise.resolve();
-        },
-
-        /**
          * call PaginatedContentMixin.getPaginatedObjects() method and handle loading
          *
          * @emits Event#count count objects event
@@ -484,8 +473,7 @@ export default {
         },
 
         /**
-         * reload all related objects
-         * UNUSED
+         * Reset the filter and reload all related objects.
          *
          * @return {Array} objs objects retrieved
          */

--- a/src/Template/Layout/js/app/components/relation-view/relations-add.js
+++ b/src/Template/Layout/js/app/components/relation-view/relations-add.js
@@ -23,7 +23,6 @@ import { warning } from 'app/components/dialog/dialog';
 const createData = (type = '') => ({
     type,
     attributes: {
-
         status: 'draft',
     },
 });

--- a/src/Template/Layout/js/config/config.js
+++ b/src/Template/Layout/js/config/config.js
@@ -50,5 +50,21 @@ Vue.mixin({
             // call ttag t method
             return t([value]);
         },
+
+        /**
+         * Capitalize a string.
+         *
+         * @param {String} str The string to capitalize
+         *
+         * @return {string}
+         */
+        capitalize: (str) => {
+            if (!str) {
+                return '';
+            }
+
+            str = str.toString();
+            return str.charAt(0).toUpperCase() + str.slice(1);
+        },
     }
 });

--- a/src/Template/Layout/js/libs/filters.js
+++ b/src/Template/Layout/js/libs/filters.js
@@ -1,14 +1,38 @@
 import Vue from 'vue';
+import { t } from 'ttag';
 
 /**
  * Converts a snake case string to title case.
  * Example: snake_case => Snake Case
  *
- * @param  {String} str the string to convert
+ * @param {String} str the string to convert
  * @return {String}
  */
-Vue.filter('humanize', function (str) {
-    return str.split('_').map(function (item) {
+Vue.filter('humanize', function(str) {
+    return str.split('_').map(function(item) {
         return item.charAt(0).toUpperCase() + item.substring(1);
     }).join(' ');
+});
+
+/**
+ * Capitalize a string.
+ *
+ * @param {String} str The string to capitalize
+ */
+Vue.filter('capitalize', function(str) {
+    if (!str) {
+        return '';
+    }
+
+    str = str.toString();
+    return str.charAt(0).toUpperCase() + str.slice(1);
+});
+
+/**
+ * Translate a string.
+ *
+ * @param {String} str The string to translate
+ */
+Vue.filter('translate', function(str) {
+    return t([str]);
 });

--- a/src/Template/Layout/js/libs/filters.js
+++ b/src/Template/Layout/js/libs/filters.js
@@ -27,15 +27,3 @@ Vue.filter('capitalize', function(str) {
     str = str.toString();
     return str.charAt(0).toUpperCase() + str.slice(1);
 });
-
-/**
- * Translate a string.
- * Only use this filter with dynamic strings.
- * For static strings use the `t` function (template literal tag).
- * @see https://ttag.js.org/docs/tag-gettext.html
- *
- * @param {String} str The string to translate
- */
-Vue.filter('translate', function(str) {
-    return t([str]);
-});

--- a/src/Template/Layout/js/libs/filters.js
+++ b/src/Template/Layout/js/libs/filters.js
@@ -30,6 +30,9 @@ Vue.filter('capitalize', function(str) {
 
 /**
  * Translate a string.
+ * Only use this filter with dynamic strings.
+ * For static strings use the `t` function (template literal tag).
+ * @see https://ttag.js.org/docs/tag-gettext.html
  *
  * @param {String} str The string to translate
  */

--- a/src/Template/Layout/js/libs/urlUtils.js
+++ b/src/Template/Layout/js/libs/urlUtils.js
@@ -1,0 +1,64 @@
+const setSearchParam = (name, value, searchParams) => {
+    if (value === null) { // typeof null === 'object', because JavaScript
+        return;
+    }
+
+    switch (typeof value) {
+        case 'bigint':
+        case 'number':
+        case 'string':
+            searchParams.set(name, value);
+
+            return;
+
+        case 'boolean':
+            searchParams.set(name, value + 0);
+
+            return;
+
+        case 'undefined':
+        case 'function':
+        case 'symbol':
+            return;
+    }
+
+    if (Array.isArray(value)) {
+        for (let i = 0; i < value.length; i++) {
+            setSearchParam(`${name}[${i}]`, value[i], searchParams,);
+        }
+
+        return;
+    }
+
+    for (let i in value) {
+        if (typeof i !== 'string') {
+            continue;
+        }
+
+        setSearchParam(`${name}[${encodeURIComponent(i)}]`, value[i], searchParams);
+    }
+};
+
+/**
+ * Build search params starting from an object and an initial URLSearchParams object
+ *
+ * @param {Object} object The object to process to build search params
+ * @param {URLSearchParams} searchParams Initial search params
+ * @returns {URLSearchParams}
+ */
+const buildSearchParams = (object, searchParams = undefined) => {
+    if (searchParams !== undefined) {
+        searchParams = new URLSearchParams();
+    }
+    for (let key in object) {
+        if (typeof key !== 'string') {
+            continue;
+        }
+
+        setSearchParam(encodeURIComponent(key), object[key], searchParams);
+    }
+
+    return searchParams;
+};
+
+export { buildSearchParams };

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -99,7 +99,7 @@ class PropertiesComponentTest extends TestCase
      *
      * @covers ::filtersByType()
      */
-    public function testfiltersByType(): void
+    public function testFiltersByType(): void
     {
         $documentsFilters = ['lang', 'categories'];
         $profilesFilters = ['modified', 'status'];
@@ -112,6 +112,9 @@ class PropertiesComponentTest extends TestCase
             'documents' => $documentsFilters,
             'profiles' => $profilesFilters,
         ];
+
+        $filters = $this->Properties->filtersByType([]);
+        static::assertEquals([], $filters);
 
         $filters = $this->Properties->filtersByType(['documents', 'profiles']);
         static::assertEquals($expected, $filters);

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -93,6 +93,31 @@ class PropertiesComponentTest extends TestCase
     }
 
     /**
+     * Test `filtersByType()` method.
+     *
+     * @return void
+     *
+     * @covers ::filtersByType()
+     */
+    public function testfiltersByType(): void
+    {
+        $documentsFilters = ['lang', 'categories'];
+        $profilesFilters = ['modified', 'status'];
+        Configure::write('Properties.documents.filter', $documentsFilters);
+        Configure::write('Properties.profiles.filter', $profilesFilters);
+
+        $this->createComponent();
+
+        $expected = [
+            'documents' => $documentsFilters,
+            'profiles' => $profilesFilters,
+        ];
+
+        $filters = $this->Properties->filtersByType(['documents', 'profiles']);
+        static::assertEquals($expected, $filters);
+    }
+
+    /**
      * Test `relationsList()` method.
      *
      * @return void


### PR DESCRIPTION
This PR mainly adds filters for related objects panel.

When a relation has more than one right type, the object type select is showed. After selecting a type, the filter-box component shows the configured filters for that type.

Other refactoring and features in this PR:
- `urlUtils` helper, containing a method to build URL search params in a cleaner way. More methods can be added to this helper when needed
- new `capitalize` and `translate` Vue filters, that can help handle some strings in Vue context, also inside twig templates
- improved some old filter behavior (like the filter methods triggered on keyup of the search input)
- typos and other minor fixes