### PR TITLE
Javascript github action node 14.x and 16.x

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - name: 'Checkout current revision'


### PR DESCRIPTION
This adds node 16.x to the list of node version to launch javascript build against