### PR TITLE
Fix file import

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,13 +20,5 @@
     </testsuite>
     <!-- Add plugin test suites here. -->
   </testsuites>
-  <!-- Setup a listener for fixtures -->
-  <listeners>
-    <listener class="\Cake\TestSuite\Fixture\FixtureInjector" file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
-      <arguments>
-        <object class="\Cake\TestSuite\Fixture\FixtureManager"/>
-      </arguments>
-    </listener>
-  </listeners>
   <!-- Ignore vendor tests in code coverage reports -->
 </phpunit>

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -83,14 +83,16 @@ class ImportController extends AppController
             $importFilter = new $filter($this->apiClient);
 
             // see http://php.net/manual/en/features.file-upload.errors.php
-            $fileError = (int)$this->getRequest()->getData('file.error', UPLOAD_ERR_NO_FILE);
+            /** @var \Laminas\Diactoros\UploadedFile $file */
+            $file = $this->getRequest()->getData('file');
+            $fileError = $file->getError();
             if ($fileError > UPLOAD_ERR_OK) {
                 throw new BadRequestException($this->uploadErrorMessage($fileError));
             }
 
             $result = $importFilter->import(
-                $this->getRequest()->getData('file.name'),
-                $this->getRequest()->getData('file.tmp_name'),
+                $file->getClientFileName(),
+                $file->getStream()->getMetadata('uri'),
                 $this->getRequest()->getData('filter_options')
             );
             $this->getRequest()->getSession()->write(['Import.result' => $result]);

--- a/tests/TestCase/Controller/ImportControllerTest.php
+++ b/tests/TestCase/Controller/ImportControllerTest.php
@@ -23,6 +23,7 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
+use Laminas\Diactoros\UploadedFile;
 
 /**
  * {@see \App\Controller\ImportController} Test Case
@@ -80,16 +81,14 @@ class ImportControllerTest extends TestCase
      */
     public function setupController(?string $filter = null): void
     {
+        $filename = sprintf('%s/tests/files/%s', getcwd(), $this->filename);
+        $file = new UploadedFile($filename, filesize($filename), $this->fileError, $this->filename);
         $config = [
             'environment' => [
                 'REQUEST_METHOD' => 'GET',
             ],
             'post' => [
-                'file' => [
-                    'name' => $this->filename,
-                    'tmp_name' => sprintf('%s/tests/files/%s', getcwd(), $this->filename),
-                    'error' => $this->fileError,
-                ],
+                'file' => $file,
                 'filter' => $filter,
             ],
         ];


### PR DESCRIPTION
This fixes a bug in import, introduced by dependencies update done with passage to cake4.

To avoid errors we use `Laminas\Diactoros\UploadedFile` methods to get `error` code, `name` of file and `tmp_file` url.

Bonus: remove fixtures (not used in this project) from `phpunit.xml.dist`. This should avoid deprecation warnings in tests (cake4 introduced a different way to load and use fixtures, ref: https://book.cakephp.org/4/en/appendices/fixture-upgrade.html)