### PR TITLE
Texts translations enhancements [not about Translation objects]

### DIFF
--- a/config/i18n_strings.php
+++ b/config/i18n_strings.php
@@ -109,3 +109,9 @@
 //  __('National Id Number');
 //  __('Vat Number');
 //  __('Pseudonym');
+
+// Folders
+// __('Folders')
+
+// Publications
+// __('Publications')

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -40,25 +40,4 @@ class Form
 
         throw new \InvalidArgumentException(sprintf('Method "%s" is not callable', $methodName));
     }
-
-    /**
-     * Return label by field name.
-     * Use `__` and `__d` to try to translate it.
-     *
-     * @param string $name The field name
-     * @return string|null
-     */
-    public static function label(string $name): ?string
-    {
-        $text = Inflector::humanize(Inflector::underscore($name));
-        $label = __($text);
-        $plugins = (array)Configure::read('Plugins');
-        $pluginName = Hash::get(array_keys($plugins), 0);
-        // if we have no actual translation and a plugin let's try with plugin's gettext
-        if ($pluginName && $label === $text) {
-            return __d($pluginName, $text);
-        }
-
-        return $label;
-    }
 }

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -13,6 +13,8 @@
 
 namespace App\Form;
 
+use Cake\Core\Configure;
+use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 
 /**
@@ -37,5 +39,26 @@ class Form
         }
 
         throw new \InvalidArgumentException(sprintf('Method "%s" is not callable', $methodName));
+    }
+
+    /**
+     * Return label by field name.
+     * Use `__` and `__d` to try to translate it.
+     *
+     * @param string $name The field name
+     * @return string|null
+     */
+    public static function label(string $name): ?string
+    {
+        $text = Inflector::humanize(Inflector::underscore($name));
+        $label = __($text);
+        $plugins = (array)Configure::read('Plugins');
+        $pluginName = Hash::get(array_keys($plugins), 0);
+        // if we have no actual translation and a plugin let's try with plugin's gettext
+        if ($pluginName && $label === $text) {
+            return __d($pluginName, $text);
+        }
+
+        return $label;
     }
 }

--- a/src/Locale/en_US/default.po
+++ b/src/Locale/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-12-22 09:11:33 \n"
+"POT-Creation-Date: 2022-02-10 16:44:24 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -41,9 +41,6 @@ msgstr ""
 msgid "All Types"
 msgstr ""
 
-msgid "All categories"
-msgstr ""
-
 msgid "All day"
 msgstr ""
 
@@ -51,9 +48,6 @@ msgid "All media"
 msgstr ""
 
 msgid "All objects"
-msgstr ""
-
-msgid "All tags"
 msgstr ""
 
 msgid "An extension stopped the file upload"
@@ -260,6 +254,9 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expired"
+msgstr ""
+
 msgid "Export"
 msgstr ""
 
@@ -306,6 +303,9 @@ msgid "From"
 msgstr ""
 
 msgid "From date"
+msgstr ""
+
+msgid "Future"
 msgstr ""
 
 msgid "Gender"
@@ -827,7 +827,7 @@ msgstr ""
 msgid "create"
 msgstr ""
 
-msgid "create new"
+msgid "create new for"
 msgstr ""
 
 msgid "created"
@@ -905,9 +905,6 @@ msgstr ""
 msgid "phone"
 msgstr ""
 
-msgid "related object"
-msgstr ""
-
 msgid "remove"
 msgstr ""
 
@@ -968,26 +965,26 @@ msgstr ""
 msgid "warning"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:165
+#: src/Template/Layout/js/app/app.js:167
 #: src/Template/Layout/js/app/components/history/history.js:111
 #, javascript-format
 msgid "Please insert a new title on \"${ title }\" clone"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:166
+#: src/Template/Layout/js/app/app.js:168
 #: src/Template/Layout/js/app/components/history/history.js:112
 msgid "copy"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:453
+#: src/Template/Layout/js/app/app.js:455
 msgid "If you confirm, this data will be gone forever. Are you sure?"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:455
+#: src/Template/Layout/js/app/app.js:457
 msgid "Do you really want to trash the object?"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:463
+#: src/Template/Layout/js/app/app.js:465
 #: src/Template/Layout/js/app/components/history/history.js:101
 #: src/Template/Layout/js/app/pages/admin/index.js:16
 #: src/Template/Layout/js/app/pages/model/index.js:261
@@ -996,7 +993,7 @@ msgstr ""
 msgid "yes, proceed"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:472
+#: src/Template/Layout/js/app/app.js:474
 msgid "There are unsaved changes, are you sure you want to leave page?"
 msgstr ""
 
@@ -1031,19 +1028,19 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/edit-relation-params.js:20
+#: src/Template/Layout/js/app/components/edit-relation-params.js:21
 msgid "Relation parameters"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/edit-relation-params.js:30
+#: src/Template/Layout/js/app/components/edit-relation-params.js:31
 msgid "In relation with"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/edit-relation-params.js:39
+#: src/Template/Layout/js/app/components/edit-relation-params.js:40
 msgid "Priority"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/edit-relation-params.js:57
+#: src/Template/Layout/js/app/components/edit-relation-params.js:58
 msgid "Cancel"
 msgstr ""
 
@@ -1055,20 +1052,20 @@ msgstr ""
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/tree-view/tree-view.js:68
+#: src/Template/Layout/js/app/components/tree-view/tree-view.js:69
 msgid "edit"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/tree-view/tree-view.js:81
+#: src/Template/Layout/js/app/components/tree-view/tree-view.js:82
 msgid "Menu"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:238
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:243
 #, javascript-format
 msgid "Missing required data \"${ required }\". Retry"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:293
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:298
 msgid "Error while creating new object."
 msgstr ""
 

--- a/src/Locale/it_IT/default.po
+++ b/src/Locale/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-12-22 09:11:33 \n"
+"POT-Creation-Date: 2022-02-10 16:52:39 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -41,9 +41,6 @@ msgstr "Tutti"
 msgid "All Types"
 msgstr "Tutti i tipi"
 
-msgid "All categories"
-msgstr "Tutte le categorie"
-
 msgid "All day"
 msgstr "Tutto il giorno"
 
@@ -52,9 +49,6 @@ msgstr "Tutti i media"
 
 msgid "All objects"
 msgstr "Tutti gli oggetti"
-
-msgid "All tags"
-msgstr "Tutti i tag"
 
 msgid "An extension stopped the file upload"
 msgstr "Un'estensione ha fermato il caricamento del file"
@@ -260,6 +254,9 @@ msgstr "Errore: %s"
 msgid "Events"
 msgstr "Eventi"
 
+msgid "Expired"
+msgstr "Scaduto"
+
 msgid "Export"
 msgstr "Esporta"
 
@@ -307,6 +304,9 @@ msgstr "Da"
 
 msgid "From date"
 msgstr "Dalla data"
+
+msgid "Future"
+msgstr "Futuro"
 
 msgid "Gender"
 msgstr "Genere"
@@ -830,8 +830,8 @@ msgstr "contesto"
 msgid "create"
 msgstr "crea"
 
-msgid "create new"
-msgstr "crea nuovo"
+msgid "create new for"
+msgstr "crea nuovo per"
 
 msgid "created"
 msgstr "creato"
@@ -908,9 +908,6 @@ msgstr "genitore"
 msgid "phone"
 msgstr "telefono"
 
-msgid "related object"
-msgstr "oggetto relazionato"
-
 msgid "remove"
 msgstr "rimuovi"
 
@@ -971,26 +968,26 @@ msgstr "visualizza genitore"
 msgid "warning"
 msgstr "attenzione"
 
-#: src/Template/Layout/js/app/app.js:165
+#: src/Template/Layout/js/app/app.js:167
 #: src/Template/Layout/js/app/components/history/history.js:111
 #, javascript-format
 msgid "Please insert a new title on \"${ title }\" clone"
 msgstr "Inserisci un nuovo titolo per la copia di \"${ title }\""
 
-#: src/Template/Layout/js/app/app.js:166
+#: src/Template/Layout/js/app/app.js:168
 #: src/Template/Layout/js/app/components/history/history.js:112
 msgid "copy"
 msgstr "copia"
 
-#: src/Template/Layout/js/app/app.js:453
+#: src/Template/Layout/js/app/app.js:455
 msgid "If you confirm, this data will be gone forever. Are you sure?"
 msgstr "Questo dato verrà eliminato definitivamente. Vuoi proseguire?"
 
-#: src/Template/Layout/js/app/app.js:455
+#: src/Template/Layout/js/app/app.js:457
 msgid "Do you really want to trash the object?"
 msgstr "Vuoi davvero spostare l'oggetto nel cestino?"
 
-#: src/Template/Layout/js/app/app.js:463
+#: src/Template/Layout/js/app/app.js:465
 #: src/Template/Layout/js/app/components/history/history.js:101
 #: src/Template/Layout/js/app/pages/admin/index.js:16
 #: src/Template/Layout/js/app/pages/model/index.js:261
@@ -999,7 +996,7 @@ msgstr "Vuoi davvero spostare l'oggetto nel cestino?"
 msgid "yes, proceed"
 msgstr "sì, prosegui"
 
-#: src/Template/Layout/js/app/app.js:472
+#: src/Template/Layout/js/app/app.js:474
 msgid "There are unsaved changes, are you sure you want to leave page?"
 msgstr "Ci sono delle modifiche non salvate, vuoi comunque lasciare la pagina?"
 
@@ -1034,19 +1031,19 @@ msgstr "fatto"
 msgid "Cancelled"
 msgstr "Annullato"
 
-#: src/Template/Layout/js/app/components/edit-relation-params.js:20
+#: src/Template/Layout/js/app/components/edit-relation-params.js:21
 msgid "Relation parameters"
 msgstr "Parametri della relazione"
 
-#: src/Template/Layout/js/app/components/edit-relation-params.js:30
+#: src/Template/Layout/js/app/components/edit-relation-params.js:31
 msgid "In relation with"
 msgstr "In relazione con"
 
-#: src/Template/Layout/js/app/components/edit-relation-params.js:39
+#: src/Template/Layout/js/app/components/edit-relation-params.js:40
 msgid "Priority"
 msgstr "Priorità"
 
-#: src/Template/Layout/js/app/components/edit-relation-params.js:57
+#: src/Template/Layout/js/app/components/edit-relation-params.js:58
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -1058,20 +1055,20 @@ msgstr "Elementi"
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr "Testo troppo breve. Lunghezza minima 3 caratteri. Riprova"
 
-#: src/Template/Layout/js/app/components/tree-view/tree-view.js:68
+#: src/Template/Layout/js/app/components/tree-view/tree-view.js:69
 msgid "edit"
 msgstr "modifica"
 
-#: src/Template/Layout/js/app/components/tree-view/tree-view.js:81
+#: src/Template/Layout/js/app/components/tree-view/tree-view.js:82
 msgid "Menu"
 msgstr "Menù"
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:238
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:243
 #, javascript-format
 msgid "Missing required data \"${ required }\". Retry"
 msgstr "Dato obbligatorio mancante \"${ required }\". Riprovare"
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:293
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:298
 msgid "Error while creating new object."
 msgstr "Si è verificato un errore durante la creazione del nuovo oggetto."
 
@@ -1079,7 +1076,7 @@ msgstr "Si è verificato un errore durante la creazione del nuovo oggetto."
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 #: src/Template/Layout/js/app/components/locations-view/location-view.js:51
 msgid "Title"
 msgstr "Titolo"
@@ -1088,7 +1085,7 @@ msgstr "Titolo"
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 #: src/Template/Layout/js/app/components/locations-view/location-view.js:70
 msgid "Address"
 msgstr "Indirizzo"
@@ -1097,7 +1094,7 @@ msgstr "Indirizzo"
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 #: src/Template/Layout/js/app/components/locations-view/location-view.js:95
 msgid "GET"
 msgstr ""
@@ -1109,7 +1106,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 #: src/Template/Layout/js/app/components/locations-view/locations-view.js:30
 msgid "add new"
 msgstr "aggiungi nuovo"
@@ -1128,7 +1125,7 @@ msgstr "Rimosso"
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 #: src/Template/Layout/js/app/components/history/history.js:31
 msgid "No History data found"
 msgstr "Nessun dato di Cronologia"

--- a/src/Locale/master.pot
+++ b/src/Locale/master.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2021-12-22 09:11:33 \n"
+"POT-Creation-Date: 2022-02-10 16:52:39 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -38,9 +38,6 @@ msgstr ""
 msgid "All Types"
 msgstr ""
 
-msgid "All categories"
-msgstr ""
-
 msgid "All day"
 msgstr ""
 
@@ -48,9 +45,6 @@ msgid "All media"
 msgstr ""
 
 msgid "All objects"
-msgstr ""
-
-msgid "All tags"
 msgstr ""
 
 msgid "An extension stopped the file upload"
@@ -257,6 +251,9 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expired"
+msgstr ""
+
 msgid "Export"
 msgstr ""
 
@@ -303,6 +300,9 @@ msgid "From"
 msgstr ""
 
 msgid "From date"
+msgstr ""
+
+msgid "Future"
 msgstr ""
 
 msgid "Gender"
@@ -824,7 +824,7 @@ msgstr ""
 msgid "create"
 msgstr ""
 
-msgid "create new"
+msgid "create new for"
 msgstr ""
 
 msgid "created"
@@ -902,9 +902,6 @@ msgstr ""
 msgid "phone"
 msgstr ""
 
-msgid "related object"
-msgstr ""
-
 msgid "remove"
 msgstr ""
 
@@ -965,26 +962,26 @@ msgstr ""
 msgid "warning"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:165
+#: src/Template/Layout/js/app/app.js:167
 #: src/Template/Layout/js/app/components/history/history.js:111
 #, javascript-format
 msgid "Please insert a new title on \"${ title }\" clone"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:166
+#: src/Template/Layout/js/app/app.js:168
 #: src/Template/Layout/js/app/components/history/history.js:112
 msgid "copy"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:453
+#: src/Template/Layout/js/app/app.js:455
 msgid "If you confirm, this data will be gone forever. Are you sure?"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:455
+#: src/Template/Layout/js/app/app.js:457
 msgid "Do you really want to trash the object?"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:463
+#: src/Template/Layout/js/app/app.js:465
 #: src/Template/Layout/js/app/components/history/history.js:101
 #: src/Template/Layout/js/app/pages/admin/index.js:16
 #: src/Template/Layout/js/app/pages/model/index.js:261
@@ -993,7 +990,7 @@ msgstr ""
 msgid "yes, proceed"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:472
+#: src/Template/Layout/js/app/app.js:474
 msgid "There are unsaved changes, are you sure you want to leave page?"
 msgstr ""
 
@@ -1028,19 +1025,19 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/edit-relation-params.js:20
+#: src/Template/Layout/js/app/components/edit-relation-params.js:21
 msgid "Relation parameters"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/edit-relation-params.js:30
+#: src/Template/Layout/js/app/components/edit-relation-params.js:31
 msgid "In relation with"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/edit-relation-params.js:39
+#: src/Template/Layout/js/app/components/edit-relation-params.js:40
 msgid "Priority"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/edit-relation-params.js:57
+#: src/Template/Layout/js/app/components/edit-relation-params.js:58
 msgid "Cancel"
 msgstr ""
 
@@ -1052,20 +1049,20 @@ msgstr ""
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/tree-view/tree-view.js:68
+#: src/Template/Layout/js/app/components/tree-view/tree-view.js:69
 msgid "edit"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/tree-view/tree-view.js:81
+#: src/Template/Layout/js/app/components/tree-view/tree-view.js:82
 msgid "Menu"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:238
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:243
 #, javascript-format
 msgid "Missing required data \"${ required }\". Retry"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/relation-view/relations-add.js:293
+#: src/Template/Layout/js/app/components/relation-view/relations-add.js:298
 msgid "Error while creating new object."
 msgstr ""
 

--- a/src/Template/Element/Form/locations.twig
+++ b/src/Template/Element/Form/locations.twig
@@ -3,5 +3,6 @@
     api-key="{{ config('Location.google.key') }}"
     api-url="{{ config('Location.google.url') }}"
     relation-name="{{ relationName }}"
+    relation-label="{{ Layout.tr(relationName) }}"
 ></locations-view>
 {{ Form.unlockField('relations.' ~ relationName ~ '.replaceRelated')}}

--- a/src/Template/Element/Form/other_properties.twig
+++ b/src/Template/Element/Form/other_properties.twig
@@ -9,12 +9,12 @@
             <header @click.prevent="toggleVisibility()"
                 class="tab unselectable"
                 :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
-                <h2>{{ __(group|humanize) }}</h2>
+                <h2>{{ Layout.tr(group|humanize) }}</h2>
             </header>
 
             <div v-show="isOpen" class="tab-container">
 
-                {% element 'Form/group_properties' {'properties' : props, 'group': group} %}
+                {% element 'Form/group_properties' {'properties' : props, 'group': Layout.tr(group)} %}
 
             </div>
         </section>

--- a/src/Template/Element/Form/other_properties.twig
+++ b/src/Template/Element/Form/other_properties.twig
@@ -9,7 +9,7 @@
             <header @click.prevent="toggleVisibility()"
                 class="tab unselectable"
                 :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
-                <h2>{{ Layout.tr(group|humanize) }}</h2>
+                <h2>{{ Layout.tr(group) }}</h2>
             </header>
 
             <div v-show="isOpen" class="tab-container">

--- a/src/Template/Element/Form/related_item.twig
+++ b/src/Template/Element/Form/related_item.twig
@@ -129,6 +129,7 @@
                 object: {{ object|json_encode }},
                 related: related,
                 relationName: relationName,
+                relationLabel: relationLabel,
                 schema: relationSchema,
             })">{{ __('Edit params') }}</button>
     </div>

--- a/src/Template/Element/Form/related_translations.twig
+++ b/src/Template/Element/Form/related_translations.twig
@@ -34,6 +34,7 @@
                 {% if object.relationships.translations %}
                 <relation-view inline-template
                     relation-name={{ resourceName }}
+                    relation-label="{{ Layout.tr(resourceName) }}"
                     config-paginate-sizes={{ config('Pagination.sizeAvailable')|json_encode()|raw }}
                     ref="relation"
 

--- a/src/Template/Element/Form/relation.twig
+++ b/src/Template/Element/Form/relation.twig
@@ -2,6 +2,7 @@
     :relation-data="{{ relationSchema|json_encode|escape('html_attr') }}"
     :data-list="dataList"
     relation-name="{{ relationName }}"
+    relation-label="{{ Layout.tr(relationName) }}"
     :pre-count="{{ preCount }}"
     config-paginate-sizes="{{ config('Pagination.sizeAvailable')|json_encode|escape('html_attr') }}"
     ref="relation"
@@ -16,6 +17,7 @@
         {% if customElement %}
             {% element customElement {
                 'relationName': relationName,
+                'relationLabel': Layout.tr(relationName),
                 'relationSchema': relationsSchema,
             } %}
         {% else %}
@@ -92,6 +94,7 @@
                     @click.prevent.stop="addRelatedObjects({
                         object: {{object|json_encode}},
                         relationName: relationName,
+                        relationLabel: relationLabel,
                         alreadyInView: alreadyInView,
                         relationTypes: relationTypes,
                     })">{{ __('add objects') }}</button>

--- a/src/Template/Element/Form/relations.twig
+++ b/src/Template/Element/Form/relations.twig
@@ -28,6 +28,7 @@
                 <div v-show="isOpen" class="tab-container">
                     {% element 'Form/relation' {
                         'relationName': relationName,
+                        'relationLabel': Layout.tr(relationLabel),
                         'relationSchema': relationsSchema[relationName],
                         'dataList': dataList,
                         'preCount': preCount,

--- a/src/Template/Element/Form/relations.twig
+++ b/src/Template/Element/Form/relations.twig
@@ -16,7 +16,7 @@
                         isOpen? 'open has-border-module-{{ currentModule.name }}' : '',
                         isLoading? 'is-loading-spinner' : ''
                     ]">
-                        <h2>{{ relationLabel }}</h2>
+                        <h2>{{ Layout.tr(relationLabel) }}</h2>
                         <div class="buttons" v-show="isOpen">
                             <button @click.prevent @click.stop="switchBlockView()" :data-active="!dataList" class="switch-view icon-th-large"></button>
                             <button @click.prevent @click.stop="switchListView()" :data-active="dataList" class="switch-view icon-th-list"></button>

--- a/src/Template/Element/Form/resource_relations.twig
+++ b/src/Template/Element/Form/resource_relations.twig
@@ -3,7 +3,7 @@
         <section class="fieldset">
             <header class="tab tab-static unselectable" v-bind:class="isLoading? 'is-loading-spinner' : ''">
                 <h2>
-                    {{ __(resourceName|humanize)|lower }}
+                    {{ Layout.tr(resourceName)|lower }}
                     <span class="tag is-smallest is-black mx-05"
                         :class="!totalObjects? 'empty' : ''"><: totalObjects :>
                     </span>
@@ -14,6 +14,7 @@
             {# <div v-show="false" class="tab-container">
                 <resource-relation-view inline-template
                     relation-name={{ resourceName }}
+                    relation-label="{{ Layout.tr(resourceName) }}"
                     ref="relation"
 
                     @loading="onToggleLoading"

--- a/src/Template/Element/Form/roles.twig
+++ b/src/Template/Element/Form/roles.twig
@@ -26,6 +26,7 @@
             <relation-view
                 inline-template
                 relation-name={{ relationName }}
+                relation-label="{{ Layout.tr(relationName) }}"
 
                 @loading="onToggleLoading"
                 @count="onCount">
@@ -34,6 +35,7 @@
                     <roles-list-view
                         inline-template
                         relation-name={{ relationName }}
+                        relation-label="{{ Layout.tr(relationName) }}"
                         :related-objects="objects"
                         @remove-relations="setRemovedRelated">
 

--- a/src/Template/Element/Form/roles.twig
+++ b/src/Template/Element/Form/roles.twig
@@ -15,7 +15,7 @@
                 isOpen? 'open has-border-module-{{ currentModule.name }}' : '',
                 isLoading? 'is-loading-spinner' : ''
             ]">
-                <h2>{{ __(relationName|humanize)|lower }}</h2>
+                <h2>{{ Layout.tr(relationName)|lower }}</h2>
                 <span class="tag is-smallest is-black mx-05" v-show="!isLoading">
                     <: totalObjects :>
                 </span>

--- a/src/Template/Element/Form/trees.twig
+++ b/src/Template/Element/Form/trees.twig
@@ -20,6 +20,7 @@
 
             <tree-view
                 relation-name={{ relationName }}
+                relation-label="{{ Layout.tr(relationName) }}"
                 :object='{{ { id: object.id, type: object.type }|json_encode }}'
                 :multiple-choice={{ options.multiple }}>
             </tree-view>

--- a/src/Template/Element/Menu/menu.twig
+++ b/src/Template/Element/Menu/menu.twig
@@ -4,7 +4,7 @@
         <nav role="menu">
             {# Core modules #}
             {% for name, module in modules if name != 'trash' %}
-                {% set label = Layout.__(module.label|default(name)|humanize) %}
+                {% set label = Layout.tr(module.label|default(name)|humanize) %}
                 {% set shortLabel = module.shortLabel|default(label[0:5]) %}
                 {% if label|length > 5 %}
                     {% set label = shortLabel %}
@@ -15,7 +15,7 @@
                 {% else %}
                     {% set url = Url.build({ '_name': 'modules:list', 'object_type': name, 'plugin': null }) %}
                 {% endif %}
-                <a href="{{ url }}" title="{{ __('Open module') }} {{ Layout.__(name|humanize) }}"
+                <a href="{{ url }}" title="{{ __('Open module') }} {{ Layout.tr(name|humanize) }}"
                     class="menu-item {{ name == currentModule.name ? 'current' : '' }}">
                     <span class="menu-item-color-bar has-background-module-{{ name }}" aria-hidden="true"></span>
                     <span class="menu-item-label">{{ label }}</span>

--- a/src/Template/Element/Menu/menu.twig
+++ b/src/Template/Element/Menu/menu.twig
@@ -4,7 +4,7 @@
         <nav role="menu">
             {# Core modules #}
             {% for name, module in modules if name != 'trash' %}
-                {% set label = Layout.tr(module.label|default(name)|humanize) %}
+                {% set label = Layout.tr(module.label|default(name)) %}
                 {% set shortLabel = module.shortLabel|default(label[0:5]) %}
                 {% if label|length > 5 %}
                     {% set label = shortLabel %}
@@ -15,7 +15,7 @@
                 {% else %}
                     {% set url = Url.build({ '_name': 'modules:list', 'object_type': name, 'plugin': null }) %}
                 {% endif %}
-                <a href="{{ url }}" title="{{ __('Open module') }} {{ Layout.tr(name|humanize) }}"
+                <a href="{{ url }}" title="{{ __('Open module') }} {{ Layout.tr(name) }}"
                     class="menu-item {{ name == currentModule.name ? 'current' : '' }}">
                     <span class="menu-item-color-bar has-background-module-{{ name }}" aria-hidden="true"></span>
                     <span class="menu-item-label">{{ label }}</span>
@@ -26,7 +26,7 @@
 
         <nav role="group" class="pt-05">
             <a class="button icon icon-trash icon-only-icon has-text-module-{{ currentModule.name }}"
-                title="{{ currentModule.name|humanize ~ __(' in Trashcan') }}"
+                title="{{ Layout.tr(currentModule.name) ~ __(' in Trashcan') }}"
                 href="{{ Url.build('trash?filter[type][0]=' ~ currentModule.name) }}"><span class="is-sr-only">{{ __('Trash') }}</span></a>
 
             <button role="search" class="icon icon-search icon-only-icon ml-05" title="{{ __('Search') }}"

--- a/src/Template/Element/Menu/menu.twig
+++ b/src/Template/Element/Menu/menu.twig
@@ -26,7 +26,7 @@
 
         <nav role="group" class="pt-05">
             <a class="button icon icon-trash icon-only-icon has-text-module-{{ currentModule.name }}"
-                title="{{ Layout.tr(currentModule.name) ~ __(' in Trashcan') }}"
+                title="{{ Layout.tr(currentModule.name|default('')) ~ __(' in Trashcan') }}"
                 href="{{ Url.build('trash?filter[type][0]=' ~ currentModule.name) }}"><span class="is-sr-only">{{ __('Trash') }}</span></a>
 
             <button role="search" class="icon icon-search icon-only-icon ml-05" title="{{ __('Search') }}"

--- a/src/Template/Element/Menu/menu.twig
+++ b/src/Template/Element/Menu/menu.twig
@@ -4,7 +4,7 @@
         <nav role="menu">
             {# Core modules #}
             {% for name, module in modules if name != 'trash' %}
-                {% set label = module.label|default(name)|humanize %}
+                {% set label = Layout.__(module.label|default(name)|humanize) %}
                 {% set shortLabel = module.shortLabel|default(label[0:5]) %}
                 {% if label|length > 5 %}
                     {% set label = shortLabel %}
@@ -15,11 +15,11 @@
                 {% else %}
                     {% set url = Url.build({ '_name': 'modules:list', 'object_type': name, 'plugin': null }) %}
                 {% endif %}
-                <a href="{{ url }}" title="{{ __('Open module') }} {{ __(name|humanize) }}"
+                <a href="{{ url }}" title="{{ __('Open module') }} {{ Layout.__(name|humanize) }}"
                     class="menu-item {{ name == currentModule.name ? 'current' : '' }}">
                     <span class="menu-item-color-bar has-background-module-{{ name }}" aria-hidden="true"></span>
-                    <span class="menu-item-label">{{ Layout.typeLabel(label) }}</span>
-                    <span class="menu-item-short-label">{{ Layout.typeLabel(shortLabel) }}</span>
+                    <span class="menu-item-label">{{ label }}</span>
+                    <span class="menu-item-short-label">{{ shortLabel }}</span>
                 </a>
             {% endfor %}
         </nav>

--- a/src/Template/Element/Modules/index_table_header.twig
+++ b/src/Template/Element/Modules/index_table_header.twig
@@ -8,9 +8,9 @@
     {% for prop in properties %}
         <div class="{{ Link.sortClass(prop) }}">
             {% if Schema.sortable(prop) %}
-                <a href="{{ Link.sortUrl(prop) }}">{{ __(prop)|humanize }}</a>
+                <a href="{{ Link.sortUrl(prop) }}">{{ Layout.tr(prop) }}</a>
             {% else %}
-                {{ __(prop)|humanize }}
+                {{ Layout.tr(prop) }}
             {% endif %}
         </div>
     {% endfor %}

--- a/src/Template/Element/Modules/index_table_row.twig
+++ b/src/Template/Element/Modules/index_table_row.twig
@@ -32,7 +32,7 @@
         {% endfor %}
 
         {% if currentModule.hints.multiple_types %}
-            <div class="type-cell"><span class="tag has-background-module-{{ object.type }}">{{ Layout.__(object.type) }}</span></div>
+            <div class="type-cell"><span class="tag has-background-module-{{ object.type }}">{{ Layout.tr(object.type) }}</span></div>
         {% endif %}
 
         {% if object.attributes.status %}

--- a/src/Template/Element/Modules/index_table_row.twig
+++ b/src/Template/Element/Modules/index_table_row.twig
@@ -32,7 +32,7 @@
         {% endfor %}
 
         {% if currentModule.hints.multiple_types %}
-            <div class="type-cell"><span class="tag has-background-module-{{ object.type }}">{{ Layout.typeLabel(object.type) }}</span></div>
+            <div class="type-cell"><span class="tag has-background-module-{{ object.type }}">{{ Layout.__(object.type) }}</span></div>
         {% endif %}
 
         {% if object.attributes.status %}

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -6,7 +6,7 @@
             :class="{ open: showCreateObjectForm }"
             :disabled="saving"
             @click="resetForms">
-            <h2><span v-show="relationName"><strong>{{ __('create new') }}</strong> "<: relationName | humanize :></span>" {{ __('related object') }}&nbsp;</h2>
+            <h2><span v-show="relationName"><strong>{{ __('create new for') }}</strong> "<: relationLabel :></span>"</h2>
         </header>
 
         <div class="create-new-object mt-1 mx-1" v-if="showCreateObjectForm">
@@ -86,7 +86,7 @@
 
     <section class="fieldset shrinks">
         <header class="mx-1 tab tab-static unselectable" v-bind:class="!objects || loading ? 'is-loading-spinner' : ''">
-            <h2><span v-show="relationName"><strong>{{ __('add') }}</strong>&nbsp;{{ __('elements to') }}&nbsp;"<strong><: relationName | humanize :></strong>"</span> relation</h2>
+            <h2><span v-show="relationName"><strong>{{ __('add') }}</strong>&nbsp;{{ __('elements to') }}&nbsp;"<strong><: relationLabel :></strong>"</span></h2>
         </header>
 
         <div class="px-1 my-1">

--- a/src/Template/Element/filter_type.twig
+++ b/src/Template/Element/filter_type.twig
@@ -15,7 +15,7 @@
             <input type="checkbox" value="{{ type }}" id="{{ type }}" v-model="selectedTypes">
             <div>
                 <i class="bullet has-background-module-{{ type }}"></i>
-                <span>{{ Layout.__(type|humanize) }}</span>
+                <span>{{ Layout.tr(type|humanize) }}</span>
             </div>
         </label>
         {% endfor %}

--- a/src/Template/Element/filter_type.twig
+++ b/src/Template/Element/filter_type.twig
@@ -15,7 +15,7 @@
             <input type="checkbox" value="{{ type }}" id="{{ type }}" v-model="selectedTypes">
             <div>
                 <i class="bullet has-background-module-{{ type }}"></i>
-                <span>{{ Layout.tr(type|humanize) }}</span>
+                <span>{{ Layout.tr(type) }}</span>
             </div>
         </label>
         {% endfor %}

--- a/src/Template/Element/filter_type.twig
+++ b/src/Template/Element/filter_type.twig
@@ -15,7 +15,7 @@
             <input type="checkbox" value="{{ type }}" id="{{ type }}" v-model="selectedTypes">
             <div>
                 <i class="bullet has-background-module-{{ type }}"></i>
-                <span>{{ Layout.typeLabel(type|humanize) }}</span>
+                <span>{{ Layout.__(type|humanize) }}</span>
             </div>
         </label>
         {% endfor %}

--- a/src/Template/Layout/js/app/components/edit-relation-params.js
+++ b/src/Template/Layout/js/app/components/edit-relation-params.js
@@ -2,6 +2,7 @@
 * View component used for editing relations param
 *
 * @property {String} relationName
+* @property {String} relationLabel
 * @property {Object} object
 * @property {Object} related
 * @property {Object} schema
@@ -17,7 +18,7 @@ export default {
     `<div v-if="relationName" class="edit-relation">
         <section>
             <header class="mx-1 mt-1 mb-1 tab unselectable">
-                <h2><span>${t`Relation parameters`} - <: relationName | humanize :></span></h2>
+                <h2><span>${t`Relation parameters`} - <: relationLabel :></span></h2>
             </header>
 
             <div class="mx-1">
@@ -65,6 +66,10 @@ export default {
 
     props: {
         relationName: {
+            type: String,
+            default: '',
+        },
+        relationLabel: {
             type: String,
             default: '',
         },

--- a/src/Template/Layout/js/app/components/locations-view/location-view.js
+++ b/src/Template/Layout/js/app/components/locations-view/location-view.js
@@ -128,6 +128,7 @@ export default {
         apiUrl: String,
         locationData: Object,
         relationName: String,
+        relationLabel: String,
     },
 
     data() {

--- a/src/Template/Layout/js/app/components/locations-view/locations-view.js
+++ b/src/Template/Layout/js/app/components/locations-view/locations-view.js
@@ -24,7 +24,7 @@ export default {
         <input type="hidden" :name="'relations[' + relationName + '][replaceRelated]'" :value="locationsData" />
         <div v-if="!locations" class="is-loading-spinner"></div>
         <div v-else v-for="(location, index) in locations">
-            <location-view :key="locationSymbol(location)" :index="index" :location-data="location" :api-key="apiKey" :api-url="apiUrl" :relation-name="relationName" />
+            <location-view :key="locationSymbol(location)" :index="index" :location-data="location" :api-key="apiKey" :api-url="apiUrl" :relation-name="relationName" :relation-label="relationLabel" />
         </div>
         <div v-if="locations" class="is-flex mt-1">
             <button @click.prevent @click="onAddNew">${t`add new`}</button>
@@ -35,6 +35,7 @@ export default {
         apiKey: String,
         apiUrl: String,
         relationName: String,
+        relationLabel: String,
     },
 
     data() {

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -7,6 +7,7 @@
  * <relation-view> component used for ModulesPage -> View
  *
  * @property {String} relationName name of the relation used by the PaginatiedContentMixin
+ * @property {String} relationLabel label of the relation
  * @property {Boolean} multipleChoice set view for multiple choice
  * @property {String} configPaginateSizes set pagination
  *
@@ -38,6 +39,10 @@ export default {
 
     props: {
         relationName: {
+            type: String,
+            required: true,
+        },
+        relationLabel: {
             type: String,
             required: true,
         },

--- a/src/Template/Layout/js/app/components/relation-view/relations-add.js
+++ b/src/Template/Layout/js/app/components/relation-view/relations-add.js
@@ -5,6 +5,7 @@
  * <relations-add> component used for Panel
  *
  * @prop {String} relationName relation name
+ * @prop {String} relationLabel relation label
  * @prop {Array} alreadyInView array of objects already added
  * @prop {Object} relationTypes list of available object types
  * @prop {String} configPaginateSizes list of sizes for pagination
@@ -38,6 +39,10 @@ export default {
 
     props: {
         relationName: {
+            type: String,
+            default: '',
+        },
+        relationLabel: {
             type: String,
             default: '',
         },

--- a/src/Template/Layout/js/app/components/relation-view/relationships-view/relationships-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relationships-view/relationships-view.js
@@ -17,6 +17,10 @@ export default {
             type: String,
             required: true,
         },
+        relationLabel: {
+            type: String,
+            required: true,
+        },
         viewVisibility: {
             type: Boolean,
             default: () => false,

--- a/src/Template/Layout/js/app/components/relation-view/resource-relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/resource-relation-view.js
@@ -7,7 +7,7 @@
  * <relation-view> component used for ModulesPage -> View
  *
  * @property {String} relationName name of the relation used by the PaginatiedContentMixin
-
+ * @property {String} relationLabel label of the relation
  * @requires
  *
  */
@@ -21,6 +21,10 @@ export default {
 
     props: {
         relationName: {
+            type: String,
+            required: true,
+        },
+        relationLabel: {
             type: String,
             required: true,
         },

--- a/src/Template/Layout/js/app/components/tree-view/tree-view.js
+++ b/src/Template/Layout/js/app/components/tree-view/tree-view.js
@@ -9,6 +9,7 @@
  * @property {Object} node The model of the tree item.
  * @property {Object} object The current item to place in the tree.
  * @property {string} relationName The name of the relation to save.
+ * @property {string} relationLabel The label of the relation to save.
  * @property {boolean} multipleChoice Should handle multiple relations.
  * @property {Array} parents The list of current item parents.
  */
@@ -108,6 +109,7 @@ export default {
                     :node="child"
                     :object="object"
                     :relation-name="relationName"
+                    :relation-label="relationLabel"
                     :multiple-choice="multipleChoice"
                 ></tree-view>
             </div>
@@ -135,6 +137,7 @@ export default {
         },
         object: Object,
         relationName: String,
+        relationLabel: String,
         multipleChoice: {
             type: Boolean,
             default: true,

--- a/src/Template/Layout/js/libs/bedita.js
+++ b/src/Template/Layout/js/libs/bedita.js
@@ -16,23 +16,24 @@ const BELoader = {
 
         plugins.forEach(element => {
             const vueComponent = window[element] || global[element];
-            if (vueComponent) {
-                const BEPlugins = vueComponent.default;
-
-                Object.keys(BEPlugins).forEach(componentName => {
-                    if (typeof BEPlugins[componentName] === 'object') {
-                        Vue.component(componentName, BEPlugins[componentName]);
-
-                        console.debug(
-                            `%c[${componentName}]%c component succesfully registred from %c${element}%c Plugin`,
-                            'color: blue',
-                            'color: black',
-                            'color: red',
-                            'color: black'
-                        );
-                    }
-                });
+            if (!vueComponent || !vueComponent.default) {
+                return;
             }
+            const BEPlugins = vueComponent.default;
+
+            Object.keys(BEPlugins).forEach(componentName => {
+                if (typeof BEPlugins[componentName] === 'object') {
+                    Vue.component(componentName, BEPlugins[componentName]);
+
+                    console.debug(
+                        `%c[${componentName}]%c component succesfully registred from %c${element}%c Plugin`,
+                        'color: blue',
+                        'color: black',
+                        'color: red',
+                        'color: black'
+                    );
+                }
+            });
         });
     }
 }

--- a/src/Template/Pages/Dashboard/index.twig
+++ b/src/Template/Pages/Dashboard/index.twig
@@ -16,7 +16,7 @@
                     {% set module = {'class': 'icon-folder'}|merge(module) %}
                 {% endif %}
 
-                {% set title = Layout.typeLabel(module.label|default(name)|humanize) %}
+                {% set title = Layout.__(module.label|default(name)|humanize) %}
 
                 {% set class = 'dashboard-item has-background-module-%s %s'|format(name, module.class|default('')) %}
                 {% if module.hints.multiple_types and not module.class %}

--- a/src/Template/Pages/Dashboard/index.twig
+++ b/src/Template/Pages/Dashboard/index.twig
@@ -16,7 +16,7 @@
                     {% set module = {'class': 'icon-folder'}|merge(module) %}
                 {% endif %}
 
-                {% set title = Layout.tr(module.label|default(name)|humanize) %}
+                {% set title = Layout.tr(module.label|default(name)) %}
 
                 {% set class = 'dashboard-item has-background-module-%s %s'|format(name, module.class|default('')) %}
                 {% if module.hints.multiple_types and not module.class %}

--- a/src/Template/Pages/Dashboard/index.twig
+++ b/src/Template/Pages/Dashboard/index.twig
@@ -16,7 +16,7 @@
                     {% set module = {'class': 'icon-folder'}|merge(module) %}
                 {% endif %}
 
-                {% set title = Layout.__(module.label|default(name)|humanize) %}
+                {% set title = Layout.tr(module.label|default(name)|humanize) %}
 
                 {% set class = 'dashboard-item has-background-module-%s %s'|format(name, module.class|default('')) %}
                 {% if module.hints.multiple_types and not module.class %}

--- a/src/Template/Pages/Trash/view.twig
+++ b/src/Template/Pages/Trash/view.twig
@@ -5,7 +5,7 @@
 
     <header>
         <h1>{{ object.attributes.title|default(__('New entry in') ~ ' ' ~ objectType) }}</h1>
-        <span class="has-background-module-{{ object.type }} tag has-font-weight-bold">{{ Layout.typeLabel(object.type)|capitalize }}</span>
+        <span class="has-background-module-{{ object.type }} tag has-font-weight-bold">{{ Layout.__(object.type)|capitalize }}</span>
     </header>
 
     <div class="module-form">

--- a/src/Template/Pages/Trash/view.twig
+++ b/src/Template/Pages/Trash/view.twig
@@ -5,7 +5,7 @@
 
     <header>
         <h1>{{ object.attributes.title|default(__('New entry in') ~ ' ' ~ objectType) }}</h1>
-        <span class="has-background-module-{{ object.type }} tag has-font-weight-bold">{{ Layout.__(object.type)|capitalize }}</span>
+        <span class="has-background-module-{{ object.type }} tag has-font-weight-bold">{{ Layout.tr(object.type)|capitalize }}</span>
     </header>
 
     <div class="module-form">

--- a/src/Utility/Translate.php
+++ b/src/Utility/Translate.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Utility;
+
+use Cake\Core\Configure;
+use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
+
+/**
+ * Translate class
+ */
+class Translate
+{
+    /**
+     * Return translated string by input string.
+     * Use `__` and `__d` to try to translate it.
+     *
+     * @param string $input The input string
+     * @return string|null
+     */
+    public static function __(string $input): ?string
+    {
+        $text = Inflector::humanize(Inflector::underscore($input));
+        $translation = __($text);
+        $plugins = (array)Configure::read('Plugins');
+        $pluginName = Hash::get(array_keys($plugins), 0);
+        if ($pluginName && $translation === $text) {
+            return __d($pluginName, $text);
+        }
+
+        return $translation;
+    }
+}

--- a/src/Utility/Translate.php
+++ b/src/Utility/Translate.php
@@ -28,9 +28,8 @@ class Translate
      *
      * @param string $input The input string
      * @return string|null
-     * phpcs:ignore
      */
-    public static function __(string $input): ?string
+    public static function get(string $input): ?string
     {
         $text = Inflector::humanize(Inflector::underscore($input));
         $translation = __($text);

--- a/src/Utility/Translate.php
+++ b/src/Utility/Translate.php
@@ -28,6 +28,7 @@ class Translate
      *
      * @param string $input The input string
      * @return string|null
+     * phpcs:ignore
      */
     public static function __(string $input): ?string
     {

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -106,7 +106,7 @@ class LayoutHelper extends Helper
             $label = Hash::get($currentModule, 'label', $name);
 
             return $this->Html->link(
-                $this->tr(Inflector::humanize($label)),
+                $this->tr($label),
                 ['_name' => 'modules:list', 'object_type' => $name],
                 ['class' => sprintf('has-background-module-%s', $name)]
             );
@@ -114,7 +114,7 @@ class LayoutHelper extends Helper
 
         // if no `currentModule` has been set a `moduleLink` must be set in controller otherwise current link is displayed
         return $this->Html->link(
-            $this->tr(Inflector::humanize($this->getView()->getName())),
+            $this->tr($this->getView()->getName()),
             (array)$this->getView()->get('moduleLink'),
             ['class' => $this->commandLinkClass()]
         );

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -170,6 +170,7 @@ class LayoutHelper extends Helper
      *
      * @param string $input The input string
      * @return string|null
+     * phpcs:ignore
      */
     public function __(string $input): ?string
     {

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -12,6 +12,7 @@
  */
 namespace App\View\Helper;
 
+use App\Utility\Translate;
 use Cake\Core\Configure;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
@@ -105,7 +106,7 @@ class LayoutHelper extends Helper
             $label = Hash::get($currentModule, 'label', $name);
 
             return $this->Html->link(
-                $this->typeLabel(Inflector::humanize($label)),
+                $this->__(Inflector::humanize($label)),
                 ['_name' => 'modules:list', 'object_type' => $name],
                 ['class' => sprintf('has-background-module-%s', $name)]
             );
@@ -113,7 +114,7 @@ class LayoutHelper extends Helper
 
         // if no `currentModule` has been set a `moduleLink` must be set in controller otherwise current link is displayed
         return $this->Html->link(
-            $this->typeLabel(Inflector::humanize($this->getView()->getName())),
+            $this->__(Inflector::humanize($this->getView()->getName())),
             (array)$this->getView()->get('moduleLink'),
             ['class' => $this->commandLinkClass()]
         );
@@ -165,21 +166,13 @@ class LayoutHelper extends Helper
     }
 
     /**
-     * Get translated model by type, using plugins (if any) translations.
+     * Get translated val by input string, using plugins (if any) translations.
      *
-     * @param string $type The type
+     * @param string $input The input string
      * @return string|null
      */
-    public function typeLabel(string $type): ?string
+    public function __(string $input): ?string
     {
-        $res = __($type);
-        $plugins = (array)Configure::read('Plugins');
-        $pluginName = Hash::get(array_keys($plugins), 0);
-        // if we have no actual translation and a plugin let's try with plugin's gettext
-        if ($pluginName && $res === $type) {
-            return __d($pluginName, $type);
-        }
-
-        return $res;
+        return Translate::__($input);
     }
 }

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -106,7 +106,7 @@ class LayoutHelper extends Helper
             $label = Hash::get($currentModule, 'label', $name);
 
             return $this->Html->link(
-                $this->__(Inflector::humanize($label)),
+                $this->tr(Inflector::humanize($label)),
                 ['_name' => 'modules:list', 'object_type' => $name],
                 ['class' => sprintf('has-background-module-%s', $name)]
             );
@@ -114,7 +114,7 @@ class LayoutHelper extends Helper
 
         // if no `currentModule` has been set a `moduleLink` must be set in controller otherwise current link is displayed
         return $this->Html->link(
-            $this->__(Inflector::humanize($this->getView()->getName())),
+            $this->tr(Inflector::humanize($this->getView()->getName())),
             (array)$this->getView()->get('moduleLink'),
             ['class' => $this->commandLinkClass()]
         );

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -170,10 +170,9 @@ class LayoutHelper extends Helper
      *
      * @param string $input The input string
      * @return string|null
-     * phpcs:ignore
      */
-    public function __(string $input): ?string
+    public function tr(string $input): ?string
     {
-        return Translate::__($input);
+        return Translate::get($input);
     }
 }

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -12,6 +12,7 @@
  */
 namespace App\View\Helper;
 
+use App\Form\Form;
 use Cake\Core\Configure;
 use Cake\Utility\Hash;
 use Cake\View\Helper;
@@ -68,6 +69,7 @@ class PropertyHelper extends Helper
     public function control(string $name, $value, array $options = [], ?string $type = null): string
     {
         $controlOptions = $this->Schema->controlOptions($name, $value, $this->schema($name, $type));
+        $controlOptions['label'] = Form::label($name);
         if (Hash::get($controlOptions, 'class') === 'json') {
             $jsonKeys = (array)Configure::read('_jsonKeys');
             Configure::write('_jsonKeys', array_merge($jsonKeys, [$name]));

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -12,7 +12,7 @@
  */
 namespace App\View\Helper;
 
-use App\Form\Form;
+use App\Utility\Translate;
 use Cake\Core\Configure;
 use Cake\Utility\Hash;
 use Cake\View\Helper;
@@ -69,7 +69,7 @@ class PropertyHelper extends Helper
     public function control(string $name, $value, array $options = [], ?string $type = null): string
     {
         $controlOptions = $this->Schema->controlOptions($name, $value, $this->schema($name, $type));
-        $controlOptions['label'] = Form::label($name);
+        $controlOptions['label'] = Translate::__($name);
         if (Hash::get($controlOptions, 'class') === 'json') {
             $jsonKeys = (array)Configure::read('_jsonKeys');
             Configure::write('_jsonKeys', array_merge($jsonKeys, [$name]));

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -69,7 +69,7 @@ class PropertyHelper extends Helper
     public function control(string $name, $value, array $options = [], ?string $type = null): string
     {
         $controlOptions = $this->Schema->controlOptions($name, $value, $this->schema($name, $type));
-        $controlOptions['label'] = Translate::__($name);
+        $controlOptions['label'] = Translate::get($name);
         if (Hash::get($controlOptions, 'class') === 'json') {
             $jsonKeys = (array)Configure::read('_jsonKeys');
             Configure::write('_jsonKeys', array_merge($jsonKeys, [$name]));

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -97,32 +97,4 @@ class FormTest extends TestCase
             ],
         ];
     }
-
-    /**
-     * Test `label` method
-     *
-     * @param string $name The field name
-     * @param string|null $expected The expected label
-     * @return void
-     * @dataProvider labelProvider()
-     * @covers ::label()
-     */
-    public function testLabel(string $name, string $expected): void
-    {
-        $actual = Form::label($name);
-        static::assertSame($expected, $actual);
-    }
-
-    /**
-     * Test `label` method, plugin case
-     *
-     * @return void
-     * @covers ::label()
-     */
-    public function testLabelPlugin(): void
-    {
-        Configure::write('Plugins', ['DummyPlugin' => ['bootstrap' => true, 'routes' => true, 'ignoreMissing' => true]]);
-        $actual = Form::label('dummy');
-        static::assertSame('Dummy', $actual);
-    }
 }

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -15,6 +15,7 @@ namespace App\Test\TestCase\Form;
 
 use App\Form\Form;
 use App\Form\Options;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -76,5 +77,52 @@ class FormTest extends TestCase
         static::expectException(get_class($expected));
         static::expectExceptionMessage($expected->getMessage());
         Form::getMethod(Form::class, $methodName);
+    }
+
+    /**
+     * Data provider for `testLabel`.
+     *
+     * @return array
+     */
+    public function labelProvider(): array
+    {
+        return [
+            'empty' => [
+                '',
+                '',
+            ],
+            'dummy' => [
+                'dummy',
+                'Dummy',
+            ],
+        ];
+    }
+
+    /**
+     * Test `label` method
+     *
+     * @param string $name The field name
+     * @param string|null $expected The expected label
+     * @return void
+     * @dataProvider labelProvider()
+     * @covers ::label()
+     */
+    public function testLabel(string $name, string $expected): void
+    {
+        $actual = Form::label($name);
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Test `label` method, plugin case
+     *
+     * @return void
+     * @covers ::label()
+     */
+    public function testLabelPlugin(): void
+    {
+        Configure::write('Plugins', ['DummyPlugin' => ['bootstrap' => true, 'routes' => true, 'ignoreMissing' => true]]);
+        $actual = Form::label('dummy');
+        static::assertSame('Dummy', $actual);
     }
 }

--- a/tests/TestCase/Utility/TranslateTest.php
+++ b/tests/TestCase/Utility/TranslateTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Test\TestCase;
+
+use App\Utility\Translate;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+
+/**
+ * App\Utility\Translate Test Case
+ *
+ * @coversDefaultClass App\Utility\Translate
+ */
+class TranslateTest extends TestCase
+{
+    /**
+     * Data provider for testTranslate
+     *
+     * @return array
+     */
+    public function translateProvider(): array
+    {
+        return [
+            'empty' => [
+                '',
+                '',
+            ],
+            'dummy' => [
+                'dummy',
+                'Dummy',
+            ],
+        ];
+    }
+
+    /**
+     * Test `__` method
+     *
+     * @param string $name The field name
+     * @param string|null $expected The expected __
+     * @return void
+     * @dataProvider translateProvider()
+     * @covers ::__()
+     */
+    public function testTranslate(string $name, string $expected): void
+    {
+        $actual = Translate::__($name);
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Test `__` method, plugin case
+     *
+     * @return void
+     * @covers ::__()
+     */
+    public function testPlugin(): void
+    {
+        Configure::write('Plugins', ['DummyPlugin' => ['bootstrap' => true, 'routes' => true, 'ignoreMissing' => true]]);
+        $actual = Translate::__('dummy');
+        static::assertSame('Dummy', $actual);
+    }
+}

--- a/tests/TestCase/Utility/TranslateTest.php
+++ b/tests/TestCase/Utility/TranslateTest.php
@@ -43,30 +43,30 @@ class TranslateTest extends TestCase
     }
 
     /**
-     * Test `__` method
+     * Test `get` method
      *
      * @param string $name The field name
-     * @param string|null $expected The expected __
+     * @param string|null $expected The expected result
      * @return void
      * @dataProvider translateProvider()
-     * @covers ::__()
+     * @covers ::get()
      */
     public function testTranslate(string $name, string $expected): void
     {
-        $actual = Translate::__($name);
+        $actual = Translate::get($name);
         static::assertSame($expected, $actual);
     }
 
     /**
-     * Test `__` method, plugin case
+     * Test `get` method, plugin case
      *
      * @return void
-     * @covers ::__()
+     * @covers ::get()
      */
     public function testPlugin(): void
     {
         Configure::write('Plugins', ['DummyPlugin' => ['bootstrap' => true, 'routes' => true, 'ignoreMissing' => true]]);
-        $actual = Translate::__('dummy');
+        $actual = Translate::get('dummy');
         static::assertSame('Dummy', $actual);
     }
 }

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -249,10 +249,10 @@ class LayoutHelperTest extends TestCase
     }
 
     /**
-     * Test `__` method
+     * Test `tr` method
      *
      * @return void
-     * @covers ::__()
+     * @covers ::tr()
      */
     public function testTranslation(): void
     {
@@ -260,12 +260,12 @@ class LayoutHelperTest extends TestCase
         $view->set('currentModule', ['name' => 'documents']);
         $layout = new LayoutHelper($view);
         $expected = __('Objects');
-        $actual = $layout->__('Objects');
+        $actual = $layout->tr('Objects');
         static::assertSame($expected, $actual);
 
         Configure::write('Plugins', ['DummyPlugin' => ['bootstrap' => true, 'routes' => true, 'ignoreMissing' => true]]);
         $expected = __d('DummyPlugin', 'Objects');
-        $actual = $layout->__('Objects');
+        $actual = $layout->tr('Objects');
         static::assertSame($expected, $actual);
     }
 

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -141,7 +141,7 @@ class LayoutHelperTest extends TestCase
     {
         return [
             'user profile' => [
-                '<a href="/user_profile" class="has-background-black icon-user">UserProfile</a>',
+                '<a href="/user_profile" class="has-background-black icon-user">User Profile</a>',
                 'UserProfile',
                 [
                     'moduleLink' => ['_name' => 'user_profile:view'],
@@ -249,23 +249,23 @@ class LayoutHelperTest extends TestCase
     }
 
     /**
-     * Test `typeLabel` method
+     * Test `__` method
      *
      * @return void
-     * @covers ::typeLabel()
+     * @covers ::__()
      */
-    public function testTypeLabel(): void
+    public function testTranslation(): void
     {
         $view = new View();
         $view->set('currentModule', ['name' => 'documents']);
         $layout = new LayoutHelper($view);
         $expected = __('Objects');
-        $actual = $layout->typeLabel('Objects');
+        $actual = $layout->__('Objects');
         static::assertSame($expected, $actual);
 
         Configure::write('Plugins', ['DummyPlugin' => ['bootstrap' => true, 'routes' => true, 'ignoreMissing' => true]]);
         $expected = __d('DummyPlugin', 'Objects');
-        $actual = $layout->typeLabel('Objects');
+        $actual = $layout->__('Objects');
         static::assertSame($expected, $actual);
     }
 


### PR DESCRIPTION
This provides some enhancements in texts translations in the Manager (i.e.: `__()` related issues, not referring to module Translation nor Translations objects).
If a plugin is found, try to get translation from plugin (if not already found in manager translations).
Text translations:

 - form elements labels when using `Property.control`
 - static string in `twig` templates using `Layout.tr(str)`
 - static string in `php` files using `Translate::get(str)`

Bonus: refactor templates to get proper string translations, i.e.: modules menu with short labels, view sections for relations and custom groups, etc.