### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,11 +61,6 @@
             "@cs-check"
         ],
         "analyze": "vendor/bin/phpstan analyse src plugins/*/*/src",
-        "cs-setup": [
-            "vendor/bin/phpcs --config-set installed_paths vendor/cakephp/cakephp-codesniffer",
-            "vendor/bin/phpcs --config-set default_standard CakePHP",
-            "vendor/bin/phpcs --config-set colors 1"
-        ],
         "cs-check": "vendor/bin/phpcs --extensions=php --colors -p ./src ./tests ./config",
         "cs-fix": "vendor/bin/phpcbf --extensions=php --colors ./src ./tests ./config",
         "test": "vendor/bin/phpunit --colors=always",
@@ -88,7 +83,7 @@
             ],
             "recurse": true,
             "replace": true,
-            "merge-dev": true,
+            "merge-dev": false,
             "merge-extra": false,
             "merge-extra-deep": false,
             "merge-scripts": false


### PR DESCRIPTION
This PR introduces two changes in composer.json

* `cs-setup` script no more necessary since we use `phpcs.xml`
* `"merge-dev": false` - this avoid some possible path conflicts with plugins