### PR TITLE
Refactor webpack - alternate paths for locales, templates and javascript root

### DIFF
--- a/webpack.config.environment.js
+++ b/webpack.config.environment.js
@@ -12,7 +12,7 @@ const { readdirSync, statSync, existsSync } = require('fs')
 const { join } = require('path')
 
 const readDirs = p => readdirSync(p).filter(f => statSync(join(p, f)).isDirectory());
-const dirExists = p => existsSync(p);
+const fileExists = p => existsSync(p);
 
 // Environment: default development
 // from Node env
@@ -95,9 +95,9 @@ const BUNDLE = {
     beditaPluginsRoot: 'plugins',
 
     // alternate folders, cake4 pattern
-    alternateJsRoot: 'templates/Layout/js',
-    alternateTemplateRoot: 'templates',
-    alternateLocaleDir: 'locales',
+    alternateJsRoots: ['templates/Layout/js', 'templates/layout/js', 'resources/js'],
+    alternateTemplateRoots: ['templates/layout', 'templates'],
+    alternateLocaleDirs: ['locales'],
 
     // destination
     webroot: 'webroot',    // destination webroot
@@ -117,15 +117,14 @@ const bundler = {
     }
 }
 
-// jsRoot or alternateJsRoot
 let jsRoot = BUNDLE.jsRoot;
-if (!dirExists(jsRoot)) {
-    console.log(`Javascript root directory "${jsRoot}" not found. Trying alternate javascript root directory.`);
-    jsRoot = BUNDLE.alternateJsRoot;
-    if (!dirExists(jsRoot)) {
-        console.error(`Javascript root directory "${jsRoot}" not found. Bye.`);
+if (!fileExists(jsRoot)) {
+    for (let root of BUNDLE.alternateJsRoots) {
+        if (fileExists(root)) {
+            jsRoot = root;
 
-        return false;
+            break;
+        }
     }
 }
 
@@ -133,27 +132,25 @@ if (!dirExists(jsRoot)) {
 // Add template dir [BUNDLE.templateRoot] alias
 const entries = readDirs(jsRoot);
 
-// templateRoot or alternateTemplateRoot
 let templateRoot = BUNDLE.templateRoot;
-if (!dirExists(templateRoot)) {
-    console.log(`Template directory "${templateRoot}" not found. Trying alternate template directory.`);
-    templateRoot = BUNDLE.alternateTemplateRoot;
-    if (!dirExists(templateRoot)) {
-        console.error(`Template directory "${templateRoot}" not found. Bye.`);
+if (!fileExists(templateRoot)) {
+    for (let root of BUNDLE.alternateTemplateRoots) {
+        if (fileExists(root)) {
+            templateRoot = root;
 
-        return false;
+            break;
+        }
     }
 }
 
-// localeDir or alternateLocaleDir
 let localeDir = BUNDLE.localeDir;
-if (!dirExists(localeDir)) {
-    console.log(`Locale directory "${localeDir}" not found. Trying alternate locale directory.`);
-    localeDir = BUNDLE.alternateLocaleDir;
-    if (!dirExists(localeDir)) {
-        console.error(`Locale directory "${localeDir}" not found. Bye.`);
+if (!fileExists(localeDir)) {
+    for (let root of BUNDLE.alternateLocaleDirs) {
+        if (fileExists(root)) {
+            localeDir = root;
 
-        return false;
+            break;
+        }
     }
 }
 
@@ -178,7 +175,7 @@ if (devMode) {
 
 const locales = require(__dirname + '/' + jsRoot + '/config/locales.js');
 
-global.dirExists = dirExists;
+global.fileExists = fileExists;
 global.readDirs = readDirs;
 global.path = path;
 global.devMode = devMode;

--- a/webpack.config.environment.js
+++ b/webpack.config.environment.js
@@ -8,10 +8,11 @@ const DEFAULT_PORT = '3000';
 const path = require('path');
 const dotenv = require('dotenv').config({path: __dirname + '/config/.env'});
 
-const { readdirSync, statSync } = require('fs')
+const { readdirSync, statSync, existsSync } = require('fs')
 const { join } = require('path')
 
 const readDirs = p => readdirSync(p).filter(f => statSync(join(p, f)).isDirectory());
+const dirExists = p => existsSync(p);
 
 // Environment: default development
 // from Node env
@@ -93,6 +94,11 @@ const BUNDLE = {
     localeDir: 'src/Locale',
     beditaPluginsRoot: 'plugins',
 
+    // alternate folders, cake4 pattern
+    alternateJsRoot: 'templates/Layout/js',
+    alternateTemplateRoot: 'templates',
+    alternateLocaleDir: 'locales',
+
     // destination
     webroot: 'webroot',    // destination webroot
     cssDir: 'css',                                  // destination css dir
@@ -111,17 +117,53 @@ const bundler = {
     }
 }
 
+// jsRoot or alternateJsRoot
+let jsRoot = BUNDLE.jsRoot;
+if (!dirExists(jsRoot)) {
+    console.log(`Javascript root directory "${jsRoot}" not found. Trying alternate javascript root directory.`);
+    jsRoot = BUNDLE.alternateJsRoot;
+    if (!dirExists(jsRoot)) {
+        console.error(`Javascript root directory "${jsRoot}" not found. Bye.`);
+
+        return false;
+    }
+}
+
 // Read dynamically src dir [BUNDLE.jsRoot] direct subdir and create aliases for import
 // Add template dir [BUNDLE.templateRoot] alias
-const entries = readDirs(BUNDLE.jsRoot);
+const entries = readDirs(jsRoot);
+
+// templateRoot or alternateTemplateRoot
+let templateRoot = BUNDLE.templateRoot;
+if (!dirExists(templateRoot)) {
+    console.log(`Template directory "${templateRoot}" not found. Trying alternate template directory.`);
+    templateRoot = BUNDLE.alternateTemplateRoot;
+    if (!dirExists(templateRoot)) {
+        console.error(`Template directory "${templateRoot}" not found. Bye.`);
+
+        return false;
+    }
+}
+
+// localeDir or alternateLocaleDir
+let localeDir = BUNDLE.localeDir;
+if (!dirExists(localeDir)) {
+    console.log(`Locale directory "${localeDir}" not found. Trying alternate locale directory.`);
+    localeDir = BUNDLE.alternateLocaleDir;
+    if (!dirExists(localeDir)) {
+        console.error(`Locale directory "${localeDir}" not found. Bye.`);
+
+        return false;
+    }
+}
 
 let SRC_TEMPLATE_ALIAS = {
-    Locale: path.resolve(__dirname, BUNDLE.localeDir),
-    Template: path.resolve(__dirname, BUNDLE.templateRoot),
+    Locale: path.resolve(__dirname, localeDir),
+    Template: path.resolve(__dirname, templateRoot),
 };
 
 for (const dir of entries) {
-    SRC_TEMPLATE_ALIAS[dir] = path.resolve(__dirname, `${BUNDLE.jsRoot}/${dir}`);
+    SRC_TEMPLATE_ALIAS[dir] = path.resolve(__dirname, `${jsRoot}/${dir}`);
 }
 
 // auto aliases for vendors dependencies TO-DO
@@ -134,8 +176,9 @@ if (devMode) {
     SRC_TEMPLATE_ALIAS['vue'] = 'vue/dist/vue.min';
 }
 
-const locales = require(__dirname + '/' + BUNDLE.jsRoot + '/config/locales.js');
+const locales = require(__dirname + '/' + jsRoot + '/config/locales.js');
 
+global.dirExists = dirExists;
 global.readDirs = readDirs;
 global.path = path;
 global.devMode = devMode;

--- a/webpack.config.environment.js
+++ b/webpack.config.environment.js
@@ -94,7 +94,7 @@ const BUNDLE = {
     localeDir: 'src/Locale',
     beditaPluginsRoot: 'plugins',
 
-    // alternate folders, cake4 pattern
+    // alternate folders
     alternateJsRoots: ['templates/Layout/js', 'templates/layout/js', 'resources/js'],
     alternateTemplateRoots: ['templates/layout', 'templates'],
     alternateLocaleDirs: ['locales'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,8 +16,20 @@ const ESLintPlugin = require('eslint-webpack-plugin');
 
 // vue dependencies
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
+
 // config
-const appEntry = `${path.resolve(__dirname, BUNDLE.jsRoot)}/${BUNDLE.appPath}/${BUNDLE.appName}`;
+// jsRoot or alternateJsRoot
+let jsRoot = BUNDLE.jsRoot;
+if (!dirExists(jsRoot)) {
+    console.log(`Javascript root directory "${jsRoot}" not found. Trying alternate javascript root directory.`);
+    jsRoot = BUNDLE.alternateJsRoot;
+    if (!dirExists(jsRoot)) {
+        console.error(`Javascript root directory "${jsRoot}" not found. Bye.`);
+
+        return false;
+    }
+}
+const appEntry = `${path.resolve(__dirname, jsRoot)}/${BUNDLE.appPath}/${BUNDLE.appName}`;
 
 let message = ' Production Bundle';
 let separator = '-------------------';
@@ -33,8 +45,7 @@ bundler.printMessage(message, separator);
 // Common Plugins
 let webpackPlugins = [
     new webpack.DefinePlugin({
-        'process.env.NODE_ENV': `${ENVIRONMENT.mode}`,
-        debug: true,
+        'process.env.NODE_ENV': `${JSON.stringify(ENVIRONMENT.mode)}`
     }),
 
     new MiniCssExtractPlugin({
@@ -81,7 +92,7 @@ if (devMode) {
             host: ENVIRONMENT.host,
             port: ENVIRONMENT.port,
             watch: true,
-            logLevel: "debug",
+            logLevel: 'debug'
         })
     );
 
@@ -89,7 +100,7 @@ if (devMode) {
     webpackPlugins.push(
         new WatchExternalFilesPlugin.default({
             files: [
-            `./${BUNDLE.templateRoot}/**/*.twig`,
+                `./${BUNDLE.templateRoot}/**/*.twig`,
             ]
         }),
     );
@@ -139,8 +150,8 @@ module.exports = {
                     'iconFuture.png',
                     'iconLocked.svg'
                 ];
-                for (let i = 0; i < preserve.length; i++) {
-                    if (asset.includes(preserve[i])) {
+                for (let p of preserve) {
+                    if (asset.includes(p)) {
                         return true;
                     }
                 }
@@ -252,7 +263,7 @@ module.exports = {
                     plugins: [
                         '@babel/plugin-syntax-dynamic-import',
                     ],
-                },
+                }
             },
             {
                 test: /\.po$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,15 +18,14 @@ const ESLintPlugin = require('eslint-webpack-plugin');
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
 
 // config
-// jsRoot or alternateJsRoot
 let jsRoot = BUNDLE.jsRoot;
-if (!dirExists(jsRoot)) {
-    console.log(`Javascript root directory "${jsRoot}" not found. Trying alternate javascript root directory.`);
-    jsRoot = BUNDLE.alternateJsRoot;
-    if (!dirExists(jsRoot)) {
-        console.error(`Javascript root directory "${jsRoot}" not found. Bye.`);
+if (!fileExists(jsRoot)) {
+    for (let root of BUNDLE.alternateJsRoots) {
+        if (fileExists(root)) {
+            jsRoot = root;
 
-        return false;
+            break;
+        }
     }
 }
 const appEntry = `${path.resolve(__dirname, jsRoot)}/${BUNDLE.appPath}/${BUNDLE.appName}`;

--- a/webpack.config.plugin.js
+++ b/webpack.config.plugin.js
@@ -3,6 +3,7 @@ require('./webpack.config.environment');
 
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const path = require('path');
 
 // auto load installed plugins
 const pluginsFound = readDirs(BUNDLE.beditaPluginsRoot);
@@ -11,7 +12,11 @@ let entries = {};
 let aliases = {};
 
 pluginsFound.forEach(plugin => {
-    entries[plugin] = path.resolve(__dirname, `${BUNDLE.beditaPluginsRoot}/${plugin}/${BUNDLE.jsRoot}/index.js`);
+    if (dirExists(`${BUNDLE.beditaPluginsRoot}/${plugin}/${BUNDLE.jsRoot}/index.js`)) {
+        entries[plugin] = path.resolve(__dirname, `${BUNDLE.beditaPluginsRoot}/${plugin}/${BUNDLE.jsRoot}/index.js`);
+    } else {
+        entries[plugin] = path.resolve(__dirname, `${BUNDLE.beditaPluginsRoot}/${plugin}/${BUNDLE.alternateJsRoot}/index.js`);
+    }
     aliases[plugin] = path.resolve(__dirname, `${BUNDLE.beditaPluginsRoot}/${plugin}/node_modules`);
 });
 

--- a/webpack.config.plugin.js
+++ b/webpack.config.plugin.js
@@ -12,11 +12,17 @@ let entries = {};
 let aliases = {};
 
 pluginsFound.forEach(plugin => {
-    if (dirExists(`${BUNDLE.beditaPluginsRoot}/${plugin}/${BUNDLE.jsRoot}/index.js`)) {
-        entries[plugin] = path.resolve(__dirname, `${BUNDLE.beditaPluginsRoot}/${plugin}/${BUNDLE.jsRoot}/index.js`);
-    } else {
-        entries[plugin] = path.resolve(__dirname, `${BUNDLE.beditaPluginsRoot}/${plugin}/${BUNDLE.alternateJsRoot}/index.js`);
+    let jsRoot = BUNDLE.jsRoot;
+    if (!fileExists(`${BUNDLE.beditaPluginsRoot}/${plugin}/${jsRoot}`)) {
+        for (let root of BUNDLE.alternateJsRoots) {
+            if (fileExists(`${BUNDLE.beditaPluginsRoot}/${plugin}/${root}`)) {
+                jsRoot = root;
+
+                break;
+            }
+        }
     }
+    entries[plugin] = path.resolve(__dirname, `${BUNDLE.beditaPluginsRoot}/${plugin}/${jsRoot}/index.js`);
     aliases[plugin] = path.resolve(__dirname, `${BUNDLE.beditaPluginsRoot}/${plugin}/node_modules`);
 });
 


### PR DESCRIPTION
This provides a way to check alternate multiple paths for locales, templates and javascript root, when building manager and plugins.

Default paths:

```
jsRoot: 'src/Template/Layout/js',
templateRoot: 'src/Template',
localeDir: 'src/Locale',
```

Alternate paths:

```
alternateJsRoots: ['templates/Layout/js', 'templates/layout/js', 'resources/js'],
alternateTemplateRoots: ['templates/layout', 'templates'],
alternateLocaleDirs: ['locales'],
```

For each type of config (locales, templates and javascript root), during build it checks if default path exists; if it doesn't, use alternate path instead, if find one available (checking folder exists).

This fixes a compatibility issue on using a plugin that uses `templates` path. This is also a step to a future "move" of files, more cake4 compliant.