### PR TITLE
Update app.default.php, doc _hidden and _readonly relations config

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -508,7 +508,7 @@ return [
      *      + 'aside' relations to show on right aside column
      *      + '_element' associative array with custom view element to use for a relation, defined like
      *          '{relation_name}' => '{MyPlugin.template_path}'
-     *      + '_hidden' array relations to hide, not viewable in view(s)
+     *      + '_hidden' array of relations to hide, not viewable in view(s)
      *      + '_readonly' array of readonly relations, to show in readonly mode in view(s)
      *
      *  - 'filter' filters to display

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -508,6 +508,8 @@ return [
      *      + 'aside' relations to show on right aside column
      *      + '_element' associative array with custom view element to use for a relation, defined like
      *          '{relation_name}' => '{MyPlugin.template_path}'
+     *      + '_hidden' array relations to hide, not viewable in view(s)
+     *      + '_readonly' array of readonly relations, to show in readonly mode in view(s)
      *
      *  - 'filter' filters to display
      *  - 'bulk' bulk actions list
@@ -553,6 +555,13 @@ return [
         //         '_element' => [
         //             // use custom element in `MyPlugin` for `fooed_by`
         //             'fooed_by' => 'MyPlugin.fooed_by',
+        //         ],
+        //         '_hidden' => [
+        //             'download',
+        //             'downloadable_by',
+        //         ],
+        //         '_readonly' => [
+        //             'seealso',
         //         ],
         //     ],
         //     'filter' => [

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -235,7 +235,7 @@ class PropertiesComponent extends Component
      */
     public function bulkList(string $type): array
     {
-        return $this->getConfig(sprintf('Properties.%s.bulk', $type), $this->defaultGroups['bulk']);
+        return (array)$this->getConfig(sprintf('Properties.%s.bulk', $type), $this->defaultGroups['bulk']);
     }
 
     /**
@@ -248,7 +248,7 @@ class PropertiesComponent extends Component
      */
     public function relationsList(string $type): array
     {
-        return $this->getConfig(sprintf('Properties.%s.relations', $type), []);
+        return (array)$this->getConfig(sprintf('Properties.%s.relations', $type), []);
     }
 
     /**
@@ -260,7 +260,7 @@ class PropertiesComponent extends Component
      */
     public function hiddenRelationsList(string $type): array
     {
-        return $this->getConfig(sprintf('Properties.%s.relations._hide', $type), []);
+        return (array)$this->getConfig(sprintf('Properties.%s.relations._hide', $type), []);
     }
 
     /**
@@ -272,6 +272,6 @@ class PropertiesComponent extends Component
      */
     public function readonlyRelationsList(string $type): array
     {
-        return $this->getConfig(sprintf('Properties.%s.relations._readonly', $type), []);
+        return (array)$this->getConfig(sprintf('Properties.%s.relations._readonly', $type), []);
     }
 }

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -172,6 +172,22 @@ class PropertiesComponentTest extends TestCase
     }
 
     /**
+     * Test `bulkList()` method.
+     *
+     * @return void
+     * @covers ::bulkList()
+     */
+    public function testBulkList(): void
+    {
+        Cache::clear();
+        $expected = ['cat', 'dog', 'horse'];
+        Configure::write('Properties.animals.bulk', $expected);
+        $this->createComponent();
+        $actual = $this->Properties->bulkList('animals');
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
      * Test `relationsList()` method.
      *
      * @return void


### PR DESCRIPTION
This provides an update in `app.default.php` with some instructions about `_hidden` and `_readonly` properties config usage, keys introduced by https://github.com/bedita/manager/pull/700.

Bonus:

 - fix a couple of issues found by scrutinizer inspection
 - add unit test for `PropertiesComponent::bulkList`