### PR TITLE
View object history when users module not accessible (without created by / modified by)

### DIFF
--- a/src/Template/Layout/js/app/components/history/history-info.js
+++ b/src/Template/Layout/js/app/components/history/history-info.js
@@ -7,8 +7,8 @@ export default {
         <section class="fieldset shrinks">
             <header class="mx-1 tab tab-static unselectable">
                 <h2>
-                    <span>${t`version by`}</span>
-                    <span class="has-font-weight-bold"><: authorName :></span>
+                    <span v-if="authorName">${t`version by`}</span>
+                    <span v-if="authorName" class="has-font-weight-bold"><: authorName :></span>
                     <span>${t`date`} <: formattedDate :></span>
                 </h2>
             </header>
@@ -52,7 +52,7 @@ export default {
          * @return {string}
          */
         authorName: function() {
-            if (!this.user) {
+            if (!this.user?.attributes) {
                 return;
             }
             const user = this.user.attributes;

--- a/src/Template/Layout/js/app/components/history/history.js
+++ b/src/Template/Layout/js/app/components/history/history.js
@@ -54,27 +54,26 @@ export default {
             const user = meta.user;
             const application = meta.application_name;
             const name = this.getAuthorName(user);
+            if (!name) {
+                return '';
+            }
             if (application) {
                 return t`by ${name} via ${application}`;
             }
-            return t`by ${name}`;
 
+            return t`by ${name}`;
         },
         /**
          * Get formatted user name.
-         * @param {Object} userObj User data
+         * @param {Object} user User data
          * @return {string}
          */
-        getAuthorName: function (userObj) {
-            if (!userObj) {
-                return;
+        getAuthorName: function (user) {
+            if (!user?.attributes) {
+                return '';
             }
-            const user = userObj.attributes;
 
-            return user.title ||
-                `${user.name || ''} ${user.surname || ''}`.trim() ||
-                user.username ||
-                '';
+            return user?.attributes?.title || `${user?.attributes?.name || ''} ${user?.attributes?.surname || ''}`.trim() || user?.attributes?.username || '';
         },
         /**
          * Open panel to show changes.
@@ -156,18 +155,29 @@ export default {
             // fetch users involved in the object history
             let usersId = this.rawHistory.map((change) => change.meta.user_id);
             usersId = [...new Set(usersId)]; // remove duplicates
-            const userRes = await fetch(`${baseUrl}api/users?filter[id]=${usersId.join(',')}`, options);
-            const userJson = await userRes.json();
-            const users = userJson.data;
 
-            // group changes by date
-            this.history = this.rawHistory.reduce((accumulator, item) => {
-                item.meta.user = users.find((user) => user.id == item.meta.user_id);
-                const createdDate = moment(item.meta.created).format('DD MMM YYYY');
-                accumulator[createdDate] = accumulator[createdDate] || [];
-                accumulator[createdDate].push(item);
-                return accumulator;
-            }, {});
+            if (BEDITA.canReadUsers) {
+                const userRes = await fetch(`${baseUrl}api/users?filter[id]=${usersId.join(',')}`, options);
+                const userJson = await userRes.json();
+                const users = userJson.data;
+
+                // group changes by date
+                this.history = this.rawHistory.reduce((accumulator, item) => {
+                    item.meta.user = users.find((user) => user.id == item.meta.user_id);
+                    const createdDate = moment(item.meta.created).format('DD MMM YYYY');
+                    accumulator[createdDate] = accumulator[createdDate] || [];
+                    accumulator[createdDate].push(item);
+                    return accumulator;
+                }, {});
+            } else {
+                this.history = this.rawHistory.reduce((accumulator, item) => {
+                    item.meta.user = {};
+                    const createdDate = moment(item.meta.created).format('DD MMM YYYY');
+                    accumulator[createdDate] = accumulator[createdDate] || [];
+                    accumulator[createdDate].push(item);
+                    return accumulator;
+                }, {});
+            }
 
             // sort changes by time in descending order
             Object.keys(this.history).forEach((date) => this.history[date].reverse());

--- a/src/Template/Layout/js/app/components/property-view/property-view.js
+++ b/src/Template/Layout/js/app/components/property-view/property-view.js
@@ -161,28 +161,30 @@ export default {
         async loadInfoUsers() {
             this.isLoading = true;
 
-            const creatorId = this.object?.meta?.created_by;
-            const modifierId = this.object?.meta?.modified_by;
-            const usersId = [creatorId, modifierId];
-            const userRes = await fetch(`${API_URL}api/users?filter[id]=${usersId.join(',')}&fields[users]=name,surname,username`, API_OPTIONS);
-            const userJson = await userRes.json();
-            const users = userJson.data;
+            if (BEDITA.canReadUsers) {
+                const creatorId = this.object?.meta?.created_by;
+                const modifierId = this.object?.meta?.modified_by;
+                const usersId = [creatorId, modifierId];
+                const userRes = await fetch(`${API_URL}api/users?filter[id]=${usersId.join(',')}&fields[users]=name,surname,username`, API_OPTIONS);
+                const userJson = await userRes.json();
+                const users = userJson.data;
 
-            users.map((user) => {
-                const href = `${BEDITA.base}/view/${user.id}`;
-                const userInfo = (user.attributes.name  != undefined || user.attributes.surname != undefined)
-                    ? user.attributes.name + ' ' + user.attributes.surname
-                    : user.attributes.username;
+                users.map((user) => {
+                    const href = `${BEDITA.base}/view/${user.id}`;
+                    const userInfo = (user.attributes.name  != undefined || user.attributes.surname != undefined)
+                        ? user.attributes.name + ' ' + user.attributes.surname
+                        : user.attributes.username;
 
-                // using == because user.id String and creatorById Number
-                if(user.id == creatorId && userInfo!= undefined) {
-                    document.querySelector(`td[name='created_by']`).innerHTML = `<a href="${href}">${userInfo}</a>`;
-                }
+                    // using == because user.id String and creatorById Number
+                    if(user.id == creatorId && userInfo!= undefined) {
+                        document.querySelector(`td[name='created_by']`).innerHTML = `<a href="${href}">${userInfo}</a>`;
+                    }
 
-                if (user.id == modifierId != undefined) {
-                    document.querySelector(`td[name='modified_by']`).innerHTML = `<a href="${href}">${userInfo}</a>`;
-                }
-            });
+                    if (user.id == modifierId != undefined) {
+                        document.querySelector(`td[name='modified_by']`).innerHTML = `<a href="${href}">${userInfo}</a>`;
+                    }
+                });
+            }
 
             this.isLoading = false;
             this.userInfoLoaded = true;

--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -85,7 +85,7 @@
             {# main relations view #}
             {{ element('Form/relations', {'relations': objectRelations.main}) }}
 
-            {% if object.id and Perms.canRead('users') %}
+            {% if object.id %}
                 {{ element('Form/history') }}
             {% endif %}
 

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -22,6 +22,7 @@ use Cake\View\Helper;
  *
  * @property \Cake\View\Helper\HtmlHelper $Html
  * @property \App\View\Helper\LinkHelper $Link
+ * @property \App\View\Helper\PermsHelper $Perms
  * @property \App\View\Helper\SystemHelper $System
  */
 class LayoutHelper extends Helper
@@ -31,7 +32,7 @@ class LayoutHelper extends Helper
      *
      * @var array
      */
-    public $helpers = ['Html', 'Link', 'System'];
+    public $helpers = ['Html', 'Link', 'Perms', 'System'];
 
     /**
      * Is Dashboard
@@ -194,6 +195,7 @@ class LayoutHelper extends Helper
             'locale' => \Cake\I18n\I18n::getLocale(),
             'csrfToken' => $this->getCsrfToken(),
             'maxFileSize' => $this->System->getMaxFileSize(),
+            'canReadUsers' => $this->Perms->canRead('users'),
         ];
     }
 

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -350,6 +350,7 @@ class LayoutHelperTest extends TestCase
             'locale' => \Cake\I18n\I18n::getLocale(),
             'csrfToken' => 'my-token',
             'maxFileSize' => $system->getMaxFileSize(),
+            'canReadUsers' => false,
         ];
         static::assertSame($expected, $conf);
     }


### PR DESCRIPTION
After https://github.com/bedita/manager/pull/763 there's no error in object view (in history fetch) when authenticated user can't access users module, but history is not available at all.

This provides a change to see history with no "created_by" nor "modified by" informations, when authenticated user can't access users module.