### PR TITLE
Add `view/download` on related stream

### DIFF
--- a/src/Template/Element/Form/related_item.twig
+++ b/src/Template/Element/Form/related_item.twig
@@ -82,9 +82,6 @@
                 </h1>
 
             {% if not add and not stage %}
-                {# <div v-if="relatedStream(related)" class="has-text-size-smallest">
-                    <: relatedStreamProp(related, 'file_name') :>
-                </div> #}
 
                 {% if in_array('admin', user.roles) %}
                 <div v-if="relatedStream(related)" class="has-text-size-smallest">

--- a/src/Template/Element/Form/related_item.twig
+++ b/src/Template/Element/Form/related_item.twig
@@ -71,7 +71,7 @@
         <header class="is-flex space-between mt-05">
             <div>
 
-                <h1 class="title m-0 has-text-size-small has-font-style-italic" style="padding-bottom: 7px;">
+                <h1 class="title m-0 has-text-size-small" style="padding-bottom: 7px;">
                     {% if translation %}
                         <span v-if="related.attributes.translated_fields && related.attributes.translated_fields.title ">
                             <: related.attributes.translated_fields.title :>
@@ -81,10 +81,10 @@
                     {% endif %}
                 </h1>
 
-            {% if not add %}
-                <div v-if="relatedStream(related)" class="has-text-size-smallest">
+            {% if not add and not stage %}
+                {# <div v-if="relatedStream(related)" class="has-text-size-smallest">
                     <: relatedStreamProp(related, 'file_name') :>
-                </div>
+                </div> #}
 
                 <div v-if="relatedStream(related)" class="has-text-size-smallest">
                     <: relatedStreamProp(related, 'mime_type') :>

--- a/src/Template/Element/Form/related_item.twig
+++ b/src/Template/Element/Form/related_item.twig
@@ -80,17 +80,23 @@
             </h1>
 
             {% if not add %}
-            <span v-if="relatedStream(related)" class="other m-0 has-text-size-small">
-                <: relatedAttribute(related, 'file_name') :>
-            </span>
+            <div v-if="relatedStream(related)">
+                <span class="other m-0 has-text-size-small">
+                    <: relatedStreamProp(related, 'file_name') :>
+                    <: relatedStreamProp(related, 'mime_type') :>
+                    <: relatedStreamProp(related, 'file_size', 'bytes') :>
+                </span>
 
-            <span v-if="relatedStream(related)" class="other m-0 has-text-size-small">
-                <: relatedAttribute(related, 'mime_type') :>
-            </span>
+                <a :href="relatedStreamProp(related, 'url')" target="_blank"
+                    class="button button-outlined">
+                        {{ __('View file') }}
+                </a>
 
-            <span v-if="relatedStream(related)" class="other m-0 has-text-size-small">
-                <: relatedAttribute(related, 'file_size', 'bytes') :>
-            </span>
+                <a :href="relatedStreamDownloadUrl(related)"
+                    class="button button-outlined ">
+                    {{ __('Download file') }}
+                </a>
+            </div>
             {% endif %}
 
             {% if not translation %}

--- a/src/Template/Element/Form/related_item.twig
+++ b/src/Template/Element/Form/related_item.twig
@@ -86,9 +86,11 @@
                     <: relatedStreamProp(related, 'file_name') :>
                 </div> #}
 
+                {% if in_array('admin', user.roles) %}
                 <div v-if="relatedStream(related)" class="has-text-size-smallest">
                     <: relatedStreamProp(related, 'mime_type') :>
                 </div>
+                {% endif %}
 
                 <div v-if="relatedStream(related)" class="has-text-size-smallest">
                     <: relatedStreamProp(related, 'file_size', 'bytes') :>

--- a/src/Template/Element/Form/related_item.twig
+++ b/src/Template/Element/Form/related_item.twig
@@ -69,35 +69,38 @@
         </div>
 
         <header class="is-flex space-between mt-05">
-            <h1 class="title m-0 has-text-size-small">
-                {% if translation %}
-                    <span v-if="related.attributes.translated_fields && related.attributes.translated_fields.title ">
-                        <: related.attributes.translated_fields.title :>
-                    </span>
-                {% else %}
-                    <: related.attributes.title || related.attributes.name || related.attributes.uname || '-' :>
-                {% endif %}
-            </h1>
+            <div>
+
+                <h1 class="title m-0 has-text-size-small has-font-style-italic" style="padding-bottom: 7px;">
+                    {% if translation %}
+                        <span v-if="related.attributes.translated_fields && related.attributes.translated_fields.title ">
+                            <: related.attributes.translated_fields.title :>
+                        </span>
+                    {% else %}
+                        <: related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-' :>
+                    {% endif %}
+                </h1>
 
             {% if not add %}
-            <div v-if="relatedStream(related)">
-                <span class="other m-0 has-text-size-small">
+                <div v-if="relatedStream(related)" class="has-text-size-smallest">
                     <: relatedStreamProp(related, 'file_name') :>
+                </div>
+
+                <div v-if="relatedStream(related)" class="has-text-size-smallest">
                     <: relatedStreamProp(related, 'mime_type') :>
+                </div>
+
+                <div v-if="relatedStream(related)" class="has-text-size-smallest">
                     <: relatedStreamProp(related, 'file_size', 'bytes') :>
-                </span>
+                </div>
 
-                <a :href="relatedStreamProp(related, 'url')" target="_blank"
-                    class="button button-outlined">
-                        {{ __('View file') }}
-                </a>
-
-                <a :href="relatedStreamDownloadUrl(related)"
-                    class="button button-outlined ">
-                    {{ __('Download file') }}
-                </a>
-            </div>
+                <div v-if="relatedStream(related)" class="has-text-size-smaller">
+                    <a :href="relatedStreamProp(related, 'url')" target="_blank" class="icon-eye-1" title="{{ __('View file') }}"></a>
+                    <a :href="relatedStreamDownloadUrl(related)" class="icon-download-1" title="{{ __('Download file') }}"></a>
+                </div>
             {% endif %}
+
+            </div>
 
             {% if not translation %}
                 <span class="modified">
@@ -105,8 +108,6 @@
                 </span>
             {% endif %}
 
-            {# <span class="id has-text-size-smallest"><: related.id :></span>
-            <span class="uname has-text-size-smallest"><: related.attributes.uname :></span> #}
         </header>
     </div>
 

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -752,37 +752,49 @@ export default {
          * Return true when related object has streams data.
          *
          * @param {Object} related The object
-         * @returns
+         * @returns {Boolean} true if a stream object is available
          */
         relatedStream(related) {
             if (!related.relationships.streams || !related.relationships.streams.data || related.relationships.streams.data.length === 0) {
                 return false;
             }
 
-            return related.relationships.streams.data[0].attributes;
+            return true;
         },
 
         /**
-         * Get related object attribute.
+         * Get related stream property.
          *
          * @param {Object} related The object
-         * @param {String} attribute The attribute name
+         * @param {String} prop The prop name
          * @param {String} format The format required, if any
          * @returns {String}
          */
-        relatedAttribute(related, attribute, format) {
+         relatedStreamProp(related, prop, format) {
             let val = '';
             const stream = related.relationships.streams.data[0];
-            if (attribute in stream.attributes) {
-                val = stream.attributes[attribute];
-            } else if (attribute in stream.meta) {
-                val = stream.meta[attribute];
+            if (prop in stream.attributes) {
+                val = stream.attributes[prop];
+            } else if (prop in stream.meta) {
+                val = stream.meta[prop];
             }
             if (format === 'bytes') {
                 return this.bytes(val);
             }
 
             return val;
+        },
+
+        /**
+         * Retrieve related stream Download URL
+         *
+         * @param {Object} related The object
+         * @returns {String}
+         */
+        relatedStreamDownloadUrl(related) {
+            const stream = related.relationships?.streams?.data[0] || {};
+
+            return `${BEDITA.base}/download/${stream?.id}`;
         },
 
         /**

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -770,9 +770,9 @@ export default {
          * @param {String} format The format required, if any
          * @returns {String}
          */
-         relatedStreamProp(related, prop, format) {
+        relatedStreamProp(related, prop, format) {
             let val = '';
-            const stream = related.relationships.streams.data[0];
+            const stream = related?.relationships?.streams?.data[0];
             if (prop in stream.attributes) {
                 val = stream.attributes[prop];
             } else if (prop in stream.meta) {
@@ -783,6 +783,19 @@ export default {
             }
 
             return val;
+        },
+
+        /**
+         * Return true if title is not filename.
+         *
+         * @param {Object} related The object
+         * @returns
+         */
+        relatedTitleNotEqualsFilename(related) {
+            const title = related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-';
+            const filename = this.relatedStreamProp(related, 'file_name');
+
+            return (title !== filename);
         },
 
         /**

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -792,9 +792,9 @@ export default {
          * @returns {String}
          */
         relatedStreamDownloadUrl(related) {
-            const stream = related.relationships?.streams?.data[0] || {};
+            const id = related.relationships?.streams?.data[0]?.id;
 
-            return `${BEDITA.base}/download/${stream?.id}`;
+            return `${BEDITA.base}/download/${id}`;
         },
 
         /**

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -771,18 +771,32 @@ export default {
          * @returns {String}
          */
         relatedStreamProp(related, prop, format) {
-            let val = '';
-            const stream = related?.relationships?.streams?.data[0];
-            if (prop in stream.attributes) {
-                val = stream.attributes[prop];
-            } else if (prop in stream.meta) {
-                val = stream.meta[prop];
+            const stream = related?.relationships?.streams?.data[0] || {};
+            const attributes = stream?.attributes || {};
+            if (prop in attributes) {
+                return this.propFormat(attributes[prop], format);
             }
-            if (format === 'bytes') {
-                return this.bytes(val);
+            const meta = stream?.meta || {};
+            if (prop in meta) {
+                return this.propFormat(meta[prop], format);
             }
 
-            return val;
+            return '';
+        },
+
+        /**
+         * Format property value
+         *
+         * @param {String} value
+         * @param {String} format
+         * @returns {String}
+         */
+        propFormat(value, format) {
+            if (format === 'bytes') {
+                return this.bytes(value);
+            }
+
+            return value;
         },
 
         /**

--- a/src/Template/Layout/js/app/components/relation-view/relation-view.js
+++ b/src/Template/Layout/js/app/components/relation-view/relation-view.js
@@ -800,19 +800,6 @@ export default {
         },
 
         /**
-         * Return true if title is not filename.
-         *
-         * @param {Object} related The object
-         * @returns
-         */
-        relatedTitleNotEqualsFilename(related) {
-            const title = related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-';
-            const filename = this.relatedStreamProp(related, 'file_name');
-
-            return (title !== filename);
-        },
-
-        /**
          * Retrieve related stream Download URL
          *
          * @param {Object} related The object


### PR DESCRIPTION
In this PR some UI elements have been added to the related media object view 

* `view` and `download` links to the stream file, if present 
* restored display of size in bytes and mime type (visible to admins only for now) 
