### PR TITLE
show upload form in media view when no stream

### DIFF
--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -34,7 +34,7 @@
 
             <div class="main-view-column is-flex is-flex-column">
                 {# Upload available only for new media objects #}
-                {% if object.id is empty and objectType in uploadable %}
+                {% if objectType in uploadable and (object.id is empty or (not streams and not object.attributes.provider_extra.html)) %}
                     {% element 'Form/upload' %}
                 {% endif %}
 


### PR DESCRIPTION
This fixes #684 providing upload form when stream is missing (in media view).