### PR TITLE
Save object: add loader and handle malformed json response

### DIFF
--- a/src/Template/Layout/js/app/pages/modules/view.js
+++ b/src/Template/Layout/js/app/pages/modules/view.js
@@ -75,7 +75,7 @@ export default {
                 if (!response.ok) {
                     // a redirect was performed; we assume it was to /login page
                     if (response.status === 0 && response.type === 'opaqueredirect') {
-                        console.warning('session expired');
+                        console.warn('session expired');
                         this.renewSession();
                         throw new Error('Unauthorized');
                     }


### PR DESCRIPTION
This provides #771.

On save:

 - loader on save button spins
 - on malformed json response (usually a warning on api save), reload page