### PR TITLE
Split bulk position actions

### DIFF
--- a/src/Controller/BulkController.php
+++ b/src/Controller/BulkController.php
@@ -194,14 +194,18 @@ class BulkController extends AppController
      */
     protected function copyToPosition(string $position): void
     {
-        $payload = [];
-        foreach ($this->ids as $id) {
-            $payload[] = compact('id') + ['type' => $this->objectType];
-        }
-        try {
-            $this->apiClient->addRelated($position, 'folders', 'children', $payload);
-        } catch (BEditaClientException $e) {
-            $this->errors[] = ['message' => $e->getAttributes()];
+        $ids = array_reverse($this->ids);
+        foreach ($ids as $id) {
+            try {
+                $this->apiClient->addRelated($position, 'folders', 'children', [
+                    [
+                        'id' => $id,
+                        'type' => $this->objectType,
+                    ],
+                ]);
+            } catch (BEditaClientException $e) {
+                $this->errors[] = ['id' => $id, 'message' => $e->getAttributes()];
+            }
         }
     }
 
@@ -213,10 +217,13 @@ class BulkController extends AppController
      */
     protected function moveToPosition(string $position): void
     {
-        $payload = ['id' => $position, 'type' => 'folders'];
-        foreach ($this->ids as $id) {
+        $ids = array_reverse($this->ids);
+        foreach ($ids as $id) {
             try {
-                $this->apiClient->replaceRelated($id, $this->objectType, 'parents', $payload);
+                $this->apiClient->replaceRelated($id, $this->objectType, 'parents', [
+                    'id' => $position,
+                    'type' => 'folders'
+                ]);
             } catch (BEditaClientException $e) {
                 $this->errors[] = ['id' => $id, 'message' => $e->getAttributes()];
             }

--- a/src/Controller/BulkController.php
+++ b/src/Controller/BulkController.php
@@ -222,7 +222,7 @@ class BulkController extends AppController
             try {
                 $this->apiClient->replaceRelated($id, $this->objectType, 'parents', [
                     'id' => $position,
-                    'type' => 'folders'
+                    'type' => 'folders',
                 ]);
             } catch (BEditaClientException $e) {
                 $this->errors[] = ['id' => $id, 'message' => $e->getAttributes()];


### PR DESCRIPTION
Bulk position operations are quite expansive for large trees, because BEdita needs to shift the nsm for every object creating a very large transaction.

With this PR, we are going to split the tree bulk update into multiple api calls in order to prevent large transactions and long table locking.