### PR TITLE
fix: Check if response exists before calling hash function

### DIFF
--- a/src/Controller/Component/ThumbsComponent.php
+++ b/src/Controller/Component/ThumbsComponent.php
@@ -91,6 +91,9 @@ class ThumbsComponent extends Component
             ]));
             $apiClient = ApiClientProvider::getApiClient();
             $res = $apiClient->get($url, $query);
+            if ($res == null) {
+                return [];
+            }
 
             return (array)Hash::combine($res, 'meta.thumbnails.{*}.id', 'meta.thumbnails.{*}.url');
         } catch (BEditaClientException $e) {

--- a/src/Controller/Component/ThumbsComponent.php
+++ b/src/Controller/Component/ThumbsComponent.php
@@ -90,10 +90,7 @@ class ThumbsComponent extends Component
                 'options' => ['w' => 400],
             ]));
             $apiClient = ApiClientProvider::getApiClient();
-            $res = $apiClient->get($url, $query);
-            if ($res == null) {
-                return [];
-            }
+            $res = (array)$apiClient->get($url, $query);
 
             return (array)Hash::combine($res, 'meta.thumbnails.{*}.id', 'meta.thumbnails.{*}.url');
         } catch (BEditaClientException $e) {


### PR DESCRIPTION
Check if api client response exists before returning thumbs data. If response is null, returns empty array and prevent error that won't let any children folder element to show up. 