### PR TITLE
chore: `loadPluginsFromConfig()` in CLI

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -58,6 +58,7 @@ class Application extends BaseApplication
         parent::bootstrapCli();
         $this->addPluginDev('IdeHelper');
         $this->addPlugin('BEdita/I18n');
+        $this->loadPluginsFromConfig();
     }
 
     /**


### PR DESCRIPTION
This PR adds dynamic plugins using CLI. Currently `loadPluginsFromConfig()` method is invoked only in `ProjectMiddleware` and therefore not available in CLI.
