### PR TITLE
Csrf token in meta config

### DIFF
--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -182,13 +182,6 @@ class LayoutHelper extends Helper
      */
     public function metaConfig(): array
     {
-        $csrfToken = null;
-        if (!empty($this->getView()->getRequest()->getParam('_csrfToken'))) {
-            $csrfToken = $this->getView()->getRequest()->getParam('_csrfToken');
-        } elseif (!empty($this->getView()->getRequest()->getData('_csrfToken'))) {
-            $csrfToken = $this->getView()->getRequest()->getData('_csrfToken');
-        }
-
         return [
             'base' => $this->Link->baseUrl(),
             'currentModule' => $this->getView()->get('currentModule', ['name' => 'home']),
@@ -197,7 +190,30 @@ class LayoutHelper extends Helper
             'plugins' => \App\Plugin::loadedAppPlugins(),
             'uploadable' => $this->getView()->get('uploadable', []),
             'locale' => \Cake\I18n\I18n::getLocale(),
-            'csrfToken' => $csrfToken,
+            'csrfToken' => $this->getCsrfToken(),
         ];
+    }
+
+    /**
+     * Get csrf token, searching in: request params, data, attributes and cookies
+     *
+     * @return string|null
+     */
+    public function getCsrfToken(): ?string
+    {
+        if (!empty($this->getView()->getRequest()->getParam('_csrfToken'))) {
+            return $this->getView()->getRequest()->getParam('_csrfToken');
+        }
+        if (!empty($this->getView()->getRequest()->getData('_csrfToken'))) {
+            return $this->getView()->getRequest()->getData('_csrfToken');
+        }
+        if (!empty($this->getView()->getRequest()->getAttribute('csrfToken'))) {
+            return $this->getView()->getRequest()->getAttribute('csrfToken');
+        }
+        if (!empty($this->getView()->getRequest()->getCookie('csrfToken'))) {
+            return $this->getView()->getRequest()->getCookie('csrfToken');
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
This fixes a problem found in BEM 3.0.0: `BEDITA.csrfToken` "sometimes" is null.

How the fix works: csrf token is seached in request attributes and in request cookies too.