### PR TITLE
Fix Properties component

### DIFF
--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -82,21 +82,11 @@ class PropertiesComponent extends Component
     ];
 
     /**
-     * {@inheritDoc}
-     */
-    public function initialize(array $config)
-    {
-        $this->init();
-
-        parent::initialize($config);
-    }
-
-    /**
      * Init properties
      *
      * @return void
      */
-    protected function init(): void
+    public function startup(): void
     {
         $cacheKey = CacheTools::cacheKey('properties');
         $properties = Cache::read($cacheKey, 'default');

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -73,7 +73,7 @@ class PropertiesComponentTest extends TestCase
      * @return void
      * @covers ::startup()
      */
-    public function testInit(): void
+    public function testStartup(): void
     {
         Cache::clear();
 

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -59,18 +59,19 @@ class PropertiesComponentTest extends TestCase
      *
      * @return void
      */
-    protected function createComponent()
+    protected function createComponent(): void
     {
         $controller = new Controller();
         $registry = $controller->components();
         $this->Properties = $registry->load(PropertiesComponent::class);
+        $this->Properties->startup();
     }
 
     /**
-     * Test `init()` method.
+     * Test `startup()` method.
      *
      * @return void
-     * @covers ::init()
+     * @covers ::startup()
      */
     public function testInit(): void
     {


### PR DESCRIPTION
This is a minor fix on `PropertiesComponent` => when using a multi-project setup if user session expires `CacheTools::cacheKey()` will try to instantiate a new API client instance that may fail because API configuration is not set.
On multi-project the project configuration file containing API config is defined in the user session.

Using `startup()` method instead, invoked by the callback lifecycle after `beforeFilter` is safer => as the session expires user is already redirected to login page.
