### PR TITLE
Refactor request & response, prepare for cakephp 4

### DIFF
--- a/src/Controller/Admin/AdministrationBaseController.php
+++ b/src/Controller/Admin/AdministrationBaseController.php
@@ -92,8 +92,8 @@ abstract class AdministrationBaseController extends AppController
      */
     public function index(): ?Response
     {
-        $this->request->allowMethod(['get']);
-        $query = $this->request->getQueryParams();
+        $this->getRequest()->allowMethod(['get']);
+        $query = $this->getRequest()->getQueryParams();
 
         try {
             $endpoint = $this->resourceType === 'roles' ? $this->endpoint : sprintf('%s/%s', $this->endpoint, $this->resourceType);
@@ -126,8 +126,8 @@ abstract class AdministrationBaseController extends AppController
      */
     public function save(): ?Response
     {
-        $this->request->allowMethod(['post']);
-        $data = (array)$this->request->getData();
+        $this->getRequest()->allowMethod(['post']);
+        $data = (array)$this->getRequest()->getData();
         $id = (string)Hash::get($data, 'id');
         unset($data['id']);
         $body = [
@@ -160,7 +160,7 @@ abstract class AdministrationBaseController extends AppController
      */
     public function remove(string $id): ?Response
     {
-        $this->request->allowMethod(['post']);
+        $this->getRequest()->allowMethod(['post']);
         try {
             $this->apiClient->delete(sprintf('%s/%s', $this->endpoint(), $id));
         } catch (BEditaClientException $e) {

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -371,11 +371,6 @@ class AppController extends Controller
      */
     protected function checkRequest(array $options = []): array
     {
-        // check request
-        if (empty($this->getRequest())) {
-            throw new BadRequestException('Empty request');
-        }
-
         // check allowed methods
         if (!empty($options['allowedMethods'])) {
             $this->getRequest()->allowMethod($options['allowedMethods']);

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -77,7 +77,7 @@ class AppController extends Controller
         $tokens = $this->Auth->user('tokens');
         if (!empty($tokens)) {
             $this->apiClient->setupTokens($tokens);
-        } elseif (!in_array($this->request->getPath(), ['/login'])) {
+        } elseif (!in_array($this->getRequest()->getPath(), ['/login'])) {
             $route = $this->loginRedirectRoute();
             $this->Flash->error(__('Login required'));
 
@@ -104,13 +104,13 @@ class AppController extends Controller
         $this->log($exception, 'error');
 
         // Log form data & session id
-        $token = (array)$this->request->getData('_Token');
+        $token = (array)$this->getRequest()->getData('_Token');
         unset($token['debug']);
         $this->log('[Blackhole] type: ' . $type, 'debug');
         $this->log('[Blackhole] form token: ' . json_encode($token), 'debug');
-        $this->log('[Blackhole] form fields: ' . json_encode(array_keys((array)$this->request->getData())), 'debug');
-        $this->log('[Blackhole] form session id: ' . (string)$this->request->getData('_session_id'), 'debug');
-        $sessionId = $this->request->getSession() ? $this->request->getSession()->id() : null;
+        $this->log('[Blackhole] form fields: ' . json_encode(array_keys((array)$this->getRequest()->getData())), 'debug');
+        $this->log('[Blackhole] form session id: ' . (string)$this->getRequest()->getData('_session_id'), 'debug');
+        $sessionId = $this->getRequest()->getSession() ? $this->getRequest()->getSession()->id() : null;
         $this->log('[Blackhole] current session id: ' . $sessionId, 'debug');
 
         // Throw a generic bad request exception.
@@ -130,13 +130,13 @@ class AppController extends Controller
         $route = ['_name' => 'login'];
 
         // if request is not a get, return route without redirect.
-        if (!$this->request->is('get')) {
+        if (!$this->getRequest()->is('get')) {
             return $route;
         }
 
         // if redirect is app webroot, return route without redirect.
-        $redirect = $this->request->getUri()->getPath();
-        if ($redirect === $this->request->getAttribute('webroot')) {
+        $redirect = $this->getRequest()->getUri()->getPath();
+        if ($redirect === $this->getRequest()->getAttribute('webroot')) {
             return $route;
         }
 
@@ -188,7 +188,7 @@ class AppController extends Controller
      */
     protected function prepareRequest($type): array
     {
-        $data = (array)$this->request->getData();
+        $data = (array)$this->getRequest()->getData();
 
         $this->specialAttributes($data);
         $this->setupParentsRelation($type, $data);
@@ -372,20 +372,20 @@ class AppController extends Controller
     protected function checkRequest(array $options = []): array
     {
         // check request
-        if (empty($this->request)) {
+        if (empty($this->getRequest())) {
             throw new BadRequestException('Empty request');
         }
 
         // check allowed methods
         if (!empty($options['allowedMethods'])) {
-            $this->request->allowMethod($options['allowedMethods']);
+            $this->getRequest()->allowMethod($options['allowedMethods']);
         }
 
         // check request required parameters, if any
         $data = [];
         if (!empty($options['requiredParameters'])) {
             foreach ($options['requiredParameters'] as $param) {
-                $val = $this->request->getData($param);
+                $val = $this->getRequest()->getData($param);
                 if (empty($val)) {
                     throw new BadRequestException(sprintf('Empty %s', $param));
                 }
@@ -409,18 +409,18 @@ class AppController extends Controller
      */
     protected function applySessionFilter(): ?Response
     {
-        $session = $this->request->getSession();
+        $session = $this->getRequest()->getSession();
         $sessionKey = sprintf('%s.filter', $this->Modules->getConfig('currentModuleName'));
 
         // if reset request, delete session data by key and redirect to proper uri
-        if ($this->request->getQuery('reset') === '1') {
+        if ($this->getRequest()->getQuery('reset') === '1') {
             $session->delete($sessionKey);
 
-            return $this->redirect((string)$this->request->getUri()->withQuery(''));
+            return $this->redirect((string)$this->getRequest()->getUri()->withQuery(''));
         }
 
         // write request query parameters (if any) in session
-        $params = $this->request->getQueryParams();
+        $params = $this->getRequest()->getQueryParams();
         if (!empty($params)) {
             unset($params['_search']);
             $session->write($sessionKey, $params);
@@ -433,7 +433,7 @@ class AppController extends Controller
         if (!empty($params)) {
             $query = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
 
-            return $this->redirect((string)$this->request->getUri()->withQuery($query));
+            return $this->redirect((string)$this->getRequest()->getUri()->withQuery($query));
         }
 
         return null;
@@ -467,7 +467,7 @@ class AppController extends Controller
                 'object_type' => Hash::get($objects, sprintf('%d.object_type', $i)),
             ];
         }
-        $session = $this->request->getSession();
+        $session = $this->getRequest()->getSession();
         $session->write('objectNav', $objectNav);
         $session->write('objectNavModule', $moduleName);
     }
@@ -481,7 +481,7 @@ class AppController extends Controller
     protected function getObjectNav($id): array
     {
         // get objectNav from session
-        $session = $this->request->getSession();
+        $session = $this->getRequest()->getSession();
         $objectNav = (array)$session->read('objectNav');
         if (empty($objectNav)) {
             return [];

--- a/src/Controller/BulkController.php
+++ b/src/Controller/BulkController.php
@@ -58,7 +58,7 @@ class BulkController extends AppController
     {
         parent::initialize();
 
-        $this->objectType = $this->request->getParam('object_type');
+        $this->objectType = $this->getRequest()->getParam('object_type');
     }
 
     /**
@@ -68,13 +68,13 @@ class BulkController extends AppController
      */
     public function attribute(): ?Response
     {
-        $this->request->allowMethod(['post']);
-        $requestData = $this->request->getData();
+        $this->getRequest()->allowMethod(['post']);
+        $requestData = $this->getRequest()->getData();
         $this->ids = explode(',', (string)Hash::get($requestData, 'ids'));
         $this->saveAttribute($requestData['attributes']);
         $this->errors();
 
-        return $this->redirect(['_name' => 'modules:list', 'object_type' => $this->objectType, '?' => $this->request->getQuery()]);
+        return $this->redirect(['_name' => 'modules:list', 'object_type' => $this->objectType, '?' => $this->getRequest()->getQuery()]);
     }
 
     /**
@@ -84,15 +84,15 @@ class BulkController extends AppController
      */
     public function categories(): ?Response
     {
-        $this->request->allowMethod(['post']);
-        $requestData = $this->request->getData();
+        $this->getRequest()->allowMethod(['post']);
+        $requestData = $this->getRequest()->getData();
         $this->ids = explode(',', (string)Hash::get($requestData, 'ids'));
         $this->categories = (string)Hash::get($requestData, 'categories');
         $this->loadCategories();
         $this->saveCategories();
         $this->errors();
 
-        return $this->redirect(['_name' => 'modules:list', 'object_type' => $this->objectType, '?' => $this->request->getQuery()]);
+        return $this->redirect(['_name' => 'modules:list', 'object_type' => $this->objectType, '?' => $this->getRequest()->getQuery()]);
     }
 
     /**
@@ -102,8 +102,8 @@ class BulkController extends AppController
      */
     public function position(): ?Response
     {
-        $this->request->allowMethod(['post']);
-        $requestData = $this->request->getData();
+        $this->getRequest()->allowMethod(['post']);
+        $requestData = $this->getRequest()->getData();
         $this->ids = explode(',', (string)Hash::get($requestData, 'ids'));
         $folder = (string)Hash::get($requestData, 'folderSelected');
         $action = (string)Hash::get($requestData, 'action');
@@ -114,7 +114,7 @@ class BulkController extends AppController
         }
         $this->errors();
 
-        return $this->redirect(['_name' => 'modules:list', 'object_type' => $this->objectType, '?' => $this->request->getQuery()]);
+        return $this->redirect(['_name' => 'modules:list', 'object_type' => $this->objectType, '?' => $this->getRequest()->getQuery()]);
     }
 
     /**

--- a/src/Controller/Component/HistoryComponent.php
+++ b/src/Controller/Component/HistoryComponent.php
@@ -126,7 +126,7 @@ class HistoryComponent extends Component
         // if keep uname, recover it from object
         if ($keepUname) {
             $response = $ApiClient->getObject($id, $objectType);
-            $attributes['uname'] = Hash::get($response, 'data.attributes.uname');
+            $attributes['uname'] = Hash::get((array)$response, 'data.attributes.uname');
         }
 
         // write attributes into session

--- a/src/Controller/Component/HistoryComponent.php
+++ b/src/Controller/Component/HistoryComponent.php
@@ -54,7 +54,7 @@ class HistoryComponent extends Component
             return;
         }
         $key = sprintf($this->key, $id);
-        $session = $this->getController()->request->getSession();
+        $session = $this->getController()->getRequest()->getSession();
         $data = (string)$session->read($key);
         if (empty($data)) {
             return;
@@ -131,7 +131,7 @@ class HistoryComponent extends Component
 
         // write attributes into session
         $key = sprintf($this->key, $id);
-        $session = $this->getController()->request->getSession();
+        $session = $this->getController()->getRequest()->getSession();
         $session->write($key, json_encode($attributes));
     }
 

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -418,7 +418,7 @@ class ModulesComponent extends Component
             return;
         }
         $key = sprintf('failedSave.%s.%s', $type, $data['id']);
-        $session = $this->getController()->request->getSession();
+        $session = $this->getController()->getRequest()->getSession();
         unset($data['id']); // remove 'id', avoid future merged with attributes
         $session->write($key, $data);
         $session->write(sprintf('%s__timestamp', $key), time());
@@ -450,7 +450,7 @@ class ModulesComponent extends Component
     protected function updateFromFailedSave(array &$object): void
     {
         // check session data for object id => use `failedSave.{type}.{id}` as key
-        $session = $this->getController()->request->getSession();
+        $session = $this->getController()->getRequest()->getSession();
         $key = sprintf(
             'failedSave.%s.%s',
             Hash::get($object, 'type'),

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -37,7 +37,7 @@ class DashboardController extends AppController
      */
     public function index(): void
     {
-        $this->request->allowMethod(['get']);
+        $this->getRequest()->allowMethod(['get']);
         $this->set('recentItems', $this->recentItems());
     }
 
@@ -48,7 +48,7 @@ class DashboardController extends AppController
      */
     public function messages(): void
     {
-        $this->request->allowMethod(['get']);
+        $this->getRequest()->allowMethod(['get']);
         $this->viewBuilder()->disableAutoLayout();
         $this->render('/Element/Dashboard/messages');
     }

--- a/src/Controller/DownloadController.php
+++ b/src/Controller/DownloadController.php
@@ -49,7 +49,7 @@ class DownloadController extends AppController
         $contentType = Hash::get($stream, 'attributes.mime_type');
 
         // output
-        $response = $this->response->withStringBody($this->content($stream));
+        $response = $this->getResponse()->withStringBody($this->content($stream));
         $response = $response->withType($contentType);
 
         return $response->withDownload($filename);

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -61,14 +61,14 @@ class ExportController extends AppController
             'requiredParameters' => ['objectType'],
         ]);
 
-        $format = (string)$this->request->getData('format');
+        $format = (string)$this->getRequest()->getData('format');
         if (!$this->Export->checkFormat($format)) {
             $this->Flash->error(__('Format choosen is not available'));
 
             return $this->redirect($this->referer());
         }
 
-        $ids = $this->request->getData('ids');
+        $ids = $this->getRequest()->getData('ids');
 
         // load data for objects by object type and ids
         $rows = $this->rows($data['objectType'], $ids);
@@ -115,7 +115,7 @@ class ExportController extends AppController
      */
     protected function apiPath(): string
     {
-        return sprintf('/%s', $this->request->getData('objectType'));
+        return sprintf('/%s', $this->getRequest()->getData('objectType'));
     }
 
     /**
@@ -168,7 +168,7 @@ class ExportController extends AppController
     protected function prepareQuery(): array
     {
         $res = [];
-        $f = (array)$this->request->getData('filter');
+        $f = (array)$this->getRequest()->getData('filter');
         if (!empty($f)) {
             $filter = [];
             foreach ($f as $v) {
@@ -176,7 +176,7 @@ class ExportController extends AppController
             }
             $res = compact('filter');
         }
-        $q = (string)$this->request->getData('q');
+        $q = (string)$this->getRequest()->getData('q');
         if (!empty($q)) {
             $res += compact('q');
         }

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -78,7 +78,7 @@ class ExportController extends AppController
         $data = $this->Export->format($format, $rows, $filename);
 
         // output
-        $response = $this->response->withStringBody(Hash::get($data, 'content'));
+        $response = $this->getResponse()->withStringBody(Hash::get($data, 'content'));
         $response = $response->withType(Hash::get($data, 'contentType'));
 
         return $response->withDownload($filename);

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -115,7 +115,7 @@ class ExportController extends AppController
      */
     protected function apiPath(): string
     {
-        return sprintf('/%s', $this->getRequest()->getData('objectType'));
+        return sprintf('/%s', (string)$this->getRequest()->getData('objectType'));
     }
 
     /**

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -68,7 +68,7 @@ class ExportController extends AppController
             return $this->redirect($this->referer());
         }
 
-        $ids = $this->getRequest()->getData('ids');
+        $ids = (string)$this->getRequest()->getData('ids');
 
         // load data for objects by object type and ids
         $rows = $this->rows($data['objectType'], $ids);

--- a/src/Controller/HistoryController.php
+++ b/src/Controller/HistoryController.php
@@ -33,8 +33,8 @@ class HistoryController extends AppController
     public function info($id): void
     {
         $this->viewBuilder()->setClassName('Json');
-        $this->request->allowMethod('get');
-        $schema = (array)$this->Schema->getSchema($this->request->getParam('object_type'));
+        $this->getRequest()->allowMethod('get');
+        $schema = (array)$this->Schema->getSchema($this->getRequest()->getParam('object_type'));
         $response = $this->History->fetch($id, $schema);
         $data = $response['data'];
         $meta = $response['meta'];
@@ -53,7 +53,7 @@ class HistoryController extends AppController
     {
         $this->setHistory($id, $historyId, false);
 
-        return $this->redirect(['_name' => 'modules:clone', 'object_type' => $this->request->getParam('object_type')] + compact('id'));
+        return $this->redirect(['_name' => 'modules:clone', 'object_type' => $this->getRequest()->getParam('object_type')] + compact('id'));
     }
 
     /**
@@ -67,7 +67,7 @@ class HistoryController extends AppController
     {
         $this->setHistory($id, $historyId, true);
 
-        return $this->redirect(['_name' => 'modules:view', 'object_type' => $this->request->getParam('object_type')] + compact('id'));
+        return $this->redirect(['_name' => 'modules:view', 'object_type' => $this->getRequest()->getParam('object_type')] + compact('id'));
     }
 
     /**
@@ -80,10 +80,10 @@ class HistoryController extends AppController
      */
     protected function setHistory($id, $historyId, $keepUname): void
     {
-        $objectType = $this->request->getParam('object_type');
+        $objectType = $this->getRequest()->getParam('object_type');
         $options = compact('objectType', 'id', 'historyId', 'keepUname') + [
             'ApiClient' => $this->apiClient,
-            'Request' => $this->request,
+            'Request' => $this->getRequest(),
             'Schema' => $this->Schema,
         ];
         $this->History->write($options);

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -48,7 +48,6 @@ class ImportController extends AppController
      * Display import page.
      *
      * @return void
-     * @codeCoverageIgnore
      */
     public function index(): void
     {

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -52,7 +52,7 @@ class ImportController extends AppController
      */
     public function index(): void
     {
-        $result = $this->request->getSession()->consume('Import.result');
+        $result = $this->getRequest()->getSession()->consume('Import.result');
         $this->set(compact('result'));
         $this->loadFilters();
     }
@@ -65,7 +65,7 @@ class ImportController extends AppController
     public function jobs(): void
     {
         $this->viewBuilder()->setClassName('Json');
-        $this->request->allowMethod('get');
+        $this->getRequest()->allowMethod('get');
         $this->loadFilters();
         $this->loadAsyncJobs();
         $this->set('_serialize', ['jobs']);
@@ -79,24 +79,24 @@ class ImportController extends AppController
     public function file(): ?Response
     {
         try {
-            $filter = $this->request->getData('filter');
+            $filter = $this->getRequest()->getData('filter');
             if (empty($filter)) {
                 throw new BadRequestException(__('Import filter not selected'));
             }
             $importFilter = new $filter($this->apiClient);
 
             // see http://php.net/manual/en/features.file-upload.errors.php
-            $fileError = (int)$this->request->getData('file.error', UPLOAD_ERR_NO_FILE);
+            $fileError = (int)$this->getRequest()->getData('file.error', UPLOAD_ERR_NO_FILE);
             if ($fileError > UPLOAD_ERR_OK) {
                 throw new BadRequestException($this->uploadErrorMessage($fileError));
             }
 
             $result = $importFilter->import(
-                $this->request->getData('file.name'),
-                $this->request->getData('file.tmp_name'),
-                $this->request->getData('filter_options')
+                $this->getRequest()->getData('file.name'),
+                $this->getRequest()->getData('file.tmp_name'),
+                $this->getRequest()->getData('filter_options')
             );
-            $this->request->getSession()->write(['Import.result' => $result]);
+            $this->getRequest()->getSession()->write(['Import.result' => $result]);
         } catch (Exception $e) {
             $this->Flash->error($e->getMessage(), ['params' => $e]);
         }

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -34,8 +34,6 @@ class ImportController extends AppController
 
     /**
      * {@inheritDoc}
-     *
-     * @codeCoverageIgnore
      */
     public function beforeRender(Event $event): ?Response
     {

--- a/src/Controller/LockController.php
+++ b/src/Controller/LockController.php
@@ -53,8 +53,8 @@ class LockController extends AppController
      */
     protected function lock(bool $locked): bool
     {
-        $type = $this->request->getParam('object_type');
-        $id = $this->request->getParam('id');
+        $type = $this->getRequest()->getParam('object_type');
+        $id = $this->getRequest()->getParam('id');
         $meta = compact('locked');
         $data = compact('id', 'type', 'meta');
         $payload = json_encode(compact('data'));

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -41,11 +41,11 @@ class LoginController extends AppController
     public function login(): ?Response
     {
         // Add `head` to avoid errors on http `HEAD /` calls since they are redirected to `HEAD /login`
-        $this->request->allowMethod(['get', 'head', 'post']);
+        $this->getRequest()->allowMethod(['get', 'head', 'post']);
 
-        if (!$this->request->is('post')) {
+        if (!$this->getRequest()->is('post')) {
             // Handle flash messages
-            $this->handleFlashMessages($this->request->getQueryParams());
+            $this->handleFlashMessages($this->getRequest()->getQueryParams());
             // Load available projects info
             $this->loadAvailableProjects();
 
@@ -66,7 +66,7 @@ class LoginController extends AppController
         $reason = __('Invalid username or password');
         // Load project config if `multi project` setup
         Application::loadProjectConfig(
-            (string)$this->request->getData('project'),
+            (string)$this->getRequest()->getData('project'),
             (string)$this->getConfig('projectsPath')
         );
         try {
@@ -126,11 +126,11 @@ class LoginController extends AppController
      */
     protected function setupCurrentProject(): void
     {
-        $project = $this->request->getData('project');
+        $project = $this->getRequest()->getData('project');
         if (empty($project)) {
             return;
         }
-        $this->request->getSession()->write('_project', $project);
+        $this->getRequest()->getSession()->write('_project', $project);
     }
 
     /**
@@ -142,7 +142,7 @@ class LoginController extends AppController
     {
         // 'timezone_offset' must contain UTC offset in seconds
         // plus Daylight Saving Time DST 0 or 1 like: '3600 1' or '7200 0'
-        $offset = $this->request->getData('timezone_offset');
+        $offset = $this->getRequest()->getData('timezone_offset');
         if (empty($offset)) {
             return 'UTC';
         }
@@ -159,9 +159,9 @@ class LoginController extends AppController
      */
     public function logout(): ?Response
     {
-        $this->request->allowMethod(['get']);
+        $this->getRequest()->allowMethod(['get']);
         $redirect = $this->redirect($this->Auth->logout());
-        $this->request->getSession()->destroy();
+        $this->getRequest()->getSession()->destroy();
 
         return $redirect;
     }
@@ -177,7 +177,7 @@ class LoginController extends AppController
     {
         if (!isset($query['redirect'])) {
             // Remove flash messages
-            $this->request->getSession()->delete('Flash');
+            $this->getRequest()->getSession()->delete('Flash');
         }
     }
 }

--- a/src/Controller/Model/CategoriesController.php
+++ b/src/Controller/Model/CategoriesController.php
@@ -51,11 +51,11 @@ class CategoriesController extends ModelBaseController
      */
     public function index(): ?Response
     {
-        $this->request->allowMethod(['get']);
+        $this->getRequest()->allowMethod(['get']);
 
         $objectTypes = $this->Schema->objectTypesFeatures()['categorized'];
         $objectTypes = array_combine($objectTypes, $objectTypes);
-        $response = $this->Categories->index(null, $this->request->getQueryParams());
+        $response = $this->Categories->index(null, $this->getRequest()->getQueryParams());
         $resources = $this->Categories->map($response);
         $roots = $this->Categories->getAvailableRoots($resources);
         $categoriesTree = $this->Categories->tree($resources);

--- a/src/Controller/Model/ExportController.php
+++ b/src/Controller/Model/ExportController.php
@@ -37,7 +37,7 @@ class ExportController extends AppController
     {
         $content = $this->apiClient->get('/model/project', [], ['Accept' => 'application/json']);
 
-        $response = $this->response->withStringBody(json_encode($content));
+        $response = $this->getResponse()->withStringBody(json_encode($content));
         $response = $response->withType('application/json');
 
         return $response->withDownload(self::FILENAME);

--- a/src/Controller/Model/ModelBaseController.php
+++ b/src/Controller/Model/ModelBaseController.php
@@ -82,8 +82,8 @@ abstract class ModelBaseController extends AppController
      */
     public function index(): ?Response
     {
-        $this->request->allowMethod(['get']);
-        $query = $this->request->getQueryParams() + ['page_size' => 500];
+        $this->getRequest()->allowMethod(['get']);
+        $query = $this->getRequest()->getQueryParams() + ['page_size' => 500];
 
         try {
             $response = $this->apiClient->get(
@@ -140,7 +140,7 @@ abstract class ModelBaseController extends AppController
      */
     public function save(): ?Response
     {
-        $data = $this->request->getData();
+        $data = $this->getRequest()->getData();
         $id = Hash::get($data, 'id');
         unset($data['id']);
         $body = [

--- a/src/Controller/Model/PropertyTypesController.php
+++ b/src/Controller/Model/PropertyTypesController.php
@@ -50,9 +50,9 @@ class PropertyTypesController extends ModelBaseController
      */
     public function save(): ?Response
     {
-        $payload = $this->request->getData();
+        $payload = $this->getRequest()->getData();
 
-        $this->request->allowMethod(['post']);
+        $this->getRequest()->allowMethod(['post']);
         $response = [];
 
         try {

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -356,7 +356,7 @@ class ModulesController extends AppController
             if (is_string($this->getRequest()->getData('ids'))) {
                 $ids = explode(',', (string)$this->getRequest()->getData('ids'));
             }
-        } else if (!empty($this->getRequest()->getData('id'))) {
+        } elseif (!empty($this->getRequest()->getData('id'))) {
             $ids = [$this->getRequest()->getData('id')];
         }
         foreach ($ids as $id) {

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -354,9 +354,9 @@ class ModulesController extends AppController
         $ids = [];
         if (!empty($this->getRequest()->getData('ids'))) {
             if (is_string($this->getRequest()->getData('ids'))) {
-                $ids = explode(',', $this->getRequest()->getData('ids'));
+                $ids = explode(',', (string)$this->getRequest()->getData('ids'));
             }
-        } else {
+        } else if (!empty($this->getRequest()->getData('id'))) {
             $ids = [$this->getRequest()->getData('id')];
         }
         foreach ($ids as $id) {

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -562,7 +562,7 @@ class ModulesController extends AppController
         $this->getRequest()->allowMethod(['post']);
 
         try {
-            $this->Categories->save($this->getRequest()->getData());
+            $this->Categories->save((array)$this->getRequest()->getData());
         } catch (BEditaClientException $e) {
             $this->log($e, 'error');
             $this->Flash->error($e->getMessage(), ['params' => $e]);

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -55,8 +55,8 @@ class ModulesController extends AppController
         $this->loadComponent('Thumbs');
         $this->loadComponent('BEdita/WebTools.ApiFormatter');
 
-        if (!empty($this->request)) {
-            $this->objectType = $this->request->getParam('object_type');
+        if (!empty($this->getRequest())) {
+            $this->objectType = $this->getRequest()->getParam('object_type');
             $this->Modules->setConfig('currentModuleName', $this->objectType);
             $this->Schema->setConfig('type', $this->objectType);
         }
@@ -82,7 +82,7 @@ class ModulesController extends AppController
      */
     public function index(): ?Response
     {
-        $this->request->allowMethod(['get']);
+        $this->getRequest()->allowMethod(['get']);
 
         // handle filter and query parameters using session
         $result = $this->applySessionFilter();
@@ -96,7 +96,7 @@ class ModulesController extends AppController
             $this->log($e, LogLevel::ERROR);
             $this->Flash->error($e->getMessage(), ['params' => $e]);
             // remove session filter to avoid error repetition
-            $session = $this->request->getSession();
+            $session = $this->getRequest()->getSession();
             $session->delete(sprintf('%s.filter', $this->Modules->getConfig('currentModuleName')));
 
             return $this->redirect(['_name' => 'dashboard']);
@@ -136,7 +136,7 @@ class ModulesController extends AppController
      */
     public function view($id): ?Response
     {
-        $this->request->allowMethod(['get']);
+        $this->getRequest()->allowMethod(['get']);
 
         try {
             $query = ['count' => 'all'];
@@ -267,7 +267,7 @@ class ModulesController extends AppController
     public function save(): void
     {
         $this->viewBuilder()->setClassName('Json'); // force json response
-        $this->request->allowMethod(['post']);
+        $this->getRequest()->allowMethod(['post']);
         $requestData = $this->prepareRequest($this->objectType);
         unset($requestData['_csrfToken']);
         // extract related objects data
@@ -325,7 +325,7 @@ class ModulesController extends AppController
             $attributes = $response['data']['attributes'];
             $attributes['uname'] = '';
             unset($attributes['relationships']);
-            $attributes['title'] = $this->request->getQuery('title');
+            $attributes['title'] = $this->getRequest()->getQuery('title');
         } catch (BEditaClientException $e) {
             $this->log($e, LogLevel::ERROR);
             $this->Flash->error($e->getMessage(), ['params' => $e]);
@@ -350,14 +350,14 @@ class ModulesController extends AppController
      */
     public function delete(): ?Response
     {
-        $this->request->allowMethod(['post']);
+        $this->getRequest()->allowMethod(['post']);
         $ids = [];
-        if (!empty($this->request->getData('ids'))) {
-            if (is_string($this->request->getData('ids'))) {
-                $ids = explode(',', $this->request->getData('ids'));
+        if (!empty($this->getRequest()->getData('ids'))) {
+            if (is_string($this->getRequest()->getData('ids'))) {
+                $ids = explode(',', $this->getRequest()->getData('ids'));
             }
         } else {
-            $ids = [$this->request->getData('id')];
+            $ids = [$this->getRequest()->getData('id')];
         }
         foreach ($ids as $id) {
             try {
@@ -365,8 +365,8 @@ class ModulesController extends AppController
             } catch (BEditaClientException $e) {
                 $this->log($e, LogLevel::ERROR);
                 $this->Flash->error($e->getMessage(), ['params' => $e]);
-                if (!empty($this->request->getData('id'))) {
-                    return $this->redirect(['_name' => 'modules:view', 'object_type' => $this->objectType, 'id' => $this->request->getData('id')]);
+                if (!empty($this->getRequest()->getData('id'))) {
+                    return $this->redirect(['_name' => 'modules:view', 'object_type' => $this->objectType, 'id' => $this->getRequest()->getData('id')]);
                 }
 
                 return $this->redirect(['_name' => 'modules:view', 'object_type' => $this->objectType, 'id' => $id]);
@@ -396,8 +396,8 @@ class ModulesController extends AppController
             return;
         }
 
-        $this->request->allowMethod(['get']);
-        $query = $this->Query->prepare($this->request->getQueryParams());
+        $this->getRequest()->allowMethod(['get']);
+        $query = $this->Query->prepare($this->getRequest()->getQueryParams());
         try {
             $response = $this->apiClient->getRelated($id, $this->objectType, $relation, $query);
             $response = $this->ApiFormatter->embedIncluded((array)$response);
@@ -426,8 +426,8 @@ class ModulesController extends AppController
      */
     public function resources($id, string $type): void
     {
-        $this->request->allowMethod(['get']);
-        $query = $this->Query->prepare($this->request->getQueryParams());
+        $this->getRequest()->allowMethod(['get']);
+        $query = $this->Query->prepare($this->getRequest()->getQueryParams());
         try {
             $response = $this->apiClient->get($type, $query);
         } catch (BEditaClientException $error) {
@@ -453,11 +453,11 @@ class ModulesController extends AppController
      */
     public function relationships($id, string $relation): void
     {
-        $this->request->allowMethod(['get']);
+        $this->getRequest()->allowMethod(['get']);
         $available = $this->availableRelationshipsUrl($relation);
 
         try {
-            $query = $this->Query->prepare($this->request->getQueryParams());
+            $query = $this->Query->prepare($this->getRequest()->getQueryParams());
             $response = $this->apiClient->get($available, $query);
 
             $this->Thumbs->urls($response);
@@ -535,8 +535,8 @@ class ModulesController extends AppController
     {
         $this->viewBuilder()->setTemplate('categories');
 
-        $this->request->allowMethod(['get']);
-        $response = $this->Categories->index($this->objectType, $this->request->getQueryParams());
+        $this->getRequest()->allowMethod(['get']);
+        $response = $this->Categories->index($this->objectType, $this->getRequest()->getQueryParams());
         $resources = $this->Categories->map($response);
         $roots = $this->Categories->getAvailableRoots($resources);
         $categoriesTree = $this->Categories->tree($resources);
@@ -559,10 +559,10 @@ class ModulesController extends AppController
      */
     public function saveCategory(): ?Response
     {
-        $this->request->allowMethod(['post']);
+        $this->getRequest()->allowMethod(['post']);
 
         try {
-            $this->Categories->save($this->request->getData());
+            $this->Categories->save($this->getRequest()->getData());
         } catch (BEditaClientException $e) {
             $this->log($e, 'error');
             $this->Flash->error($e->getMessage(), ['params' => $e]);
@@ -584,7 +584,7 @@ class ModulesController extends AppController
     public function removeCategory(string $id): ?Response
     {
         try {
-            $type = $this->request->getData('object_type_name');
+            $type = $this->getRequest()->getData('object_type_name');
             $this->Categories->delete($id, $type);
         } catch (BEditaClientException $e) {
             $this->log($e, 'error');

--- a/src/Controller/PasswordController.php
+++ b/src/Controller/PasswordController.php
@@ -54,14 +54,14 @@ class PasswordController extends AppController
      */
     public function reset(): ?Response
     {
-        $this->request->allowMethod(['get', 'post']);
+        $this->getRequest()->allowMethod(['get', 'post']);
 
-        if ($this->request->is('get')) {
+        if ($this->getRequest()->is('get')) {
             return null;
         }
 
         $data = [
-            'contact' => $this->request->getData('email'),
+            'contact' => $this->getRequest()->getData('email'),
             'change_url' => Router::url(['_name' => 'password:change'], true),
         ];
         try {
@@ -88,17 +88,17 @@ class PasswordController extends AppController
      */
     public function change(): ?Response
     {
-        $this->request->allowMethod(['get', 'post']);
+        $this->getRequest()->allowMethod(['get', 'post']);
 
-        if ($this->request->is('get')) {
-            $this->set('uuid', $this->request->getQuery('uuid'));
+        if ($this->getRequest()->is('get')) {
+            $this->set('uuid', $this->getRequest()->getQuery('uuid'));
 
             return null;
         }
 
         $data = [
-            'uuid' => $this->request->getData('uuid'),
-            'password' => $this->request->getData('password'),
+            'uuid' => $this->getRequest()->getData('uuid'),
+            'password' => $this->getRequest()->getData('password'),
             'login' => true,
         ];
         try {

--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -38,7 +38,7 @@ class TranslationsController extends ModulesController
      */
     public function initialize(): void
     {
-        $this->request = $this->request->withParam('object_type', 'translations');
+        $this->setRequest($this->getRequest()->withParam('object_type', 'translations'));
         parent::initialize();
         $this->Query->setConfig('include', 'object');
     }
@@ -51,7 +51,7 @@ class TranslationsController extends ModulesController
      */
     public function add($id): ?Response
     {
-        $this->request->allowMethod(['get']);
+        $this->getRequest()->allowMethod(['get']);
         $this->objectType = $this->typeFromUrl();
 
         try {
@@ -83,7 +83,7 @@ class TranslationsController extends ModulesController
      */
     public function edit($id, $lang): ?Response
     {
-        $this->request->allowMethod(['get']);
+        $this->getRequest()->allowMethod(['get']);
         $this->objectType = $this->typeFromUrl();
 
         $translation = [];
@@ -124,7 +124,7 @@ class TranslationsController extends ModulesController
      */
     public function save(): void
     {
-        $this->request->allowMethod(['post']);
+        $this->getRequest()->allowMethod(['post']);
         $this->objectType = $this->typeFromUrl();
         $requestData = $this->prepareRequest($this->objectType);
         $objectId = $requestData['object_id'];
@@ -139,7 +139,7 @@ class TranslationsController extends ModulesController
             $this->log($e, LogLevel::ERROR);
             $this->Flash->error($e->getMessage(), ['params' => $e]);
 
-            if ($this->request->getData('id')) {
+            if ($this->getRequest()->getData('id')) {
                 $this->redirect([
                     '_name' => 'translations:edit',
                     'object_type' => $this->objectType,
@@ -181,9 +181,9 @@ class TranslationsController extends ModulesController
      */
     public function delete(): Response
     {
-        $this->request->allowMethod(['post']);
+        $this->getRequest()->allowMethod(['post']);
         $this->objectType = $this->typeFromUrl();
-        $requestData = $this->request->getData();
+        $requestData = $this->getRequest()->getData();
         try {
             if (empty($requestData[0])) {
                 throw new BadRequestException(__('Empty request data'));
@@ -220,7 +220,7 @@ class TranslationsController extends ModulesController
         if ($this->objectType !== 'translations') {
             return $this->objectType;
         }
-        $here = (string)$this->request->getAttribute('here');
+        $here = (string)$this->getRequest()->getAttribute('here');
 
         return substr($here, 1, strpos(substr($here, 1), '/'));
     }

--- a/src/Controller/TranslatorController.php
+++ b/src/Controller/TranslatorController.php
@@ -37,14 +37,14 @@ class TranslatorController extends AppController
     public function translate(): void
     {
         $this->viewBuilder()->setClassName('Json');
-        $this->request->allowMethod(['post']);
-        $text = $this->request->getData('text', '');
+        $this->getRequest()->allowMethod(['post']);
+        $text = $this->getRequest()->getData('text', '');
         $texts = (is_array($text)) ? $text : [$text];
         try {
             $json = $this->Translator->translate(
                 $texts,
-                (string)$this->request->getData('from'),
-                (string)$this->request->getData('to')
+                (string)$this->getRequest()->getData('from'),
+                (string)$this->getRequest()->getData('to')
             );
             $decoded = json_decode($json);
             $this->set('translation', $decoded->translation);

--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -58,10 +58,10 @@ class TrashController extends AppController
      */
     public function index(): ?Response
     {
-        $this->request->allowMethod(['get']);
+        $this->getRequest()->allowMethod(['get']);
 
         try {
-            $response = $this->apiClient->getObjects('trash', $this->request->getQueryParams());
+            $response = $this->apiClient->getObjects('trash', $this->getRequest()->getQueryParams());
         } catch (BEditaClientException $e) {
             // Error! Back to dashboard.
             $this->log($e, LogLevel::ERROR);
@@ -89,7 +89,7 @@ class TrashController extends AppController
      */
     public function view($id): ?Response
     {
-        $this->request->allowMethod(['get']);
+        $this->getRequest()->allowMethod(['get']);
 
         try {
             $response = $this->apiClient->getObject($id, 'trash');
@@ -117,15 +117,15 @@ class TrashController extends AppController
      */
     public function restore(): ?Response
     {
-        $this->request->allowMethod(['post']);
+        $this->getRequest()->allowMethod(['post']);
         $ids = [];
-        if (!empty($this->request->getData('ids'))) {
-            $ids = $this->request->getData('ids');
+        if (!empty($this->getRequest()->getData('ids'))) {
+            $ids = $this->getRequest()->getData('ids');
             if (is_string($ids)) {
-                $ids = explode(',', $this->request->getData('ids'));
+                $ids = explode(',', $this->getRequest()->getData('ids'));
             }
         } else {
-            $ids = [$this->request->getData('id')];
+            $ids = [$this->getRequest()->getData('id')];
         }
         foreach ($ids as $id) {
             try {
@@ -135,7 +135,7 @@ class TrashController extends AppController
                 $this->log($e, LogLevel::ERROR);
                 $this->Flash->error($e->getMessage(), ['params' => $e]);
 
-                if (!empty($this->request->getData('ids'))) {
+                if (!empty($this->getRequest()->getData('ids'))) {
                     return $this->redirect(['_name' => 'trash:list'] + $this->listQuery());
                 }
 
@@ -153,15 +153,15 @@ class TrashController extends AppController
      */
     public function delete(): ?Response
     {
-        $this->request->allowMethod(['post']);
+        $this->getRequest()->allowMethod(['post']);
         $ids = [];
-        if (!empty($this->request->getData('ids'))) {
-            $ids = $this->request->getData('ids');
+        if (!empty($this->getRequest()->getData('ids'))) {
+            $ids = $this->getRequest()->getData('ids');
             if (is_string($ids)) {
-                $ids = explode(',', $this->request->getData('ids'));
+                $ids = explode(',', $this->getRequest()->getData('ids'));
             }
         } else {
-            $ids = [$this->request->getData('id')];
+            $ids = [$this->getRequest()->getData('id')];
         }
         foreach ($ids as $id) {
             try {
@@ -171,7 +171,7 @@ class TrashController extends AppController
                 $this->log($e, LogLevel::ERROR);
                 $this->Flash->error($e->getMessage(), ['params' => $e]);
 
-                if (!empty($this->request->getData('ids'))) {
+                if (!empty($this->getRequest()->getData('ids'))) {
                     return $this->redirect(['_name' => 'trash:list'] + $this->listQuery());
                 }
 
@@ -191,7 +191,7 @@ class TrashController extends AppController
      */
     protected function listQuery(): array
     {
-        $query = $this->request->getData('query');
+        $query = $this->getRequest()->getData('query');
         if (empty($query)) {
             return [];
         }
@@ -208,7 +208,7 @@ class TrashController extends AppController
      */
     public function empty(): ?Response
     {
-        $this->request->allowMethod(['post']);
+        $this->getRequest()->allowMethod(['post']);
 
         $query = array_filter(array_intersect_key($this->listQuery(), ['filter' => '']));
         // cycle over trash results

--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -122,7 +122,7 @@ class TrashController extends AppController
         if (!empty($this->getRequest()->getData('ids'))) {
             $ids = $this->getRequest()->getData('ids');
             if (is_string($ids)) {
-                $ids = explode(',', $this->getRequest()->getData('ids'));
+                $ids = explode(',', (string)$this->getRequest()->getData('ids'));
             }
         } else {
             $ids = [$this->getRequest()->getData('id')];
@@ -158,7 +158,7 @@ class TrashController extends AppController
         if (!empty($this->getRequest()->getData('ids'))) {
             $ids = $this->getRequest()->getData('ids');
             if (is_string($ids)) {
-                $ids = explode(',', $this->getRequest()->getData('ids'));
+                $ids = explode(',', (string)$this->getRequest()->getData('ids'));
             }
         } else {
             $ids = [$this->getRequest()->getData('id')];

--- a/src/Controller/UserProfileController.php
+++ b/src/Controller/UserProfileController.php
@@ -54,7 +54,7 @@ class UserProfileController extends AppController
      */
     public function view(): void
     {
-        $this->request->allowMethod(['get']);
+        $this->getRequest()->allowMethod(['get']);
 
         try {
             $response = $this->apiClient->get('/auth/user');
@@ -77,7 +77,7 @@ class UserProfileController extends AppController
      */
     public function save(): void
     {
-        $data = $this->request->getData();
+        $data = $this->getRequest()->getData();
         try {
             $this->apiClient->patch('/auth/user', json_encode($data));
             $this->Flash->success(__('User profile saved'));

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -43,6 +43,6 @@ class AjaxView extends AppView
     {
         parent::initialize();
 
-        $this->response = $this->response->withType('ajax');
+        $this->setResponse($this->getResponse()->withType('ajax'));
     }
 }

--- a/tests/TestCase/Controller/Admin/AdministrationBaseControllerTest.php
+++ b/tests/TestCase/Controller/Admin/AdministrationBaseControllerTest.php
@@ -277,7 +277,7 @@ class AdministrationBaseControllerTest extends TestCase
         $response = $this->RlsController->save();
         static::assertEquals(302, $response->getStatusCode());
         static::assertEquals('/admin/roles', $response->getHeader('Location')[0]);
-        $flash = $this->RlsController->request->getSession()->read('Flash');
+        $flash = $this->RlsController->getRequest()->getSession()->read('Flash');
         $actual = $flash['flash'][0]['message'];
         static::assertEquals($expected, $actual);
     }
@@ -303,7 +303,7 @@ class AdministrationBaseControllerTest extends TestCase
         $response = $this->RlsController->remove('9999999999');
         static::assertEquals(302, $response->getStatusCode());
         static::assertEquals('/admin/roles', $response->getHeader('Location')[0]);
-        $flash = $this->RlsController->request->getSession()->read('Flash');
+        $flash = $this->RlsController->getRequest()->getSession()->read('Flash');
         $expected = __('[404] Not Found');
         $message = $flash['flash'][0]['message'];
         static::assertEquals($expected, $message);

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -634,7 +634,7 @@ class AppControllerTest extends TestCase
         $this->setupController($config);
 
         if ($config == null) {
-            $this->AppController->getRequest() = $config;
+            $this->AppController->setRequest(new ServerRequest($config));
         }
 
         if ($expected instanceof \Exception) {

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -1013,5 +1013,4 @@ class AppControllerTest extends TestCase
 
         static::assertSame($expected, $actual);
     }
-
 }

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -633,10 +633,6 @@ class AppControllerTest extends TestCase
     {
         $this->setupController($config);
 
-        if ($config == null) {
-            $this->AppController->setRequest(new ServerRequest($config));
-        }
-
         if ($expected instanceof \Exception) {
             $this->expectException(get_class($expected));
         }

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -583,11 +583,6 @@ class AppControllerTest extends TestCase
     public function checkRequestProvider(): array
     {
         return [
-            'badRequest' => [
-                new BadRequestException('Empty request'),
-                [],
-                null,
-            ],
             'methodNotAllowed' => [
                 new MethodNotAllowedException(),
                 ['allowedMethods' => 'POST'],

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -110,7 +110,7 @@ class AppControllerTest extends TestCase
 
         $event = $this->AppController->dispatchEvent('Controller.initialize');
 
-        $flash = $this->AppController->request->getSession()->read('Flash');
+        $flash = $this->AppController->getRequest()->getSession()->read('Flash');
 
         $expected = __('Login required');
         $message = $flash['flash'][0]['message'];
@@ -634,7 +634,7 @@ class AppControllerTest extends TestCase
         $this->setupController($config);
 
         if ($config == null) {
-            $this->AppController->request = $config;
+            $this->AppController->getRequest() = $config;
         }
 
         if ($expected instanceof \Exception) {
@@ -760,7 +760,7 @@ class AppControllerTest extends TestCase
         $this->setupController($requestConfig);
 
         // get session and write data on it
-        $session = $this->AppController->request->getSession();
+        $session = $this->AppController->getRequest()->getSession();
         $session->write($sessionKey, $sessionValue);
 
         // do controller call
@@ -886,7 +886,7 @@ class AppControllerTest extends TestCase
         $method->invokeArgs($this->AppController, [ $objects ]);
 
         // verify session data
-        $session = $this->AppController->request->getSession();
+        $session = $this->AppController->getRequest()->getSession();
         static::assertEquals($session->read('objectNav'), $expectedObjectNav);
         static::assertEquals($session->read('objectNavModule'), $expectedObjectNavModule);
     }
@@ -946,7 +946,7 @@ class AppControllerTest extends TestCase
         $method->invokeArgs($this->AppController, [ $objects ]);
 
         // get session data
-        $session = $this->AppController->request->getSession();
+        $session = $this->AppController->getRequest()->getSession();
         $objectNav = $session->read('objectNav');
 
         foreach ($objects as $object) {

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -984,4 +984,34 @@ class AppControllerTest extends TestCase
         // verify objectNavModule
         static::assertEquals($session->read('objectNavModule'), $moduleName);
     }
+
+    /**
+     * Test `getObjectNav`, when empty
+     *
+     * @return void
+     * @covers ::getObjectNav()
+     */
+    public function testGetObjectNavEmpty(): void
+    {
+        // Setup controller for test
+        $this->setupController();
+
+        // set objectNav data to empty array
+        $reflectionClass = new \ReflectionClass($this->AppController);
+        $method = $reflectionClass->getMethod('setObjectNav');
+        $method->setAccessible(true);
+        $method->invokeArgs($this->AppController, [ [] ]);
+
+        // get session data
+        $session = $this->AppController->getRequest()->getSession();
+        $expected = $session->read('objectNav');
+
+        // do controller call
+        $method = $reflectionClass->getMethod('getObjectNav');
+        $method->setAccessible(true);
+        $actual = $method->invokeArgs($this->AppController, [ '' ]);
+
+        static::assertSame($expected, $actual);
+    }
+
 }

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -712,6 +712,22 @@ class AppControllerTest extends TestCase
                 null, // expected http status code
                 null, // result type
             ],
+            'empty params' => [
+                [ // request config
+                    'environment' => [
+                        'REQUEST_METHOD' => 'GET',
+                    ],
+                    '?' => [],
+                    'params' => [
+                        'object_type' => 'documents',
+                    ],
+                ],
+                'App.filter', // session key
+                null, // session value
+                null, // expected session value
+                null, // expected http status code
+                null, // result type
+            ],
             'data from session' => [ // expected read session filter and redirect
                 [ // request config
                     'environment' => [

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -488,6 +488,21 @@ class AppControllerTest extends TestCase
                     '_changedParents' => true,
                 ],
             ],
+            'categories' => [
+                'documents',
+                [
+                    'id' => '2',
+                    'categories' => [
+                        ['name' => 'Blu'],
+                        ['name' => 'Red'],
+                        ['name' => 'Green'],
+                    ],
+                ],
+                [
+                    'id' => '2',
+                    'categories' => ['Blu', 'Red', 'Green'],
+                ],
+            ],
         ];
     }
 

--- a/tests/TestCase/Controller/BulkControllerTest.php
+++ b/tests/TestCase/Controller/BulkControllerTest.php
@@ -42,7 +42,7 @@ class BulkControllerTest extends BaseControllerTest
     {
         // Setup controller for test
         $this->setupController();
-        $actual = (string)$this->controller->request->getParam('object_type');
+        $actual = (string)$this->controller->getRequest()->getParam('object_type');
         $expected = 'documents';
         static::assertEquals($expected, $actual);
     }
@@ -400,13 +400,13 @@ class BulkControllerTest extends BaseControllerTest
         $method = $reflectionClass->getMethod('errors');
         $method->setAccessible(true);
         $method->invokeArgs($this->controller, []);
-        $message = $this->controller->request->getSession()->read('Flash');
+        $message = $this->controller->getRequest()->getSession()->read('Flash');
         static::assertEmpty($message);
 
         // not empty
         $this->controller->errors = ['something bad happened'];
         $method->invokeArgs($this->controller, []);
-        $message = $this->controller->request->getSession()->read('Flash');
+        $message = $this->controller->getRequest()->getSession()->read('Flash');
         static::assertNotEmpty($message);
     }
 }

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -71,14 +71,14 @@ class FlashComponentTest extends TestCase
         // message without params
         $expected = 'debug';
         $this->Flash->set($expected, []);
-        $flash = $this->controller->request->getSession()->read('Flash');
+        $flash = $this->controller->getRequest()->getSession()->read('Flash');
         static::assertEquals($expected, $flash['flash'][0]['message']);
 
         // message with params exception
         $expected = 'debug';
         $expectedExceptionMessage = 'something went wrong';
         $this->Flash->set('debug', ['params' => new BEditaClientException($expectedExceptionMessage)]);
-        $flash = $this->controller->request->getSession()->read('Flash');
+        $flash = $this->controller->getRequest()->getSession()->read('Flash');
         $message = $flash['flash'][0]['message'];
         static::assertEquals($expected, $flash['flash'][0]['message']);
         static::assertEquals($expected, $flash['flash'][1]['message']);

--- a/tests/TestCase/Controller/Component/HistoryComponentTest.php
+++ b/tests/TestCase/Controller/Component/HistoryComponentTest.php
@@ -131,7 +131,7 @@ class HistoryComponentTest extends TestCase
      */
     public function testLoad(array $object, string $expected): void
     {
-        $session = $this->HistoryComponent->getController()->request->getSession();
+        $session = $this->HistoryComponent->getController()->getRequest()->getSession();
         if ($expected != '') {
             $key = sprintf('history.%s.attributes', $this->documentId);
             $session->write($key, $expected);
@@ -191,7 +191,7 @@ class HistoryComponentTest extends TestCase
             'Request' => $this->Request,
         ];
         $this->HistoryComponent->write($options);
-        $session = $this->HistoryComponent->getController()->request->getSession();
+        $session = $this->HistoryComponent->getController()->getRequest()->getSession();
         $actual = $session->read(sprintf('history.%s.attributes', $options['id']));
         static::assertEquals($expected, $actual);
     }

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -990,7 +990,7 @@ class ModulesComponentTest extends TestCase
 
         // verify data
         $key = sprintf('failedSave.%s.%s', $type, $expected['id']);
-        $actual = $this->Modules->getController()->request->getSession()->read($key);
+        $actual = $this->Modules->getController()->getRequest()->getSession()->read($key);
         unset($expected['id']);
         static::assertEquals($expected, $actual);
     }

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -982,6 +982,11 @@ class ModulesComponentTest extends TestCase
      */
     public function testSetDataFromFailedSave(): void
     {
+        // empty case
+        $this->Modules->setDataFromFailedSave('', ['id' => 123]);
+        $actual = $this->Modules->getController()->request->getSession()->read('failedSave.123');
+        static::assertEmpty($actual);
+
         // data and expected
         $expected = [ 'id' => 999, 'name' => 'gustavo' ];
         $type = 'documents';
@@ -1005,6 +1010,12 @@ class ModulesComponentTest extends TestCase
      */
     public function testUpdateFromFailedSave(): void
     {
+        // empty case
+        $this->Modules->setDataFromFailedSave('', ['id' => 123]); // wrong data, missing type
+        $object = ['id' => 123, 'type' => 'documents'];
+        $this->Modules->setupAttributes($object);
+        static::assertArrayNotHasKey('attributes', $object);
+
         // write to session data, to simulate recover from session.
         $object = [
             'id' => 999,

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -369,7 +369,7 @@ class SchemaComponentTest extends TestCase
         $result = $this->Schema->getRelationsSchema();
         static::assertEmpty($result);
 
-        $message = $this->Schema->getController()->request->getSession()->read('Flash.flash.0.message');
+        $message = $this->Schema->getController()->getRequest()->getSession()->read('Flash.flash.0.message');
         static::assertEquals('Client Exception', $message);
     }
 

--- a/tests/TestCase/Controller/DashboardControllerTest.php
+++ b/tests/TestCase/Controller/DashboardControllerTest.php
@@ -118,7 +118,7 @@ class DashboardControllerTest extends TestCase
 
         $this->setupController($requestConfig);
         $this->Dashboard->index();
-        $response = $this->Dashboard->response;
+        $response = $this->Dashboard->getResponse();
 
         static::assertEquals(200, $response->getStatusCode());
         // recent items
@@ -141,7 +141,7 @@ class DashboardControllerTest extends TestCase
             ],
         ]);
         $this->Dashboard->messages();
-        $response = $this->Dashboard->response;
+        $response = $this->Dashboard->getResponse();
         static::assertEquals(200, $response->getStatusCode());
     }
 

--- a/tests/TestCase/Controller/ExportControllerTest.php
+++ b/tests/TestCase/Controller/ExportControllerTest.php
@@ -176,7 +176,7 @@ class ExportControllerTest extends TestCase
         // call export.
         $response = $this->Export->export();
         static::assertEquals(302, $response->getStatusCode());
-        $flash = (array)$this->Export->request->getSession()->read('Flash.flash');
+        $flash = (array)$this->Export->getRequest()->getSession()->read('Flash.flash');
         static::assertEquals('Format choosen is not available', Hash::get($flash, '0.message'));
     }
 

--- a/tests/TestCase/Controller/HistoryControllerTest.php
+++ b/tests/TestCase/Controller/HistoryControllerTest.php
@@ -210,7 +210,7 @@ class HistoryControllerTest extends TestCase
         // call protected method using AppControllerTest->invokeMethod
         $test = new AppControllerTest(new ServerRequest());
         $test->invokeMethod($this->HistoryController, 'setHistory', [$id, $historyId, $keepUname]);
-        $actual = $this->HistoryController->request->getSession()->read(sprintf('history.%s.attributes', $id));
+        $actual = $this->HistoryController->getRequest()->getSession()->read(sprintf('history.%s.attributes', $id));
         static::assertEquals($actual, $expected);
     }
 }

--- a/tests/TestCase/Controller/ImportControllerTest.php
+++ b/tests/TestCase/Controller/ImportControllerTest.php
@@ -328,4 +328,36 @@ class ImportControllerTest extends TestCase
         static::assertEquals('An expected exception', Hash::get($flash, '0.message'));
         static::assertEquals(500, Hash::get($flash, '0.params.status'));
     }
+
+    /**
+     * Test `index`
+     *
+     * @return void
+     * @covers ::index()
+     */
+    public function testIndex(): void
+    {
+        $this->setupController();
+        $this->Import->index();
+        static::assertEmpty($this->Import->viewVars['jobs']);
+        static::assertEmpty($this->Import->viewVars['services']);
+        static::assertEmpty($this->Import->viewVars['filters']);
+        static::assertEmpty($this->Import->viewVars['result']);
+    }
+
+    /**
+     * Test `jobs`
+     *
+     * @return void
+     * @covers ::jobs()
+     */
+    public function testJobs(): void
+    {
+        $this->setupController();
+        $this->Import->jobs();
+        static::assertNotEmpty($this->Import->viewVars['_serialize']);
+        static::assertEmpty($this->Import->viewVars['jobs']);
+        static::assertEmpty($this->Import->viewVars['services']);
+        static::assertEmpty($this->Import->viewVars['filters']);
+    }
 }

--- a/tests/TestCase/Controller/ImportControllerTest.php
+++ b/tests/TestCase/Controller/ImportControllerTest.php
@@ -19,6 +19,7 @@ use App\Core\Result\ImportResult;
 use BEdita\SDK\BEditaClient;
 use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;
+use Cake\Core\Configure;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -177,13 +178,31 @@ class ImportControllerTest extends TestCase
      */
     public function testLoadFilters(): void
     {
+        $filters = [
+            [
+                'class' => 'App\Test\TestCase\Controller\ImportFilterSample',
+                'label' => 'Dummy Filter',
+                'options' => [],
+            ],
+        ];
+        Configure::write('Filters.import', $filters);
         $this->setupController('App\Test\TestCase\Controller\ImportFilterSample');
         $reflectionClass = new \ReflectionClass($this->Import);
         $method = $reflectionClass->getMethod('loadFilters');
         $method->setAccessible(true);
         $method->invokeArgs($this->Import, []);
         static::assertTrue(is_array($this->Import->viewVars['filters']));
+        $expected = [
+            [
+                'value' => 'App\Test\TestCase\Controller\ImportFilterSample',
+                'text' => 'Dummy Filter',
+                'options' => [],
+            ]
+        ];
+        static::assertEquals($expected, $this->Import->viewVars['filters']);
         static::assertTrue(is_array($this->Import->viewVars['services']));
+        static::assertSame(['ImportFilterSampleService'], $this->Import->viewVars['services']);
+        Configure::write('Filters.import', []);
     }
 
     /**

--- a/tests/TestCase/Controller/ImportControllerTest.php
+++ b/tests/TestCase/Controller/ImportControllerTest.php
@@ -334,6 +334,7 @@ class ImportControllerTest extends TestCase
      *
      * @return void
      * @covers ::index()
+     * @covers ::beforeRender()
      */
     public function testIndex(): void
     {
@@ -343,6 +344,8 @@ class ImportControllerTest extends TestCase
         static::assertEmpty($this->Import->viewVars['services']);
         static::assertEmpty($this->Import->viewVars['filters']);
         static::assertEmpty($this->Import->viewVars['result']);
+        $this->Import->dispatchEvent('Controller.beforeRender');
+        static::assertEquals(['_name' => 'import:index'], $this->Import->viewVars['moduleLink']);
     }
 
     /**

--- a/tests/TestCase/Controller/ImportControllerTest.php
+++ b/tests/TestCase/Controller/ImportControllerTest.php
@@ -197,7 +197,7 @@ class ImportControllerTest extends TestCase
                 'value' => 'App\Test\TestCase\Controller\ImportFilterSample',
                 'text' => 'Dummy Filter',
                 'options' => [],
-            ]
+            ],
         ];
         static::assertEquals($expected, $this->Import->viewVars['filters']);
         static::assertTrue(is_array($this->Import->viewVars['services']));

--- a/tests/TestCase/Controller/ImportControllerTest.php
+++ b/tests/TestCase/Controller/ImportControllerTest.php
@@ -163,7 +163,7 @@ class ImportControllerTest extends TestCase
 
         $response = $this->Import->file();
         static::assertEquals(302, $response->getStatusCode());
-        $result = $this->Import->request->getSession()->read('Import.result');
+        $result = $this->Import->getRequest()->getSession()->read('Import.result');
         $expected = new ImportResult($this->filename, 10, 0, 0, 'ok', '', ''); // ($created, $updated, $errors, $info, $warn, $error)
         static::assertEquals($result, $expected);
     }
@@ -257,7 +257,7 @@ class ImportControllerTest extends TestCase
         $this->setupController();
         $response = $this->Import->file();
         static::assertEquals(302, $response->getStatusCode());
-        $flash = $this->Import->request->getSession()->read('Flash.flash');
+        $flash = $this->Import->getRequest()->getSession()->read('Flash.flash');
         static::assertEquals('Import filter not selected', Hash::get($flash, '0.message'));
         static::assertEquals(400, Hash::get($flash, '0.params.status'));
     }
@@ -277,7 +277,7 @@ class ImportControllerTest extends TestCase
 
         $response = $this->Import->file();
         static::assertEquals(302, $response->getStatusCode());
-        $flash = $this->Import->request->getSession()->read('Flash.flash');
+        $flash = $this->Import->getRequest()->getSession()->read('Flash.flash');
         static::assertEquals('Missing import file', Hash::get($flash, '0.message'));
         static::assertEquals(400, Hash::get($flash, '0.params.status'));
     }
@@ -324,7 +324,7 @@ class ImportControllerTest extends TestCase
         $this->setupController('App\Test\TestCase\Controller\ImportFilterSampleError');
         $response = $this->Import->file();
         static::assertEquals(302, $response->getStatusCode());
-        $flash = $this->Import->request->getSession()->read('Flash.flash');
+        $flash = $this->Import->getRequest()->getSession()->read('Flash.flash');
         static::assertEquals('An expected exception', Hash::get($flash, '0.message'));
         static::assertEquals(500, Hash::get($flash, '0.params.status'));
     }

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -214,7 +214,7 @@ class LoginControllerTest extends TestCase
 
         $response = $this->Login->login();
         static::assertEquals(302, $response->getStatusCode());
-        static::assertEquals('test', $this->Login->request->getSession()->read('_project'));
+        static::assertEquals('test', $this->Login->getRequest()->getSession()->read('_project'));
     }
 
     /**
@@ -235,8 +235,8 @@ class LoginControllerTest extends TestCase
         $response = $this->Login->logout();
         static::assertEquals(302, $response->getStatusCode());
         static::assertEquals('/login', $response->getHeaderLine('Location'));
-        static::assertNull($this->Login->request->getSession()->read('Auth'));
-        static::assertNull($this->Login->request->getSession()->read('_project'));
+        static::assertNull($this->Login->getRequest()->getSession()->read('Auth'));
+        static::assertNull($this->Login->getRequest()->getSession()->read('_project'));
     }
 
     /**
@@ -256,15 +256,15 @@ class LoginControllerTest extends TestCase
         ]);
 
         // case 1: remove message
-        $this->Login->request->getSession()->write('Flash', 'something');
+        $this->Login->getRequest()->getSession()->write('Flash', 'something');
         $this->Login->handleFlashMessages([]);
-        $message = $this->Login->request->getSession()->read('Flash');
+        $message = $this->Login->getRequest()->getSession()->read('Flash');
         static::assertEmpty($message);
 
         // case 2: do not remove message
-        $this->Login->request->getSession()->write('Flash', 'something');
+        $this->Login->getRequest()->getSession()->write('Flash', 'something');
         $this->Login->handleFlashMessages(['redirect' => 'dummy']);
-        $message = $this->Login->request->getSession()->read('Flash');
+        $message = $this->Login->getRequest()->getSession()->read('Flash');
         static::assertEquals('something', $message);
     }
 }

--- a/tests/TestCase/Controller/Model/ModelBaseControllerTest.php
+++ b/tests/TestCase/Controller/Model/ModelBaseControllerTest.php
@@ -293,7 +293,7 @@ class ModelBaseControllerTest extends TestCase
     {
         $this->ModelController->setSingleView($singleView);
         foreach ($data as $name => $value) {
-            $this->ModelController->request = $this->ModelController->request->withData($name, $value);
+            $this->ModelController->setRequest($this->ModelController->getRequest()->withData($name, $value));
         }
         $result = $this->ModelController->save();
 
@@ -315,11 +315,11 @@ class ModelBaseControllerTest extends TestCase
             'id' => 99999,
         ];
         foreach ($data as $name => $value) {
-            $this->ModelController->request = $this->ModelController->request->withData($name, $value);
+            $this->ModelController->setRequest($this->ModelController->getRequest()->withData($name, $value));
         }
         $result = $this->ModelController->save();
         static::assertInstanceOf(Response::class, $result);
-        $flash = $this->ModelController->request->getSession()->read('Flash.flash.0.message');
+        $flash = $this->ModelController->getRequest()->getSession()->read('Flash.flash.0.message');
         static::assertEquals('[404] Not Found', $flash);
     }
 
@@ -337,7 +337,7 @@ class ModelBaseControllerTest extends TestCase
             'singular' => 'foo',
         ];
         foreach ($data as $name => $value) {
-            $this->ModelController->request = $this->ModelController->request->withData($name, $value);
+            $this->ModelController->setRequest($this->ModelController->getRequest()->withData($name, $value));
         }
         $result = $this->ModelController->save();
         static::assertInstanceOf(Response::class, $result);
@@ -357,7 +357,7 @@ class ModelBaseControllerTest extends TestCase
     {
         $result = $this->ModelController->remove(99999);
         static::assertInstanceOf(Response::class, $result);
-        $flash = $this->ModelController->request->getSession()->read('Flash.flash.0.message');
+        $flash = $this->ModelController->getRequest()->getSession()->read('Flash.flash.0.message');
         static::assertEquals('[404] Not Found', $flash);
     }
 }

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -213,7 +213,7 @@ class ModulesControllerTest extends BaseControllerTest
         static::assertEquals(302, $this->controller->response->getStatusCode());
 
         // verify session filter is empty
-        $filter = $this->controller->request->getSession()->read('documents.filter');
+        $filter = $this->controller->getRequest()->getSession()->read('documents.filter');
         static::assertNull($filter);
     }
 
@@ -1019,7 +1019,7 @@ class ModulesControllerTest extends BaseControllerTest
         static::assertNotNull($result);
         static::assertEquals(302, $this->controller->response->getStatusCode());
         static::assertEquals('text/html', $this->controller->response->getType());
-        $flash = $this->controller->request->getSession()->read('Flash');
+        $flash = $this->controller->getRequest()->getSession()->read('Flash');
         $expected = '[400] Invalid data';
         $actual = $flash['flash'][0]['message'];
         static::assertEquals($expected, $actual);
@@ -1051,7 +1051,7 @@ class ModulesControllerTest extends BaseControllerTest
         static::assertNotNull($result);
         static::assertEquals(302, $this->controller->response->getStatusCode());
         static::assertEquals('text/html', $this->controller->response->getType());
-        $flash = $this->controller->request->getSession()->read('Flash');
+        $flash = $this->controller->getRequest()->getSession()->read('Flash');
         $expected = '[404] Not Found';
         $actual = $flash['flash'][0]['message'];
         static::assertEquals($expected, $actual);

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -153,8 +153,8 @@ class ModulesControllerTest extends BaseControllerTest
 
         // verify response status code and type
         static::assertNull($result);
-        static::assertEquals(200, $this->controller->response->getStatusCode());
-        static::assertEquals('text/html', $this->controller->response->getType());
+        static::assertEquals(200, $this->controller->getResponse()->getStatusCode());
+        static::assertEquals('text/html', $this->controller->getResponse()->getType());
 
         // verify expected vars in view
         $this->assertExpectedViewVars(['objects', 'meta', 'links', 'types', 'properties']);
@@ -186,8 +186,8 @@ class ModulesControllerTest extends BaseControllerTest
 
         // verify response status code and type
         static::assertNotNull($result);
-        static::assertEquals(302, $this->controller->response->getStatusCode());
-        static::assertEquals('text/html', $this->controller->response->getType());
+        static::assertEquals(302, $this->controller->getResponse()->getStatusCode());
+        static::assertEquals('text/html', $this->controller->getResponse()->getType());
     }
 
     /**
@@ -210,7 +210,7 @@ class ModulesControllerTest extends BaseControllerTest
 
         // verify response status code and type
         static::assertNotNull($result);
-        static::assertEquals(302, $this->controller->response->getStatusCode());
+        static::assertEquals(302, $this->controller->getResponse()->getStatusCode());
 
         // verify session filter is empty
         $filter = $this->controller->getRequest()->getSession()->read('documents.filter');
@@ -237,8 +237,8 @@ class ModulesControllerTest extends BaseControllerTest
 
         // verify response status code and type
         static::assertNull($result);
-        static::assertEquals(200, $this->controller->response->getStatusCode());
-        static::assertEquals('text/html', $this->controller->response->getType());
+        static::assertEquals(200, $this->controller->getResponse()->getStatusCode());
+        static::assertEquals('text/html', $this->controller->getResponse()->getType());
 
         // verify expected vars in view
         $this->assertExpectedViewVars(['object', 'included', 'schema', 'properties', 'objectRelations']);
@@ -377,8 +377,8 @@ class ModulesControllerTest extends BaseControllerTest
 
         // verify response status code and type
         static::assertNull($result);
-        static::assertEquals(200, $this->controller->response->getStatusCode());
-        static::assertEquals('text/html', $this->controller->response->getType());
+        static::assertEquals(200, $this->controller->getResponse()->getStatusCode());
+        static::assertEquals('text/html', $this->controller->getResponse()->getType());
 
         // verify expected vars in view
         $this->assertExpectedViewVars(['object', 'schema', 'properties']);
@@ -985,8 +985,8 @@ class ModulesControllerTest extends BaseControllerTest
 
         // verify response status code and type
         static::assertNull($result);
-        static::assertEquals(200, $this->controller->response->getStatusCode());
-        static::assertEquals('text/html', $this->controller->response->getType());
+        static::assertEquals(200, $this->controller->getResponse()->getStatusCode());
+        static::assertEquals('text/html', $this->controller->getResponse()->getType());
 
         // verify expected vars in view
         $expected = ['resources', 'roots', 'categoriesTree', 'meta', 'links', 'schema', 'properties', 'filter', 'object_types'];
@@ -1017,8 +1017,8 @@ class ModulesControllerTest extends BaseControllerTest
 
         // verify response status code and type
         static::assertNotNull($result);
-        static::assertEquals(302, $this->controller->response->getStatusCode());
-        static::assertEquals('text/html', $this->controller->response->getType());
+        static::assertEquals(302, $this->controller->getResponse()->getStatusCode());
+        static::assertEquals('text/html', $this->controller->getResponse()->getType());
         $flash = $this->controller->getRequest()->getSession()->read('Flash');
         $expected = '[400] Invalid data';
         $actual = $flash['flash'][0]['message'];
@@ -1049,8 +1049,8 @@ class ModulesControllerTest extends BaseControllerTest
 
         // verify response status code and type
         static::assertNotNull($result);
-        static::assertEquals(302, $this->controller->response->getStatusCode());
-        static::assertEquals('text/html', $this->controller->response->getType());
+        static::assertEquals(302, $this->controller->getResponse()->getStatusCode());
+        static::assertEquals('text/html', $this->controller->getResponse()->getType());
         $flash = $this->controller->getRequest()->getSession()->read('Flash');
         $expected = '[404] Not Found';
         $actual = $flash['flash'][0]['message'];

--- a/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -104,7 +104,7 @@ class TranslationsControllerTest extends TestCase
     {
         $request = new ServerRequest($this->defaultRequestConfig);
         $this->controller = new TranslationsController($request);
-        $actual = (string)$this->controller->request->getParam('object_type');
+        $actual = (string)$this->controller->getRequest()->getParam('object_type');
         $expected = 'translations';
         static::assertEquals($expected, $actual);
     }

--- a/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -128,8 +128,8 @@ class TranslationsControllerTest extends TestCase
 
         // verify response status code and type
         static::assertNull($result);
-        static::assertEquals(200, $this->controller->response->getStatusCode());
-        static::assertEquals('text/html', $this->controller->response->getType());
+        static::assertEquals(200, $this->controller->getResponse()->getStatusCode());
+        static::assertEquals('text/html', $this->controller->getResponse()->getType());
 
         // verify expected vars in view
         $this->assertExpectedViewVars(['schema', 'object', 'translation']);
@@ -161,8 +161,8 @@ class TranslationsControllerTest extends TestCase
 
         // verify response status code and type
         static::assertNull($result);
-        static::assertEquals(200, $this->controller->response->getStatusCode());
-        static::assertEquals('text/html', $this->controller->response->getType());
+        static::assertEquals(200, $this->controller->getResponse()->getStatusCode());
+        static::assertEquals('text/html', $this->controller->getResponse()->getType());
 
         // verify expected vars in view
         $this->assertExpectedViewVars(['schema', 'object', 'translation']);

--- a/tests/TestCase/Controller/TrashControllerTest.php
+++ b/tests/TestCase/Controller/TrashControllerTest.php
@@ -191,7 +191,7 @@ class TrashControllerTest extends TestCase
         static::assertEquals(302, $response->getStatusCode());
         static::assertEquals('/trash', $response->getHeaderLine('Location'));
 
-        $message = $this->Trash->request->getSession()->read('Flash.flash.0.message');
+        $message = $this->Trash->getRequest()->getSession()->read('Flash.flash.0.message');
         static::assertEquals('[404] Not Found', $message);
     }
 
@@ -274,7 +274,7 @@ class TrashControllerTest extends TestCase
         static::assertEquals(302, $response->getStatusCode());
         static::assertEquals('/trash', $response->getHeaderLine('Location'));
 
-        $message = $this->Trash->request->getSession()->read('Flash.flash.0.message');
+        $message = $this->Trash->getRequest()->getSession()->read('Flash.flash.0.message');
         static::assertEquals('[404] Not Found', $message);
     }
 


### PR DESCRIPTION
This is a refactor PR, to prepare project for cakephp 4.

Main task:

 - use `$this->setRequest` and `$this->getRequest` instead of `$this->request`
 - use `$this->setResponse` and `$this->getResponse` instead of `$this->response`

Bonus: more tests and coverage