### PR TITLE
Properties init and cache

### DIFF
--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -13,6 +13,8 @@
 
 namespace App\Controller\Component;
 
+use App\Utility\CacheTools;
+use Cake\Cache\Cache;
 use Cake\Controller\Component;
 use Cake\Core\Configure;
 use Cake\Utility\Hash;
@@ -84,10 +86,43 @@ class PropertiesComponent extends Component
      */
     public function initialize(array $config)
     {
-        Configure::load('properties');
-        $propConfig = array_merge(Configure::read('DefaultProperties'), (array)Configure::read('Properties'));
-        $this->setConfig('Properties', $propConfig);
+        $this->init();
+
         parent::initialize($config);
+    }
+
+    /**
+     * Init properties
+     *
+     * @return void
+     */
+    protected function init(): void
+    {
+        $cacheKey = CacheTools::cacheKey('properties');
+        $properties = Cache::read($cacheKey, 'default');
+        if (!empty($properties)) {
+            return;
+        }
+
+        Configure::load('properties');
+        $properties = (array)Configure::read('Properties');
+        $defaultProperties = (array)Configure::read('DefaultProperties');
+        $keys = array_unique(
+            array_merge(
+                array_keys($properties),
+                array_keys($defaultProperties)
+            )
+        );
+        sort($keys);
+        $config = [];
+        foreach ($keys as $key) {
+            $config[$key] = array_merge(
+                (array)Hash::get($defaultProperties, $key),
+                (array)Hash::get($properties, $key)
+            );
+        }
+        $this->setConfig('Properties', $config);
+        Cache::write($cacheKey, $config);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -75,6 +75,8 @@ class PropertiesComponentTest extends TestCase
      */
     public function testInit(): void
     {
+        Cache::clear();
+
         // test 1: read properties and write to cache
         Configure::write('Properties.users.fastCreate', [
             'required' => ['status', 'username'],
@@ -106,6 +108,8 @@ class PropertiesComponentTest extends TestCase
      */
     public function testIndexList(): void
     {
+        Cache::clear();
+
         $index = ['legs', 'pet_name'];
         Configure::write('Properties.cats.index', $index);
 
@@ -124,6 +128,8 @@ class PropertiesComponentTest extends TestCase
      */
     public function testFilterList(): void
     {
+        Cache::clear();
+
         $filter = ['modified'];
         Configure::write('Properties.documents.filter', $filter);
 
@@ -144,6 +150,8 @@ class PropertiesComponentTest extends TestCase
      */
     public function testFiltersByType(): void
     {
+        Cache::clear();
+
         $documentsFilters = ['lang', 'categories'];
         $profilesFilters = ['modified', 'status'];
         Configure::write('Properties.documents.filter', $documentsFilters);
@@ -172,6 +180,8 @@ class PropertiesComponentTest extends TestCase
      */
     public function testRelationsList(): void
     {
+        Cache::clear();
+
         $index = ['has_food', 'is_tired', 'sleeps_with'];
         Configure::write('Properties.cats.relations', $index);
 
@@ -422,6 +432,8 @@ class PropertiesComponentTest extends TestCase
      */
     public function testViewGroups($expected, $object, string $type, array $config = []): void
     {
+        Cache::clear();
+
         if (!empty($config)) {
             Configure::write(sprintf('Properties.%s.view', $type), $config);
         }


### PR DESCRIPTION
This fixes #655 

Bonus: caching the properties, so that the properties init is done just once, and not every time the component is used.