### PR TITLE
fix: prevent editor to break with old placeholders

### DIFF
--- a/src/Template/Layout/js/app/plugins/tinymce/placeholders.js
+++ b/src/Template/Layout/js/app/plugins/tinymce/placeholders.js
@@ -69,6 +69,9 @@ tinymce.util.Tools.resolve('tinymce.PluginManager').add('placeholders', function
         editor.parser.addAttributeFilter('data-placeholder', function(nodes) {
             nodes.forEach((node) => {
                 let comment = node.firstChild.value;
+                if (!comment) {
+                    return;
+                }
                 let match = comment.match(regex);
                 if (!match) {
                     return;


### PR DESCRIPTION
This PR prevents the rich text editor to break with some old placeholders.