### PR TITLE
Fix missing model-type in fast create media form

### DIFF
--- a/src/Template/Layout/js/app/components/relation-view/relations-add.js
+++ b/src/Template/Layout/js/app/components/relation-view/relations-add.js
@@ -262,6 +262,10 @@ export default {
                 formData.set('url', this.url);
             }
 
+            if (this.file || this.url) {
+                formData.append('model-type', type);
+            }
+
             const options = {
                 method: 'POST',
                 credentials: 'same-origin',


### PR DESCRIPTION
This fixes https://github.com/bedita/manager/issues/646