### PR TITLE
Custom labels

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -515,8 +515,8 @@ return [
      *  - 'bulk' bulk actions list
      *  - 'fastCreate' fields for fast creation forms, by type
      *  - 'labels' to customize labels of properties names and their options, it can have two keys `fields` and `options`
-         + 'fields' contains an associative array with property names as keys and labels as values 
-         + 'options' contains an associative array with property names as keys and an array containing option items and the custom labels to use
+     *   + 'fields' contains an associative array with property names as keys and labels as values
+     *   + 'options' contains an associative array with property names as keys and an array containing option items and the custom labels to use
      * A special custom element 'Form/empty' can be used to hide a property group or relation via `_element`
      */
     // 'Properties' => [

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -515,6 +515,14 @@ return [
      *  - 'bulk' bulk actions list
      *  - 'fastCreate' fields for fast creation forms, by type
      *  - 'labels' to customize labels by properties
+     *    + 'fields'
+     *      + fieldName => string
+     *      + fieldName => string
+     *      + fieldName => string
+     *    + 'options'
+     *      + fieldName => array
+     *      + fieldName => array
+     *      + fieldName => array
      *
      * A special custom element 'Form/empty' can be used to hide a property group or relation via `_element`
      */

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -514,16 +514,9 @@ return [
      *  - 'filter' filters to display
      *  - 'bulk' bulk actions list
      *  - 'fastCreate' fields for fast creation forms, by type
-     *  - 'labels' to customize labels by properties
-     *    + 'fields'
-     *      + fieldName => string
-     *      + fieldName => string
-     *      + fieldName => string
-     *    + 'options'
-     *      + fieldName => array
-     *      + fieldName => array
-     *      + fieldName => array
-     *
+     *  - 'labels' to customize labels of properties names and their options, it can have two keys `fields` and `options`
+         + 'fields' contains an associative array with property names as keys and labels as values 
+         + 'options' contains an associative array with property names as keys and an array containing option items and the custom labels to use
      * A special custom element 'Form/empty' can be used to hide a property group or relation via `_element`
      */
     // 'Properties' => [

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -514,6 +514,7 @@ return [
      *  - 'filter' filters to display
      *  - 'bulk' bulk actions list
      *  - 'fastCreate' fields for fast creation forms, by type
+     *  - 'labels' to customize labels by properties
      *
      * A special custom element 'Form/empty' can be used to hide a property group or relation via `_element`
      */
@@ -575,6 +576,13 @@ return [
         //     'fastCreate' => [
         //         'required' => ['status', 'title'],
         //         'all' => ['status', 'title', 'description'],
+        //     ],
+        //     'labels' => [
+        //         'status' => [
+        //             'on' => 'O N',
+        //             'off' => 'O F F',
+        //             'draft' => 'D R A F T',
+        //         ],
         //     ],
         // ],
     // ],

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -579,10 +579,15 @@ return [
         //         'all' => ['status', 'title', 'description'],
         //     ],
         //     'labels' => [
-        //         'status' => [
-        //             'on' => 'O N',
-        //             'off' => 'O F F',
-        //             'draft' => 'D R A F T',
+        //         'fields' => [
+        //             'description' => 'summary',
+        //         ],
+        //         'options' => [
+        //             'status' => [
+        //                 'on' => 'published',
+        //                 'off' => 'archived',
+        //                 'draft' => 'in progress',
+        //             ],
         //         ],
         //     ],
         // ],

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -191,14 +191,7 @@ class Control
 
         $options = [];
         foreach ($schema['oneOf'] as $one) {
-            if (!empty($one['type']) && ($one['type'] === 'array')) {
-                $options = array_map(
-                    function ($item) {
-                        return ['value' => $item, 'text' => Inflector::humanize($item)];
-                    },
-                    (array)Hash::extract($one, 'items.enum')
-                );
-            }
+            self::oneOptions($options, $one);
         }
         if (!empty($options)) {
             return [
@@ -212,6 +205,27 @@ class Control
             'type' => 'checkbox',
             'checked' => filter_var($value, FILTER_VALIDATE_BOOLEAN),
         ];
+    }
+
+    /**
+     * Set options for one of `oneOf` items.
+     *
+     * @param array $options The options to update
+     * @param array $one The one item to check
+     * @return void
+     */
+    public static function oneOptions(array &$options, array $one): void
+    {
+        $type = Hash::get($one, 'type');
+        if ($type !== 'array') {
+            return;
+        }
+        $options = array_map(
+            function ($item) {
+                return ['value' => $item, 'text' => Inflector::humanize($item)];
+            },
+            (array)Hash::extract($one, 'items.enum')
+        );
     }
 
     /**

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -254,7 +254,7 @@ class Control
             'type' => 'select',
             'options' => array_map(
                 function (string $value) use ($objectType, $property) {
-                    $text = self::label($objectType, $property, $value);
+                    $text = self::label((string)$objectType, (string)$property, $value);
 
                     return compact('text', 'value');
                 },

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -57,7 +57,7 @@ class Control
             'type' => 'textarea',
             'v-jsoneditor' => 'true',
             'class' => 'json',
-            'value' => json_encode((string)Hash::get($options, 'value')),
+            'value' => json_encode(Hash::get($options, 'value')),
         ];
     }
 
@@ -71,7 +71,7 @@ class Control
     {
         return [
             'type' => 'textarea',
-            'value' => (string)Hash::get($options, 'value'),
+            'value' => Hash::get($options, 'value'),
         ];
     }
 
@@ -84,7 +84,7 @@ class Control
     public static function richtext(array $options): array
     {
         $schema = (array)Hash::get($options, 'schema');
-        $value = (string)Hash::get($options, 'value');
+        $value = Hash::get($options, 'value');
         $key = !empty($schema['placeholders']) ? 'v-richeditor.placeholders' : 'v-richeditor';
 
         return [
@@ -107,7 +107,7 @@ class Control
             'v-datepicker' => 'true',
             'date' => 'true',
             'time' => 'true',
-            'value' => (string)Hash::get($options, 'value'),
+            'value' => Hash::get($options, 'value'),
             'templates' => [
                 'inputContainer' => '<div class="input datepicker {{type}}{{required}}">{{content}}</div>',
             ],
@@ -126,7 +126,7 @@ class Control
             'type' => 'text',
             'v-datepicker' => 'true',
             'date' => 'true',
-            'value' => (string)Hash::get($options, 'value'),
+            'value' => Hash::get($options, 'value'),
             'templates' => [
                 'inputContainer' => '<div class="input datepicker {{type}}{{required}}">{{content}}</div>',
             ],
@@ -142,12 +142,12 @@ class Control
     public static function categories(array $options): array
     {
         $schema = (array)Hash::get($options, 'schema');
-        $value = (string)Hash::get($options, 'value');
+        $value = Hash::get($options, 'value');
         $categories = $schema['categories'];
         $options = array_map(
             function ($category) {
                 return [
-                    'value' => (string)Hash::get($category, 'name'),
+                    'value' => Hash::get($category, 'name'),
                     'text' => empty($category['label']) ? $category['name'] : $category['label'],
                 ];
             },
@@ -181,7 +181,7 @@ class Control
     public static function checkbox(array $options): array
     {
         $schema = (array)Hash::get($options, 'schema');
-        $value = (string)Hash::get($options, 'value');
+        $value = Hash::get($options, 'value');
         if (empty($schema['oneOf'])) {
             return [
                 'type' => 'checkbox',
@@ -223,9 +223,9 @@ class Control
     public static function enum(array $options): array
     {
         $schema = (array)Hash::get($options, 'schema');
-        $value = (string)Hash::get($options, 'value');
-        $objectType = (string)Hash::get($options, 'objectType');
-        $property = (string)Hash::get($options, 'property');
+        $value = Hash::get($options, 'value');
+        $objectType = Hash::get($options, 'objectType');
+        $property = Hash::get($options, 'property');
 
         if (!empty($schema['oneOf'])) {
             foreach ($schema['oneOf'] as $one) {
@@ -252,7 +252,7 @@ class Control
 
     /**
      * Label for property.
-     * If set in config Properties.<type>.labels.<property>, return it.
+     * If set in config Properties.<type>.labels.options.<property>, return it.
      * Return humanize of value, otherwise.
      *
      * @param string $type The object type
@@ -262,13 +262,13 @@ class Control
      */
     public static function label(string $type, string $property, string $value): string
     {
-        $label = Configure::read(sprintf('Properties.%s.labels.%s', $type, $property));
+        $label = Configure::read(sprintf('Properties.%s.labels.options.%s', $type, $property));
         if (empty($label)) {
             return Inflector::humanize($value);
         }
-        $labelVal = (string)Configure::read(sprintf('Properties.%s.labels.%s.%s', $type, $property, $value));
+        $labelVal = (string)Configure::read(sprintf('Properties.%s.labels.options.%s.%s', $type, $property, $value));
         if (empty($labelVal)) {
-            return (string)$label;
+            return Inflector::humanize($value);
         }
 
         return $labelVal;

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -57,7 +57,7 @@ class Control
             'type' => 'textarea',
             'v-jsoneditor' => 'true',
             'class' => 'json',
-            'value' => json_encode($options['value']),
+            'value' => json_encode((string)Hash::get($options, 'value')),
         ];
     }
 
@@ -71,7 +71,7 @@ class Control
     {
         return [
             'type' => 'textarea',
-            'value' => $options['value'],
+            'value' => (string)Hash::get($options, 'value'),
         ];
     }
 
@@ -83,8 +83,8 @@ class Control
      */
     public static function richtext(array $options): array
     {
-        $schema = $options['schema'];
-        $value = $options['value'];
+        $schema = (array)Hash::get($options, 'schema');
+        $value = (string)Hash::get($options, 'value');
         $key = !empty($schema['placeholders']) ? 'v-richeditor.placeholders' : 'v-richeditor';
 
         return [
@@ -107,7 +107,7 @@ class Control
             'v-datepicker' => 'true',
             'date' => 'true',
             'time' => 'true',
-            'value' => $options['value'],
+            'value' => (string)Hash::get($options, 'value'),
             'templates' => [
                 'inputContainer' => '<div class="input datepicker {{type}}{{required}}">{{content}}</div>',
             ],
@@ -126,7 +126,7 @@ class Control
             'type' => 'text',
             'v-datepicker' => 'true',
             'date' => 'true',
-            'value' => $options['value'],
+            'value' => (string)Hash::get($options, 'value'),
             'templates' => [
                 'inputContainer' => '<div class="input datepicker {{type}}{{required}}">{{content}}</div>',
             ],
@@ -141,13 +141,13 @@ class Control
      */
     public static function categories(array $options): array
     {
-        $schema = $options['schema'];
-        $value = $options['value'];
+        $schema = (array)Hash::get($options, 'schema');
+        $value = (string)Hash::get($options, 'value');
         $categories = $schema['categories'];
         $options = array_map(
             function ($category) {
                 return [
-                    'value' => $category['name'],
+                    'value' => (string)Hash::get($category, 'name'),
                     'text' => empty($category['label']) ? $category['name'] : $category['label'],
                 ];
             },
@@ -180,8 +180,8 @@ class Control
      */
     public static function checkbox(array $options): array
     {
-        $schema = $options['schema'];
-        $value = $options['value'];
+        $schema = (array)Hash::get($options, 'schema');
+        $value = (string)Hash::get($options, 'value');
         if (empty($schema['oneOf'])) {
             return [
                 'type' => 'checkbox',
@@ -222,10 +222,10 @@ class Control
      */
     public static function enum(array $options): array
     {
-        $schema = $options['schema'];
-        $value = $options['value'];
-        $objectType = $options['objectType'];
-        $property = $options['property'];
+        $schema = (array)Hash::get($options, 'schema');
+        $value = (string)Hash::get($options, 'value');
+        $objectType = (string)Hash::get($options, 'objectType');
+        $property = (string)Hash::get($options, 'property');
 
         if (!empty($schema['oneOf'])) {
             foreach ($schema['oneOf'] as $one) {

--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -85,7 +85,7 @@ class Options
      */
     public static function dateRanges($value): array
     {
-        return Control::datetime($value);
+        return Control::datetime(compact('value'));
     }
 
     /**
@@ -96,7 +96,7 @@ class Options
      */
     public static function startDate($value): array
     {
-        return Control::datetime($value);
+        return Control::datetime(compact('value'));
     }
 
     /**
@@ -107,7 +107,7 @@ class Options
      */
     public static function endDate($value): array
     {
-        return Control::datetime($value);
+        return Control::datetime(compact('value'));
     }
 
     /**

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -69,7 +69,7 @@ class PropertyHelper extends Helper
     public function control(string $name, $value, array $options = [], ?string $type = null): string
     {
         $controlOptions = $this->Schema->controlOptions($name, $value, $this->schema($name, $type));
-        $controlOptions['label'] = Translate::get($name);
+        $controlOptions['label'] = $this->fieldLabel($name, $type);
         if (Hash::get($controlOptions, 'class') === 'json') {
             $jsonKeys = (array)Configure::read('_jsonKeys');
             Configure::write('_jsonKeys', array_merge($jsonKeys, [$name]));
@@ -79,6 +79,27 @@ class PropertyHelper extends Helper
         }
 
         return $this->Form->control($name, array_merge($controlOptions, $options));
+    }
+
+    /**
+     * Return label for field by name and type.
+     * If there's a config for the field and type, return it.
+     * Return translation of name, otherwise.
+     *
+     * @param string $name The field name
+     * @param string|null $type The object type
+     * @return string
+     */
+    public function fieldLabel(string $name, ?string $type = null): string
+    {
+        $defaultLabel = Translate::get($name);
+        $t = empty($type) ? $this->getView()->get('objectType') : $type;
+        if (empty($t)) {
+            return $defaultLabel;
+        }
+        $key = sprintf('Properties.%s.labels.fields.%s', $t, $name);
+
+        return Configure::read($key, $defaultLabel);
     }
 
     /**

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -73,7 +73,13 @@ class SchemaHelper extends Helper
         }
         $type = ControlType::fromSchema((array)$schema);
 
-        return Control::control((array)$schema, $type, $value);
+        return Control::control([
+            'objectType' => $objectType,
+            'property' => $name,
+            'value' => $value,
+            'schema' => (array)$schema,
+            'propertyType' => $type,
+        ]);
     }
 
     /**

--- a/tests/TestCase/Form/ControlTest.php
+++ b/tests/TestCase/Form/ControlTest.php
@@ -245,15 +245,16 @@ class ControlTest extends TestCase
      * @param array $expected The expected control.
      * @return void
      * @dataProvider controlProvider()
-     * @covers ::control
-     * @covers ::json
-     * @covers ::richtext
-     * @covers ::plaintext
-     * @covers ::datetime
-     * @covers ::date
-     * @covers ::checkbox
-     * @covers ::enum
-     * @covers ::categories
+     * @covers ::control()
+     * @covers ::json()
+     * @covers ::richtext()
+     * @covers ::plaintext()
+     * @covers ::datetime()
+     * @covers ::date()
+     * @covers ::checkbox()
+     * @covers ::enum()
+     * @covers ::categories()
+     * @covers ::oneOptions()
      */
     public function testControl(array $schema, string $type, $value, array $expected): void
     {
@@ -332,6 +333,33 @@ class ControlTest extends TestCase
             );
         }
         $actual = Control::label($type, $property, $value);
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Test `oneOptions`
+     *
+     * @return void
+     * @dataProvider labelProvider()
+     * @covers ::oneOptions()
+     */
+    public function testOneOptions(): void
+    {
+        // empty one
+        $expected = [];
+        $actual = [];
+        Control::oneOptions($actual, []);
+        static::assertSame($expected, $actual);
+
+        // empty one
+        $expected = [
+            ['value' => 'on', 'text' => 'On'],
+            ['value' => 'off', 'text' => 'Off'],
+            ['value' => 'draft', 'text' => 'Draft'],
+        ];
+        $actual = [];
+        $one = ['type' => 'array', 'items' => ['enum' => ['on', 'off', 'draft']]];
+        Control::oneOptions($actual, $one);
         static::assertSame($expected, $actual);
     }
 }

--- a/tests/TestCase/Form/ControlTest.php
+++ b/tests/TestCase/Form/ControlTest.php
@@ -14,6 +14,7 @@
 namespace App\Test\TestCase\Form;
 
 use App\Form\Control;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -178,9 +179,10 @@ class ControlTest extends TestCase
                 [
                     'type' => 'select',
                     'options' => [
-                        ['value' => 'good', 'text' => 'Good'],
-                        ['value' => 'bad', 'text' => 'Bad'],
+                        ['text' => 'Good', 'value' => 'good'],
+                        ['text' => 'Bad', 'value' => 'bad'],
                     ],
+                    'value' => 'good',
                 ],
             ],
             'enum nullable' => [
@@ -203,10 +205,11 @@ class ControlTest extends TestCase
                 [
                     'type' => 'select',
                     'options' => [
-                        ['value' => '', 'text' => ''],
-                        ['value' => 'good', 'text' => 'Good'],
-                        ['value' => 'bad', 'text' => 'Bad'],
+                        ['text' => '', 'value' => ''],
+                        ['text' => 'Good', 'value' => 'good'],
+                        ['text' => 'Bad', 'value' => 'bad'],
                     ],
+                    'value' => 'good',
                 ],
             ],
             'categories' => [
@@ -254,8 +257,77 @@ class ControlTest extends TestCase
      */
     public function testControl(array $schema, string $type, $value, array $expected): void
     {
-        $actual = Control::control($schema, $type, $value);
+        $options = [
+            'objectType' => 'documents',
+            'property' => 'dummy',
+            'value' => $value,
+            'schema' => (array)$schema,
+            'propertyType' => $type,
+        ];
+        $actual = Control::control($options);
 
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Provider for testLabel
+     *
+     * @return array
+     */
+    public function labelProvider(): array
+    {
+        return [
+            'no custom config' => [
+                'dummies',
+                'status',
+                'on',
+                null,
+                'On',
+            ],
+            'custom config property' => [
+                'dummies',
+                'status',
+                'off',
+                'OOFF',
+                'OOFF',
+            ],
+            'custom config property value' => [
+                'dummies',
+                'status',
+                'draft',
+                [
+                    'on' => 'OOONNN',
+                    'off' => 'OOOFFF',
+                    'draft' => 'DDDRRRAAAFFFTTT',
+                ],
+                'DDDRRRAAAFFFTTT',
+            ],
+        ];
+    }
+
+    /**
+     * Test `label`
+     *
+     * @param string $type The type
+     * @param string $property The property
+     * @param mixed|null $customConfig The custom configuration
+     * @param string $expected The expected label
+     * @return void
+     * @dataProvider labelProvider()
+     * @covers ::label()
+     */
+    public function testLabel(string $type, string $property, string $value, $customConfig, string $expected): void
+    {
+        if (!empty($customConfig)) {
+            Configure::write(
+                sprintf('Properties.%s.labels', $type),
+                array_merge(
+                    (array)\Cake\Core\Configure::read(sprintf('Properties.%s.labels', $type)),
+                    [$property => $customConfig]
+                )
+            );
+        }
+        $actual = Control::label($type, $property, $value);
         static::assertSame($expected, $actual);
     }
 }

--- a/tests/TestCase/Form/ControlTest.php
+++ b/tests/TestCase/Form/ControlTest.php
@@ -284,12 +284,16 @@ class ControlTest extends TestCase
                 null,
                 'On',
             ],
-            'custom config property' => [
+            'other value not in config' => [
                 'dummies',
                 'status',
-                'off',
-                'OOFF',
-                'OOFF',
+                'other',
+                [
+                    'on' => 'OOONNN',
+                    'off' => 'OOOFFF',
+                    'draft' => 'DDDRRRAAAFFFTTT',
+                ],
+                'Other',
             ],
             'custom config property value' => [
                 'dummies',
@@ -320,10 +324,10 @@ class ControlTest extends TestCase
     {
         if (!empty($customConfig)) {
             Configure::write(
-                sprintf('Properties.%s.labels', $type),
+                sprintf('Properties.%s', $type),
                 array_merge(
-                    (array)\Cake\Core\Configure::read(sprintf('Properties.%s.labels', $type)),
-                    [$property => $customConfig]
+                    (array)\Cake\Core\Configure::read(sprintf('Properties.%s', $type)),
+                    ['labels' => ['options' => [$property => $customConfig]]]
                 )
             );
         }

--- a/tests/TestCase/View/Helper/PropertyHelperTest.php
+++ b/tests/TestCase/View/Helper/PropertyHelperTest.php
@@ -280,4 +280,37 @@ class PropertyHelperTest extends TestCase
     {
         return ['html' => sprintf('<dummy>%s</dummy>', $value)];
     }
+
+    /**
+     * Test `fieldLabel`.
+     *
+     * @return void
+     * @covers ::fieldLabel()
+     */
+    public function testFieldLabel(): void
+    {
+        // no type
+        $view = new View(null, null, null, []);
+        $helper = new PropertyHelper($view);
+        $actual = $helper->fieldLabel('dummy');
+        $expected = 'Dummy';
+        static::assertEquals($expected, $actual);
+
+        // type without config
+        $actual = $helper->fieldLabel('info', 'dummies');
+        $expected = 'Info';
+        static::assertEquals($expected, $actual);
+
+        // type with config
+        $expected = 'A B O U T';
+        Configure::write(
+            'Properties.dummies',
+            array_merge(
+                (array)\Cake\Core\Configure::read('Properties.dummies'),
+                ['labels' => ['fields' => ['about' => $expected]]]
+            )
+        );
+        $actual = $helper->fieldLabel('about', 'dummies');
+        static::assertEquals($expected, $actual);
+    }
 }

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -244,6 +244,7 @@ class SchemaHelperTest extends TestCase
                         ['value' => 'bad', 'text' => 'Bad'],
                     ],
                     'type' => 'select',
+                    'value' => 'good',
                 ],
                 // schema type
                 [
@@ -265,6 +266,7 @@ class SchemaHelperTest extends TestCase
                         ['value' => 'bad', 'text' => 'Bad'],
                     ],
                     'type' => 'select',
+                    'value' => 'good',
                 ],
                 // schema type
                 [


### PR DESCRIPTION
This provides a way to customize labels.

You can customize the labels for a control setting a configuration `Properties.$objectType.labels` as follows.
```
'Properties' => [
    // ...
    'documents' => [
        // ...
        'labels' => [
            'fields' => [
                'description' => 'D E S C R I P T I O N',
            ],
            'options' => [
                'related_stuff' => [
                    81231 => 'Dummy article',
                    12156 => 'Interesting stuff',
                    15975 => 'Whatever',
                ],
            ],
        ],
    ],
],

// resulting description field
<label for="description">D E S C R I P T I O N</label>
// ...

// resulting combo will be something like
<select name="related_stuff">
    <option value="281231">Dummy article</option>
    <option value="12156">Interesting stuff</option>
    <option value="15975">Whatever</option>
</select>
```
