### PR TITLE
chore: avoid `underscore`

### DIFF
--- a/src/Utility/Translate.php
+++ b/src/Utility/Translate.php
@@ -31,7 +31,7 @@ class Translate
      */
     public static function get(string $input): ?string
     {
-        $text = Inflector::humanize(Inflector::underscore($input));
+        $text = Inflector::humanize($input);
         $translation = __($text);
         $plugins = (array)Configure::read('Plugins');
         $pluginName = Hash::get(array_keys($plugins), 0);

--- a/tests/TestCase/Utility/TranslateTest.php
+++ b/tests/TestCase/Utility/TranslateTest.php
@@ -39,6 +39,10 @@ class TranslateTest extends TestCase
                 'dummy',
                 'Dummy',
             ],
+            'label' => [
+                'PR expert',
+                'PR Expert',
+            ],
         ];
     }
 

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -141,7 +141,7 @@ class LayoutHelperTest extends TestCase
     {
         return [
             'user profile' => [
-                '<a href="/user_profile" class="has-background-black icon-user">User Profile</a>',
+                '<a href="/user_profile" class="has-background-black icon-user">UserProfile</a>',
                 'UserProfile',
                 [
                     'moduleLink' => ['_name' => 'user_profile:view'],


### PR DESCRIPTION
Labels like `EU countries` should become `EU Countries` (or translated version) instead of `E U Countries` (like now)