### PR TITLE
Video metadata from url

### DIFF
--- a/src/Utility/OEmbed.php
+++ b/src/Utility/OEmbed.php
@@ -68,9 +68,9 @@ class OEmbed
      */
     protected function fetchJson(string $oemBedurl): array
     {
-        $json = (new Client())->get($oemBedurl)->json;
+        $o = (new Client())->get($oemBedurl, [], ['type' => 'json']);
 
-        return empty($json) ? [] : $json;
+        return $o->getJson() ?? [];
     }
 
     /**


### PR DESCRIPTION
This fixes a buggy behavior on creating new video from url.

Expected behavior: get metadata for video, if available, and save them with new video.
The buggy behavior: not getting metadata.

How we solve it: in `Oembed` utility where we fetch metadata, we can't access `json` property on `\Cake\Http\Client\Response`, we have to use `getJson()` method.