### PR TITLE
Fix filter-box initFolder + save json field

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -259,7 +259,7 @@ class AppController extends Controller
         $types = (array)Hash::get($data, '_types');
         if (!empty($types)) {
             foreach ($types as $field => $type) {
-                if ($type === 'json') {
+                if ($type === 'json' && is_string($data[$field])) {
                     $data[$field] = json_decode($data[$field], true);
                 }
             }

--- a/src/Template/Layout/js/app/components/filter-box.js
+++ b/src/Template/Layout/js/app/components/filter-box.js
@@ -177,10 +177,10 @@ export default {
 
         initFolder() {
             if (!this.initFilter?.filter) {
-                return {};
+                return '';
             }
 
-            return this.initFilter?.filter[this.positionFilterName];
+            return this.initFilter?.filter[this.positionFilterName] || '';
         },
 
         /**


### PR DESCRIPTION
This fixes 2 bug:

 - initFolder return object instead of a string
 - save fails when json object has value array instead of string