### PR TITLE
Load bootstrap CLI

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -54,6 +54,11 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
     public function bootstrap(): void
     {
         parent::bootstrap();
+
+        if (PHP_SAPI === 'cli') {
+            $this->bootstrapCli();
+        }
+
         $this->addPlugin('BEdita/WebTools');
         $this->addPlugin('BEdita/I18n');
         $this->addPlugin('Authentication');

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -69,6 +69,25 @@ class ApplicationTest extends TestCase
     }
 
     /**
+     * Test `bootstrap` method
+     *
+     * @return void
+     * @covers ::bootstrap()
+     * @covers ::bootstrapCli()
+     */
+    public function testBootstrap(): void
+    {
+        $app = new Application(CONFIG);
+        $app->bootstrap();
+
+        static::assertTrue($app->getPlugins()->has('Bake'));
+        static::assertTrue($app->getPlugins()->has('IdeHelper'));
+        static::assertTrue($app->getPlugins()->has('BEdita/WebTools'));
+        static::assertTrue($app->getPlugins()->has('BEdita/I18n'));
+        static::assertTrue($app->getPlugins()->has('Authentication'));
+    }
+
+    /**
      * Test `loadPluginsFromConfig` method
      *
      * @return void


### PR DESCRIPTION
This PR fixes a problem on application bootstrap: `bootstrapCli()` method was never called and related plugins wer never loaded