### PR TITLE
Add form attribute to filter inputs

### DIFF
--- a/src/Template/Element/FilterBox/filter_box_common.twig
+++ b/src/Template/Element/FilterBox/filter_box_common.twig
@@ -3,6 +3,7 @@
         {# search #}
         <div class="filter-container filter-search input">
             <input type="text"
+                form="_filters"
                 :placeholder="placeholder"
                 v-model.trim="queryFilter.q"
                 @keydown.enter.prevent="applyFilter"
@@ -28,7 +29,7 @@
         {# Checkbox my contents #}
         <div class="filter-container checkbox" v-if="showAdvanced">
             <label>
-                <input type="checkbox" v-model="queryFilter.filter['history_editor']" :initvalue="initHistoryEditor">{{ __('Only my contents') }}</input>
+                <input type="checkbox" form="_filters" v-model="queryFilter.filter['history_editor']" :initvalue="initHistoryEditor">{{ __('Only my contents') }}</input>
             </label>
         </div>
 
@@ -40,6 +41,7 @@
         <div class="filter-container search-types" v-if="rightTypes.length > 1">
             <label>{{ __('Type') }}</label>
             <select v-model="selectedType"
+                form="_filters"
                 class="has-background-gray-700 has-border-gray-700 has-font-weight-light has-text-gray-200 has-text-size-smallest"
             >
                 <option selected value="" label="{{ __('All Types') }}"></option>
@@ -51,14 +53,14 @@
         <div class="filter-container" v-if="statusFilter.options">
             <label>{{ __('Status') }}</label>
             <label v-for="s in statusFilter.options">
-                <input type="checkbox" :id="s.value" :name="statusFilter.name" :value="s.value" v-model="selectedStatuses">
+                <input type="checkbox" form="_filters" :id="s.value" :name="statusFilter.name" :value="s.value" v-model="selectedStatuses">
                 <: s.text :>
             </label>
         </div>
 
         {# other dynamic filters #}
         <div v-for="filter in dynamicFilters" class="filter-container" :class="[filter.name, filter.type, filter.date ? 'date' : '']">
-            <input type="hidden" :name="filter.name" :value="filter.value">
+            <input type="hidden" form="_filters" :name="filter.name" :value="filter.value">
             <label class="filter-label"><: filter.name | humanize :></label>
 
             <span v-if="filter.name === 'categories'">
@@ -71,6 +73,7 @@
                             :categories="{{ typeSchema.categories|json_encode }}"
                             :initial-categories="initCategories"
                             id="category-filter"
+                            form="_filters"
                             label=""
                             @change="onCategoryChange"
                         ></category-picker>
@@ -80,6 +83,7 @@
                         :categories="{{ schema.categories|json_encode }}"
                         :initial-categories="initCategories"
                         id="category-filter"
+                        form="_filters"
                         label=""
                         @change="onCategoryChange"
                     ></category-picker>
@@ -89,6 +93,7 @@
             <span v-else-if="filter.name === 'tags'">
                 <tag-picker
                     id="tag-filter"
+                    form="_filters"
                     :initial-tags="initTags"
                     :searchonly="true"
                     @change="onTagChange"></tag-picker>
@@ -97,12 +102,13 @@
             <span v-else-if="filter.name === 'parent'" class="position-filter">
                 <label>{{ __('Folder') }}</label>
 
-                <folder-picker label="" :initial-folder="initFolder" @change="onFolderChange"></folder-picker>
+                <folder-picker form="_filters" label="" :initial-folder="initFolder" @change="onFolderChange"></folder-picker>
 
                 <span class="descendants-filter">
                     <label for="descendants">{{ __('Descendants') }}</label>
                     <input
                         id="descendants"
+                        form="_filters"
                         type="checkbox"
                         v-model="filterByDescendants"
                         @change="onPositionFilterChange"
@@ -112,15 +118,15 @@
 
             <span v-else-if="filter.name === 'date_ranges'" class="date-filter date-ranges-item">
                 <div>
-                    <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['from_date']" :attrs="filter" />
+                    <input-dynamic-attributes form="_filters" :value.sync="queryFilter.filter['date_ranges']['from_date']" :attrs="filter" />
                 </div>
                 <div>
-                    <input-dynamic-attributes :value.sync="queryFilter.filter['date_ranges']['to_date']" :attrs="filter" />
+                    <input-dynamic-attributes form="_filters" :value.sync="queryFilter.filter['date_ranges']['to_date']" :attrs="filter" />
                 </div>
             </span>
 
             <span v-else-if="filter.type === 'select' || filter.type === 'radio'">
-                <select v-model="queryFilter.filter[filter.name]" :id="filter.name">
+                <select form="_filters" v-model="queryFilter.filter[filter.name]" :id="filter.name">
                     <option value="">
                         {{ __('All') }}
                     </option>
@@ -132,30 +138,30 @@
 
             <span v-else-if="filter.type === 'checkbox'">
                 <label>
-                    <input type="radio" v-model="queryFilter.filter[filter.name]" value="">
+                    <input type="radio" form="_filters" v-model="queryFilter.filter[filter.name]" value="">
                     {{ __('Any') }}
                 </label>
                 <label>
-                    <input type="radio" v-model="queryFilter.filter[filter.name]" value="true">
+                    <input type="radio" form="_filters" v-model="queryFilter.filter[filter.name]" value="true">
                     {{ __('Yes') }}
                 </label>
                 <label>
-                    <input type="radio" v-model="queryFilter.filter[filter.name]" value="false">
+                    <input type="radio" form="_filters" v-model="queryFilter.filter[filter.name]" value="false">
                     {{ __('No') }}
                 </label>
             </span>
 
             <span v-else-if="filter.date">
                 <label>{{ __('From') }}
-                    <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]['gte']" :attrs="filter" />
+                    <input-dynamic-attributes form="_filters" :value.sync="queryFilter.filter[filter.name]['gte']" :attrs="filter" />
                 </label>
                 <label>{{ __('To') }}
-                    <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]['lte']" :attrs="filter" />
+                    <input-dynamic-attributes form="_filters" :value.sync="queryFilter.filter[filter.name]['lte']" :attrs="filter" />
                 </label>
             </span>
 
             <span v-else-if="filter.type === 'text' || filter.type === 'number'">
-                <input-dynamic-attributes :value.sync="queryFilter.filter[filter.name]" :attrs="filter"/>
+                <input-dynamic-attributes form="_filters" :value.sync="queryFilter.filter[filter.name]" :attrs="filter"/>
             </span>
         </div>
     </div>

--- a/src/Template/Element/FilterBox/filter_box_page_toolbar.twig
+++ b/src/Template/Element/FilterBox/filter_box_page_toolbar.twig
@@ -7,7 +7,7 @@
 
     <div class="page-size" v-show="pagination.count > paginateSizes[0]">
         <span>{{ __('Size') }}</span>
-        <select class="page-size-selector {{ selectBaseClasses }}" v-model="pageSize">
+        <select form="_pagination" class="page-size-selector {{ selectBaseClasses }}" v-model="pageSize">
             <option v-for="size in paginateSizes"><: size :></option>
         </select>
     </div>

--- a/src/Template/Layout/js/app/components/category-picker/category-picker.js
+++ b/src/Template/Layout/js/app/components/category-picker/category-picker.js
@@ -11,6 +11,7 @@ export default {
             <label v-if="label" :for="id"><: label :></label>
             <Treeselect
                 placeholder
+                :form="form"
                 :options="categoriesOptions"
                 :disabled="disabled"
                 :disable-branch-nodes="true"
@@ -18,7 +19,7 @@ export default {
                 v-model="selectedIds"
                 @input="onChange"
             />
-            <input type="hidden" :id="id" name="categories" :value="selectedIds" />
+            <input type="hidden" :form="form" :id="id" name="categories" :value="selectedIds" />
         </div>
     `,
 
@@ -27,6 +28,7 @@ export default {
         categories: Array,
         disabled: Boolean,
         label: String,
+        form: String,
         initialCategories: Array,
     },
 

--- a/src/Template/Layout/js/app/components/folder-picker/folder-picker.js
+++ b/src/Template/Layout/js/app/components/folder-picker/folder-picker.js
@@ -36,13 +36,14 @@ export default {
             value-format="object"
             @input="onChange"
         />
-        <input type="hidden" name="folderSelected" :value="selectedFolder?.id" />
+        <input type="hidden" :form="form" name="folderSelected" :value="selectedFolder?.id" />
     </div>`,
 
     props: {
         disabled: Boolean,
         initialFolder: String,
         label: String,
+        form: String,
     },
 
     /**

--- a/src/Template/Layout/js/app/components/input-dynamic-attributes.js
+++ b/src/Template/Layout/js/app/components/input-dynamic-attributes.js
@@ -8,9 +8,10 @@
  */
 
 export default {
-    name: "InputDynamicAttributes",
+    name: 'InputDynamicAttributes',
 
     props: {
+        form: String,
         value: {
             type: [String, Boolean],
         },
@@ -27,7 +28,7 @@ export default {
      * @returns {VNode} input element
      */
     render(createElement) {
-        const attrs = this.attrs;
+        const attrs = { ...(this.attrs || {}), form: this.form };
         const directivesName = Object.keys(attrs).filter(attr => attr.startsWith('v-'));
 
         // remove 'v-' text from vue directives
@@ -35,16 +36,16 @@ export default {
             const directiveName = name.split('v-').pop();
             return {
                 name: directiveName,
-            }
+            };
         });
 
         let domProps = { value: this.value };
-        let on = { input: e => { this.$emit("update:value", e.target.value); } };
+        let on = { input: e => { this.$emit('update:value', e.target.value); } };
 
         // if checkbox is to be rendered a different mapping is needed
         if (attrs.type === 'checkbox') {
             domProps = { checked: this.value === 'true' };
-            on = { input: e => { this.$emit("update:value", e.target.checked); } };
+            on = { input: e => { this.$emit('update:value', e.target.checked); } };
         }
 
         // create and return input element

--- a/src/Template/Layout/js/app/components/tag-picker/tag-picker.js
+++ b/src/Template/Layout/js/app/components/tag-picker/tag-picker.js
@@ -36,12 +36,12 @@ export default {
             <div class="new-tag" v-show="!searchonly">
                 <label for="new-tag">${t`Add new tag`}</label>
                 <div class="input-container">
-                    <input type="text" :value="text" id="new-tag" @input="update($event.target.value)" />
+                    <input type="text" :form="form" :value="text" id="new-tag" @input="update($event.target.value)" />
                     <button @click.prevent="addNewTag">${t`Add`}</button>
                 </div>
             </div>
-            <input type="hidden" :id="id" name="tags" :value="modifiedTags" />
-            <input type="hidden" name="_types[tags]" value="json" />
+            <input type="hidden" :form="form" :id="id" name="tags" :value="modifiedTags" />
+            <input type="hidden" :form="form" name="_types[tags]" value="json" />
         </div>
     `,
 
@@ -49,6 +49,7 @@ export default {
         id: String,
         disabled: Boolean,
         label: String,
+        form: String,
         initialTags: Array,
         searchonly: false,
     },


### PR DESCRIPTION
This PR applies the `form="_filters"` attribute to filter box inputs. This change is required to exclude filter inputs from the object form data, preventing the object property from being overwritten when a filter with the same name exists.