### PR TITLE
Admin config

### DIFF
--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -28,7 +28,6 @@ use Exception;
  */
 class Installer
 {
-
     /**
      * An array of directories to be made writable
      */

--- a/src/Controller/Admin/ApplicationsController.php
+++ b/src/Controller/Admin/ApplicationsController.php
@@ -23,5 +23,5 @@ class ApplicationsController extends AdministrationBaseController
     /**
      * {@inheritDoc}
      */
-    protected $properties = ['name', 'description', 'bool' => 'enabled'];
+    protected $properties = ['name', 'text' => 'description', 'bool' => 'enabled'];
 }

--- a/src/Controller/Admin/ConfigController.php
+++ b/src/Controller/Admin/ConfigController.php
@@ -1,6 +1,10 @@
 <?php
 namespace App\Controller\Admin;
 
+use Cake\Event\Event;
+use Cake\Http\Response;
+use Cake\Utility\Hash;
+
 /**
  * Config Controller
  *
@@ -18,5 +22,26 @@ class ConfigController extends AdministrationBaseController
     /**
      * {@inheritDoc}
      */
-    protected $properties = ['name', 'context', 'content', 'application_id'];
+    protected $readonly = false;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $properties = ['name', 'context', 'json' => 'content', 'applications' => 'application_id'];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beforeFilter(Event $event): ?Response
+    {
+        parent::beforeFilter($event);
+        $response = $this->apiClient->get('/admin/applications', ['filter' => ['enabled' => 1]]);
+        $applications = array_merge(
+            ['' => __('No application')],
+            (array)Hash::combine($response['data'], '{n}.id', '{n}.attributes.name')
+        );
+        $this->set('applications', $applications);
+
+        return null;
+    }
 }

--- a/src/Controller/Admin/ConfigController.php
+++ b/src/Controller/Admin/ConfigController.php
@@ -36,7 +36,7 @@ class ConfigController extends AdministrationBaseController
     {
         parent::beforeFilter($event);
         $response = $this->apiClient->get('/admin/applications', ['filter' => ['enabled' => 1]]);
-        $applications = array_merge(
+        $applications = ['' => __('No application')] + Hash::combine($response['data'], '{n}.id', '{n}.attributes.name');
             ['' => __('No application')],
             (array)Hash::combine($response['data'], '{n}.id', '{n}.attributes.name')
         );

--- a/src/Controller/Admin/ConfigController.php
+++ b/src/Controller/Admin/ConfigController.php
@@ -37,9 +37,6 @@ class ConfigController extends AdministrationBaseController
         parent::beforeFilter($event);
         $response = $this->apiClient->get('/admin/applications', ['filter' => ['enabled' => 1]]);
         $applications = ['' => __('No application')] + Hash::combine($response['data'], '{n}.id', '{n}.attributes.name');
-            ['' => __('No application')],
-            (array)Hash::combine($response['data'], '{n}.id', '{n}.attributes.name')
-        );
         $this->set('applications', $applications);
 
         return null;

--- a/src/Controller/Admin/RolesController.php
+++ b/src/Controller/Admin/RolesController.php
@@ -26,5 +26,5 @@ class RolesController extends AdministrationBaseController
     /**
      * {@inheritDoc}
      */
-    protected $properties = ['name', 'description'];
+    protected $properties = ['name', 'text' => 'description'];
 }

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -30,7 +30,6 @@ use Cake\Utility\Hash;
  */
 class AppController extends Controller
 {
-
     /**
      * BEdita4 API client
      *

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -23,7 +23,6 @@ use Cake\Utility\Hash;
  */
 class FlashComponent extends CakeFlashComponent
 {
-
     /**
      * {@inheritDoc}
      */

--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -25,7 +25,6 @@ use Psr\Log\LogLevel;
  */
 class TrashController extends AppController
 {
-
     /**
      * {@inheritDoc}
      * @codeCoverageIgnore

--- a/src/Shell/ConsoleShell.php
+++ b/src/Shell/ConsoleShell.php
@@ -24,7 +24,6 @@ use Psy\Shell as PsyShell;
  */
 class ConsoleShell extends Shell
 {
-
     /**
      * Start the shell and interactive console.
      *

--- a/src/Template/Element/Admin/index_content.twig
+++ b/src/Template/Element/Admin/index_content.twig
@@ -2,15 +2,6 @@
 
 {% do _view.assign('title', __('Administration') ~ ' ' ~ __(resourceType|humanize)) %}
 {% do _view.assign('bodyViewClass',  'view-module view-admin') %}
-{% set txtOptions = {'label': '', 'size': 40} %}
-{% set boolOptions = {
-    'label': '',
-    'type':'radio',
-    'options': [
-        { 'value': 1, 'text': __('Yes') },
-        { 'value': 0, 'text': __('No') }
-    ]
-} %}
 
 <div class="module-header">
     <header>
@@ -52,9 +43,8 @@
                 })|raw }}
                     <div>{{ __('NEW') }}</div>
                     {% for type, property in properties %}
-                        {% set options = type is same as ('bool') ? boolOptions|merge({'value': 1}) : txtOptions %}
                         <div class="{{ property }}-cell" untitled-label="{{ __('Untitled') }}">
-                            {{ Property.control(property, '', options)|raw }}
+                            {{ Admin.control(type, property, null)|raw }}
                         </div>
                     {% endfor %}
                     {% for key in metaColumns %}
@@ -83,13 +73,8 @@
                     </div>
                     {% for type,property in properties %}
                         {% set val = resource.attributes[property] %}
-                        {% set options = type is same as ('bool') ? boolOptions|merge({'value': val}) : txtOptions %}
                         <div class="{{ property }}-cell" untitled-label="{{ __('Untitled') }}">
-                            {% if readonly or resource.meta.unchangeable %}
-                                {{ Schema.format(val, schema.properties[property]) }}
-                            {% else %}
-                                {{ Property.control(property, val, options)|raw }}
-                            {% endif %}
+                            {{ Admin.control(type, property, val)|raw }}
                         </div>
                     {% endfor %}
                     {% for key in metaColumns %}

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -23,7 +23,6 @@ use Cake\Http\ServerRequest;
  */
 class AjaxView extends AppView
 {
-
     /**
      * The name of the layout file to render the view inside of. The name
      * specified is the filename of the layout in /src/Template/Layout without

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -19,7 +19,7 @@ use Cake\Utility\Hash;
 /**
  * Application View default class
  *
- *
+ * @property \App\View\Helper\AdminHelper $Admin
  * @property \App\View\Helper\CalendarHelper $Calendar
  * @property \App\View\Helper\CategoriesHelper $Categories
  * @property \App\View\Helper\EditorsHelper $Editors
@@ -50,6 +50,7 @@ class AppView extends TwigView
                 'inputContainer' => '<div class="input {{type}}{{required}} {{containerClass}}">{{content}}</div>',
             ],
         ]);
+        $this->loadHelper('Admin');
         $this->loadHelper('Calendar');
         $this->loadHelper('Categories');
         $this->loadHelper('Editors');

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -34,7 +34,6 @@ use Cake\Utility\Hash;
  */
 class AppView extends TwigView
 {
-
     /**
      * {@inheritDoc}
      */

--- a/src/View/Helper/AdminHelper.php
+++ b/src/View/Helper/AdminHelper.php
@@ -56,7 +56,7 @@ class AdminHelper extends Helper
                 'options' => [
                     ['value' => 1, 'text' => __('Yes')],
                     ['value' => 0, 'text' => __('No')],
-                ]
+                ],
             ],
             'json' => [
                 'label' => false,

--- a/src/View/Helper/AdminHelper.php
+++ b/src/View/Helper/AdminHelper.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\View\Helper;
+
+use Cake\Utility\Hash;
+use Cake\View\Helper;
+
+/**
+ * Helper class to generate properties html for admin pages
+ *
+ * @property \Cake\View\Helper\FormHelper $Form The form helper
+ * @property \App\View\Helper\PropertyHelper $Property The properties helper
+ * @property \App\View\Helper\SchemaHelper $Schema The schema helper
+ */
+class AdminHelper extends Helper
+{
+    /**
+     * List of helpers used by this helper
+     *
+     * @var array
+     */
+    public $helpers = ['Form', 'Property', 'Schema'];
+
+    /**
+     * Options
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->options = [
+            'text' => [
+                'label' => false,
+                'size' => 40,
+            ],
+            'bool' => [
+                'label' => false,
+                'type' => 'radio',
+                'options' => [
+                    ['value' => 1, 'text' => __('Yes')],
+                    ['value' => 0, 'text' => __('No')],
+                ]
+            ],
+            'json' => [
+                'label' => false,
+                'type' => 'textarea',
+                'v-jsoneditor' => 'true',
+                'class' => 'json',
+            ],
+            'combo' => [
+                'label' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Control by type, property, value.
+     *
+     * @param string $type The type
+     * @param string $property The property
+     * @param mixed $value The value
+     * @return string
+     */
+    public function control(string $type, string $property, $value): string
+    {
+        $readonly = (bool)$this->_View->get('readonly');
+        $resource = (array)$this->_View->get('resource');
+        $unchangeable = (bool)Hash::get($resource, 'meta.unchangeable', false);
+        if ($readonly === true || $unchangeable === true) {
+            $schema = (array)$this->_View->get('schema');
+
+            return $this->Schema->format($value, (array)Hash::get($schema, sprintf('properties.%s', $property)));
+        }
+
+        if (in_array($type, ['bool', 'json', 'text'])) {
+            return $this->Form->control($property, $this->options[$type] + compact('value'));
+        }
+
+        if ($type === 'applications') {
+            $options = (array)$this->_View->get('applications');
+
+            return $this->Form->control($property, $this->options['combo'] + compact('options', 'value'));
+        }
+
+        return $this->Property->control($property, $value, $this->options['text']);
+    }
+}

--- a/src/View/Helper/LinkHelper.php
+++ b/src/View/Helper/LinkHelper.php
@@ -26,7 +26,6 @@ use Cake\View\Helper;
  */
 class LinkHelper extends Helper
 {
-
     /**
      * List of helpers used by this helper
      *

--- a/tests/TestCase/Controller/Admin/ConfigControllerTest.php
+++ b/tests/TestCase/Controller/Admin/ConfigControllerTest.php
@@ -108,6 +108,6 @@ class ConfigControllerTest extends TestCase
         $event = $this->CfgController->dispatchEvent('Controller.beforeFilter');
         $this->CfgController->beforeFilter($event);
         $viewVars = (array)$this->CfgController->viewVars;
-        static::assertEquals(['' => __('No application'), 0 => 'default-app', 1 => 'manager'], $viewVars['applications']);
+        static::assertEquals(['' => __('No application'), 1 => 'default-app', 2 => 'manager'], $viewVars['applications']);
     }
 }

--- a/tests/TestCase/Controller/Admin/ConfigControllerTest.php
+++ b/tests/TestCase/Controller/Admin/ConfigControllerTest.php
@@ -2,6 +2,7 @@
 namespace App\Test\TestCase\Controller\Admin;
 
 use App\Controller\Admin\ConfigController;
+use BEdita\SDK\BEditaClient;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -94,5 +95,19 @@ class ConfigControllerTest extends TestCase
         }
         static::assertEquals('config', $viewVars['resourceType']);
         static::assertEquals(['name'], $viewVars['properties']);
+    }
+
+    /**
+     * Test `beforeFilter`
+     *
+     * @return void
+     * @covers ::beforeFilter()
+     */
+    public function testBeforeFilter(): void
+    {
+        $event = $this->CfgController->dispatchEvent('Controller.beforeFilter');
+        $this->CfgController->beforeFilter($event);
+        $viewVars = (array)$this->CfgController->viewVars;
+        static::assertEquals(['' => __('No application'), 0 => 'default-app', 1 => 'manager'], $viewVars['applications']);
     }
 }

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -29,7 +29,6 @@ use Cake\TestSuite\TestCase;
  */
 class AppControllerTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -56,7 +56,6 @@ class MyModulesComponent extends ModulesComponent
  */
 class ModulesComponentTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
  */
 class PropertiesComponentTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -17,7 +17,6 @@ use Cake\TestSuite\TestCase;
  */
 class SchemaComponentTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/TestCase/Controller/DashboardControllerTest.php
+++ b/tests/TestCase/Controller/DashboardControllerTest.php
@@ -28,7 +28,6 @@ use Cake\TestSuite\TestCase;
  */
 class DashboardControllerTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/TestCase/Controller/ErrorControllerTest.php
+++ b/tests/TestCase/Controller/ErrorControllerTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class ErrorControllerTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/TestCase/View/AppViewTest.php
+++ b/tests/TestCase/View/AppViewTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class AppViewTest extends TestCase
 {
-
     /**
      * Test `initialize` method
      *

--- a/tests/TestCase/View/Helper/AdminHelperTest.php
+++ b/tests/TestCase/View/Helper/AdminHelperTest.php
@@ -80,6 +80,12 @@ class AdminHelperTest extends TestCase
                 '1',
                 '<div class="input select"><select name="applications" id="applications"><option value="">No application</option><option value="1" selected="selected">Dummy app</option><option value="2">Another dummy app</option></select></div>',
             ],
+            'applications value not null' => [
+                'default',
+                'dummy',
+                'something',
+                '<div class="input text"><input type="text" name="dummy" size="40" id="dummy" value="something"/></div>',
+            ],
         ];
     }
 
@@ -94,6 +100,7 @@ class AdminHelperTest extends TestCase
      *
      * @dataProvider controlProvider()
      * @covers ::control()
+     * @covers ::initialize()
      */
     public function testControl(string $type, string $property, $value, string $expected = ''): void
     {

--- a/tests/TestCase/View/Helper/AdminHelperTest.php
+++ b/tests/TestCase/View/Helper/AdminHelperTest.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\AdminHelper;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+/**
+ * {@see \App\View\Helper\AdminHelper} Test Case
+ *
+ * @coversDefaultClass \App\View\Helper\AdminHelper
+ */
+class AdminHelperTest extends TestCase
+{
+    /**
+     * Data provider for `testControl` test case.
+     *
+     * @return array
+     */
+    public function controlProvider(): array
+    {
+        return [
+            'text value null' => [
+                'text',
+                'title',
+                null,
+                '<div class="input text"><input type="text" name="title" size="40" id="title"/></div>',
+            ],
+            'text value not null' => [
+                'text',
+                'title',
+                'something',
+                '<div class="input text"><input type="text" name="title" size="40" id="title" value="something"/></div>',
+            ],
+            'bool value null' => [
+                'bool',
+                'flag',
+                null,
+                '<div class="input radio"><input type="hidden" name="flag" value=""/><label for="flag-1"><input type="radio" name="flag" value="1" id="flag-1">Yes</label><label for="flag-0"><input type="radio" name="flag" value="0" id="flag-0">No</label></div>',
+            ],
+            'bool value not null' => [
+                'bool',
+                'flag',
+                'something',
+                '<div class="input radio"><input type="hidden" name="flag" value=""/><label for="flag-1"><input type="radio" name="flag" value="1" id="flag-1">Yes</label><label for="flag-0"><input type="radio" name="flag" value="0" id="flag-0">No</label></div>',
+            ],
+            'json value null' => [
+                'json',
+                'extra',
+                null,
+                '<div class="input textarea"><textarea name="extra" v-jsoneditor="true" class="json" id="extra" rows="5"></textarea></div>',
+            ],
+            'json value not null' => [
+                'json',
+                'extra',
+                '{"something":"else"}',
+                '<div class="input textarea"><textarea name="extra" v-jsoneditor="true" class="json" id="extra" rows="5">{&quot;something&quot;:&quot;else&quot;}</textarea></div>',
+            ],
+            'applications value null' => [
+                'applications',
+                'applications',
+                null,
+                '<div class="input select"><select name="applications" id="applications"><option value="">No application</option><option value="1">Dummy app</option><option value="2">Another dummy app</option></select></div>',
+            ],
+            'applications value not null' => [
+                'applications',
+                'applications',
+                '1',
+                '<div class="input select"><select name="applications" id="applications"><option value="">No application</option><option value="1" selected="selected">Dummy app</option><option value="2">Another dummy app</option></select></div>',
+            ],
+        ];
+    }
+
+    /**
+     * Test `control`
+     *
+     * @param string $type The type
+     * @param string $property The property
+     * @param mixed $value The value
+     * @param string $expected The expected result
+     * @return void
+     *
+     * @dataProvider controlProvider()
+     * @covers ::control()
+     */
+    public function testControl(string $type, string $property, $value, string $expected = ''): void
+    {
+        $view = new View(null, null, null, []);
+        $view->set('applications', ['' => __('No application'), 1 => 'Dummy app', 2 => 'Another dummy app']);
+        $helper = new AdminHelper($view);
+        $actual = $helper->control($type, $property, $value);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testControlReadonly` test case.
+     *
+     * @return array
+     */
+    public function controlProviderReadonly(): array
+    {
+        return [
+            'readonly' => [
+                true,
+                [],
+                'title',
+                'something',
+                'something',
+            ],
+            'unchangeable' => [
+                false,
+                ['meta' => ['unchangeable' => true]],
+                'title',
+                'something',
+                'something',
+            ],
+        ];
+    }
+
+    /**
+     * Test `control` on readonly / unchangeable cases.
+     *
+     * @param bool $readonly The readonly
+     * @param array $resource The resource
+     * @param string $property The property
+     * @param mixed $value The value
+     * @param string $expected The expected result
+     * @return void
+     *
+     * @dataProvider controlProviderReadonly()
+     * @covers ::control()
+     */
+    public function testControlReadonly(bool $readonly, array $resource, string $property, $value, string $expected = ''): void
+    {
+        $view = new View(null, null, null, []);
+        if ($readonly === true) {
+            $view->set('readonly', true);
+        }
+        if (!empty($resource)) {
+            $view->set('resource', $resource);
+        }
+        $helper = new AdminHelper($view);
+        $actual = $helper->control('text', $property, $value);
+        static::assertEquals($expected, $actual);
+    }
+}

--- a/tests/TestCase/View/Helper/ArrayHelperTest.php
+++ b/tests/TestCase/View/Helper/ArrayHelperTest.php
@@ -24,7 +24,6 @@ use Cake\View\View;
  */
 class ArrayHelperTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/TestCase/View/Helper/CalendarHelperTest.php
+++ b/tests/TestCase/View/Helper/CalendarHelperTest.php
@@ -24,7 +24,6 @@ use Cake\View\View;
  */
 class CalendarHelperTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -27,7 +27,6 @@ use Cake\View\View;
  */
 class SchemaHelperTest extends TestCase
 {
-
     /**
      * Test subject
      *


### PR DESCRIPTION
This resolves [#627](https://github.com/bedita/manager/issues/627) providing admin config page CRUD.

Bonuses:

 - AdminHelper to avoid too much code in twig template.
 - Fix Applications and Roles pages, avoiding multiple tinymce editors
 - Fix phpcs in many files (remove empty line after class "{".