### PR TITLE
Compute relations list with not-in-schema associations

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -167,7 +167,7 @@ class ModulesController extends AppController
 
         $computedRelations = array_reduce(
             array_keys($object['relationships']),
-            function($acc, $relName) use ($schema) {
+            function ($acc, $relName) use ($schema) {
                 $acc[$relName] = Hash::get($schema, sprintf('relations.%s', $relName), []);
 
                 return $acc;

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -168,7 +168,7 @@ class ModulesController extends AppController
         $computedRelations = array_reduce(
             array_keys($object['relationships']),
             function($acc, $relName) use ($schema) {
-                $acc[$relName] = $schema['relations'][$relName] ?? [];
+                $acc[$relName] = Hash::get($schema, sprintf('relations.%s', $relName), []);
 
                 return $acc;
             },

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -165,10 +165,20 @@ class ModulesController extends AppController
         $this->set(compact('object', 'included', 'schema', 'streams'));
         $this->set('properties', $this->Properties->viewGroups($object, $this->objectType));
 
+        $computedRelations = array_reduce(
+            array_keys($object['relationships']),
+            function($acc, $relName) use ($schema) {
+                $acc[$relName] = $schema['relations'][$relName] ?? [];
+
+                return $acc;
+            },
+            []
+        );
+
         // setup relations metadata
         $this->Modules->setupRelationsMeta(
             $this->Schema->getRelationsSchema(),
-            $schema['relations'],
+            $computedRelations,
             $this->Properties->relationsList($this->objectType),
             $this->Properties->hiddenRelationsList($this->objectType),
             $this->Properties->readonlyRelationsList($this->objectType)


### PR DESCRIPTION
Handle a [wrong assumption](https://github.com/bedita/manager/pull/700/files#diff-72a6e9c54bff26799a2e2fb2bd1f7525ff991b520683455522a87698ff46db52R171) that all relations are listed under the `$schema['relations']`. Now, we are going to use computed `object['relationships']` list populated with schema informations.