### PR TITLE
Replace more aliased classes

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -161,6 +161,9 @@ jobs:
       - name: 'Install dependencies with Composer'
         run: 'composer install --prefer-dist --no-interaction'
 
+      - name: 'Dump Composer autoloader'
+        run: 'composer dump-autoload --classmap-authoritative --no-cache'
+
       - name: 'Run PHPUnit with coverage'
         run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
 

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "cakephp/plugin-installer": true,
-            "wikimedia/composer-merge-plugin": true
+            "wikimedia/composer-merge-plugin": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "extra": {

--- a/src/Command/ConsoleCommand.php
+++ b/src/Command/ConsoleCommand.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
  */
 namespace App\Command;
 
+use Cake\Command\Command;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Log\Log;

--- a/src/Core/Exception/UploadException.php
+++ b/src/Core/Exception/UploadException.php
@@ -13,12 +13,12 @@
 
 namespace App\Core\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Exception raised when uploading from form fails
  */
-class UploadException extends Exception
+class UploadException extends CakeException
 {
     /**
      * Array to map upload error codes with proper message string


### PR DESCRIPTION
In production environments it is advisable to dump an authoritative class map with `composer dump-autoload --classmap-authoritative --no-cache`. However, aliased classes such as `\Cake\Console\Command` are not included in the generated static class map and cause errors.

This PR runs that command before running unit tests so that hopefully we catch more of these errors in advance. Additionally, it aims to get rid of all deprecated aliased classes.

It is a follow up on #735, which only addressed part of the issue.