### PR TITLE
Admin config page, content json field min-width 400

### DIFF
--- a/src/Template/Element/Admin/index_content.twig
+++ b/src/Template/Element/Admin/index_content.twig
@@ -22,7 +22,7 @@
                 <div>{{ __('Id') }}</div>
                 {% for key in allProperties %}
                     {% set label = key %}
-                    <div class="{{ Link.sortClass(key) }}"><a href="{{ Link.sortUrl(key) }}">{{ __(label)|humanize }}</a></div>
+                    <div class="{{ Link.sortClass(key) }} {{ key }}"><a href="{{ Link.sortUrl(key) }}">{{ __(label)|humanize }}</a></div>
                 {% endfor %}
                 {% for key in metaColumns %}
                     <div>{{ __(key) }}</div>

--- a/src/Template/Pages/Admin/_admin.scss
+++ b/src/Template/Pages/Admin/_admin.scss
@@ -10,3 +10,7 @@ body.view-admin {
         color: white;
     }
 }
+
+.content {
+    min-width: 400px;
+}


### PR DESCRIPTION
This avoids a UI bug in `/admin/config` page: the overlapping of `content` json field with adiacent `application id` combo. 

## Actual behaviour

![ko](https://user-images.githubusercontent.com/2227145/167160441-db9c379d-1ea3-42db-a3bf-365ba8d4111f.png)

## Expected behaviour (with this PR)

![ok](https://user-images.githubusercontent.com/2227145/167160471-c63bd0ed-a41d-480b-9a8c-cbcb98d0e725.png)
