### PR TITLE
Fix filter-box in relation box of an object view: filters disappear when using more filters

### DIFF
--- a/src/Template/Element/Form/relation.twig
+++ b/src/Template/Element/Form/relation.twig
@@ -26,12 +26,22 @@
         <div class="related-list-container">
             {# FilterBoxView #}
             <div class="mb-1" v-show="showFilter">
+                {% set list = {} %}
+                {% for type, filters in filtersByType %}
+                    {% set options = [] %}
+                    {% for f in filters %}
+                        {% set o = Schema.controlOptions(f, null, schemasByType[type].properties[f]) %}
+                        {% set options = options|merge([o|merge({ 'name': f })]) %}
+                    {% endfor %}
+                    {% set list = list|merge({ (type): options }) %}
+                {% endfor %}
                 <filter-box-view
                     :config-paginate-sizes="configPaginateSizes"
                     :pagination.sync="pagination"
                     :show-advanced="false"
                     :relation-types="relationTypes"
                     :init-filter="activeFilter"
+                    :filters-by-type="{{ list|json_encode|escape('html_attr') }}"
                     objects-label="{{ __('objects') }}"
                     @filter-update-current-page="onUpdateCurrentPage"
                     @filter-update-page-size="onUpdatePageSize"

--- a/src/Template/Layout/js/app/components/filter-box.js
+++ b/src/Template/Layout/js/app/components/filter-box.js
@@ -150,6 +150,10 @@ export default {
         },
 
         initFolder() {
+            if (!this.initFilter?.filter) {
+                return {};
+            }
+
             return this.initFilter?.filter[this.positionFilterName];
         },
 
@@ -214,7 +218,10 @@ export default {
          * @param {String} type Selected object type
          */
         selectedType(type) {
-            this.availableFilters = this.filtersByType[type] || [];
+            this.availableFilters = [];
+            if (this.filtersByType && this.filtersByType[type]) {
+                this.availableFilters = this.filtersByType[type];
+            };
             const query = this.getCleanQuery();
             // persist old compatible filter values
             query.q = this.queryFilter.q;

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -107,6 +107,8 @@ export default {
          */
         showFilter() {
             return this.activeFilter.q ||
+                this.activeFilter?.filter?.status ||
+                this.activeFilter?.filter?.type ||
                 this.pagination.page_count > 1 ||
                 this.alreadyInView.length > this.pagination.page_size;
         },


### PR DESCRIPTION
This fixes an unexpected behaviour in filter-box with "more filters".

# Actual behaviour
When applying extra filter, data is shown but filters disappear.

# Expected behaviour
Use extra filters, and filter results. Reset filters when you want to see all related data.
