### PR TITLE
Categories tree in object view

### DIFF
--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -221,6 +221,7 @@ class SchemaComponent extends Component
                     'id' => Hash::get((array)$item, 'id'),
                     'name' => Hash::get((array)$item, 'attributes.name'),
                     'label' => Hash::get((array)$item, 'attributes.label'),
+                    'parent_id' => Hash::get((array)$item, 'attributes.parent_id'),
                 ];
             },
             (array)Hash::get((array)$response, 'data')

--- a/src/Template/Element/Form/categories.scss
+++ b/src/Template/Element/Form/categories.scss
@@ -1,5 +1,12 @@
-.categories {
-    .select {
-        columns: 2 auto;
+.categories-container {
+    .categories {
+        margin-top: 15px;
+        .select {
+            columns: 2 auto;
+        }
+        h3 {
+            font-weight: bold;
+            text-transform: uppercase;
+        }
     }
 }

--- a/src/Template/Element/Form/categories.scss
+++ b/src/Template/Element/Form/categories.scss
@@ -1,6 +1,6 @@
 .categories-container {
     .categories {
-        margin-top: 15px;
+        margin-top: $gutter;
         .select {
             columns: 2 auto;
         }

--- a/src/Template/Element/Form/categories.twig
+++ b/src/Template/Element/Form/categories.twig
@@ -8,8 +8,10 @@
                 <h2>{{ __('Categories') }}</h2>
             </header>
 
-            <div v-show="isOpen" class="tab-container categories">
-                {{ Property.control('categories', object.attributes.categories, {'label': false})|raw }}
+            <div v-show="isOpen" class="tab-container">
+                <div class="categories-container">
+                    {{ Categories.control('categories', object.attributes.categories)|raw }}
+                </div>
             </div>
         </section>
 

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -20,6 +20,7 @@ use Cake\Utility\Hash;
  * Application View default class
  *
  *
+ * @property \App\View\Helper\CategoriesHelper $Categories
  * @property \App\View\Helper\EditorsHelper $Editors
  * @property \App\View\Helper\LayoutHelper $Layout
  * @property \App\View\Helper\ArrayHelper $Array
@@ -48,6 +49,7 @@ class AppView extends TwigView
                 'inputContainer' => '<div class="input {{type}}{{required}} {{containerClass}}">{{content}}</div>',
             ],
         ]);
+        $this->loadHelper('Categories');
         $this->loadHelper('Editors');
         $this->loadHelper('Layout');
         $this->loadHelper('Array');

--- a/src/View/Helper/CategoriesHelper.php
+++ b/src/View/Helper/CategoriesHelper.php
@@ -175,7 +175,7 @@ class CategoriesHelper extends Helper
         if ($aCount === $bCount) {
             return strcmp(
                 strtolower((string)Hash::get($a, 'name')),
-                strtolower((string)Hash::get($b, 'name')),
+                strtolower((string)Hash::get($b, 'name'))
             );
         }
 

--- a/src/View/Helper/CategoriesHelper.php
+++ b/src/View/Helper/CategoriesHelper.php
@@ -111,9 +111,8 @@ class CategoriesHelper extends Helper
 
             return $controlOptions;
         }
-        $key = 0;
-        foreach ($node['children'] as $child) {
-            $controlOptions['options'][$key++] = ['value' => $child['name'], 'text' => $child['label']];
+        foreach ($node['children'] as $key => $child) {
+            $controlOptions['options'][$key] = ['value' => $child['name'], 'text' => $child['label']];
         }
 
         return $controlOptions;

--- a/src/View/Helper/CategoriesHelper.php
+++ b/src/View/Helper/CategoriesHelper.php
@@ -141,9 +141,17 @@ class CategoriesHelper extends Helper
             }
         }
 
-        foreach ($roots as $key => $root) {
+        foreach ($roots as $key => &$root) {
+            if (!empty($root['children'])) {
+                $children = $root['children'];
+                usort($children, [$this, 'sortRoots']);
+                $root['children'] = $children;
+            }
             if (empty($root['parent_id']) && empty($root['children'])) {
                 $roots[0]['children'][] = $root;
+                $children = $roots[0]['children'];
+                usort($children, [$this, 'sortRoots']);
+                $roots[0]['children'] = $children;
                 unset($roots[$key]);
             }
         }
@@ -167,19 +175,10 @@ class CategoriesHelper extends Helper
      */
     public function sortRoots(array $a, array $b): int
     {
-        $aChildren = (array)Hash::get($a, 'children');
-        $bChildren = (array)Hash::get($b, 'children');
-        $aCount = count($aChildren);
-        $bCount = count($bChildren);
-
-        if ($aCount === $bCount) {
-            return strcmp(
-                strtolower((string)Hash::get($a, 'name')),
-                strtolower((string)Hash::get($b, 'name'))
-            );
-        }
-
-        return $aCount > $bCount;
+        return strcmp(
+            strtolower((string)Hash::get($a, 'name')),
+            strtolower((string)Hash::get($b, 'name'))
+        );
     }
 
     /**

--- a/src/View/Helper/CategoriesHelper.php
+++ b/src/View/Helper/CategoriesHelper.php
@@ -148,21 +148,7 @@ class CategoriesHelper extends Helper
             }
         }
 
-        usort($roots, function ($a, $b) {
-            $aChildren = (array)Hash::get($a, 'children');
-            $bChildren = (array)Hash::get($b, 'children');
-            $aCount = count($aChildren);
-            $bCount = count($bChildren);
-
-            if ($aCount === $bCount) {
-                return strcmp(
-                    strtolower((string)Hash::get($a, 'name')),
-                    strtolower((string)Hash::get($b, 'name')),
-                );
-            }
-
-            return $aCount > $bCount;
-        });
+        usort($roots, [$this, 'sortRoots']);
 
         $roots[0]['id'] = '0';
         $roots[0]['name'] = __('Global');
@@ -170,6 +156,30 @@ class CategoriesHelper extends Helper
         $roots[0]['parent_id'] = null;
 
         return $roots;
+    }
+
+    /**
+     * Sort roots. Global first.
+     *
+     * @param array $a The first node
+     * @param array $b The second node
+     * @return int
+     */
+    public function sortRoots(array $a, array $b): int
+    {
+        $aChildren = (array)Hash::get($a, 'children');
+        $bChildren = (array)Hash::get($b, 'children');
+        $aCount = count($aChildren);
+        $bCount = count($bChildren);
+
+        if ($aCount === $bCount) {
+            return strcmp(
+                strtolower((string)Hash::get($a, 'name')),
+                strtolower((string)Hash::get($b, 'name')),
+            );
+        }
+
+        return $aCount > $bCount;
     }
 
     /**

--- a/src/View/Helper/CategoriesHelper.php
+++ b/src/View/Helper/CategoriesHelper.php
@@ -143,15 +143,11 @@ class CategoriesHelper extends Helper
 
         foreach ($roots as $key => &$root) {
             if (!empty($root['children'])) {
-                $children = $root['children'];
-                usort($children, [$this, 'sortRoots']);
-                $root['children'] = $children;
+                usort($root['children'], [$this, 'sortRoots']);
             }
             if (empty($root['parent_id']) && empty($root['children'])) {
                 $roots[0]['children'][] = $root;
-                $children = $roots[0]['children'];
-                usort($children, [$this, 'sortRoots']);
-                $roots[0]['children'] = $children;
+                usort($roots[0]['children'], [$this, 'sortRoots']);
                 unset($roots[$key]);
             }
         }

--- a/src/View/Helper/CategoriesHelper.php
+++ b/src/View/Helper/CategoriesHelper.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\View\Helper;
+
+use Cake\Utility\Hash;
+use Cake\View\Helper;
+
+/**
+ * Categories helper
+ *
+ * @property \Cake\View\Helper\FormHelper $Form
+ * @property \App\View\Helper\PropertyHelper $Property
+ */
+class CategoriesHelper extends Helper
+{
+    public $helpers = ['Form', 'Property'];
+
+    /**
+     * Control for categories
+     *
+     * @param string $name The name
+     * @param mixed|null $value The value
+     * @return string
+     */
+    public function control(string $name, $value): string
+    {
+        $options = ['label' => false];
+        if (!$this->isTree()) {
+            return sprintf(
+                '<div class="categories"><h3>%s</h3>%s</div>',
+                __('Global'),
+                $this->Property->control($name, $value, $options)
+            );
+        }
+
+        return $this->html($name, $value, $options);
+    }
+
+    /**
+     * Html for categories tree
+     *
+     * @param string $name The name
+     * @param mixed|null $value The value
+     * @param array $options The options
+     * @return string
+     */
+    public function html(string $name, $value, array $options): string
+    {
+        $html = '';
+        $tree = $this->tree();
+        $hiddenField = true; // hiddenField false on all controls except the first
+        foreach ($tree as $node) {
+            $html .= $this->node($node, $name, $value, $options, $hiddenField);
+        }
+
+        return $html;
+    }
+
+    /**
+     * Html for single node of categories tree
+     *
+     * @param array $node The category node
+     * @param string $name The name
+     * @param mixed|null $value The value
+     * @param array $options The options
+     * @param bool $hiddenField The hiddenField flag
+     * @return string
+     */
+    public function node(array $node, string $name, $value, array $options, bool &$hiddenField): string
+    {
+        $controlOptions = $this->controlOptions($node, $value, $options, $hiddenField);
+        $title = count(array_keys($controlOptions['options'])) === 1 ? __('Global') : $node['label'];
+
+        return sprintf(
+            '<div class="categories"><h3>%s</h3>%s</div>',
+            $title,
+            $this->Form->control($name, $controlOptions)
+        );
+    }
+
+    /**
+     * Control options for category node.
+     *
+     * @param array $node The category node
+     * @param mixed|null $value The value
+     * @param array $options The options
+     * @param bool $hiddenField The hiddenField flag
+     * @return array
+     */
+    public function controlOptions(array $node, $value, array $options, bool &$hiddenField): array
+    {
+        $controlOptions = $options + [
+            'type' => 'select',
+            'multiple' => 'checkbox',
+            'value' => (array)Hash::extract((array)$value, '{n}.name'),
+            'hiddenField' => $hiddenField,
+        ];
+        $hiddenField = false;
+        if (empty($node['children'])) {
+            $controlOptions['options'][0] = ['value' => $node['name'], 'text' => $node['label']];
+
+            return $controlOptions;
+        }
+        $key = 0;
+        foreach ($node['children'] as $child) {
+            $controlOptions['options'][$key++] = ['value' => $child['name'], 'text' => $child['label']];
+        }
+
+        return $controlOptions;
+    }
+
+    /**
+     * Categories tree.
+     * Return roots with children in 'children'.
+     *
+     * @return array
+     */
+    public function tree(): array
+    {
+        $schema = (array)$this->_View->get('schema');
+        $categories = (array)Hash::get($schema, 'categories');
+        if (empty($categories)) {
+            return [];
+        }
+
+        $roots = [];
+        foreach ($categories as $category) {
+            if (empty($category['parent_id'])) { // root
+                $roots[$category['id']] = $category;
+            } else { // child
+                $roots[$category['parent_id']]['children'][] = $category;
+            }
+        }
+
+        return $roots;
+    }
+
+    /**
+     * Return true when a category parent id is not null, among schema.categories.
+     * False otherwise.
+     *
+     * @return bool
+     */
+    public function isTree(): bool
+    {
+        $schema = (array)$this->_View->get('schema');
+        $categories = (array)Hash::get($schema, 'categories');
+        if (empty($categories)) {
+            return false;
+        }
+        foreach ($categories as $category) {
+            if (!empty($category['parent_id'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/View/Helper/CategoriesHelper.php
+++ b/src/View/Helper/CategoriesHelper.php
@@ -135,7 +135,7 @@ class CategoriesHelper extends Helper
         $roots = [];
         foreach ($categories as $category) {
             if (empty($category['parent_id'])) { // root
-                $roots[$category['id']] = $category;
+                $roots[$category['id']] = array_merge($category, (array)Hash::get($roots, $category['id']));
             } else { // child
                 $roots[$category['parent_id']]['children'][] = $category;
             }
@@ -143,14 +143,10 @@ class CategoriesHelper extends Helper
 
         foreach ($roots as $key => $root) {
             if (empty($root['parent_id']) && empty($root['children'])) {
-                $roots[-1]['children'][] = $root;
+                $roots[0]['children'][] = $root;
                 unset($roots[$key]);
             }
         }
-        $roots[-1]['id'] = '-1';
-        $roots[-1]['name'] = __('Global');
-        $roots[-1]['label'] = __('Global');
-        $roots[-1]['parent_id'] = null;
 
         usort($roots, function ($a, $b) {
             $aChildren = (array)Hash::get($a, 'children');
@@ -159,21 +155,19 @@ class CategoriesHelper extends Helper
             $bCount = count($bChildren);
 
             if ($aCount === $bCount) {
-                if ($a['name'] === 'Global') {
-                    return -1;
-                }
-                if ($b['name'] === 'Global') {
-                    return 1;
-                }
-
-                return strcmp(strtolower($a['name']), strtolower($b['name']));
-            }
-            if ($aCount > $bCount) {
-                return 1;
+                return strcmp(
+                    strtolower((string)Hash::get($a, 'name')),
+                    strtolower((string)Hash::get($b, 'name')),
+                );
             }
 
-            return -1;
+            return $aCount > $bCount;
         });
+
+        $roots[0]['id'] = '0';
+        $roots[0]['name'] = __('Global');
+        $roots[0]['label'] = __('Global');
+        $roots[0]['parent_id'] = null;
 
         return $roots;
     }

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -517,11 +517,13 @@ class SchemaComponentTest extends TestCase
                 'name' => 'cat-1',
                 'label' => 'Category 1',
                 'id' => '1',
+                'parent_id' => null,
             ],
             [
                 'name' => 'cat-2',
                 'label' => 'Category 2',
                 'id' => '2',
+                'parent_id' => null,
             ],
         ];
         static::assertEquals($expected, $result['categories']);

--- a/tests/TestCase/View/Helper/CategoriesHelperTest.php
+++ b/tests/TestCase/View/Helper/CategoriesHelperTest.php
@@ -176,7 +176,7 @@ class CategoriesHelperTest extends TestCase
     public function nodeProvider(): array
     {
         return [
-            'global' => [
+            'no children' => [
                 [
                     'name' => 'dummy1',
                     'label' => 'Dummy 1',
@@ -184,9 +184,9 @@ class CategoriesHelperTest extends TestCase
                 'categories',
                 [['name' => 'dummy1', 'label' => 'Dummy 1'], ['name' => 'dummy2', 'label' => 'Dummy 2']],
                 [],
-                '<div class="categories"><h3>Global</h3><div class="input select"><label for="categories">Categories</label><div class="checkbox"><label for="categories-dummy1" class="selected"><input type="checkbox" name="categories[]" value="dummy1" checked="checked" id="categories-dummy1">Dummy 1</label></div></div></div>',
+                '<div class="categories"><h3>Dummy 1</h3><div class="input select"><label for="categories">Categories</label><div class="checkbox"><label for="categories-dummy1" class="selected"><input type="checkbox" name="categories[]" value="dummy1" checked="checked" id="categories-dummy1">Dummy 1</label></div></div></div>',
             ],
-            'non global' => [
+            'children' => [
                 [
                     'name' => 'dummy1',
                     'label' => 'Dummy 1',
@@ -334,30 +334,53 @@ class CategoriesHelperTest extends TestCase
             'schema categories with all parent_id null' => [
                 [
                     'categories' => [
-                        ['id' => 1, 'parent_id' => null],
-                        ['id' => 2, 'parent_id' => null],
-                        ['id' => 3, 'parent_id' => null],
+                        ['id' => 1, 'name' => 'dummy1', 'parent_id' => null],
+                        ['id' => 2, 'name' => 'dummy2', 'parent_id' => null],
+                        ['id' => 3, 'name' => 'dummy3', 'parent_id' => null],
                     ],
                 ],
                 false,
                 [
-                    1 => ['id' => 1, 'parent_id' => null],
-                    2 => ['id' => 2, 'parent_id' => null],
-                    3 => ['id' => 3, 'parent_id' => null],
+                    [
+                        'id' => '-1',
+                        'name' => 'Global',
+                        'label' => 'Global',
+                        'children' => [
+                            ['id' => 1, 'name' => 'dummy1', 'parent_id' => null],
+                            ['id' => 2, 'name' => 'dummy2', 'parent_id' => null],
+                            ['id' => 3, 'name' => 'dummy3', 'parent_id' => null],
+                        ],
+                        'parent_id' => null,
+                    ]
                 ],
             ],
             'schema categories with a parent_id not null' => [
                 [
                     'categories' => [
-                        ['id' => 1, 'parent_id' => null],
-                        ['id' => 2, 'parent_id' => null],
-                        ['id' => 3, 'parent_id' => 1],
+                        ['id' => 1, 'name' => 'dummy1', 'parent_id' => null],
+                        ['id' => 2, 'name' => 'dummy2', 'parent_id' => null],
+                        ['id' => 3, 'name' => 'dummy3', 'parent_id' => 1],
                     ],
                 ],
                 true,
                 [
-                    1 => ['id' => 1, 'parent_id' => null, 'children' => [['id' => 3, 'parent_id' => 1]]],
-                    2 => ['id' => 2, 'parent_id' => null],
+                    [
+                        'id' => '-1',
+                        'name' => 'Global',
+                        'label' => 'Global',
+                        'children' => [
+                            ['id' => 2, 'name' => 'dummy2', 'parent_id' => null],
+                        ],
+                        'parent_id' => null,
+                    ],
+                    [
+                        'id' => 1,
+                        'name' => 'dummy1',
+                        'children' => [
+                            ['id' => 3, 'name' => 'dummy3', 'parent_id' => 1],
+                        ],
+                        'parent_id' => null,
+                    ],
                 ],
             ],
         ];

--- a/tests/TestCase/View/Helper/CategoriesHelperTest.php
+++ b/tests/TestCase/View/Helper/CategoriesHelperTest.php
@@ -1,0 +1,388 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\CategoriesHelper;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+/**
+ * {@see \App\View\Helper\CategoriesHelper} Test Case
+ *
+ * @coversDefaultClass \App\View\Helper\CategoriesHelper
+ */
+class CategoriesHelperTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \App\View\Helper\CategoriesHelper
+     */
+    public $Categories;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->Categories = new CategoriesHelper(new View(null, null, null, []));
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        unset($this->Categories);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Data provider for `testControl` method.
+     *
+     * @return array
+     */
+    public function controlProvider(): array
+    {
+        return [
+            'is not tree' => [
+                [
+                    'categories' => [
+                        ['id' => 1, 'name' => 'dummy1', 'label' => 'Dummy 1', 'parent_id' => null],
+                        ['id' => 2, 'name' => 'dummy2', 'label' => 'Dummy 2', 'parent_id' => null],
+                        ['id' => 3, 'name' => 'dummy3', 'label' => 'Dummy 3', 'parent_id' => null],
+                        ['id' => 4, 'name' => 'dummy4', 'label' => 'Dummy 4', 'parent_id' => null],
+                        ['id' => 5, 'name' => 'dummy5', 'label' => 'Dummy 5', 'parent_id' => null],
+                    ],
+                ],
+                'categories',
+                [
+                    ['name' => 'dummy1', 'label' => 'Dummy 1'],
+                    ['name' => 'dummy3', 'label' => 'Dummy 3'],
+                ],
+                '<div class="categories"><h3>Global</h3><div class="input select"><input type="hidden" name="categories" value=""/><div class="checkbox"><label for="categories-dummy1" class="selected"><input type="checkbox" name="categories[]" value="dummy1" checked="checked" id="categories-dummy1">Dummy 1</label></div><div class="checkbox"><label for="categories-dummy2"><input type="checkbox" name="categories[]" value="dummy2" id="categories-dummy2">Dummy 2</label></div><div class="checkbox"><label for="categories-dummy3" class="selected"><input type="checkbox" name="categories[]" value="dummy3" checked="checked" id="categories-dummy3">Dummy 3</label></div><div class="checkbox"><label for="categories-dummy4"><input type="checkbox" name="categories[]" value="dummy4" id="categories-dummy4">Dummy 4</label></div><div class="checkbox"><label for="categories-dummy5"><input type="checkbox" name="categories[]" value="dummy5" id="categories-dummy5">Dummy 5</label></div></div></div>',
+            ],
+            'is tree' => [
+                [
+                    'categories' => [
+                        ['id' => 1, 'name' => 'dummy1', 'label' => 'Dummy 1', 'parent_id' => null],
+                        ['id' => 2, 'name' => 'dummy2', 'label' => 'Dummy 2', 'parent_id' => null],
+                        ['id' => 3, 'name' => 'dummy3', 'label' => 'Dummy 3', 'parent_id' => 2],
+                        ['id' => 4, 'name' => 'dummy4', 'label' => 'Dummy 4', 'parent_id' => 2],
+                        ['id' => 5, 'name' => 'dummy5', 'label' => 'Dummy 5', 'parent_id' => 2],
+                    ],
+                ],
+                'categories',
+                [
+                    ['name' => 'dummy1', 'label' => 'Dummy 1'],
+                    ['name' => 'dummy3', 'label' => 'Dummy 3'],
+                ],
+                '<div class="categories"><h3>Global</h3><div class="input select"><input type="hidden" name="categories" value=""/><div class="checkbox"><label for="categories-dummy1" class="selected"><input type="checkbox" name="categories[]" value="dummy1" checked="checked" id="categories-dummy1">Dummy 1</label></div></div></div><div class="categories"><h3>Dummy 2</h3><div class="input select"><div class="checkbox"><label for="categories-dummy3" class="selected"><input type="checkbox" name="categories[]" value="dummy3" checked="checked" id="categories-dummy3">Dummy 3</label></div><div class="checkbox"><label for="categories-dummy4"><input type="checkbox" name="categories[]" value="dummy4" id="categories-dummy4">Dummy 4</label></div><div class="checkbox"><label for="categories-dummy5"><input type="checkbox" name="categories[]" value="dummy5" id="categories-dummy5">Dummy 5</label></div></div></div>',
+            ],
+        ];
+    }
+
+    /**
+     * Test `control` method
+     *
+     * @param array $schema The schema
+     * @param string $name The name
+     * @param mixed|null $value The value
+     * @param string $expected The expected result
+     * @return void
+     * @dataProvider controlProvider()
+     * @covers ::control()
+     */
+    public function testControl(array $schema, string $name, $value, string $expected): void
+    {
+        $view = new View(null, null, null, []);
+        $view->set('schema', $schema);
+        $this->Categories = new CategoriesHelper($view);
+        $actual = $this->Categories->control($name, $value);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testHtml` method.
+     *
+     * @return array
+     */
+    public function htmlProvider(): array
+    {
+        return [
+            'multiple nodes' => [
+                [
+                    'categories' => [
+                        ['id' => 1, 'name' => 'dummy1', 'label' => 'Dummy 1', 'parent_id' => null],
+                        ['id' => 2, 'name' => 'dummy2', 'label' => 'Dummy 2', 'parent_id' => null],
+                        ['id' => 3, 'name' => 'dummy3', 'label' => 'Dummy 3', 'parent_id' => 2],
+                        ['id' => 4, 'name' => 'dummy4', 'label' => 'Dummy 4', 'parent_id' => 2],
+                        ['id' => 5, 'name' => 'dummy5', 'label' => 'Dummy 5', 'parent_id' => 2],
+                    ],
+                ],
+                'categories',
+                [
+                    ['name' => 'dummy1', 'label' => 'Dummy 1'],
+                    ['name' => 'dummy3', 'label' => 'Dummy 3'],
+                ],
+                [],
+                '<div class="categories"><h3>Global</h3><div class="input select"><label for="categories">Categories</label><input type="hidden" name="categories" value=""/><div class="checkbox"><label for="categories-dummy1" class="selected"><input type="checkbox" name="categories[]" value="dummy1" checked="checked" id="categories-dummy1">Dummy 1</label></div></div></div><div class="categories"><h3>Dummy 2</h3><div class="input select"><label for="categories">Categories</label><div class="checkbox"><label for="categories-dummy3" class="selected"><input type="checkbox" name="categories[]" value="dummy3" checked="checked" id="categories-dummy3">Dummy 3</label></div><div class="checkbox"><label for="categories-dummy4"><input type="checkbox" name="categories[]" value="dummy4" id="categories-dummy4">Dummy 4</label></div><div class="checkbox"><label for="categories-dummy5"><input type="checkbox" name="categories[]" value="dummy5" id="categories-dummy5">Dummy 5</label></div></div></div>',
+            ],
+        ];
+    }
+
+    /**
+     * Test `html` method
+     *
+     * @param array $schema The schema
+     * @param string $name The name
+     * @param mixed|null $value The value
+     * @param array $options The options
+     * @param string $expected The expected result
+     * @return void
+     * @dataProvider htmlProvider()
+     * @covers ::html()
+     */
+    public function testHtml(array $schema, string $name, $value, array $options, string $expected): void
+    {
+        $view = new View(null, null, null, []);
+        $view->set('schema', $schema);
+        $this->Categories = new CategoriesHelper($view);
+        $actual = $this->Categories->html($name, $value, $options);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testNode` method.
+     *
+     * @return array
+     */
+    public function nodeProvider(): array
+    {
+        return [
+            'global' => [
+                [
+                    'name' => 'dummy1',
+                    'label' => 'Dummy 1',
+                ],
+                'categories',
+                [['name' => 'dummy1', 'label' => 'Dummy 1'], ['name' => 'dummy2', 'label' => 'Dummy 2']],
+                [],
+                '<div class="categories"><h3>Global</h3><div class="input select"><label for="categories">Categories</label><div class="checkbox"><label for="categories-dummy1" class="selected"><input type="checkbox" name="categories[]" value="dummy1" checked="checked" id="categories-dummy1">Dummy 1</label></div></div></div>',
+            ],
+            'non global' => [
+                [
+                    'name' => 'dummy1',
+                    'label' => 'Dummy 1',
+                    'children' => [
+                        ['name' => 'son1', 'label' => 'Son 1'],
+                        ['name' => 'son2', 'label' => 'Son 2'],
+                        ['name' => 'son3', 'label' => 'Son 3'],
+                    ],
+                ],
+                'categories',
+                [['name' => 'dummy1', 'label' => 'Dummy 1'], ['name' => 'dummy2', 'label' => 'Dummy 2']],
+                [],
+                '<div class="categories"><h3>Dummy 1</h3><div class="input select"><label for="categories">Categories</label><div class="checkbox"><label for="categories-son1"><input type="checkbox" name="categories[]" value="son1" id="categories-son1">Son 1</label></div><div class="checkbox"><label for="categories-son2"><input type="checkbox" name="categories[]" value="son2" id="categories-son2">Son 2</label></div><div class="checkbox"><label for="categories-son3"><input type="checkbox" name="categories[]" value="son3" id="categories-son3">Son 3</label></div></div></div>',
+            ],
+        ];
+    }
+
+    /**
+     * Test `node` method
+     *
+     * @param array $node The node
+     * @param string $name The name
+     * @param mixed|null $value The value
+     * @param array $options The options
+     * @param string $expected The expected result
+     * @return void
+     * @dataProvider nodeProvider()
+     * @covers ::node()
+     */
+    public function testNode(array $node, string $name, $value, array $options, string $expected): void
+    {
+        $hiddenField = false;
+        $actual = $this->Categories->node(
+            $node,
+            $name,
+            $value,
+            $options,
+            $hiddenField
+        );
+
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testControlOptions` method.
+     *
+     * @return array
+     */
+    public function controlOptionsProvider(): array
+    {
+        return [
+            'empty node children, empty categories' => [
+                ['name' => 'dummy', 'label' => 'Dummy'],
+                null,
+                ['class' => 'testClass'],
+                [
+                    'class' => 'testClass',
+                    'type' => 'select',
+                    'multiple' => 'checkbox',
+                    'value' => [],
+                    'hiddenField' => false,
+                    'options' => [['value' => 'dummy', 'text' => 'Dummy']],
+                ],
+            ],
+            'empty node children, not empty categories' => [
+                ['name' => 'dummy1', 'label' => 'Dummy 1'],
+                [['name' => 'dummy1', 'label' => 'Dummy 1'], ['name' => 'dummy2', 'label' => 'Dummy 2']],
+                ['class' => 'testClass'],
+                [
+                    'class' => 'testClass',
+                    'type' => 'select',
+                    'multiple' => 'checkbox',
+                    'value' => ['dummy1', 'dummy2'],
+                    'hiddenField' => false,
+                    'options' => [
+                        ['value' => 'dummy1', 'text' => 'Dummy 1'],
+                    ],
+                ],
+            ],
+            'not empty node children, not empty categories' => [
+                [
+                    'name' => 'dummy1',
+                    'label' => 'Dummy 1',
+                    'children' => [
+                        ['name' => 'son1', 'label' => 'Son 1'],
+                        ['name' => 'son2', 'label' => 'Son 2'],
+                        ['name' => 'son3', 'label' => 'Son 3'],
+                    ],
+                ],
+                [['name' => 'dummy1', 'label' => 'Dummy 1'], ['name' => 'dummy2', 'label' => 'Dummy 2']],
+                ['class' => 'testClass'],
+                [
+                    'class' => 'testClass',
+                    'type' => 'select',
+                    'multiple' => 'checkbox',
+                    'value' => ['dummy1', 'dummy2'],
+                    'hiddenField' => false,
+                    'options' => [
+                        ['value' => 'son1', 'text' => 'Son 1'],
+                        ['value' => 'son2', 'text' => 'Son 2'],
+                        ['value' => 'son3', 'text' => 'Son 3'],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `controlOptions` method
+     *
+     * @param array $node The node
+     * @param mixed|null $value The value
+     * @param array $options The options
+     * @param array $expected The expected result
+     * @return void
+     * @dataProvider controlOptionsProvider()
+     * @covers ::controlOptions()
+     */
+    public function testControlOptions(array $node, $value, array $options, array $expected): void
+    {
+        $hiddenField = false;
+        $actual = $this->Categories->controlOptions(
+            $node,
+            $value,
+            $options,
+            $hiddenField
+        );
+
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testTree` method.
+     *
+     * @return array
+     */
+    public function treeProvider(): array
+    {
+        return [
+            'empty schema' => [
+                [],
+                false,
+                [],
+            ],
+            'schema categories with all parent_id null' => [
+                [
+                    'categories' => [
+                        ['id' => 1, 'parent_id' => null],
+                        ['id' => 2, 'parent_id' => null],
+                        ['id' => 3, 'parent_id' => null],
+                    ],
+                ],
+                false,
+                [
+                    1 => ['id' => 1, 'parent_id' => null],
+                    2 => ['id' => 2, 'parent_id' => null],
+                    3 => ['id' => 3, 'parent_id' => null],
+                ],
+            ],
+            'schema categories with a parent_id not null' => [
+                [
+                    'categories' => [
+                        ['id' => 1, 'parent_id' => null],
+                        ['id' => 2, 'parent_id' => null],
+                        ['id' => 3, 'parent_id' => 1],
+                    ],
+                ],
+                true,
+                [
+                    1 => ['id' => 1, 'parent_id' => null, 'children' => [['id' => 3, 'parent_id' => 1]]],
+                    2 => ['id' => 2, 'parent_id' => null],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `isTree` method
+     *
+     * @param array $schema The schema
+     * @param bool $expectedIsTree The expected for isTree
+     * @param array $expectedTree The expected for Tree
+     * @return void
+     * @dataProvider treeProvider()
+     * @covers ::tree()
+     * @covers ::isTree()
+     */
+    public function testTree(array $schema, bool $expectedIsTree, array $expectedTree): void
+    {
+        $view = new View(null, null, null, []);
+        $view->set('schema', $schema);
+        $this->Categories = new CategoriesHelper($view);
+        $actual = $this->Categories->isTree();
+        static::assertEquals($expectedIsTree, $actual);
+
+        $actual = $this->Categories->tree();
+        static::assertEquals($expectedTree, $actual);
+    }
+}

--- a/tests/TestCase/View/Helper/CategoriesHelperTest.php
+++ b/tests/TestCase/View/Helper/CategoriesHelperTest.php
@@ -331,6 +331,48 @@ class CategoriesHelperTest extends TestCase
                 false,
                 [],
             ],
+            'order 1' => [
+                [
+                    'categories' => [
+                        ['id' => 1, 'name' => 'dummy1', 'parent_id' => null],
+                        ['id' => 2, 'name' => 'dummy2', 'parent_id' => null],
+                        ['id' => 3, 'name' => 'dummy3', 'parent_id' => 10],
+                        ['id' => 4, 'name' => 'dummy4', 'parent_id' => 1],
+                        ['id' => 5, 'name' => 'dummy5', 'parent_id' => 1],
+                        ['id' => 6, 'name' => 'dummy6', 'parent_id' => null],
+                        ['id' => 7, 'name' => 'dummy7', 'parent_id' => 10],
+                        ['id' => 8, 'name' => 'dummy8', 'parent_id' => 10],
+                        ['id' => 9, 'name' => 'dummy9', 'parent_id' => 1],
+                        ['id' => 10, 'name' => 'dummy10', 'parent_id' => null],
+                    ],
+                ],
+                true,
+                [
+                    [
+                        'id' => '0', 'name' => 'Global', 'label' => 'Global', 'parent_id' => null,
+                        'children' => [
+                            ['id' => 2, 'name' => 'dummy2', 'parent_id' => null],
+                            ['id' => 6, 'name' => 'dummy6', 'parent_id' => null],
+                        ],
+                    ],
+                    [
+                        'id' => 1, 'name' => 'dummy1', 'parent_id' => null,
+                        'children' => [
+                            ['id' => 4, 'name' => 'dummy4', 'parent_id' => 1],
+                            ['id' => 5, 'name' => 'dummy5', 'parent_id' => 1],
+                            ['id' => 9, 'name' => 'dummy9', 'parent_id' => 1],
+                        ],
+                    ],
+                    [
+                        'id' => 10, 'name' => 'dummy10', 'parent_id' => null,
+                        'children' => [
+                            ['id' => 3, 'name' => 'dummy3', 'parent_id' => 10],
+                            ['id' => 7, 'name' => 'dummy7', 'parent_id' => 10],
+                            ['id' => 8, 'name' => 'dummy8', 'parent_id' => 10],
+                        ],
+                    ],
+                ],
+            ],
             'schema categories with all parent_id null' => [
                 [
                     'categories' => [
@@ -342,7 +384,7 @@ class CategoriesHelperTest extends TestCase
                 false,
                 [
                     [
-                        'id' => '-1',
+                        'id' => '0',
                         'name' => 'Global',
                         'label' => 'Global',
                         'children' => [
@@ -351,7 +393,7 @@ class CategoriesHelperTest extends TestCase
                             ['id' => 3, 'name' => 'dummy3', 'parent_id' => null],
                         ],
                         'parent_id' => null,
-                    ]
+                    ],
                 ],
             ],
             'schema categories with a parent_id not null' => [
@@ -365,7 +407,7 @@ class CategoriesHelperTest extends TestCase
                 true,
                 [
                     [
-                        'id' => '-1',
+                        'id' => '0',
                         'name' => 'Global',
                         'label' => 'Global',
                         'children' => [

--- a/tests/TestCase/View/Helper/CategoriesHelperTest.php
+++ b/tests/TestCase/View/Helper/CategoriesHelperTest.php
@@ -436,6 +436,7 @@ class CategoriesHelperTest extends TestCase
      * @param array $expectedTree The expected for Tree
      * @return void
      * @dataProvider treeProvider()
+     * @covers ::sortRoots()
      * @covers ::tree()
      * @covers ::isTree()
      */


### PR DESCRIPTION
This provides https://github.com/bedita/manager/issues/640: categories groups, when categories are organized as tree (with parent_id not null in schema), by introducing `CategoriesHelper`. 

Categories without a parent and without children belongs to a special group "global", put at the beginning of categories box.

I.e.:

![categories](https://user-images.githubusercontent.com/2227145/140093363-aee7f8a9-9330-45ff-bc3c-257b39434caf.png)

Rif: https://chialab.atlassian.net/browse/BEM-63