### PR TITLE
fix: use `?` in route array

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -140,7 +140,7 @@ class AppController extends Controller
             return $route;
         }
 
-        return $route + compact('redirect');
+        return $route + ['?' => compact('redirect')];
     }
 
     /**

--- a/src/Template/Pages/Login/login.twig
+++ b/src/Template/Pages/Login/login.twig
@@ -19,7 +19,7 @@
     <div class="login-form">
 
         {{ Form.create(null, {
-            'url': {'_name': 'login', 'redirect': _view.request.getQuery('redirect') },
+            'url': {'_name': 'login', '?': {'redirect': _view.request.getQuery('redirect')}},
         })|raw }}
 
         {% if projects %}

--- a/tests/TestCase/Authentication/Identifier/Resolver/ApiResolverTest.php
+++ b/tests/TestCase/Authentication/Identifier/Resolver/ApiResolverTest.php
@@ -123,6 +123,7 @@ class ApiResolverTest extends TestCase
         $token = $identity['tokens']['renew'];
         $identity = $resolver->find(compact('token'));
 
+        unset($expected['tokens'], $identity['tokens']);
         foreach ($expected as $key => $val) {
             $this->assertEquals($val, $identity[$key]);
         }

--- a/tests/TestCase/Authentication/Identifier/Resolver/ApiResolverTest.php
+++ b/tests/TestCase/Authentication/Identifier/Resolver/ApiResolverTest.php
@@ -83,7 +83,6 @@ class ApiResolverTest extends TestCase
                         'publish_end' => null,
                     ],
                     'id' => '1',
-                    'tokens' => [],
                 ],
             ],
         ];
@@ -104,11 +103,6 @@ class ApiResolverTest extends TestCase
         $resolver = new ApiResolver();
         $identity = $resolver->find($credentials);
 
-        if (isset($expected['tokens'])) {
-            $client = ApiClientProvider::getApiClient();
-            $expected['tokens'] = $client->getTokens();
-        }
-
         if ($expected === null) {
             static::assertNull($identity);
 
@@ -123,7 +117,6 @@ class ApiResolverTest extends TestCase
         $token = $identity['tokens']['renew'];
         $identity = $resolver->find(compact('token'));
 
-        unset($expected['tokens'], $identity['tokens']);
         foreach ($expected as $key => $val) {
             $this->assertEquals($val, $identity[$key]);
         }

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -221,7 +221,7 @@ class AppControllerTest extends TestCase
             ],
             'redirect to /' => [
                 ['environment' => ['REQUEST_METHOD' => 'GET'], 'params' => ['object_type' => 'documents']], // config
-                ['_name' => 'login', 'redirect' => '/'], // expected
+                ['_name' => 'login', '?' => ['redirect' => '/']], // expected
             ],
         ];
     }


### PR DESCRIPTION
This PR fixes a problem when a user logout happens caused by session expiration. 
The new `/login` URL must have a `redirect` query string used to return to the same location after a successful login. 

In Cake 4 `Router::url(['_name' => 'login', 'redirect' => '/documents'])` is not returning the expected URL `/login?redirect=/documents` like in Cake 3 and apparently like the official Cake 4 documentation states https://book.cakephp.org/4/en/development/routing.html#using-named-routes 

