### PR TITLE
Update phpstan/phpstan to version 1.5 + fix php workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: 'Run PHP STAN'
         run: |
-          vendor/bin/phpstan analyse --no-progress src
+          vendor/bin/phpstan analyse --no-progress --error-format=github
 
   unit:
     name: 'Run unit tests'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -72,7 +72,7 @@ jobs:
         uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '${{ matrix.php-version }}'
-          tools: 'composer:v2, phpstan'
+          tools: 'composer:v2'
           extensions: 'mbstring, intl'
           coverage: 'none'
 
@@ -94,7 +94,7 @@ jobs:
 
       - name: 'Run PHP STAN'
         run: |
-          phpstan analyse --no-progress src
+          vendor/bin/phpstan analyse --no-progress src
 
   unit:
     name: 'Run unit tests'

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /index.html
 /logs/*
 !/logs/.gitkeep
+/phpstan.neon
 /phpunit.xml
 /provision/*
 /tests/.env

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "cakephp/cakephp-codesniffer": "~4.5.1",
         "cakephp/debug_kit": "^4.7.1",
         "dereuromark/cakephp-ide-helper": "~1.17.0",
-        "phpstan/phpstan": "^1.4",
+        "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^9",
         "psy/psysh": "@stable"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+  bootstrapFiles:
+    - tests/bootstrap.php
+  paths:
+    - src
+    - tests
+  level: 0

--- a/tests/TestCase/Controller/BulkControllerTest.php
+++ b/tests/TestCase/Controller/BulkControllerTest.php
@@ -20,6 +20,13 @@ use ReflectionProperty;
 class BulkControllerTest extends BaseControllerTest
 {
     /**
+     * Test Modules controller
+     *
+     * @var \App\Controller\BulkController
+     */
+    public $controller;
+
+    /**
      * @inheritDoc
      */
     public function setUp(): void

--- a/tests/TestCase/Controller/Component/CategoriesComponentTest.php
+++ b/tests/TestCase/Controller/Component/CategoriesComponentTest.php
@@ -72,7 +72,7 @@ class CategoriesComponentTest extends TestCase
             ->getMock();
         $apiClient->method('get')
             ->with('/model/categories')
-            ->will($this->returnCallback(function () use (&$expected) {
+            ->will($this->returnCallback(function () {
                 $args = func_get_args();
 
                 return $args[1]; // options

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -49,6 +49,13 @@ class ModulesComponentTest extends TestCase
      */
     public $Modules;
 
+    /**
+     * Authentication component
+     *
+     * @var \Authentication\Controller\Component\AuthenticationComponent;
+     */
+    public $Authentication;
+
     public $MyModules;
 
     /**

--- a/tests/TestCase/Controller/Component/ObjectsEditorsComponentTest.php
+++ b/tests/TestCase/Controller/Component/ObjectsEditorsComponentTest.php
@@ -28,6 +28,13 @@ class ObjectsEditorsComponentTest extends TestCase
     public $ObjectsEditors;
 
     /**
+     * Authentication component
+     *
+     * @var \Authentication\Controller\Component\AuthenticationComponent;
+     */
+    public $Authentication;
+
+    /**
      * @inheritDoc
      */
     public function setUp(): void

--- a/tests/TestCase/Controller/Component/ThumbsComponentTest.php
+++ b/tests/TestCase/Controller/Component/ThumbsComponentTest.php
@@ -68,12 +68,12 @@ class ThumbsComponentTest extends TestCase
                 [],
             ],
             // test with objct without ids
-            'responseWithoutIds' => [
+            'responseWithoutIds 1' => [
                 ['data' => []],
                 ['data' => []],
             ],
             // test with objct without ids
-            'responseWithoutIds' => [
+            'responseWithoutIds 2' => [
                 ['data' => [
                     'ids' => [],
                 ]],

--- a/tests/TestCase/Controller/ExportControllerTest.php
+++ b/tests/TestCase/Controller/ExportControllerTest.php
@@ -350,8 +350,9 @@ class ExportControllerTest extends TestCase
         $reflectionClass = new \ReflectionClass($this->Export);
         $method = $reflectionClass->getMethod('fillDataFromResponse');
         $method->setAccessible(true);
-        extract($input); // => $fields, $response
         $data = [];
+        $response = $input['response'];
+        $fields = $input['fields'];
         $method->invokeArgs($this->Export, [&$data, $response, $fields]);
         static::assertEquals($expected, $data);
     }
@@ -477,7 +478,8 @@ class ExportControllerTest extends TestCase
         $reflectionClass = new \ReflectionClass($this->Export);
         $method = $reflectionClass->getMethod('rowFields');
         $method->setAccessible(true);
-        extract($input); // => $data, $field
+        $data = $input['data'];
+        $fields = $input['fields'];
         $row = $method->invokeArgs($this->Export, [&$data, $fields]);
         static::assertEquals($expected, $row);
     }

--- a/tests/TestCase/Controller/Model/CategoriesControllerTest.php
+++ b/tests/TestCase/Controller/Model/CategoriesControllerTest.php
@@ -34,6 +34,13 @@ class CategoriesControllerTest extends TestCase
     public $Categories;
 
     /**
+     * Client API
+     *
+     * @var \BEdita\WebTools\ApiClientProvider
+     */
+    public $client;
+
+    /**
      * Test request config
      *
      * @var array

--- a/tests/TestCase/Controller/Model/ExportControllerTest.php
+++ b/tests/TestCase/Controller/Model/ExportControllerTest.php
@@ -36,6 +36,13 @@ class ExportControllerTest extends TestCase
     public $Export;
 
     /**
+     * Client API
+     *
+     * @var \BEdita\WebTools\ApiClientProvider
+     */
+    public $apiClient;
+
+    /**
      * @inheritDoc
      */
     public function setUp(): void

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -44,6 +44,13 @@ class ObjectTypesControllerTest extends TestCase
     public $ModelController;
 
     /**
+     * Client API
+     *
+     * @var \BEdita\WebTools\ApiClientProvider
+     */
+    public $client;
+
+    /**
      * Test request config
      *
      * @var array

--- a/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -36,6 +36,13 @@ class PropertyTypesControllerTest extends TestCase
     public $ModelController;
 
     /**
+     * Client API
+     *
+     * @var \BEdita\WebTools\ApiClientProvider
+     */
+    public $client;
+
+    /**
      * Test request config
      *
      * @var array

--- a/tests/TestCase/Controller/Model/TagsControllerTest.php
+++ b/tests/TestCase/Controller/Model/TagsControllerTest.php
@@ -33,6 +33,13 @@ class TagsControllerTest extends TestCase
     public $Tags;
 
     /**
+     * Client API
+     *
+     * @var \BEdita\WebTools\ApiClientProvider
+     */
+    public $client;
+
+    /**
      * Test request config
      *
      * @var array

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -32,12 +32,12 @@ class FormTest extends TestCase
     public function getMethodProvider(): array
     {
         return [
-            'name with chars to remove' => [
+            'name with chars to remove 1' => [
                 Options::class,
                 'old_password',
                 [Options::class, 'oldPassword'],
             ],
-            'name with chars to remove' => [
+            'name with chars to remove 2' => [
                 Options::class,
                 'confirm_password',
                 [Options::class, 'confirmPassword'],

--- a/tests/TestCase/View/Helper/AdminHelperTest.php
+++ b/tests/TestCase/View/Helper/AdminHelperTest.php
@@ -74,13 +74,13 @@ class AdminHelperTest extends TestCase
                 null,
                 '<div class="input select"><select name="applications" id="applications"><option value="">No application</option><option value="1">Dummy app</option><option value="2">Another dummy app</option></select></div>',
             ],
-            'applications value not null' => [
+            'applications value not null 1' => [
                 'applications',
                 'applications',
                 '1',
                 '<div class="input select"><select name="applications" id="applications"><option value="">No application</option><option value="1" selected="selected">Dummy app</option><option value="2">Another dummy app</option></select></div>',
             ],
-            'applications value not null' => [
+            'applications value not null 2' => [
                 'default',
                 'dummy',
                 'something',

--- a/tests/Utils/ModulesControllerSample.php
+++ b/tests/Utils/ModulesControllerSample.php
@@ -28,7 +28,7 @@ class ModulesControllerSample extends ModulesController
      */
     public function descendants(): array
     {
-        return parent::descendants();
+        return $this->Schema->descendants($this->objectType);
     }
 
     /**
@@ -39,17 +39,6 @@ class ModulesControllerSample extends ModulesController
     public function availableRelationshipsUrl(string $relation): string
     {
         return parent::availableRelationshipsUrl($relation);
-    }
-
-    /**
-     * Update media urls, public for testing
-     *
-     * @param array $response The response
-     * @return void
-     */
-    public function updateMediaUrls(array &$response): void
-    {
-        parent::updateMediaUrls($response);
     }
 
     /**


### PR DESCRIPTION
This updates `php` workflow, so that `phpstan` dependency version is used (instead of downloading it with composer, during CI).

This activity got the idea from https://github.com/bedita/bedita/pull/1889