### PR TITLE
Dialog functions in BEDITA object (for plugins usage)

### DIFF
--- a/src/Template/Layout/js/app/app.js
+++ b/src/Template/Layout/js/app/app.js
@@ -8,7 +8,7 @@ import 'Template/Layout/style.scss';
 import { BELoader } from 'libs/bedita';
 
 import { PanelView, PanelEvents } from 'app/components/panel-view';
-import { confirm, prompt } from 'app/components/dialog/dialog';
+import { confirm, error, info, prompt, warning } from 'app/components/dialog/dialog';
 
 import datepicker from 'app/directives/datepicker';
 import jsoneditor from 'app/directives/jsoneditor';
@@ -145,7 +145,10 @@ const _vueInstance = new Vue({
             this.alertBeforePageUnload(BEDITA.template);
             // register functions in BEDITA to make them reusable in plugins
             BEDITA.confirm = confirm;
+            BEDITA.error = error;
+            BEDITA.info = info;
             BEDITA.prompt = prompt;
+            BEDITA.warning = warning;
         });
     },
 

--- a/src/Template/Layout/js/app/app.js
+++ b/src/Template/Layout/js/app/app.js
@@ -143,6 +143,9 @@ const _vueInstance = new Vue({
     mounted: function () {
         this.$nextTick(function () {
             this.alertBeforePageUnload(BEDITA.template);
+            // register functions in BEDITA to make them reusable in plugins
+            BEDITA.confirm = confirm;
+            BEDITA.prompt = prompt;
         });
     },
 


### PR DESCRIPTION
Javascript dialog functions (as confirm, prompt, info, warning, error) can be useful in BEdita Manager plugins too.

This provides a registration of those functions in `BEDITA` object.

Examples of usage in plugins:
```
BEDITA.info('Some important info ...');

BEDITA.warning('Pay attention to ...');

BEDITA.error('Something bad happened ...');

BEDITA.confirm(
    'Doing something dangerous. Continue?',
    'yes, proceed',
    () => {
        // do the logic
    }
);

BEDITA.prompt(
    'Write your name',
    'Gustavo',
    (dialog) => {
        // do the logic
        dialog.hide(true);
    }
);
```