### PR TITLE
Placeholders plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,11 @@
     },
     "prefer-stable": true,
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "cakephp/plugin-installer": true,
+            "wikimedia/composer-merge-plugin": true
+        }
     },
     "extra": {
         "merge-plugin": {

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -735,6 +735,7 @@ return [
     //             '|',
     //             'alignment',
     //             '|',
+    //             'placeholders',
     //             'specialCharacters',
     //             'link',
     //             'bulletedList',

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -489,11 +489,11 @@ class ModulesComponent extends Component
     public function setupRelationsMeta(array $schema, array $relationships, array $order = [], array $hidden = [], array $readonly = []): void
     {
         // relations between objects
-        $relationsSchema = $this->relationsSchema($schema, $relationships, $readonly);
+        $relationsSchema = $this->relationsSchema($schema, $relationships, $hidden, $readonly);
         // relations between objects and resources
-        $resourceRelations = array_diff(array_keys($relationships), array_keys($relationsSchema), self::FIXED_RELATIONSHIPS);
+        $resourceRelations = array_diff(array_keys($relationships), array_keys($relationsSchema), $hidden, self::FIXED_RELATIONSHIPS);
         // set objectRelations array with name as key and label as value
-        $relationNames = array_diff(array_keys($relationsSchema), $hidden);
+        $relationNames = array_keys($relationsSchema);
 
         // define 'main' and 'aside' relation groups
         $aside = array_intersect((array)Hash::get($order, 'aside'), $relationNames);
@@ -514,14 +514,15 @@ class ModulesComponent extends Component
      *
      * @param array $schema The schema
      * @param array $relationships The relationships
+     * @param array $hidden Hidden relationships
      * @param array $readonly Readonly relationships
      * @return array
      */
-    protected function relationsSchema(array $schema, array $relationships, array $readonly = []): array
+    protected function relationsSchema(array $schema, array $relationships, array $hidden = [], array $readonly = []): array
     {
         $types = $this->objectTypes(false);
         sort($types);
-        $relationsSchema = array_intersect_key($schema, $relationships);
+        $relationsSchema = array_diff_key(array_intersect_key($schema, $relationships), array_flip($hidden));
 
         foreach ($relationsSchema as $relName => &$relSchema) {
             if (in_array('objects', (array)Hash::get($relSchema, 'right'))) {

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -250,4 +250,28 @@ class PropertiesComponent extends Component
     {
         return $this->getConfig(sprintf('Properties.%s.relations', $type), []);
     }
+
+    /**
+     * List of hidden relations.
+     *
+     * @param string $type Object type name
+     *
+     * @return array
+     */
+    public function hiddenRelationsList(string $type): array
+    {
+        return $this->getConfig(sprintf('Properties.%s.relations._hide', $type), []);
+    }
+
+    /**
+     * List of readonly relations.
+     *
+     * @param string $type Object type name
+     *
+     * @return array
+     */
+    public function readonlyRelationsList(string $type): array
+    {
+        return $this->getConfig(sprintf('Properties.%s.relations._readonly', $type), []);
+    }
 }

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -168,8 +168,10 @@ class ModulesController extends AppController
         // setup relations metadata
         $this->Modules->setupRelationsMeta(
             $this->Schema->getRelationsSchema(),
-            $object['relationships'],
-            $this->Properties->relationsList($this->objectType)
+            $schema['relations'],
+            $this->Properties->relationsList($this->objectType),
+            $this->Properties->hiddenRelationsList($this->objectType),
+            $this->Properties->readonlyRelationsList($this->objectType)
         );
 
         $rightTypes = \App\Utility\Schema::rightTypes($this->viewVars['relationsSchema']);

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -81,11 +81,13 @@ class Control
      * @param mixed|null $value Property value.
      * @return array
      */
-    public static function richtext($value): array
+    public static function richtext($value, $schema): array
     {
+        $key = !empty($schema['placeholders']) ? 'v-richeditor.placeholders' : 'v-richeditor';
+
         return [
             'type' => 'textarea',
-            'v-richeditor' => json_encode(Configure::read('RichTextEditor.default.toolbar', '')),
+            $key => json_encode(Configure::read('RichTextEditor.default.toolbar', '')),
             'value' => $value,
         ];
     }

--- a/src/Template/Element/Form/related_item.twig
+++ b/src/Template/Element/Form/related_item.twig
@@ -123,6 +123,7 @@
         <button v-if="isPanelOpen(related.id)" class="is-small icon-coffee"
                 @click.prevent.stop="closePanel()">{{ __('cancel') }}</button>
 
+        {% if not readonly %}
         <button v-else class="is-small icon-th-list-1"
             :disabled="isPanelOpen()"
             @click.prevent.stop="editRelationParams({
@@ -132,6 +133,7 @@
                 relationLabel: relationLabel,
                 schema: relationSchema,
             })">{{ __('Edit params') }}</button>
+        {% endif %}
     </div>
     {% endif %}
 
@@ -155,7 +157,9 @@
     <footer class="is-flex space-between mt-05 p-05">
         {% if stage %}
             <a class="button button-outlined-white is-small mr-1" :href="$helpers.buildViewUrl(related.id)" target="_blank">{{ __('Edit') }}</a>
+            {% if not readonly %}
             <a class="button button-outlined-white is-small" @click.prevent="removeAddedRelations(related.id)">{{ __('Remove') }}</a>
+            {% endif %}
 
         {% elseif add %}
             <button class="is-small has-font-weight-bold mr-1"
@@ -171,9 +175,11 @@
 
         {% else %}
             <a class="button button-outlined-white is-small mr-1" :href="$helpers.buildViewUrl(related.id)" target="_blank" v-show="moduleAvailable(related.type)">{{ __('Edit') }}</a>
+            {% if not readonly %}
             <a class="button button-text is-small" @click.prevent="relationToggle(related)" :class="containsId(removedRelated, related.id) ? 'icon-cw-2' : 'icon-unlink'"
                 v-html="containsId(removedRelated, related.id) ? '{{__('undo') }}' : '{{ __('remove') }}'">
             </a>
+            {% endif %}
         {% endif %}
     </footer>
     {% endif %}

--- a/src/Template/Element/Form/relation.twig
+++ b/src/Template/Element/Form/relation.twig
@@ -1,6 +1,7 @@
 <relation-view inline-template
     :relation-data="{{ relationSchema|json_encode|escape('html_attr') }}"
     :data-list="dataList"
+    :readonly={{ readonly ? 'true' : 'false' }}
     relation-name="{{ relationName }}"
     relation-label="{{ Layout.tr(relationName) }}"
     :pre-count="{{ preCount }}"
@@ -56,10 +57,11 @@
                         {% if relationName == 'children' %}
                             {% element 'Form/related_item' { 'children': true } %}
                         {% else %}
-                            {% element 'Form/related_item' { 'common': true } %}
+                            {% element 'Form/related_item' { 'common': true, 'readonly': readonly } %}
                         {% endif %}
                     </div>
 
+                    {% if not readonly %}
                     {# STAGED OBJECTS (new relations) #}
                     <div v-if="addedRelations.length"
                         class="related-item-column column added is-3 is-one-half-mobile is-one-third-tablet is-one-quarter-desktop is-one-fifth-widescreen is-one-sixth-fullhd"
@@ -68,12 +70,13 @@
 
                         {% element 'Form/related_item' { 'stage': true } %}
                     </div>
+                    {% endif %}
                 </div>
             </div>
 
         </div>
 
-        {% if Perms.canSave() %}
+        {% if Perms.canSave() and not readonly %}
         <div class="mt-5">
             {# DROP FILES #}
             {% if uploadableNum %}
@@ -105,6 +108,7 @@
         {# End relation custom or default view #}
         {% endif %}
 
+        {% if not readonly %}
         {# hidden field - relations serialized json #}
         {{ Form.control(relationName ~ 'removeRelated', {
             'type': 'hidden',
@@ -120,6 +124,7 @@
             'v-model': 'addedRelationsData'
         })|raw }}
         {{ Form.unlockField('relations.' ~ relationName ~ '.addRelated')}}
+        {% endif %}
 
     </div>
 </relation-view>

--- a/src/Template/Element/Form/relations.twig
+++ b/src/Template/Element/Form/relations.twig
@@ -31,6 +31,7 @@
                         'relationLabel': Layout.tr(relationLabel),
                         'relationSchema': relationsSchema[relationName],
                         'dataList': dataList,
+                        'readonly': relationsSchema[relationName].readonly,
                         'preCount': preCount,
                         'uploadableNum': uploadableNum,
                     } %}

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -66,6 +66,10 @@ export default {
             type: Number,
             default: -1,
         },
+        readonly: {
+            type: Boolean,
+            default: false,
+        },
     },
 
     data() {

--- a/src/Template/Layout/js/app/directives/richeditor.js
+++ b/src/Template/Layout/js/app/directives/richeditor.js
@@ -10,6 +10,7 @@ import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
 import 'tinymce/plugins/table';
 import 'tinymce/plugins/hr';
+import '../plugins/tinymce/placeholders.js';
 
 const DEFAULT_TOOLBAR = [
     'styleselect',
@@ -25,6 +26,7 @@ const DEFAULT_TOOLBAR = [
     'bullist',
     'numlist',
     '|',
+    'placeholders',
     'link',
     'blockquote',
     'charmap',
@@ -74,6 +76,10 @@ export default {
                     items = DEFAULT_TOOLBAR;
                 }
 
+                if (!binding.modifiers?.placeholders) {
+                    items = items.replace(/\bplaceholders\b/, '');
+                }
+
                 const { default: contentCSS } = await import('../../../richeditor.lazy.scss');
                 const [editor] = await tinymce.init({
                     target: element,
@@ -82,7 +88,7 @@ export default {
                     menubar: false,
                     branding: false,
                     max_height: 500,
-                    toolbar: DEFAULT_TOOLBAR,
+                    toolbar: items,
                     toolbar_mode: 'wrap',
                     block_formats: 'Paragraph=p; Header 1=h1; Header 2=h2; Header 3=h3',
                     entity_encoding: 'raw',
@@ -96,9 +102,11 @@ export default {
                         'table',
                         'hr',
                         'code',
+                        'placeholders',
                     ].join(' '),
                     autoresize_bottom_margin: 50,
-                    relative_urls : false,
+                    relative_urls: false,
+                    paste_block_drop: true,
                 });
 
                 element.editor = editor;

--- a/src/Template/Layout/js/app/plugins/tinymce/placeholders.js
+++ b/src/Template/Layout/js/app/plugins/tinymce/placeholders.js
@@ -1,0 +1,134 @@
+import { t } from 'ttag';
+import 'tinymce/tinymce';
+import { PanelEvents } from 'app/components/panel-view';
+import tinymce from 'tinymce/tinymce';
+
+const cache = {};
+const regex = /BE-PLACEHOLDER\.(\d+)(?:\.([-A-Za-z0-9+=]{1,50}|=[^=]|={3,}))?/;
+const baseUrl = new URL(BEDITA.base).pathname;
+const options = {
+    credentials: 'same-origin',
+    headers: {
+        accept: 'application/json',
+    }
+};
+
+function fetchData(id) {
+    if (!cache[id]) {
+        let fetchType = fetch(`${baseUrl}api/objects/${id}`, options)
+            .then((response) => response.json())
+            .then((json) => json.data.type);
+        cache[id] = fetchType
+            .then((type) => fetch(`${baseUrl}api/${type}/${id}`, options))
+            .then((response) => response.json());
+    }
+
+    return cache[id];
+}
+
+function loadPreview(editor, node, id) {
+    node.empty();
+
+    let text = tinymce.html.Node.create('#text');
+    text.value = `${t('loading')}…`;
+    node.append(text);
+
+    fetchData(id)
+        .then((json) => json.data)
+        .then((data) => {
+            if (!data) {
+                return;
+            }
+
+            let domElements = editor.getBody().querySelectorAll(`[data-placeholder="${data.id}"]`);
+            [...domElements].forEach((dom) => {
+                let content = '';
+                switch (data.type) {
+                    case 'images':
+                        content = `<img src="${data.meta.media_url}" alt="${data.attributes.title}" />`;
+                        break;
+                    default:
+                        if (data.meta.media_url) {
+                            content = `<iframe src="${data.meta.media_url}"></iframe>`;
+                        } else {
+                            content = `<div class="embed-card">
+                                <div class="title">${data.attributes.title || t('Untitled')}</div>
+                                <div class="description">${data.attributes.description || ''}</div>
+                            </div>`
+                        }
+                        break;
+                }
+
+                dom.innerHTML = content;
+            });
+        });
+}
+
+tinymce.util.Tools.resolve('tinymce.PluginManager').add('placeholders', function(editor) {
+    editor.on('PreInit', function () {
+        editor.parser.addAttributeFilter('data-placeholder', function(nodes) {
+            nodes.forEach((node) => {
+                let comment = node.firstChild.value;
+                let match = comment.match(regex);
+                if (!match) {
+                    return;
+                }
+                let [, id, params] = match;
+                node.attr('style', params || '');
+                node.attr('contenteditable', 'false');
+                loadPreview(editor, node, id);
+            });
+        });
+        editor.serializer.addAttributeFilter('data-placeholder', function(nodes) {
+            nodes.forEach((node) => {
+                let id = node.attributes.map['data-placeholder'];
+                let params = node.attributes.map['style'];
+                node.empty();
+                let comment = tinymce.html.Node.create('#comment');
+                comment.value = `BE-PLACEHOLDER.${id}.${btoa(params)}`;
+                node.append(comment);
+            });
+        });
+    });
+
+    editor.ui.registry.addButton('placeholders', {
+        icon: 'image',
+        tooltip: 'Add placeholder',
+        onAction() {
+            PanelEvents.requestPanel({
+                action: 'relations-add',
+                from: this,
+                data: {
+                    relationName: 'placeholder',
+                    relationLabel: 'Placeholder',
+                },
+            });
+
+            let onSave = (objects) => {
+                PanelEvents.closePanel();
+                PanelEvents.stop('relations-add:save', this, onSave);
+                PanelEvents.stop('panel:closed', null, onClose);
+                objects.forEach((data) => {
+                    let node = editor.selection.getNode();
+                    let isEmptyBlock = node && node.children.length === 1 && node.children[0].tagName === 'BR';
+                    let view = editor.dom.create(isEmptyBlock ? 'div' : 'span', {
+                        'data-placeholder': data.id,
+                        'style': data.params,
+                    }, `<!-- BE-PLACEHOLDER.${data.id}.${btoa(data.params)} -->`);
+                    editor.insertContent(view.outerHTML);
+                    if (isEmptyBlock) {
+                        tinymce.dom.DOMUtils.DOM.remove(node);
+                    }
+                });
+            };
+
+            let onClose = () => {
+                PanelEvents.stop('relations-add:save', this, onSave);
+                PanelEvents.stop('panel:closed', null, onClose);
+            };
+
+            PanelEvents.listen('relations-add:save', this, onSave);
+            PanelEvents.listen('panel:closed', null, onClose);
+        },
+    });
+});

--- a/src/Template/Layout/richeditor.lazy.scss
+++ b/src/Template/Layout/richeditor.lazy.scss
@@ -51,3 +51,37 @@ a:link, a:hover, a:active, a:visited {
    margin-top:1rem;
    margin-bottom:.5rem;
 }
+
+[data-placeholder] {
+    &[data-mce-selected] {
+        outline: solid 2px $info;
+    }
+}
+
+span[data-placeholder] {
+    display: inline-flex;
+    align-self: center;
+    margin: 0.5em;
+    padding: 0.25em;
+    border: solid 1px currentColor;
+
+    img {
+        width: 3em;
+        height: 3em;
+        object-fit: cover;
+        object-position: center;
+        -webkit-user-drag: none;
+    }
+}
+
+div[data-placeholder] {
+    display: flex;
+    margin: 0.5em 0;
+    padding: 0.25em;
+    border: solid 1px currentColor;
+
+    img {
+        width: 100%;
+        height: auto;
+    }
+}

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1386,6 +1386,35 @@ class ModulesComponentTest extends TestCase
                     ],
                 ], // expected
             ],
+            'readonly' => [
+                [
+                    'hates' => [
+                        'left' => ['elefants'],
+                        'right' => ['mices'],
+                    ],
+                    'loves' => [
+                        'left' => ['robots'],
+                        'right' => ['objects'],
+                    ],
+                ], // schema
+                [
+                    'hates' => [
+                        'readonly' => true
+                    ],
+                    'loves' => [],
+                ], // relationships
+                [
+                    'hates' => [
+                        'left' => ['elefants'],
+                        'right' => ['mices'],
+                        'readonly' => true,
+                    ],
+                    'loves' => [
+                        'left' => ['robots'],
+                        'right' => ['cats', 'dogs', 'elefants', 'mices'],
+                    ],
+                ], // expected
+            ]
         ];
     }
 

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1399,7 +1399,7 @@ class ModulesComponentTest extends TestCase
                 ], // schema
                 [
                     'hates' => [
-                        'readonly' => true
+                        'readonly' => true,
                     ],
                     'loves' => [],
                 ], // relationships
@@ -1414,7 +1414,7 @@ class ModulesComponentTest extends TestCase
                         'right' => ['cats', 'dogs', 'elefants', 'mices'],
                     ],
                 ], // expected
-            ]
+            ],
         ];
     }
 

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1075,8 +1075,6 @@ class ModulesComponentTest extends TestCase
                 [
                     'has_media' => [],
                 ],
-                [],
-                [],
             ],
             'inverse' => [
                 [
@@ -1111,8 +1109,6 @@ class ModulesComponentTest extends TestCase
                 [
                     'media_of' => [],
                 ],
-                [],
-                [],
             ],
             'ordered' => [
                 [
@@ -1173,8 +1169,6 @@ class ModulesComponentTest extends TestCase
                     'aside' => [
                     ],
                 ],
-                [],
-                [],
             ],
             'hidden' => [
                 [
@@ -1227,7 +1221,6 @@ class ModulesComponentTest extends TestCase
                     ],
                 ],
                 ['attach'],
-                [],
             ],
             'readonly' => [
                 [
@@ -1263,6 +1256,7 @@ class ModulesComponentTest extends TestCase
                 [
                     'has_media' => [],
                 ],
+                [],
                 [],
                 ['has_media'],
             ],

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1075,6 +1075,8 @@ class ModulesComponentTest extends TestCase
                 [
                     'has_media' => [],
                 ],
+                [],
+                [],
             ],
             'inverse' => [
                 [
@@ -1109,6 +1111,8 @@ class ModulesComponentTest extends TestCase
                 [
                     'media_of' => [],
                 ],
+                [],
+                [],
             ],
             'ordered' => [
                 [
@@ -1169,8 +1173,99 @@ class ModulesComponentTest extends TestCase
                     'aside' => [
                     ],
                 ],
+                [],
+                [],
             ],
-
+            'hidden' => [
+                [
+                    'relationsSchema' => [
+                        'has_media' => [
+                            'attributes' => [
+                                'name' => 'has_media',
+                                'label' => 'Has Media',
+                                'inverse_name' => 'media_of',
+                                'inverse_label' => 'Media Of',
+                            ],
+                        ],
+                    ],
+                    'resourceRelations' => [],
+                    'objectRelations' => [
+                        'main' => [
+                            'has_media' => 'Has Media',
+                        ],
+                        'aside' => [
+                        ],
+                    ],
+                ],
+                [
+                    'has_media' => [
+                        'attributes' => [
+                            'name' => 'has_media',
+                            'label' => 'Has Media',
+                            'inverse_name' => 'media_of',
+                            'inverse_label' => 'Media Of',
+                        ],
+                    ],
+                    'attach' => [
+                        'attributes' => [
+                            'name' => 'attach',
+                            'label' => 'Attach',
+                            'inverse_name' => 'attached_to',
+                            'inverse_label' => 'Attached To',
+                        ],
+                    ],
+                ],
+                [
+                    'has_media' => [],
+                    'attach' => [],
+                ],
+                [
+                    'main' => [
+                        'attach',
+                    ],
+                    'aside' => [
+                    ],
+                ],
+                ['attach'],
+                [],
+            ],
+            'readonly' => [
+                [
+                    'relationsSchema' => [
+                        'has_media' => [
+                            'attributes' => [
+                                'name' => 'has_media',
+                                'label' => 'Has Media',
+                                'inverse_name' => 'media_of',
+                                'inverse_label' => 'Media Of',
+                            ],
+                            'readonly' => true,
+                        ],
+                    ],
+                    'resourceRelations' => [],
+                    'objectRelations' => [
+                        'main' => [
+                            'has_media' => 'Has Media',
+                        ],
+                        'aside' => [],
+                    ],
+                ],
+                [
+                    'has_media' => [
+                        'attributes' => [
+                            'name' => 'has_media',
+                            'label' => 'Has Media',
+                            'inverse_name' => 'media_of',
+                            'inverse_label' => 'Media Of',
+                        ],
+                    ],
+                ],
+                [
+                    'has_media' => [],
+                ],
+                [],
+                ['has_media'],
+            ],
         ];
     }
 
@@ -1187,10 +1282,12 @@ class ModulesComponentTest extends TestCase
      * @param array $schema Schema array.
      * @param array $relationships Relationships array.
      * @param array $order Order array.
+     * @param array $hidden Hidden array.
+     * @param array $readonly Readonly array.
      */
-    public function testSetupRelationsMeta(array $expected, array $schema, array $relationships, array $order = []): void
+    public function testSetupRelationsMeta(array $expected, array $schema, array $relationships, array $order = [], array $hidden = [], array $readonly = []): void
     {
-        $this->Modules->setupRelationsMeta($schema, $relationships, $order);
+        $this->Modules->setupRelationsMeta($schema, $relationships, $order, $hidden, $readonly);
 
         $viewVars = $this->Modules->getController()->viewVars;
 

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -203,7 +203,7 @@ class PropertiesComponentTest extends TestCase
         Cache::clear();
 
         $index = ['has_food', 'is_tired', 'sleeps_with'];
-        Configure::write('Properties.cats.relations._hidden', $index);
+        Configure::write('Properties.cats.relations._hide', $index);
 
         $this->createComponent();
 

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -192,6 +192,46 @@ class PropertiesComponentTest extends TestCase
     }
 
     /**
+     * Test `hiddenRelationsList()` method.
+     *
+     * @return void
+     *
+     * @covers ::hiddenRelationsList()
+     */
+    public function testHiddenRelationsList(): void
+    {
+        Cache::clear();
+
+        $index = ['has_food', 'is_tired', 'sleeps_with'];
+        Configure::write('Properties.cats.relations._hidden', $index);
+
+        $this->createComponent();
+
+        $list = $this->Properties->hiddenRelationsList('cats');
+        static::assertEquals($index, $list);
+    }
+
+    /**
+     * Test `readonlyRelationsList()` method.
+     *
+     * @return void
+     *
+     * @covers ::readonlyRelationsList()
+     */
+    public function testReadonlyRelationsList(): void
+    {
+        Cache::clear();
+
+        $index = ['has_food', 'is_tired', 'sleeps_with'];
+        Configure::write('Properties.cats.relations._readonly', $index);
+
+        $this->createComponent();
+
+        $list = $this->Properties->readonlyRelationsList('cats');
+        static::assertEquals($index, $list);
+    }
+
+    /**
      * Data provider for `testViewGroups` test case.
      *
      * @return array


### PR DESCRIPTION
Introducing the placeholders plugin for Tinymce. This feature is enabled when plugin [BEdita/Placeholders](https://github.com/bedita/placeholders) is installed.

Also, since `placeholder` relations should be handled by the editor plugin only, we are introducing a configuration for hidden and readonly relations.