### PR TITLE
Pagination bar after objects' list

### DIFF
--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -5,6 +5,7 @@
             <input type="text"
                 :placeholder="placeholder"
                 v-model.trim="queryFilter.q"
+                @keyup.enter="applyFilter"
             />
         </div>
 

--- a/src/Template/Element/Modules/index_bulk.twig
+++ b/src/Template/Element/Modules/index_bulk.twig
@@ -3,9 +3,9 @@
         {% element 'Form/bulk_export' %}
     </div>
 
-    <h3 class="bulk-header">{{ __('Actions on selected items') }}</h3>
+    <div class="bulk-header">{{ __('Actions on selected items') }}</div>
 
-    <div :class="{ disabled: !selectedRows.length }">
+    <div :class="[!selectedRows.length ? 'disabled' : '', 'is-flex', 'is-flex-column']">
         {% element 'Form/bulk_properties' %}
 
         {% element 'Form/bulk_category' %}

--- a/src/Template/Layout/js/app/app.js
+++ b/src/Template/Layout/js/app/app.js
@@ -119,6 +119,10 @@ const _vueInstance = new Vue({
             bodyEl.classList.remove('panel-is-open');
             rootEl.classList.remove('is-clipped');
         });
+
+        // listen events emitted on this vue instance
+        this.$on('filter-update-page-size', this.onUpdatePageSize);
+        this.$on('filter-update-current-page', this.onUpdateCurrentPage);
     },
 
     watch: {

--- a/src/Template/Layout/js/app/pages/modules/index.js
+++ b/src/Template/Layout/js/app/pages/modules/index.js
@@ -1,4 +1,3 @@
-import { AppEventBus } from 'app/app';
 import { confirm } from 'app/components/dialog/dialog';
 import { t } from 'ttag';
 

--- a/src/Template/Layout/js/app/pages/modules/index.js
+++ b/src/Template/Layout/js/app/pages/modules/index.js
@@ -1,3 +1,4 @@
+import { AppEventBus } from 'app/app';
 import { confirm } from 'app/components/dialog/dialog';
 import { t } from 'ttag';
 
@@ -14,6 +15,7 @@ export default {
         FolderPicker: () => import(/* webpackChunkName: "folder-picker" */'app/components/folder-picker/folder-picker'),
         DateRangesList: () => import(/* webpackChunkName: "date-ranges-list" */'app/components/date-ranges-list/date-ranges-list'),
         TreeView: () => import(/* webpackChunkName: "tree-view" */'app/components/tree-view/tree-view'),
+        FilterBoxView: () => import(/* webpackChunkName: "tree-view" */'app/components/filter-box'),
     },
 
     /**
@@ -172,6 +174,14 @@ export default {
                     this.selectedRows.push(cb.value);
                 }
             }
+        },
+
+        onUpdatePageSize(event) {
+            window._vueInstance.$emit('filter-update-page-size', event);
+        },
+
+        onUpdateCurrentPage(event) {
+            window._vueInstance.$emit('filter-update-current-page', event);
         },
     }
 }

--- a/src/Template/Pages/Modules/_modules-index.scss
+++ b/src/Template/Pages/Modules/_modules-index.scss
@@ -132,7 +132,7 @@ body.view-module {
             display: flex;
             justify-content: space-between;
             flex-wrap: wrap;
-            margin-top: $gutter;
+            margin: $gutter 0;
         }
 
         .bulk-actions {

--- a/src/Template/Pages/Modules/_modules-index.scss
+++ b/src/Template/Pages/Modules/_modules-index.scss
@@ -130,9 +130,19 @@ body.view-module {
 
         .module-footer {
             display: flex;
-            justify-content: space-between;
-            flex-wrap: wrap;
+            flex-wrap: wrap-reverse;
             margin: $gutter 0;
+            align-items: flex-end;
+
+            @media screen and (max-width: 1023px) {
+                > * {
+                    margin-bottom: $gutter;
+                }
+            }
+
+            .pagination {
+                margin-left: auto;
+            }
         }
 
         .bulk-actions {

--- a/src/Template/Pages/Modules/_modules-index.scss
+++ b/src/Template/Pages/Modules/_modules-index.scss
@@ -128,67 +128,71 @@ body.view-module {
             }
         }
 
-        .bulk-actions {
+        .module-footer {
+            display: flex;
+            justify-content: space-between;
+            flex-wrap: wrap;
             margin-top: $gutter;
+        }
 
+        .bulk-actions {
             .bulk-header {
-                margin-top: $gutter;
+                font-size: $font-size-base;
+
+                & + * {
+                    margin-top: $gutter;
+                }
             }
 
             > .disabled {
                 opacity: .3;
             }
 
-            > * {
-                display: flex;
-                flex-direction: column;
+            form {
+                .fieldset {
+                    display: inline-flex;
+                    align-items: center;
+                    margin-bottom: $gutter;
 
-                form {
-                    .fieldset {
+                    & > *:not([type='hidden']) ~ *:not([type='hidden']) {
+                        margin-left: $gutter * .5;
+                    }
+
+                    &[disabled] {
+                        .clear-button {
+                            display: none;
+                        }
+
+                        .input.textarea {
+                            border-color: #adb5bd !important;
+                        }
+                    }
+
+                    .input,
+                    .input > * {
                         display: inline-flex;
                         align-items: center;
-                        margin-bottom: $gutter;
-
-                        & > *:not([type='hidden']) ~ *:not([type='hidden']) {
-                            margin-left: $gutter * .5;
-                        }
-
-                        &[disabled] {
-                            .clear-button {
-                                display: none;
-                            }
-
-                            .input.textarea {
-                                border-color: #adb5bd !important;
-                            }
-                        }
-
-                        .input,
-                        .input > * {
-                            display: inline-flex;
-                            align-items: center;
-                        }
-
-                        .input label:first-of-type {
-                            margin-right: $gutter;
-                        }
-
-                        label {
-                            margin-right: $gutter * .5;
-                        }
                     }
 
-                    .bulk-categories,
-                    .bulk-folders {
-                        & > * {
-                            display: inline-flex;
-                            align-items: center;
-                        }
+                    .input label:first-of-type {
+                        margin-right: $gutter;
                     }
 
-                    .bulk-folders .folder-picker {
-                        margin-left: $gutter !important;
+                    label {
+                        margin-right: $gutter * .5;
                     }
+                }
+
+                .bulk-categories,
+                .bulk-folders {
+                    & > * {
+                        display: inline-flex;
+                        align-items: center;
+                    }
+                }
+
+                .bulk-folders .folder-picker {
+                    margin-left: $gutter !important;
                 }
             }
         }

--- a/src/Template/Pages/Modules/index.twig
+++ b/src/Template/Pages/Modules/index.twig
@@ -8,35 +8,45 @@
 {% set ids = Array.extract(objects, '{*}.id') %}
 <modules-index inline-template ids='{{ ids|json_encode }}'>
     <div class="module-index">
-
         {% if treeView %}
-
             <tree-view></tree-view>
-
         {% else %}
+            <div class="table-container">
+                <div class="list-objects">
+                    {% if objects %}
+                        {% element 'Modules/index_table_header' { 'refObject': objects[0] } %}
+                    {% endif %}
 
-        <div class="table-container">
+                    {% for object in objects %}
+                        {% element 'Modules/index_table_row' { 'object': object } %}
+                    {% else %}
+                        {{ __('No items found') }}
+                    {% endfor %}
+                </div>
+            </div>
 
-            <div class="list-objects">
+            <div class="module-footer">
+                {# bulk actions #}
                 {% if objects %}
-                    {% element 'Modules/index_table_header' { 'refObject': objects[0] } %}
+                    {% element 'Modules/index_bulk' {} %}
                 {% endif %}
 
-                {% for object in objects %}
-                    {% element 'Modules/index_table_row' { 'object': object } %}
-                {% else %}
-                    {{ __('No items found') }}
-                {% endfor %}
+                {% if not treeView %}
+                    <filter-box-view
+                        inline-template
+                        :pagination="{{ meta.pagination|json_encode|escape('html_attr') }}"
+                        config-paginate-sizes="{{ config('Pagination.sizeAvailable')|json_encode|escape('html_attr') }}"
+                        page-size="{{ meta.pagination.page_size }}"
+                        @filter-update-page-size="onUpdatePageSize"
+                        @filter-update-current-page="onUpdateCurrentPage"
+                    >
+                        <div v-if="pagination.count">
+                            {% element 'FilterBox/filter_box_page_toolbar' %}
+                        </div>
+                    </filter-box-view>
+                {% endif %}
             </div>
-        </div>
-
-            {# bulk actions #}
-            {% if objects %}
-                {% element 'Modules/index_bulk' {} %}
-            {% endif %}
-
         {% endif %}
-
 
         {# commands to append in side bar (commands menu) #}
         {% if Perms.canCreate() %}
@@ -47,6 +57,5 @@
                 )|raw
             ) %}
         {% endif %}
-
     </div> {# end module-content #}
 </modules-index>

--- a/src/Template/Pages/Modules/index.twig
+++ b/src/Template/Pages/Modules/index.twig
@@ -40,9 +40,9 @@
                         @filter-update-page-size="onUpdatePageSize"
                         @filter-update-current-page="onUpdateCurrentPage"
                     >
-                        <div v-if="pagination.count">
+                        <template v-if="pagination.count">
                             {% element 'FilterBox/filter_box_page_toolbar' %}
-                        </div>
+                        </template>
                     </filter-box-view>
                 {% endif %}
             </div>

--- a/src/Template/Pages/Trash/index.twig
+++ b/src/Template/Pages/Trash/index.twig
@@ -7,11 +7,8 @@
 {% set q = _view.request.getQuery()|serialize|escape %}
 
 <trash-index inline-template ids='{{ ids|json_encode }}'>
-    <div>
-        <div class="module-index">
-
-          <div class="table-container">
-
+    <div class="module-index">
+        <div class="table-container">
             <div class="list-objects">
                 {% if objects %}
                     {% element 'Modules/index_table_header' { 'refObject': objects[0] } %}
@@ -23,40 +20,43 @@
                     {{ __('No items found') }}
                 {% endfor %}
             </div>
-
-          </div>
-
-            {% if objects %}
-            <div class="bulk-actions has-border-module-{{ currentModule.name }}">
-                <header>
-                    <p>{{ __('Actions on selected items') }}</p>
-                </header>
-                <nav>
-                    {% if (objects) and Perms.canSave() %}
-                        {{ Form.create(null, {'id': 'form-restore', 'url': {'_name': 'trash:restore', 'object_type': objectType}})|raw }}
-                            <input type="hidden" name="ids" v-bind:value="selectedRows">
-                            {{ Form.unlockField('ids') }}
-                            <button @click.prevent="restoreItem" :disabled="!selectedRows.length">{{ __('Restore') }}</button>
-                        {{ Form.end()|raw }}
-                    {% endif %}
-                    {% if (objects) and Perms.canDelete({type: objectType}) %}
-                        {{ Form.create(null, {'id': 'form-delete', 'url': {'_name': 'trash:delete', 'object_type': objectType}})|raw }}
-                            <input type="hidden" name="ids" v-bind:value="selectedRows">
-                            {{ Form.unlockField('ids') }}
-                            <button @click.prevent="deleteItem" :disabled="!selectedRows.length">{{ __('Delete') }}</button>
-                        {{ Form.end()|raw }}
-                    {% endif %}
-                </nav>
-            </div>
-            {% endif %}
-
-            {# Append "Empty" button in commands menu. #}
-            {% do _view.append('module-buttons',
-                Form.postButton(__('Empty-verb'), {'_name': 'trash:empty'}, {
-                    'data': {'query': q},
-                    'class': 'button button-primary button-primary-hover-module-' ~ currentModule.name
-                })|raw
-            )%}
         </div>
+
+        {% if objects %}
+        <div class="bulk-actions mt-1 has-border-module-{{ currentModule.name }}">
+            <header class="bulk-header">
+                {{ __('Actions on selected items') }}
+            </header>
+
+            <div class="is-flex">
+                {% if (objects) and Perms.canSave() %}
+                    {{ Form.create(null, {
+                        'id': 'form-restore',
+                        'url': {'_name': 'trash:restore', 'object_type': objectType},
+                        'class': 'mr-1'
+                    })|raw }}
+                        <input type="hidden" name="ids" v-bind:value="selectedRows">
+                        {{ Form.unlockField('ids') }}
+                        <button @click.prevent="restoreItem" :disabled="!selectedRows.length">{{ __('Restore') }}</button>
+                    {{ Form.end()|raw }}
+                {% endif %}
+                {% if (objects) and Perms.canDelete({type: objectType}) %}
+                    {{ Form.create(null, {'id': 'form-delete', 'url': {'_name': 'trash:delete', 'object_type': objectType}})|raw }}
+                        <input type="hidden" name="ids" v-bind:value="selectedRows">
+                        {{ Form.unlockField('ids') }}
+                        <button @click.prevent="deleteItem" :disabled="!selectedRows.length">{{ __('Delete') }}</button>
+                    {{ Form.end()|raw }}
+                {% endif %}
+            </div>
+        </div>
+        {% endif %}
+
+        {# Append "Empty" button in commands menu. #}
+        {% do _view.append('module-buttons',
+            Form.postButton(__('Empty-verb'), {'_name': 'trash:empty'}, {
+                'data': {'query': q},
+                'class': 'button button-primary button-primary-hover-module-' ~ currentModule.name
+            })|raw
+        )%}
     </div>
 </trash-index>


### PR DESCRIPTION
This PR adds the pagination bar after the objects' list in the modules index page, restores the behavior of filtering object on "Enter" keyup (when focusing the text input) and fixes some style