### PR TITLE
Show history when manager user can access `users` module

### DIFF
--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -85,7 +85,7 @@
             {# main relations view #}
             {{ element('Form/relations', {'relations': objectRelations.main}) }}
 
-            {% if object.id %}
+            {% if object.id and Perms.canRead('users') %}
                 {{ element('Form/history') }}
             {% endif %}
 


### PR DESCRIPTION
This fixes a bug, described below.

# Actual behaviour

History data are not loaded in object view, for manager users that have no access to `users` module (nor `/api/users`). The history block loader keeps going with no result.

# Expected behaviour

Manager users that have not access to `users` module (nor `/api/users`) don't see history block in object view.