### PR TITLE
Use Cake\Database\TypeFactory instead of alias Cake\Database\Type

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -33,7 +33,7 @@ use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\IniConfig;
 use Cake\Core\Configure\Engine\PhpConfig;
-use Cake\Database\Type;
+use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
 use Cake\Error\ConsoleErrorHandler;
 use Cake\Error\ErrorHandler;
@@ -199,10 +199,10 @@ ServerRequest::addDetector('tablet', function ($request) {
  * locale specific date formats. For details see
  * @link https://book.cakephp.org/3.0/en/core-libraries/internationalization-and-localization.html#parsing-localized-datetime-data
  */
-Type::build('time');
-Type::build('date');
-Type::build('datetime');
-Type::build('timestamp');
+TypeFactory::build('time');
+TypeFactory::build('date');
+TypeFactory::build('datetime');
+TypeFactory::build('timestamp');
 
 /*
  * Custom Inflector rules, can be set to correctly pluralize or singularize


### PR DESCRIPTION
`Cake\Database\Type` is a deprecated alias for `Cake\Database\TypeFactory`. Better using `TypeFactory`.

https://github.com/cakephp/cakephp/blob/4.x/src/Database/Type.php