### PR TITLE
properties view _hide config

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -492,6 +492,7 @@ return [
      *
      *  - 'view' properties groups to present in object view, where groups are:
      *      + '_keep' special group of properties to keep and display even if not found in object
+     *      + '_hide' special group of properties to not display
      *      + 'core' always open on the top
      *      + 'publish' publishing related
      *      + 'advanced' for power users
@@ -519,6 +520,9 @@ return [
         //     'view' => [
         //         '_keep' => [
         //             'some_field',
+        //         ],
+        //         '_hide' => [
+        //             'some_other_field',
         //         ],
         //         'core' => [
         //              'some_field',

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -155,8 +155,8 @@ class PropertiesComponent extends Component
     public function viewGroups(array $object, string $type): array
     {
         $properties = $used = [];
-        $keep = $this->getConfig(sprintf('Properties.%s.view._keep', $type), []);
-        $hide = $this->getConfig(sprintf('Properties.%s.view._hide', $type), []);
+        $keep = (array)$this->getConfig(sprintf('Properties.%s.view._keep', $type), []);
+        $hide = (array)$this->getConfig(sprintf('Properties.%s.view._hide', $type), []);
         $attributes = array_merge(array_fill_keys($keep, ''), (array)Hash::get($object, 'attributes'));
         $attributes = array_diff_key($attributes, array_flip($this->excluded));
         $attributes = array_diff_key($attributes, array_flip($hide));

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -143,6 +143,8 @@ class PropertiesComponent extends Component
      * Properties not present in $object will not be set in any group unless they're listed
      * under `_keep` in the above configuration.
      *
+     * Properties in `Properties.{type}.view._hide` will be removed from groups.
+     *
      * Properties in internal `$excluded` array will be removed from groups.
      *
      * @param array  $object Object data to view
@@ -154,8 +156,10 @@ class PropertiesComponent extends Component
     {
         $properties = $used = [];
         $keep = $this->getConfig(sprintf('Properties.%s.view._keep', $type), []);
+        $hide = $this->getConfig(sprintf('Properties.%s.view._hide', $type), []);
         $attributes = array_merge(array_fill_keys($keep, ''), (array)Hash::get($object, 'attributes'));
         $attributes = array_diff_key($attributes, array_flip($this->excluded));
+        $attributes = array_diff_key($attributes, array_flip($hide));
         $defaults = array_merge($this->getConfig(sprintf('Properties.%s.view', $type), []), $this->defaultGroups['view']);
         unset($defaults['_keep']);
 


### PR DESCRIPTION
This provides #676 

Usage: in `config/app.php`, `Properties.<module>.view._hide` set fields to hide.
```
'Properties' => [
    // ...
    'documents' => [
        'view' => [
            '_hide' => [
                'some_field',
            ],
            // ...
```