### PR TITLE
Cakephp 4 twigview version compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.1",
         "bedita/i18n": "^1.7",
-        "bedita/web-tools": "^1.8",
+        "bedita/web-tools": "^1.9",
         "cakephp/cakephp": "^3.10",
         "cakephp/plugin-installer": "^1.1",
         "josegonzalez/dotenv": "2.*",

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -168,7 +168,7 @@ class ModulesController extends AppController
         $computedRelations = array_reduce(
             array_keys($object['relationships']),
             function ($acc, $relName) use ($schema) {
-                $acc[$relName] = Hash::get($schema, sprintf('relations.%s', $relName), []);
+                $acc[$relName] = (array)Hash::get($schema, sprintf('relations.%s', $relName), []);
 
                 return $acc;
             },

--- a/src/Template/Element/Admin/index_content.twig
+++ b/src/Template/Element/Admin/index_content.twig
@@ -1,4 +1,4 @@
-{% element ('Admin/sidebar') %}
+{{ element('Admin/sidebar') }}
 
 {% do _view.assign('title', __('Administration') ~ ' ' ~ __(resourceType|humanize)) %}
 {% do _view.assign('bodyViewClass',  'view-module view-admin') %}
@@ -9,7 +9,7 @@
     </header>
 </div>
 
-{% element 'Modules/index_header' { 'meta': meta, 'hideFilter': 1, 'Schema': Schema, 'hidePagination': treeView} %}
+{{ element('Modules/index_header', { 'meta': meta, 'hideFilter': 1, 'Schema': Schema, 'hidePagination': treeView}) }}
 
 <admin-index inline-template>
 

--- a/src/Template/Element/FilterBox/filter_box.twig
+++ b/src/Template/Element/FilterBox/filter_box.twig
@@ -1,14 +1,14 @@
 <div class="filter-box">
     {% if not hideFilter %}
     <div>
-        {% element 'FilterBox/filter_box_common' %}
+        {{ element('FilterBox/filter_box_common') }}
     </div>
     {% endif %}
 
     <div class="pagination">
     {% if not hidePagination %}
         <div v-if="pagination.count">
-            {% element 'FilterBox/filter_box_page_toolbar' %}
+            {{ element('FilterBox/filter_box_page_toolbar') }}
         </div>
     {% endif %}
     </div>

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -74,7 +74,7 @@
                             label=""
                             @change="onCategoryChange"
                         ></category-picker>
-                        {{ Form.unlockField('categories') }}
+                        {% do Form.unlockField('categories') %}
                     {% endfor %}
                 {% elseif schema %}
                     <category-picker
@@ -84,7 +84,7 @@
                         label=""
                         @change="onCategoryChange"
                     ></category-picker>
-                    {{ Form.unlockField('categories') }}
+                    {% do Form.unlockField('categories') %}
                 {% endif %}
             </span>
 
@@ -92,7 +92,7 @@
                 <label>{{ __('Folder') }}</label>
 
                 <folder-picker label="" :initial-folder="initFolder" @change="onFolderChange"></folder-picker>
-                {{ Form.unlockField('folderSelected') }}
+                {% do Form.unlockField('folderSelected') %}
 
                 <span class="descendants-filter">
                     <label for="descendants">{{ __('Descendants') }}</label>

--- a/src/Template/Element/Flash/error.twig
+++ b/src/Template/Element/Flash/error.twig
@@ -1,1 +1,1 @@
-{% element 'Flash/flash' {'level': 'error', 'message': message, 'params': params} %}
+{{ element('Flash/flash', {'level': 'error', 'message': message, 'params': params}) }}

--- a/src/Template/Element/Flash/flash.twig
+++ b/src/Template/Element/Flash/flash.twig
@@ -34,13 +34,15 @@
                 <a @click="isDumpVisible = true" v-show="!isDumpVisible">{{ __('code') }}: {{ params.status }} {{ params.code }}<i class="icon-down-dir"></i></a>
                 <div class="dump" v-show="isDumpVisible">
                     <code>
-                    {% for key, value in params if value %}
-                        {% if value is not iterable %}
-                            {{ key }}: {{ value|nl2br|raw }}<br>
-                        {% else %}
-                            {{ key }}:<br>
-                            <pre>{{ value|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
-                            <br>
+                    {% for key, value in params %}
+                        {% if value %}
+                            {% if value is not iterable %}
+                                {{ key }}: {{ value|nl2br|raw }}<br>
+                            {% else %}
+                                {{ key }}:<br>
+                                <pre>{{ value|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
+                                <br>
+                            {% endif %}
                         {% endif %}
                     {% endfor %}
                     </code>

--- a/src/Template/Element/Flash/info.twig
+++ b/src/Template/Element/Flash/info.twig
@@ -1,2 +1,1 @@
-{% element 'Flash/flash' {'level': 'info', 'message': message, 'params': params} %}
-
+{{ element('Flash/flash', {'level': 'info', 'message': message, 'params': params}) }}

--- a/src/Template/Element/Flash/success.twig
+++ b/src/Template/Element/Flash/success.twig
@@ -1,1 +1,1 @@
-{% element 'Flash/flash' {'level': 'success', 'message': message, 'params': params} %}
+{{ element('Flash/flash', {'level': 'success', 'message': message, 'params': params}) }}

--- a/src/Template/Element/Flash/warning.twig
+++ b/src/Template/Element/Flash/warning.twig
@@ -1,1 +1,1 @@
-{% element 'Flash/flash' {'level': 'warning', 'message': message, 'params': params} %}
+{{ element('Flash/flash', {'level': 'warning', 'message': message, 'params': params}) }}

--- a/src/Template/Element/Form/advanced_properties.twig
+++ b/src/Template/Element/Form/advanced_properties.twig
@@ -10,7 +10,7 @@
 
         <div v-show="isOpen" class="tab-container">
 
-            {% element 'Form/group_properties' {'properties' : properties.advanced, 'group': 'advanced'} %}
+            {{ element('Form/group_properties', {'properties' : properties.advanced, 'group': 'advanced'}) }}
 
         </div>
 

--- a/src/Template/Element/Form/bulk_category.twig
+++ b/src/Template/Element/Form/bulk_category.twig
@@ -5,10 +5,10 @@
 })|raw }}
     <div class="fieldset bulk-categories">
         <category-picker label="{{ __('Categories') }}" :categories="{{ schema.categories|json_encode }}" :disabled="!selectedRows.length"></category-picker>
-        {{ Form.unlockField('categories') }}
+        {% do Form.unlockField('categories') %}
 
         <input type="hidden" name="ids" :value="selectedRows"/>
-        {{ Form.unlockField('ids') }}
+        {% do Form.unlockField('ids') %}
 
         <button class="button button-outlined" @click.prevent="bulkActions('bulk-categories')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
     </div>

--- a/src/Template/Element/Form/bulk_export.twig
+++ b/src/Template/Element/Form/bulk_export.twig
@@ -17,10 +17,10 @@
             {% endfor %}
             </select>
 
-            {{ Form.unlockField('format') }}
+            {% do Form.unlockField('format') %}
 
             <input type="hidden" name="ids" v-model="selectedRows">
-            {{ Form.unlockField('ids') }}
+            {% do Form.unlockField('ids') %}
             {{ Form.hidden('objectType', {'value': objectType})|raw }}
 
             <button class="button button-outlined" @click.prevent="exportSelected" :disabled="!selectedRows.length">{{ __('Export') }}</button>

--- a/src/Template/Element/Form/bulk_position.twig
+++ b/src/Template/Element/Form/bulk_position.twig
@@ -13,17 +13,17 @@
             <label for="bulk-move">{{ __('Move to') }}</label>
             <input id="bulk-move" :disabled="!selectedRows.length" name="action" v-model="bulkAction" type="radio" value="move"/>
         </div>
-        {{ Form.unlockField('action') }}
+        {% do Form.unlockField('action') %}
 
         <folder-picker
             label="{{ __('Folder') }}"
             :disabled="!selectedRows.length || !bulkAction"
             @change="bulkFolder = $event?.id"
         ></folder-picker>
-        {{ Form.unlockField('folderSelected') }}
+        {% do Form.unlockField('folderSelected') %}
 
         <input type="hidden" name="ids" :value="selectedRows"/>
-        {{ Form.unlockField('ids') }}
+        {% do Form.unlockField('ids') %}
 
         <button
             class="button button-outlined"

--- a/src/Template/Element/Form/bulk_properties.twig
+++ b/src/Template/Element/Form/bulk_properties.twig
@@ -6,7 +6,7 @@
     })|raw }}
         <div class="fieldset" :disabled="!selectedRows.length">
             <input type="hidden" name="ids" v-bind:value="selectedRows">
-            {{ Form.unlockField('ids') }}
+            {% do Form.unlockField('ids') %}
 
             {% set options = Schema.controlOptions(key, null, schema.properties[key]) %}
             {% set options = options|merge({

--- a/src/Template/Element/Form/bulk_trash.twig
+++ b/src/Template/Element/Form/bulk_trash.twig
@@ -4,7 +4,7 @@
     'url': {'_name': 'modules:delete', 'object_type': objectType}
 })|raw}}
     <input type="hidden" name="ids" v-bind:value="selectedRows">
-    {{ Form.unlockField('ids') }}
+    {% do Form.unlockField('ids') %}
 
     <div class="fieldset">
         <button

--- a/src/Template/Element/Form/calendar.twig
+++ b/src/Template/Element/Form/calendar.twig
@@ -53,7 +53,7 @@
                 <button @click.prevent="add">{{ __('Add') }}</button>
             </div>
         </date-ranges-view>
-        {{ Form.unlockField('date_ranges')}}
+        {% do Form.unlockField('date_ranges') %}
     </div>
 </section>
 </property-view>

--- a/src/Template/Element/Form/core_properties.twig
+++ b/src/Template/Element/Form/core_properties.twig
@@ -1,7 +1,7 @@
 <section class="fieldset">
     <div class="tab-container">
 
-        {% element 'Form/group_properties' {'properties' : properties.core, 'group': 'core'} %}
+        {{ element('Form/group_properties', {'properties' : properties.core, 'group': 'core'}) }}
 
     </div>
 </section>

--- a/src/Template/Element/Form/group_properties.twig
+++ b/src/Template/Element/Form/group_properties.twig
@@ -1,7 +1,7 @@
 
     {% set customElement = Layout.customElement(group, 'group') %}
     {% if customElement %}
-        {% element customElement {'properties' : properties} %}
+        {{ element(customElement, {'properties' : properties}) }}
     {% else %}
 
         {% for key, value in properties %}

--- a/src/Template/Element/Form/locations.twig
+++ b/src/Template/Element/Form/locations.twig
@@ -5,4 +5,4 @@
     relation-name="{{ relationName }}"
     relation-label="{{ Layout.tr(relationName) }}"
 ></locations-view>
-{{ Form.unlockField('relations.' ~ relationName ~ '.replaceRelated')}}
+{% do Form.unlockField('relations.' ~ relationName ~ '.replaceRelated') %}

--- a/src/Template/Element/Form/other_properties.twig
+++ b/src/Template/Element/Form/other_properties.twig
@@ -14,7 +14,7 @@
 
             <div v-show="isOpen" class="tab-container">
 
-                {% element 'Form/group_properties' {'properties' : props, 'group': Layout.tr(group)} %}
+                {{ element('Form/group_properties', {'properties' : props, 'group': Layout.tr(group)}) }}
 
             </div>
         </section>

--- a/src/Template/Element/Form/publish_properties.twig
+++ b/src/Template/Element/Form/publish_properties.twig
@@ -1,7 +1,7 @@
 <section class="fieldset" id="publish-properties">
     <div class="tab-container">
 
-        {% element 'Form/group_properties' {'properties' : properties.publish, 'group': 'publish'} %}
+        {{ element('Form/group_properties', {'properties' : properties.publish, 'group': 'publish'}) }}
 
     </div>
 </section>

--- a/src/Template/Element/Form/related_translations.twig
+++ b/src/Template/Element/Form/related_translations.twig
@@ -63,7 +63,7 @@
                             'name': 'relations[' ~ resourceName ~ '][removeRelated]',
                             'v-model': 'removedRelationsData'
                         })|raw }}
-                        {{ Form.unlockField('relations.' ~ resourceName ~ '.removeRelated')}}
+                        {% do Form.unlockField('relations.' ~ resourceName ~ '.removeRelated') %}
 
                     </div>
                 </relation-view>

--- a/src/Template/Element/Form/related_translations.twig
+++ b/src/Template/Element/Form/related_translations.twig
@@ -50,7 +50,7 @@
                                     :key="related.id"
                                     :class="containsId(removedRelated, related.id)? 'removed' : ''">
 
-                                    {% element 'Form/related_item' { 'translation': true } %}
+                                    {{ element('Form/related_item', { 'translation': true }) }}
 
                                 </div>
                             </div>

--- a/src/Template/Element/Form/relation.twig
+++ b/src/Template/Element/Form/relation.twig
@@ -115,7 +115,7 @@
             'name': 'relations[' ~ relationName ~ '][removeRelated]',
             'v-model': 'removedRelationsData'
         })|raw }}
-        {{ Form.unlockField('relations.' ~ relationName ~ '.removeRelated')}}
+        {% do Form.unlockField('relations.' ~ relationName ~ '.removeRelated') %}
 
         {# Relations serialized json form element #}
         {{ Form.control(relationName ~ 'addRelated', {
@@ -123,7 +123,7 @@
             'name': 'relations[' ~ relationName ~ '][addRelated]',
             'v-model': 'addedRelationsData'
         })|raw }}
-        {{ Form.unlockField('relations.' ~ relationName ~ '.addRelated')}}
+        {% do Form.unlockField('relations.' ~ relationName ~ '.addRelated') %}
         {% endif %}
 
     </div>

--- a/src/Template/Element/Form/relation.twig
+++ b/src/Template/Element/Form/relation.twig
@@ -16,11 +16,11 @@
         Then load custom element or use default relation view #}
         {% set customElement = Layout.customElement(relationName) %}
         {% if customElement %}
-            {% element customElement {
+            {{ element(customElement, {
                 'relationName': relationName,
                 'relationLabel': Layout.tr(relationName),
                 'relationSchema': relationsSchema,
-            } %}
+            }) }}
         {% else %}
 
         <div class="related-list-container">
@@ -39,7 +39,7 @@
                     @filter-reset="reloadObjects"
                     inline-template
                 >
-                    {% element 'FilterBox/filter_box' %}
+                    {{ element('FilterBox/filter_box') }}
                 </filter-box-view>
             </div>
 
@@ -55,9 +55,9 @@
                         :drag-data="JSON.stringify(related)">
 
                         {% if relationName == 'children' %}
-                            {% element 'Form/related_item' { 'children': true } %}
+                            {{ element('Form/related_item', { 'children': true }) }}
                         {% else %}
-                            {% element 'Form/related_item' { 'common': true, 'readonly': readonly } %}
+                            {{ element('Form/related_item', { 'common': true, 'readonly': readonly }) }}
                         {% endif %}
                     </div>
 
@@ -68,7 +68,7 @@
                         v-for="related in addedRelations"
                         :key="related.id">
 
-                        {% element 'Form/related_item' { 'stage': true } %}
+                        {{ element('Form/related_item', { 'stage': true }) }}
                     </div>
                     {% endif %}
                 </div>

--- a/src/Template/Element/Form/relations.twig
+++ b/src/Template/Element/Form/relations.twig
@@ -26,7 +26,7 @@
                         </span>
                 </header>
                 <div v-show="isOpen" class="tab-container">
-                    {% element 'Form/relation' {
+                    {{ element('Form/relation', {
                         'relationName': relationName,
                         'relationLabel': Layout.tr(relationLabel),
                         'relationSchema': relationsSchema[relationName],
@@ -34,7 +34,7 @@
                         'readonly': relationsSchema[relationName].readonly,
                         'preCount': preCount,
                         'uploadableNum': uploadableNum,
-                    } %}
+                    }) }}
                 </div>
 
             </section>

--- a/src/Template/Element/Form/roles.twig
+++ b/src/Template/Element/Form/roles.twig
@@ -2,7 +2,7 @@
 
 {% set customElement = Layout.customElement(relationName) %}
 {% if customElement %}
-   {% element customElement %}
+   {{ element(customElement) }}
 {% else %}
 
 <property-view inline-template :tab-open="tabsOpen" tab-name="roles">

--- a/src/Template/Element/Form/roles.twig
+++ b/src/Template/Element/Form/roles.twig
@@ -52,7 +52,7 @@
                                     'name': 'relations[' ~ relationName ~ '][addRelated]',
                                     'v-model': 'relationsData'
                                 })|raw }}
-                                {{ Form.unlockField('relations.' ~ relationName ~ '.addRelated')}}
+                                {% do Form.unlockField('relations.' ~ relationName ~ '.addRelated') %}
                             </div>
                         </div>
 
@@ -65,7 +65,7 @@
                             'name': 'relations[' ~ relationName ~ '][removeRelated]',
                             'v-model': 'removedRelationsData'
                         })|raw }}
-                        {{ Form.unlockField('relations.' ~ relationName ~ '.removeRelated')}}
+                        {% do Form.unlockField('relations.' ~ relationName ~ '.removeRelated') %}
                     </div>
                 </div>
 

--- a/src/Template/Element/Form/trees.twig
+++ b/src/Template/Element/Form/trees.twig
@@ -24,10 +24,10 @@
                 :object='{{ { id: object.id, type: object.type }|json_encode }}'
                 :multiple-choice={{ options.multiple }}>
             </tree-view>
-            {{ Form.unlockField('relations.' ~ relationName ~ '.replaceRelated')}}
+            {% do Form.unlockField('relations.' ~ relationName ~ '.replaceRelated') %}
             {{ Form.hidden('_changedParents', {'value': '0', 'id': 'changedParents'})|raw }}
-            {{ Form.unlockField('_changedParents')}}
-            {{ Form.unlockField('_changedCanonical')}}
+            {% do Form.unlockField('_changedParents') %}
+            {% do Form.unlockField('_changedCanonical') %}
         </div>
     </section>
 </property-view>

--- a/src/Template/Element/Form/upload.twig
+++ b/src/Template/Element/Form/upload.twig
@@ -44,7 +44,7 @@
                         'type': 'hidden',
                         'v-bind:value': 'activeIndex == 0? `file` : `embed`'
                     }) | raw }}
-                    {{ Form.unlockField('upload_behavior')}}
+                    {% do Form.unlockField('upload_behavior') %}
 
                 </div>
 

--- a/src/Template/Element/Form/upload.twig
+++ b/src/Template/Element/Form/upload.twig
@@ -26,7 +26,7 @@
 
                 <div class="h-tabs-contents">
                     <div class="h-tab" v-show="activeIndex == 0">
-                        {% element 'Form/form_file_upload' %}
+                        {{ element('Form/form_file_upload') }}
                         {{ Form.control('model-type', { 'type': 'hidden', 'value': object.type}) | raw }}
                     </div>
 

--- a/src/Template/Element/Menu/menu.twig
+++ b/src/Template/Element/Menu/menu.twig
@@ -3,24 +3,26 @@
 
         <nav role="menu">
             {# Core modules #}
-            {% for name, module in modules if name != 'trash' %}
-                {% set label = Layout.tr(module.label|default(name)) %}
-                {% set shortLabel = module.shortLabel|default(label[0:5]) %}
-                {% if label|length > 5 %}
-                    {% set label = shortLabel %}
-                {% endif %}
+            {% for name, module in modules %}
+                {% if name != 'trash' %}
+                    {% set label = Layout.tr(module.label|default(name)) %}
+                    {% set shortLabel = module.shortLabel|default(label[0:5]) %}
+                    {% if label|length > 5 %}
+                        {% set label = shortLabel %}
+                    {% endif %}
 
-                {% if module.route %}
-                    {% set url = Url.build(module.route) %}
-                {% else %}
-                    {% set url = Url.build({ '_name': 'modules:list', 'object_type': name, 'plugin': null }) %}
+                    {% if module.route %}
+                        {% set url = Url.build(module.route) %}
+                    {% else %}
+                        {% set url = Url.build({ '_name': 'modules:list', 'object_type': name, 'plugin': null }) %}
+                    {% endif %}
+                    <a href="{{ url }}" title="{{ __('Open module') }} {{ Layout.tr(name) }}"
+                        class="menu-item {{ name == currentModule.name ? 'current' : '' }}">
+                        <span class="menu-item-color-bar has-background-module-{{ name }}" aria-hidden="true"></span>
+                        <span class="menu-item-label">{{ label }}</span>
+                        <span class="menu-item-short-label">{{ shortLabel }}</span>
+                    </a>
                 {% endif %}
-                <a href="{{ url }}" title="{{ __('Open module') }} {{ Layout.tr(name) }}"
-                    class="menu-item {{ name == currentModule.name ? 'current' : '' }}">
-                    <span class="menu-item-color-bar has-background-module-{{ name }}" aria-hidden="true"></span>
-                    <span class="menu-item-label">{{ label }}</span>
-                    <span class="menu-item-short-label">{{ shortLabel }}</span>
-                </a>
             {% endfor %}
         </nav>
 

--- a/src/Template/Element/Menu/sidebar.twig
+++ b/src/Template/Element/Menu/sidebar.twig
@@ -30,7 +30,7 @@
             <div class="module-buttons">
                 {{ _view.fetch('module-buttons')|raw }}
                 {% if currentModule.hints.multiple_types and types.right is iterable %}
-                    {% element 'filter_type' %}
+                    {{ element('filter_type') }}
                 {% endif %}
             </div>
 
@@ -79,6 +79,6 @@
 
     <div class="sidebar-footer">
         <div class="sidebar-bedita-logo white">{# css logo #}</div>
-        {% element 'Menu/colophon' %}
+        {{ element('Menu/colophon') }}
     </div>
 </div>

--- a/src/Template/Element/Model/index_content.twig
+++ b/src/Template/Element/Model/index_content.twig
@@ -7,7 +7,7 @@
     </header>
 </div>
 
-{% element 'Modules/index_header' { 'meta': meta, 'filter': filter, 'Schema': Schema, 'hidePagination': treeView} %}
+{{ element('Modules/index_header', { 'meta': meta, 'filter': filter, 'Schema': Schema, 'hidePagination': treeView}) }}
 
 <div class="module-index">
     <div class="list-objects">
@@ -76,6 +76,6 @@
     </div>
     {# end list-objects #}
 
-    {% element 'Model/sidebar_links' %}
+    {{ element('Model/sidebar_links') }}
 
 </div> {# end module-index #}

--- a/src/Template/Element/Modules/index_bulk.twig
+++ b/src/Template/Element/Modules/index_bulk.twig
@@ -1,17 +1,17 @@
 <div class="bulk-actions">
     <div>
-        {% element 'Form/bulk_export' %}
+        {{ element('Form/bulk_export') }}
     </div>
 
     <div class="bulk-header">{{ __('Actions on selected items') }}</div>
 
     <div :class="[!selectedRows.length ? 'disabled' : '', 'is-flex', 'is-flex-column']">
-        {% element 'Form/bulk_properties' %}
+        {{ element('Form/bulk_properties') }}
 
-        {% element 'Form/bulk_category' %}
+        {{ element('Form/bulk_category') }}
 
-        {% element 'Form/bulk_position' %}
+        {{ element('Form/bulk_position') }}
 
-        {% element 'Form/bulk_trash' %}
+        {{ element('Form/bulk_trash') }}
     </div>
 </div>

--- a/src/Template/Element/Modules/index_header.twig
+++ b/src/Template/Element/Modules/index_header.twig
@@ -25,6 +25,6 @@
         @filter-update-page-size="onUpdatePageSize"
         inline-template
     >
-        {% element 'FilterBox/filter_box' { 'meta': meta, 'hideFilter': hideFilter, 'hidePagination': hidePagination } %}
+        {{ element('FilterBox/filter_box', { 'meta': meta, 'hideFilter': hideFilter, 'hidePagination': hidePagination }) }}
     </filter-box-view>
 </div>

--- a/src/Template/Element/Modules/index_table_row.twig
+++ b/src/Template/Element/Modules/index_table_row.twig
@@ -15,14 +15,14 @@
 
         <div class="thumb-cell narrow">
             {%- if not isTrash %}
-                {% element 'Modules/thumb' { 'object': object } %}
+                {{ element('Modules/thumb', { 'object': object }) }}
             {% endif -%}
         </div>
 
         {% for prop in properties %}
             {% if (prop == 'date_ranges') %}
                 <div class="{{ prop }}-cell">
-                    {% element 'Modules/index_properties_date_ranges' { dateRanges: object.attributes[prop] } %}
+                    {{ element('Modules/index_properties_date_ranges', { dateRanges: object.attributes[prop] }) }}
                 </div>
             {% else %}
                 <div class="{{ prop }}-cell" untitled-label="{{ __('Untitled') }}">

--- a/src/Template/Element/Modules/index_table_row.twig
+++ b/src/Template/Element/Modules/index_table_row.twig
@@ -9,7 +9,7 @@
     class="table-row object-status-{{ object.attributes.status }} {{ Layout.publishStatus(object | default({})) }}">
 
         <div class="select-cell narrow" @click="selectRow">
-            {{ Form.unlockField('oneItem') }}
+            {% do Form.unlockField('oneItem') %}
             <input type="checkbox" name="oneItem" value="{{ object.id }}" v-model="selectedRows" {% if not Perms.canRead(object.type) %}disabled="disabled"{% endif %}>
         </div>
 

--- a/src/Template/Element/Panel/panel.twig
+++ b/src/Template/Element/Panel/panel.twig
@@ -3,7 +3,7 @@
 <panel-view :custom-footer="true" :custom-header="true">
     <div class="panel-slot" slot-scope="props">
         <relations-add v-if="props.action === 'relations-add'" v-bind="props.data" inline-template>
-            {% element 'Panel/relations_add' %}
+            {{ element('Panel/relations_add') }}
         </relations-add>
         <component v-else v-bind:is="props.action" v-bind="props.data"></component>
     </div>

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -35,7 +35,7 @@
                         'type': 'hidden',
                         'v-bind:value': 'file'
                     }) | raw }}
-                    {{ Form.unlockField('upload_behavior')}}
+                    {% do Form.unlockField('upload_behavior') %}
 
                     <section class="fieldset mb-1">
                         <div class="container">

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -126,14 +126,14 @@
 
                 inline-template
             >
-                {% element 'FilterBox/filter_box' %}
+                {{ element('FilterBox/filter_box') }}
             </filter-box-view>
         </div>
 
         <div class="px-1 shrinks">
             <div class="columns">
                 <div class="related-item-column column is-3 is-one-quarter-fullhd" v-for="related in objects" v-if="relationName !== 'children' || related.type !== 'folders'">
-                    {% element 'Form/related_item' { 'add': true } %}
+                    {{ element('Form/related_item', { 'add': true }) }}
                 </div>
             </div>
         </div>

--- a/src/Template/Element/custom_colors.twig
+++ b/src/Template/Element/custom_colors.twig
@@ -1,15 +1,17 @@
 <style type="text/css">
 
     {# module colors #}
-    {% for name, module in modules if module.color %}
-        {% set color = module.color %}
-        :root { --color-{{ name }}: {{ color }}; {% if currentModule is not empty and currentModule.name == name %}--color-module: {{ color }};{% endif %} }
-        .has-background-module-{{ name }} { background-color: {{ color }} !important; }
-        .has-border-module-{{ name }} { border-color: {{ color }} !important; }
-        .has-text-module-{{ name }} { color: {{ color }} !important; }
-        .button-primary-hover-module-{{ name }}:hover { background-color: {{ color }}; border-color: {{ color }}; color: #fff; }
-        .button-outlined-hover-module-{{ name }}:hover { background-color: transparent !important; border-color: {{ color }}; }
-        .has-shadow-color-{{ name }} { --box-shadow-color: {{ color }}; }
+    {% for name, module in modules %}
+        {% if module.color %}
+            {% set color = module.color %}
+            :root { --color-{{ name }}: {{ color }}; {% if currentModule is not empty and currentModule.name == name %}--color-module: {{ color }};{% endif %} }
+            .has-background-module-{{ name }} { background-color: {{ color }} !important; }
+            .has-border-module-{{ name }} { border-color: {{ color }} !important; }
+            .has-text-module-{{ name }} { color: {{ color }} !important; }
+            .button-primary-hover-module-{{ name }}:hover { background-color: {{ color }}; border-color: {{ color }}; color: #fff; }
+            .button-outlined-hover-module-{{ name }}:hover { background-color: transparent !important; border-color: {{ color }}; }
+            .has-shadow-color-{{ name }} { --box-shadow-color: {{ color }}; }
+        {% endif %}
     {%- endfor -%}
 
     {# override alert message color if in config #}

--- a/src/Template/Element/filter_type.twig
+++ b/src/Template/Element/filter_type.twig
@@ -10,14 +10,16 @@
                 <span>{{ __('All Types') }}</span>
             </div>
         </label>
-        {% for type in types.right if modules[type] %}
-        <label>
-            <input type="checkbox" value="{{ type }}" id="{{ type }}" v-model="selectedTypes">
-            <div>
-                <i class="bullet has-background-module-{{ type }}"></i>
-                <span>{{ Layout.tr(type) }}</span>
-            </div>
-        </label>
+        {% for type in types.right %}
+            {% if modules[type] %}
+                <label>
+                    <input type="checkbox" value="{{ type }}" id="{{ type }}" v-model="selectedTypes">
+                    <div>
+                        <i class="bullet has-background-module-{{ type }}"></i>
+                        <span>{{ Layout.tr(type) }}</span>
+                    </div>
+                </label>
+            {% endif %}
         {% endfor %}
     </div>
 

--- a/src/Template/Layout/default.twig
+++ b/src/Template/Layout/default.twig
@@ -14,7 +14,7 @@ BEdita 4 ~ @ 2018 from ChannelWeb & Chialab with love
 <html lang="{{ config('I18n.lang', 'en')}}">
 <head>
     {{ Html.charset()|raw }}
-    {% element 'meta' %}
+    {{ element('meta') }}
     <title>{{ "#{_view.fetch('title')} | #{project.name ?: 'BEdita 4'}" }}</title>
 
     {# fonts #}
@@ -25,12 +25,12 @@ BEdita 4 ~ @ 2018 from ChannelWeb & Chialab with love
     {# {{ Html.css(['app.b59441'])|raw }} #}
     {{ Link.cssBundle([ 'app', 'vendors' ])|raw }}
 
-    {% element 'custom_colors' %}
+    {{ element('custom_colors') }}
 
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,200;0,400;1,200;1,400&family=IBM+Plex+Sans:ital,wght@0,200;0,300;0,400;0,500;1,200;1,300;1,400;1,500&family=IBM+Plex+Serif:ital,wght@0,200;0,400;0,700;1,200;1,400;1,700&display=swap" rel="stylesheet">
 
-    {% element 'json_meta_config' %}
+    {{ element('json_meta_config') }}
 </head>
 
 {% set bodyClass = _view.fetch('bodyViewClass') %}
@@ -47,13 +47,13 @@ BEdita 4 ~ @ 2018 from ChannelWeb & Chialab with love
 
         {% if not Layout.isLogin() and user %}
         <aside class="layout-sidebar">
-            {% element 'Menu/sidebar' %}
+            {{ element('Menu/sidebar') }}
         </aside>
         {% endif %}
 
         {% if not Layout.isLogin() and not Layout.isDashboard() and user %}
             <header class="layout-header">
-                {% element 'Menu/menu' %}
+                {{ element('Menu/menu') }}
             </header>
         {% endif %}
 
@@ -63,12 +63,12 @@ BEdita 4 ~ @ 2018 from ChannelWeb & Chialab with love
 
         {% if not Layout.isLogin() and user %}
         <div class="layout-footer">
-            {% element 'Menu/colophon' %}
+            {{ element('Menu/colophon') }}
         </div>
         {% endif %}
 
         {% if not Layout.isLogin() and not Layout.isDashboard() and user %}
-            {% element 'Panel/panel' %}
+            {{ element('Panel/panel') }}
         {% endif %}
 
         {# flash messages #}

--- a/src/Template/Layout/default.twig
+++ b/src/Template/Layout/default.twig
@@ -29,7 +29,7 @@ BEdita 4 ~ @ 2018 from ChannelWeb & Chialab with love
 
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,200;0,400;1,200;1,400&family=IBM+Plex+Sans:ital,wght@0,200;0,300;0,400;0,500;1,200;1,300;1,400;1,500&family=IBM+Plex+Serif:ital,wght@0,200;0,400;0,700;1,200;1,400;1,700&display=swap" rel="stylesheet">
-    
+
     {% element 'json_meta_config' %}
 </head>
 
@@ -86,7 +86,7 @@ BEdita 4 ~ @ 2018 from ChannelWeb & Chialab with love
         {{ Link.pluginsBundle()|raw }}
     {% else %}
         {# timezone-offset used in controller and TWIG #}
-        {{ Html.script('libs/timezone.js')|raw }}
+        {{ Html.script('libs/timezone')|raw }}
     {% endif %}
 
     {{ Link.jsBundle([ 'manifest', 'vendors', 'app' ])|raw }}

--- a/src/Template/Layout/error.twig
+++ b/src/Template/Layout/error.twig
@@ -27,11 +27,11 @@ BEdita 4 ~ @ 2018 from ChannelWeb & Chialab with love
 
     <link href="https://fonts.googleapis.com/css?family=Mukta:300,400,700&amp;subset=latin-ext" rel="stylesheet">
 
-    {% element 'custom_colors' %}
+    {{ element('custom_colors') }}
 
     <title>{{ "#{_view.fetch('title')} | #{project.name ?: 'BEdita 4'}" }}</title>
 
-    {% element 'json_meta_config' %}
+    {{ element('json_meta_config') }}
 </head>
 
 <body class="{% if currentModule %}view-module module-{{ currentModule.name }}{% endif %} {{ _view.fetch('bodyViewClass') }}"
@@ -40,7 +40,7 @@ BEdita 4 ~ @ 2018 from ChannelWeb & Chialab with love
     <main class="layout" v-show="vueLoaded" v-bind:class="panelIsOpen? 'panel-is-open' : ''">
 
         <div class="layout-content">
-            {% element 'Modules/header' %}
+            {{ element('Modules/header') }}
             {{ _view.fetch('content')|raw }}
         </div>
 

--- a/src/Template/Pages/Admin/Applications/index.twig
+++ b/src/Template/Pages/Admin/Applications/index.twig
@@ -1,1 +1,1 @@
-{% element 'Admin/index_content' { 'title': __(resourceType|humanize) } %}
+{{ element('Admin/index_content', { 'title': __(resourceType|humanize) }) }}

--- a/src/Template/Pages/Admin/AsyncJobs/index.twig
+++ b/src/Template/Pages/Admin/AsyncJobs/index.twig
@@ -1,1 +1,1 @@
-{% element 'Admin/index_content' { 'title': __(resourceType|humanize) } %}
+{{ element('Admin/index_content', { 'title': __(resourceType|humanize) }) }}

--- a/src/Template/Pages/Admin/Config/index.twig
+++ b/src/Template/Pages/Admin/Config/index.twig
@@ -1,1 +1,1 @@
-{% element 'Admin/index_content' { 'title': __(resourceType|humanize) } %}
+{{ element('Admin/index_content', { 'title': __(resourceType|humanize) }) }}

--- a/src/Template/Pages/Admin/Endpoints/index.twig
+++ b/src/Template/Pages/Admin/Endpoints/index.twig
@@ -1,1 +1,1 @@
-{% element 'Admin/index_content' { 'title': __(resourceType|humanize) } %}
+{{ element('Admin/index_content', { 'title': __(resourceType|humanize) }) }}

--- a/src/Template/Pages/Admin/Roles/index.twig
+++ b/src/Template/Pages/Admin/Roles/index.twig
@@ -1,1 +1,1 @@
-{% element 'Admin/index_content' { 'title': __(resourceType|humanize) } %}
+{{ element('Admin/index_content', { 'title': __(resourceType|humanize) }) }}

--- a/src/Template/Pages/Dashboard/index.twig
+++ b/src/Template/Pages/Dashboard/index.twig
@@ -5,33 +5,33 @@
     <div class="dashboard">
         <section class="dashboard-section">
             <div class="dashboard-items">
-            {% for name, module in modules if not in_array(name, ['trash', 'users']) %}
+            {% for name, module in modules %}
+                {% if not in_array(name, ['trash', 'users']) %}
+                    {# Special cases - set defaults on objects, publications, folders #}
+                    {% if name == 'objects' %}
+                        {% set module = {'label': __('All objects')}|merge(module) %}
+                    {% elseif name == 'publications' %}
+                        {% set module = {'class': 'icon-globe-1'}|merge(module) %}
+                    {% elseif name == 'folders' %}
+                        {% set module = {'class': 'icon-folder'}|merge(module) %}
+                    {% endif %}
 
-                {# Special cases - set defaults on objects, publications, folders #}
-                {% if name == 'objects' %}
-                    {% set module = {'label': __('All objects')}|merge(module) %}
-                {% elseif name == 'publications' %}
-                    {% set module = {'class': 'icon-globe-1'}|merge(module) %}
-                {% elseif name == 'folders' %}
-                    {% set module = {'class': 'icon-folder'}|merge(module) %}
+                    {% set title = Layout.tr(module.label|default(name)) %}
+
+                    {% set class = 'dashboard-item has-background-module-%s %s'|format(name, module.class|default('')) %}
+                    {% if module.hints.multiple_types and not module.class %}
+                        {% set class = class ~ ' icon-th-large-1' %}
+                    {% endif %}
+
+                    {% if module.route %}
+                        {% set url = Url.build(module.route) %}
+                    {% else %}
+                        {% set url = Url.build({ '_name': 'modules:list', 'object_type': name, 'plugin': null }) %}
+                    {% endif %}
+                    <a href="{{ url }}" class="{{ class }}">
+                        <span>{{ title }}</span>
+                    </a>
                 {% endif %}
-
-                {% set title = Layout.tr(module.label|default(name)) %}
-
-                {% set class = 'dashboard-item has-background-module-%s %s'|format(name, module.class|default('')) %}
-                {% if module.hints.multiple_types and not module.class %}
-                    {% set class = class ~ ' icon-th-large-1' %}
-                {% endif %}
-
-                {% if module.route %}
-                    {% set url = Url.build(module.route) %}
-                {% else %}
-                    {% set url = Url.build({ '_name': 'modules:list', 'object_type': name, 'plugin': null }) %}
-                {% endif %}
-                <a href="{{ url }}" class="{{ class }}">
-                    <span>{{ title }}</span>
-                </a>
-
             {% endfor %}
             </div>
         </section>

--- a/src/Template/Pages/Import/index.twig
+++ b/src/Template/Pages/Import/index.twig
@@ -40,7 +40,7 @@
                                 {% for optionName,optionData in datum.options %}
                                 <div>
                                     <label>{{ optionData.label }}</label>
-                                    {{ Form.unlockField(optionName) }}
+                                    {% do Form.unlockField(optionName) %}
                                     {% if optionData.dataType == 'boolean' %}
                                         {{ Form.control(optionName, {
                                             'type': 'checkbox',

--- a/src/Template/Pages/Login/login.twig
+++ b/src/Template/Pages/Login/login.twig
@@ -68,7 +68,7 @@
     <footer>
         <div class="sidebar-footer">
             <div class="sidebar-bedita-logo white">{# css logo #}</div>
-            {% element 'Menu/colophon' %}
+            {{ element('Menu/colophon') }}
         </div>
     </footer>
 </div>

--- a/src/Template/Pages/Model/Categories/index.twig
+++ b/src/Template/Pages/Model/Categories/index.twig
@@ -7,14 +7,14 @@
     </header>
 </div>
 
-{% element 'Modules/index_header' %}
+{{ element('Modules/index_header') }}
 
 <div class="module-index">
-    {% element 'Modules/index_categories' {
+    {{ element('Modules/index_categories', {
         'saveAction': { '_name': 'model:save:categories' },
         'removeAction': { '_name': 'model:remove:categories' }
-    } %}
+    }) }}
 
-    {% element 'Model/sidebar_links' %}
+    {{ element('Model/sidebar_links') }}
 
 </div> {# end module-content #}

--- a/src/Template/Pages/Model/ObjectTypes/index.twig
+++ b/src/Template/Pages/Model/ObjectTypes/index.twig
@@ -1,1 +1,1 @@
-{% element 'Model/index_content' { 'title': __(resourceType|humanize) } %}
+{{ element('Model/index_content', { 'title': __(resourceType|humanize) }) }}

--- a/src/Template/Pages/Model/ObjectTypes/view.twig
+++ b/src/Template/Pages/Model/ObjectTypes/view.twig
@@ -58,7 +58,7 @@
                     </div>
                 </section>
 
-                {% element 'Form/meta' %}
+                {{ element('Form/meta') }}
             </div>
 
         {{ Form.end()|raw }}
@@ -89,7 +89,7 @@
         <header class="unselectable"><h2>{{ __('Core properties') }}</h2></header>
         <div class="properties-container">
             {% for prop in objectTypeProperties.core %}
-                {% element 'Model/object_property' { 'prop': prop, 'type': 'core' }  %}
+                {{ element('Model/object_property', { 'prop': prop, 'type': 'core' }) }}
             {% else %}
                 <p>No Core properties</p>
             {% endfor %}
@@ -101,11 +101,11 @@
         <header class="unselectable"><h2>{{ __('Inherited properties') }}</h2></header>
         <div class="properties-container">
             {% for prop in objectTypeProperties.inherited %}
-                {% element 'Model/object_property' {
+                {{ element('Model/object_property', {
                     'prop': prop,
                     'type': 'inherited',
                     'noButtonsFor': ['id', 'status', 'uname'],
-                }  %}
+                }) }}
             {% else %}
                 <p>No inherited properties</p>
             {% endfor %}
@@ -117,14 +117,14 @@
         <header class="unselectable"><h2>{{ __('Custom properties') }}</h2></header>
         <div class="properties-container">
             {% for prop in objectTypeProperties.custom %}
-                {% element 'Model/object_property' { 'prop': prop, 'type': 'custom' }  %}
+                {{ element('Model/object_property', { 'prop': prop, 'type': 'custom' }) }}
             {% else %}
                 <p>No custom properties</p>
             {% endfor %}
         </div>
     </section>
 
-    {% element 'Model/sidebar_links' %}
+    {{ element('Model/sidebar_links') }}
 
 </div>
 </modules-view>

--- a/src/Template/Pages/Model/PropertyTypes/index.twig
+++ b/src/Template/Pages/Model/PropertyTypes/index.twig
@@ -6,7 +6,7 @@
 {# {% set resourceType = _view.request.params.resource_type %} #}
 {% set _csrfToken = _view.request.params['_csrfToken']|json_encode %}
 
-{% element 'Modules/index_header' { 'meta': meta, 'filter': filter, 'Schema': Schema, 'hidePagination': treeView} %}
+{{ element('Modules/index_header', { 'meta': meta, 'filter': filter, 'Schema': Schema, 'hidePagination': treeView}) }}
 
 <model-index inline-template ids='{{ ids|json_encode }}' resources='{{ resources|json_encode }}' :csrf-token='{{ _csrfToken }}'>
     <div class="model-index">
@@ -126,7 +126,7 @@
         </div>
         {# end list-objects #}
 
-    {% element 'Model/sidebar_links' %}
+    {{ element('Model/sidebar_links') }}
 
     </div> {# end module-content #}
 </model-index>

--- a/src/Template/Pages/Model/Relations/index.twig
+++ b/src/Template/Pages/Model/Relations/index.twig
@@ -7,7 +7,7 @@
     </header>
 </div>
 
-{% element 'Modules/index_header' { 'meta': meta, 'filter': filter, 'Schema': Schema, 'hidePagination': treeView} %}
+{{ element('Modules/index_header', { 'meta': meta, 'filter': filter, 'Schema': Schema, 'hidePagination': treeView}) }}
 
 <div class="module-index">
     <div class="list-objects">
@@ -81,6 +81,6 @@
     </div>
     {# end list-objects #}
 
-    {% element 'Model/sidebar_links' %}
+    {{ element('Model/sidebar_links') }}
 
 </div> {# end module-index #}

--- a/src/Template/Pages/Model/Relations/view.twig
+++ b/src/Template/Pages/Model/Relations/view.twig
@@ -19,12 +19,12 @@
         })|raw }}
 
             <div class="main-view-column">
-                {% element 'Form/core_properties' %}
-                {% element 'Model/relation' %}
+                {{ element('Form/core_properties') }}
+                {{ element('Model/relation') }}
             </div>
 
             <div class="side-view-column">
-                {% element 'Form/meta' %}
+                {{ element('Form/meta') }}
             </div>
 
         {{ Form.end()|raw }}
@@ -34,7 +34,7 @@
         {# {% do _view.append('module-buttons', Form.postButton(__('Delete'), {'_name': 'model:delete', 'resource_type': resourceType}, {'data': {'id': resource.id}})) %} #}
     </div>
 
-    {% element 'Model/sidebar_links' %}
+    {{ element('Model/sidebar_links') }}
 
 </div>
 </modules-view>

--- a/src/Template/Pages/Model/Tags/index.twig
+++ b/src/Template/Pages/Model/Tags/index.twig
@@ -7,13 +7,13 @@
     </header>
 </div>
 
-{% element 'Modules/index_header' {'hideFilter': 1} %}
+{{ element('Modules/index_header', {'hideFilter': 1}) }}
 
 <div class="module-index">
-    {% element 'Modules/index_tags' {
+    {{ element('Modules/index_tags', {
         'saveAction': { '_name': 'model:save:tags' },
         'removeAction': { '_name': 'model:remove:tags' }
-    } %}
+    }) }}
 
-    {% element 'Model/sidebar_links' %}
+    {{ element('Model/sidebar_links') }}
 </div>

--- a/src/Template/Pages/Modules/categories.twig
+++ b/src/Template/Pages/Modules/categories.twig
@@ -6,13 +6,13 @@
     </header>
 </div>
 
-{% element 'Modules/index_header' %}
+{{ element('Modules/index_header') }}
 
 <div class="module-index">
-    {% element 'Modules/index_categories' {
+    {{ element('Modules/index_categories', {
         'saveAction': { '_name': 'modules:categories:save', 'object_type': objectType },
         'removeAction': { '_name': 'modules:categories:remove', 'object_type': objectType },
-    } %}
+    }) }}
 
     {% do _view.append('module-buttons',
         Html.link(__('List'),

--- a/src/Template/Pages/Modules/index.twig
+++ b/src/Template/Pages/Modules/index.twig
@@ -3,7 +3,7 @@
 {% set query = _view.getRequest().getQueryParams() %}
 {% set treeView = currentModule.name == 'folders' and query is empty %}
 
-{% element 'Modules/index_header' { 'meta': meta, 'filter': filter, 'Schema': Schema, 'hidePagination': treeView} %}
+{{ element('Modules/index_header', { 'meta': meta, 'filter': filter, 'Schema': Schema, 'hidePagination': treeView}) }}
 
 {% set ids = Array.extract(objects, '{*}.id') %}
 <modules-index inline-template ids='{{ ids|json_encode }}'>
@@ -14,11 +14,11 @@
             <div class="table-container">
                 <div class="list-objects">
                     {% if objects %}
-                        {% element 'Modules/index_table_header' { 'refObject': objects[0] } %}
+                        {{ element('Modules/index_table_header', { 'refObject': objects[0] }) }}
                     {% endif %}
 
                     {% for object in objects %}
-                        {% element 'Modules/index_table_row' { 'object': object } %}
+                        {{ element('Modules/index_table_row', { 'object': object }) }}
                     {% else %}
                         {{ __('No items found') }}
                     {% endfor %}
@@ -28,7 +28,7 @@
             <div class="module-footer">
                 {# bulk actions #}
                 {% if objects %}
-                    {% element 'Modules/index_bulk' {} %}
+                    {{ element('Modules/index_bulk', {}) }}
                 {% endif %}
 
                 {% if not treeView %}
@@ -41,7 +41,7 @@
                         @filter-update-current-page="onUpdateCurrentPage"
                     >
                         <template v-if="pagination.count">
-                            {% element 'FilterBox/filter_box_page_toolbar' %}
+                            {{ element('FilterBox/filter_box_page_toolbar') }}
                         </template>
                     </filter-box-view>
                 {% endif %}

--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -35,58 +35,58 @@
             <div class="main-view-column is-flex is-flex-column">
                 {# Upload available only for new media objects #}
                 {% if objectType in uploadable and (object.id is empty or (not streams and not object.attributes.provider_extra.html)) %}
-                    {% element 'Form/upload' %}
+                    {{ element('Form/upload') }}
                 {% endif %}
 
-                {% element 'Form/core_properties' %}
+                {{ element('Form/core_properties') }}
 
-                {% element 'Form/custom_left' %}
+                {{ element('Form/custom_left') }}
 
                 {# calendar using `date_ranges` #}
-                {% element 'Form/calendar' %}
+                {{ element('Form/calendar') }}
 
-                {% element 'Form/categories' %}
+                {{ element('Form/categories') }}
 
-                {% element 'Form/tags' %}
+                {{ element('Form/tags') }}
 
-                {% element 'Form/media' %}
+                {{ element('Form/media') }}
 
-                {% element 'Form/map' %}
+                {{ element('Form/map') }}
 
-                {% element 'Form/other_properties' %}
+                {{ element('Form/other_properties') }}
             </div>
 
             <div class="side-view-column is-flex is-flex-column">
-                {% element 'Form/publish_properties' %}
+                {{ element('Form/publish_properties') }}
 
                 {% if modules.folders and _view.getRequest().getParam('action') != 'clone' %}
-                    {% element 'Form/trees' %}
+                    {{ element('Form/trees') }}
                 {% endif %}
 
-                {% element 'Form/custom_right' %}
+                {{ element('Form/custom_right') }}
 
                 {# if `roles` in relationships (`users` only) display custom roles element #}
                 {% if object.relationships.roles %}
-                    {% element 'Form/roles' %}
+                    {{ element('Form/roles') }}
                 {% endif %}
 
-                {% element 'Form/related_translations' {'resourceName': 'translations'} %}
+                {{ element('Form/related_translations', {'resourceName': 'translations'}) }}
 
-                {% element 'Form/meta' %}
+                {{ element('Form/meta') }}
 
-                {% element 'Form/advanced_properties' %}
+                {{ element('Form/advanced_properties') }}
 
-                {% element 'Form/resource_relations' %}
+                {{ element('Form/resource_relations') }}
 
                 {# aside relations view #}
-                {% element 'Form/relations' {'relations': objectRelations.aside} %}
+                {{ element('Form/relations', {'relations': objectRelations.aside}) }}
             </div>
 
             {# main relations view #}
-            {% element 'Form/relations' {'relations': objectRelations.main} %}
+            {{ element('Form/relations', {'relations': objectRelations.main}) }}
 
             {% if object.id %}
-                {% element 'Form/history' %}
+                {{ element('Form/history') }}
             {% endif %}
 
             {# Set `_jsonKeys` hidden input from config #}

--- a/src/Template/Pages/Password/reset.twig
+++ b/src/Template/Pages/Password/reset.twig
@@ -17,7 +17,7 @@
      </div>
 
     <div class="login-form">
-    
+
         <div class="mb-1">
             <h1>{{ __('Password reset') }}</h1>
             <p>{{ __('Submit your email address and follow the instructions sent by email.') }}</p>
@@ -48,14 +48,14 @@
         {{ Form.end()|raw }}
 
          <p class="mt-1">{{ Html.link( __('Back to login'), '/' ) | raw }}</p>
-    
+
     </div>
 
     <footer>
         <div class="sidebar-footer">
             <div class="sidebar-bedita-logo white">{# css logo #}</div>
-            {% element 'Menu/colophon' %}
-        </div>  
+            {{ element('Menu/colophon') }}
+        </div>
     </footer>
 
 </div>

--- a/src/Template/Pages/Translations/add.twig
+++ b/src/Template/Pages/Translations/add.twig
@@ -1,1 +1,1 @@
-{% element 'translation' %}
+{{ element('translation') }}

--- a/src/Template/Pages/Translations/edit.twig
+++ b/src/Template/Pages/Translations/edit.twig
@@ -1,1 +1,1 @@
-{% element 'translation' %}
+{{ element('translation') }}

--- a/src/Template/Pages/Translations/index.twig
+++ b/src/Template/Pages/Translations/index.twig
@@ -1,7 +1,7 @@
 {% do _view.assign('title', __('Translations')) %}
 {% set languages = config('I18n.languages') %}
 
-{% element 'Modules/index_header' { 'meta': meta, 'filter': filter, 'Schema': Schema } %}
+{{ element('Modules/index_header', { 'meta': meta, 'filter': filter, 'Schema': Schema }) }}
 
 {% set ids = Array.extract(objects, '{*}.id') %}
 <modules-index inline-template ids='{{ ids|json_encode }}'>

--- a/src/Template/Pages/Trash/index.twig
+++ b/src/Template/Pages/Trash/index.twig
@@ -1,6 +1,6 @@
 {% do _view.assign('title', currentModule.name|humanize) %}
 
-{% element 'Modules/index_header' %}
+{{ element('Modules/index_header') }}
 
 {% set ids = Array.extract(objects, '{*}.id') %}
 
@@ -11,11 +11,11 @@
         <div class="table-container">
             <div class="list-objects">
                 {% if objects %}
-                    {% element 'Modules/index_table_header' { 'refObject': objects[0] } %}
+                    {{ element('Modules/index_table_header', { 'refObject': objects[0] }) }}
                 {% endif %}
 
                 {% for object in objects %}
-                    {% element 'Modules/index_table_row' { 'object': object, 'isTrash': true } %}
+                    {{ element('Modules/index_table_row', { 'object': object, 'isTrash': true }) }}
                 {% else %}
                     {{ __('No items found') }}
                 {% endfor %}

--- a/src/Template/Pages/Trash/index.twig
+++ b/src/Template/Pages/Trash/index.twig
@@ -36,14 +36,14 @@
                         'class': 'mr-1'
                     })|raw }}
                         <input type="hidden" name="ids" v-bind:value="selectedRows">
-                        {{ Form.unlockField('ids') }}
+                        {% do Form.unlockField('ids') %}
                         <button @click.prevent="restoreItem" :disabled="!selectedRows.length">{{ __('Restore') }}</button>
                     {{ Form.end()|raw }}
                 {% endif %}
                 {% if (objects) and Perms.canDelete({type: objectType}) %}
                     {{ Form.create(null, {'id': 'form-delete', 'url': {'_name': 'trash:delete', 'object_type': objectType}})|raw }}
                         <input type="hidden" name="ids" v-bind:value="selectedRows">
-                        {{ Form.unlockField('ids') }}
+                        {% do Form.unlockField('ids') %}
                         <button @click.prevent="deleteItem" :disabled="!selectedRows.length">{{ __('Delete') }}</button>
                     {{ Form.end()|raw }}
                 {% endif %}

--- a/src/Template/Pages/Trash/view.twig
+++ b/src/Template/Pages/Trash/view.twig
@@ -15,27 +15,27 @@
         })|raw }}
 
             <div class="main-view-column">
-                {% element 'Form/core_properties' %}
-                {% element 'Form/custom_left' %}
+                {{ element('Form/core_properties') }}
+                {{ element('Form/custom_left') }}
 
                 {# calendar using `date_ranges` #}
-                {% element 'Form/calendar' %}
+                {{ element('Form/calendar') }}
 
-                {% element 'Form/categories' %}
+                {{ element('Form/categories') }}
 
-                {% element 'Form/media' %}
+                {{ element('Form/media') }}
 
-                {% element 'Form/map' %}
+                {{ element('Form/map') }}
 
-                {% element 'Form/other_properties' %}
+                {{ element('Form/other_properties') }}
             </div>
 
             <div class="side-view-column">
-                {% element 'Form/publish_properties' %}
+                {{ element('Form/publish_properties') }}
 
-                {% element 'Form/advanced_properties' %}
+                {{ element('Form/advanced_properties') }}
 
-                {% element 'Form/meta' %}
+                {{ element('Form/meta') }}
             </div>
 
         {{ Form.end()|raw }}

--- a/src/Template/Pages/UserProfile/view.twig
+++ b/src/Template/Pages/UserProfile/view.twig
@@ -20,40 +20,44 @@
             <div class="main-view-column">
 
                 {% set jsonKeys = [] %}
-                {% for group, attributes in properties if group != 'other' and group != 'password_change' and attributes %}
-                    <section class="fieldset">
-                        {% if group|trim  %}
-                            <header>
-                                <h2 class="m-0">{{ __(group|humanize) }}</h2>
-                            </header>
-                        {% endif %}
+                {% for group, attributes in properties %}
+                    {% if group != 'other' and group != 'password_change' and attributes %}
+                        <section class="fieldset">
+                            {% if group|trim  %}
+                                <header>
+                                    <h2 class="m-0">{{ __(group|humanize) }}</h2>
+                                </header>
+                            {% endif %}
 
-                        <div class="tab-container">
-                            {% for key, value in attributes %}
-                                {% set options = {} %}
-                                {% if key == 'email' or key == 'username' %}
-                                    {% set options = options|merge({'readonly': 'true'}) %}
-                                {% endif %}
-                                {{ Property.control(key, value, options)|raw }}
-                            {% endfor %}
-                        </div>
-                    </section>
+                            <div class="tab-container">
+                                {% for key, value in attributes %}
+                                    {% set options = {} %}
+                                    {% if key == 'email' or key == 'username' %}
+                                        {% set options = options|merge({'readonly': 'true'}) %}
+                                    {% endif %}
+                                    {{ Property.control(key, value, options)|raw }}
+                                {% endfor %}
+                            </div>
+                        </section>
+                    {% endif %}
                 {% endfor %}
             </div>
 
             <div class="side-view-column">
-                {% for group, attributes in properties if group == 'password_change' and attributes %}
-                    <section class="fieldset">
-                        <header class="mt-25">
-                            <h3 class="is-uppercase">{{ __('Change password') }}</h3>
-                        </header>
+                {% for group, attributes in properties %}
+                    {% if group == 'password_change' and attributes %}
+                        <section class="fieldset">
+                            <header class="mt-25">
+                                <h3 class="is-uppercase">{{ __('Change password') }}</h3>
+                            </header>
 
-                        <div class="tab-container">
-                            {% for key, value in attributes %}
-                                {{ Property.control(key, value)|raw }}
-                            {% endfor %}
-                        </div>
-                    </section>
+                            <div class="tab-container">
+                                {% for key, value in attributes %}
+                                    {{ Property.control(key, value)|raw }}
+                                {% endfor %}
+                            </div>
+                        </section>
+                    {% endif %}
                 {% endfor %}
             </div>
 


### PR DESCRIPTION
This applies a refactor on twig templates. with "non-breaking" changes for new twig version compatibility.

Non-breaking changes:

 - where `{{ Form.unlockField('variable') }}` is used to avoid output errors use `{% do Form.unlockField('variable') %}`
 - replace `{% spaceless %} ... {% endspaceless %}` => `{% apply spaceless %} ... {% endapply %}`
 - remove .js/.css suffix creating links with Html helper
 - from `{{ Html.script('script.js')|raw }}` to `{{ Html.script('script')|raw }}`
 - from `{{ Html.css('style.css')|raw }}` to `{{ Html.css('style')|raw }}`
 - if in for loop is deprecated - `{% for name in data if name != 'some' %}` use if inside loop
 
Breaking change (refactor possible thanks to https://github.com/bedita/web-tools/pull/59, version 1.9 of `bedita/web-tools`):

-  use `{{ element('###', {}) }}` instead of `{% element '###' {} %}`