### PR TITLE
Show categories buttons only when in schema

### DIFF
--- a/src/Template/Pages/Model/Categories/index.twig
+++ b/src/Template/Pages/Model/Categories/index.twig
@@ -10,7 +10,7 @@
 {% element 'Modules/index_header' %}
 
 <div class="module-index">
-    {% if schema.categories %}
+    {% if schema.properties.categories %}
     {% element 'Modules/index_categories' {
         'saveAction': { '_name': 'model:save:categories' },
         'removeAction': { '_name': 'model:remove:categories' }

--- a/src/Template/Pages/Model/Categories/index.twig
+++ b/src/Template/Pages/Model/Categories/index.twig
@@ -10,12 +10,10 @@
 {% element 'Modules/index_header' %}
 
 <div class="module-index">
-    {% if schema.properties.categories %}
     {% element 'Modules/index_categories' {
         'saveAction': { '_name': 'model:save:categories' },
         'removeAction': { '_name': 'model:remove:categories' }
     } %}
-    {% endif %}
 
     {% element 'Model/sidebar_links' %}
 

--- a/src/Template/Pages/Model/Categories/index.twig
+++ b/src/Template/Pages/Model/Categories/index.twig
@@ -10,10 +10,12 @@
 {% element 'Modules/index_header' %}
 
 <div class="module-index">
+    {% if schema.categories %}
     {% element 'Modules/index_categories' {
         'saveAction': { '_name': 'model:save:categories' },
         'removeAction': { '_name': 'model:remove:categories' }
     } %}
+    {% endif %}
 
     {% element 'Model/sidebar_links' %}
 

--- a/src/Template/Pages/Modules/index.twig
+++ b/src/Template/Pages/Modules/index.twig
@@ -58,12 +58,14 @@
             ) %}
         {% endif %}
 
+        {% if schema.properties.categories %}
         {% do _view.append('module-buttons',
             Html.link(__('Categories'),
                 {'_name': 'modules:categories:index', 'object_type': objectType},
                 {'class': 'button button-outlined button-outlined-hover-module-' ~ currentModule.name}
             )|raw
         ) %}
+        {% endif %}
 
     </div> {# end module-content #}
 </modules-index>


### PR DESCRIPTION
This fixes an unexpected behavior, that make categories buttons always visible in object index and view.
Categories buttons should be visible only when schema contains 'categories'.