### PR TITLE
Refactor: use Form helper to create form - Cake 4 compatibility

### DIFF
--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -1,4 +1,3 @@
-{{ Form.create(null, {'id': 'filter-box-form', 'name': 'filter-box-form'})|raw }}
 <div class="filters-container" :class="{ 'filters-container-active': filterActive }">
     <div class="basic-filters">
         {# search #}
@@ -75,7 +74,6 @@
                             label=""
                             @change="onCategoryChange"
                         ></category-picker>
-                        {% do Form.unlockField('categories') %}
                     {% endfor %}
                 {% elseif schema %}
                     <category-picker
@@ -85,7 +83,6 @@
                         label=""
                         @change="onCategoryChange"
                     ></category-picker>
-                    {% do Form.unlockField('categories') %}
                 {% endif %}
             </span>
 
@@ -93,7 +90,6 @@
                 <label>{{ __('Folder') }}</label>
 
                 <folder-picker label="" :initial-folder="initFolder" @change="onFolderChange"></folder-picker>
-                {% do Form.unlockField('folderSelected') %}
 
                 <span class="descendants-filter">
                     <label for="descendants">{{ __('Descendants') }}</label>
@@ -164,4 +160,3 @@
         {{ __('Data is filtered') }}
     </p>
 </div>
-{{ Form.end()|raw }}

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -1,8 +1,6 @@
 {{ Form.create(null, {'id': 'filter-box-form', 'name': 'filter-box-form'})|raw }}
 <div class="filters-container" :class="{ 'filters-container-active': filterActive }">
-
     <div class="basic-filters">
-
         {# search #}
         <div class="filter-container filter-search input">
             <input type="text"
@@ -158,9 +156,7 @@
                 <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]" :attrs="filter"/>
             </span>
         </div>
-
     </div>
-
 </div>
 
 <div v-if="filterActive">
@@ -168,5 +164,4 @@
         {{ __('Data is filtered') }}
     </p>
 </div>
-
 {{ Form.end()|raw }}

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -1,3 +1,9 @@
+{{ Form.create(null, {
+    'name': 'filter-box-form',
+    'id': 'filter-box-form',
+    'v-if': "object.type == '" ~ type ~ "'"
+})|raw }}
+
 <div class="filters-container" :class="{ 'filters-container-active': filterActive }">
     <div class="basic-filters">
         {# search #}
@@ -163,3 +169,5 @@
         {{ __('Data is filtered') }}
     </p>
 </div>
+
+{{ Form.end() }}

--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -1,11 +1,8 @@
-{{ Form.create(null, {
-    'name': 'filter-box-form',
-    'id': 'filter-box-form',
-    'v-if': "object.type == '" ~ type ~ "'"
-})|raw }}
-
+{{ Form.create(null, {'id': 'filter-box-form', 'name': 'filter-box-form'})|raw }}
 <div class="filters-container" :class="{ 'filters-container-active': filterActive }">
+
     <div class="basic-filters">
+
         {# search #}
         <div class="filter-container filter-search input">
             <input type="text"
@@ -161,7 +158,9 @@
                 <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]" :attrs="filter"/>
             </span>
         </div>
+
     </div>
+
 </div>
 
 <div v-if="filterActive">
@@ -170,4 +169,4 @@
     </p>
 </div>
 
-{{ Form.end() }}
+{{ Form.end()|raw }}

--- a/src/Template/Element/Modules/index_table_row.twig
+++ b/src/Template/Element/Modules/index_table_row.twig
@@ -9,8 +9,10 @@
     class="table-row object-status-{{ object.attributes.status }} {{ Layout.publishStatus(object | default({})) }}">
 
         <div class="select-cell narrow" @click="selectRow">
-            {% do Form.unlockField('oneItem') %}
-            <input type="checkbox" name="oneItem" value="{{ object.id }}" v-model="selectedRows" {% if not Perms.canRead(object.type) %}disabled="disabled"{% endif %}>
+            {{ Form.create(null, {'name': 'index-table-form', 'id': 'index-table-form'})|raw }}
+                {% do Form.unlockField('oneItem') %}
+                <input type="checkbox" name="oneItem" value="{{ object.id }}" v-model="selectedRows" {% if not Perms.canRead(object.type) %}disabled="disabled"{% endif %}>
+            {{ Form.end()|raw }}
         </div>
 
         <div class="thumb-cell narrow">

--- a/src/Template/Element/Modules/index_table_row.twig
+++ b/src/Template/Element/Modules/index_table_row.twig
@@ -9,10 +9,7 @@
     class="table-row object-status-{{ object.attributes.status }} {{ Layout.publishStatus(object | default({})) }}">
 
         <div class="select-cell narrow" @click="selectRow">
-            {{ Form.create(null, {'name': 'index-table-form', 'id': 'index-table-form'})|raw }}
-                {% do Form.unlockField('oneItem') %}
-                <input type="checkbox" name="oneItem" value="{{ object.id }}" v-model="selectedRows" {% if not Perms.canRead(object.type) %}disabled="disabled"{% endif %}>
-            {{ Form.end()|raw }}
+            <input type="checkbox" name="oneItem" value="{{ object.id }}" v-model="selectedRows" {% if not Perms.canRead(object.type) %}disabled="disabled"{% endif %}>
         </div>
 
         <div class="thumb-cell narrow">

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -26,7 +26,7 @@
                 {% set prefix = '_fast_create_' ~ type ~ '_' %}
                 {{ Form.create({
                     'name': 'create-object',
-                    'class': 'object-form fast-create'
+                    'class': 'object-form fast-create',
                     ':disable': 'saving',
                     'id': type ~ '-form',
                     'v-if': "object.type == '" ~ type ~ "'"

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -24,7 +24,7 @@
 
             {% for type in Schema.rightTypes() %}
                 {% set prefix = '_fast_create_' ~ type ~ '_' %}
-                {{ Form.create({
+                {{ Form.create(null, {
                     'name': 'create-object',
                     'class': 'object-form fast-create',
                     ':disable': 'saving',

--- a/src/Template/Element/Panel/relations_add.twig
+++ b/src/Template/Element/Panel/relations_add.twig
@@ -24,7 +24,13 @@
 
             {% for type in Schema.rightTypes() %}
                 {% set prefix = '_fast_create_' ~ type ~ '_' %}
-                <form name="create-object" class="object-form fast-create" :disabled="saving" id="{{ type }}-form" v-if="object.type == '{{ type }}'">
+                {{ Form.create({
+                    'name': 'create-object',
+                    'class': 'object-form fast-create'
+                    ':disable': 'saving',
+                    'id': type ~ '-form',
+                    'v-if': "object.type == '" ~ type ~ "'"
+                })|raw }}
                     {{ Form.control('upload_behavior', {
                         'id': 'url_behavior',
                         'type': 'hidden',
@@ -92,7 +98,7 @@
                     </section>
                     <button @click="createObject" type="button">{{ __('create') }}</button>
                     <button @click="resetForm">{{ __('reset') }}</button>
-                </form>
+                {{ Form.end()|raw }}
             {% endfor %}
         </div>
     </section>


### PR DESCRIPTION
When `Form.unlockField` is used inside a `<form>` (not created via `FormHelper`), there's an error in cakephp4: 
```
ERROR: `FormProtector` instance has not been created. Ensure you have loaded the `FormProtectionComponent` in your controller and called `FormHelper::create()` before calling `FormHelper::unlockField()`.
```

This provides a refactor to:

 - use `Form.create` and `Form.end` in templates, when inside form there are `Form.unlockField()` statements
 - remove not necessary `Form.unlockField()` 

