### PR TITLE
Decode json serialized fields

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -244,6 +244,17 @@ class AppController extends Controller
                 return ['name' => $category];
             }, $data['categories']);
         }
+
+        // decode json fields
+        $types = (array)Hash::get($data, '_types');
+        if (!empty($types)) {
+            foreach ($types as $field => $type) {
+                if ($type === 'json') {
+                    $data[$field] = json_decode($data[$field], true);
+                }
+            }
+            unset($data['_types']);
+        }
     }
 
     /**

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -503,6 +503,26 @@ class AppControllerTest extends TestCase
                     'categories' => ['Blu', 'Red', 'Green'],
                 ],
             ],
+            'types' => [
+                'documents',
+                [
+                    'id' => '3',
+                    'a' => ['a' => 1],
+                    'b' => ['b' => 2],
+                    'c' => 'c',
+                ],
+                [
+                    'id' => '3',
+                    'a' => '{"a": 1}',
+                    'b' => '{"b": 2}',
+                    'c' => 'c',
+                    '_types' => [
+                        'a' => 'json',
+                        'b' => 'json',
+                        'c' => 'other',
+                    ],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
This provides a way to use form serialized fields, saving them properly by `json_decode` deserializing.

Example, in form:
```
<input type="hidden" name="somefield" value="{\"some\":\"thing\"}" />
<input type="hidden" name="_types[somefield]" value="json" />
```

Save will auto-set `$data['somefield']` to `json_decode($data['somefield'], true)` and remove `$data['_types']`.