### PR TITLE
fix vulnerability - follow-redirects from 1.14.4 to 1.14.7

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -7,12 +7,14 @@ on:
       - '**/*.scss'
       - '.github/workflows/javascript.yml'
       - 'package.json'
+      - 'yarn.lock'
   push:
     paths:
       - '**/*.js'
       - '**/*.scss'
       - '.github/workflows/javascript.yml'
       - 'package.json'
+      - 'yarn.lock'
 
 jobs:
   javascript-build:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,10 +2810,10 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4:
-  version "1.14.4"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
-  integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
+follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.7:
+  version "1.14.7"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 foreachasync@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Bumps follow-redirects from 1.14.4 to 1.14.7.

Bonus: launch javascript workflow on yarn.lock changes too.