### PR TITLE
Clone object with relations

### DIFF
--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -71,11 +71,13 @@ class CloneComponent extends Component
      */
     public function filterRelations(array $relationships): array
     {
-        return array_filter(
-            $relationships,
-            function ($relationship) {
-                return !in_array($relationship, ['children', 'parents', 'translations']);
-            }
+        return array_values(
+            array_filter(
+                $relationships,
+                function ($relationship) {
+                    return !in_array($relationship, ['children', 'parents', 'translations']);
+                }
+            )
         );
     }
 

--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -57,15 +57,26 @@ class CloneComponent extends Component
         $sourceId = (string)Hash::get($source, 'data.id');
         $type = (string)Hash::get($source, 'data.type');
         $relationships = array_keys((array)Hash::extract($source, 'data.relationships'));
-        $relationships = array_filter(
+        $relationships = $this->filterRelations($relationships);
+        foreach ($relationships as $relation) {
+            $this->relation($sourceId, $type, $relation, $destinationId);
+        }
+    }
+
+    /**
+     * Filter relationships, remove not allowed 'children', 'parents', 'translations'
+     *
+     * @param array $relationships The relationships
+     * @return array
+     */
+    public function filterRelations(array $relationships): array
+    {
+        return array_filter(
             $relationships,
             function ($relationship) {
                 return !in_array($relationship, ['children', 'parents', 'translations']);
             }
         );
-        foreach ($relationships as $relation) {
-            $this->relation($sourceId, $type, $relation, $destinationId);
-        }
     }
 
     /**

--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Controller\Component;
+
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Controller\Component;
+use Cake\Utility\Hash;
+
+/**
+ * Clone component
+ */
+class CloneComponent extends Component
+{
+    /**
+     * BEdita Api client
+     *
+     * @var \BEdita\SDK\BEditaClient
+     */
+    protected $apiClient = null;
+
+    /**
+     * {@inheritDoc}
+     * {@codeCoverageIgnore}
+     */
+    public function initialize(array $config): void
+    {
+        $this->apiClient = ApiClientProvider::getApiClient();
+        parent::initialize($config);
+    }
+
+    /**
+     * Clone relation from source object $source to destination object ID $destination.
+     * Exclude 'children', if present.
+     *
+     * @param array $source The source object
+     * @param string $destinationId The destination ID
+     * @return void
+     */
+    public function relations(array $source, string $destinationId): void
+    {
+        $cloneRelations = $this->getController()->getRequest()->getQuery('cloneRelations');
+        if (filter_var($cloneRelations, FILTER_VALIDATE_BOOLEAN) === false) {
+            return;
+        }
+        $sourceId = (string)Hash::get($source, 'data.id');
+        $type = (string)Hash::get($source, 'data.type');
+        $relationships = array_keys((array)Hash::extract($source, 'data.relationships'));
+        $relationships = array_filter(
+            $relationships,
+            function ($relationship) {
+                return !in_array($relationship, ['children']);
+            }
+        );
+        foreach ($relationships as $relation) {
+            $this->relation($sourceId, $type, $relation, $destinationId);
+        }
+    }
+
+    /**
+     * Clone single relation data.
+     * This calls multiple times `BEditaClient::addRelated`, instead of calling it once,
+     * to avoid time and resources consuming api operations locking tables.
+     *
+     * @param string $sourceId The source ID
+     * @param string $type The object type
+     * @param string $relation The relation name
+     * @param string $destinationId The destination ID
+     * @return void
+     */
+    protected function relation(string $sourceId, string $type, string $relation, string $destinationId): void
+    {
+        $related = $this->apiClient->getRelated($sourceId, $type, $relation);
+        if (empty($related['data'])) {
+            return;
+        }
+        foreach ($related['data'] as $obj) {
+            $this->apiClient->addRelated($destinationId, $type, $relation, [
+                [
+                    'id' => (string)Hash::get($obj, 'id'),
+                    'type' => (string)Hash::get($obj, 'type'),
+                ],
+            ]);
+        }
+    }
+}

--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -60,7 +60,7 @@ class CloneComponent extends Component
         $relationships = array_filter(
             $relationships,
             function ($relationship) {
-                return !in_array($relationship, ['children']);
+                return !in_array($relationship, ['children', 'parents', 'translations']);
             }
         );
         foreach ($relationships as $relation) {

--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -89,7 +89,7 @@ class CloneComponent extends Component
             array_filter(
                 $relationships,
                 function ($relationship) {
-                    return !in_array($relationship, ['children', 'parents', 'translations']);
+                    return !in_array($relationship, ModulesComponent::FIXED_RELATIONSHIPS);
                 }
             )
         );

--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -79,7 +79,7 @@ class CloneComponent extends Component
      * @param string $destinationId The destination ID
      * @return void
      */
-    protected function relation(string $sourceId, string $type, string $relation, string $destinationId): void
+    public function relation(string $sourceId, string $type, string $relation, string $destinationId): void
     {
         $related = $this->apiClient->getRelated($sourceId, $type, $relation);
         if (empty($related['data'])) {

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -32,7 +32,7 @@ use Psr\Log\LogLevel;
  */
 class ModulesComponent extends Component
 {
-    protected const FIXED_RELATIONSHIPS = [
+    public const FIXED_RELATIONSHIPS = [
         'parent',
         'children',
         'parents',

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -340,6 +340,7 @@ class ModulesController extends AppController
             $attributes['uname'] = '';
             unset($attributes['relationships']);
             $attributes['title'] = $this->getRequest()->getQuery('title');
+            $attributes['status'] = 'draft';
             $save = $this->apiClient->save($this->objectType, $attributes);
             $destination = (string)Hash::get($save, 'data.id');
             $this->Clone->relations($source, $destination);

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -22,6 +22,7 @@ use Psr\Log\LogLevel;
  * Modules controller: list, add, edit, remove objects
  *
  * @property \App\Controller\Component\CategoriesComponent $Categories
+ * @property \App\Controller\Component\CloneComponent $Clone
  * @property \App\Controller\Component\HistoryComponent $History
  * @property \App\Controller\Component\ObjectsEditorsComponent $ObjectsEditors
  * @property \App\Controller\Component\ProjectConfigurationComponent $ProjectConfiguration
@@ -47,6 +48,7 @@ class ModulesController extends AppController
         parent::initialize();
 
         $this->loadComponent('Categories');
+        $this->loadComponent('Clone');
         $this->loadComponent('History');
         $this->loadComponent('ObjectsEditors');
         $this->loadComponent('Properties');
@@ -333,26 +335,21 @@ class ModulesController extends AppController
             return $this->redirect(['_name' => 'modules:list', 'object_type' => $this->objectType]);
         }
         try {
-            $response = $this->apiClient->getObject($id, $this->objectType);
-            $attributes = $response['data']['attributes'];
+            $source = $this->apiClient->getObject($id, $this->objectType);
+            $attributes = $source['data']['attributes'];
             $attributes['uname'] = '';
             unset($attributes['relationships']);
             $attributes['title'] = $this->getRequest()->getQuery('title');
+            $save = $this->apiClient->save($this->objectType, $attributes);
+            $destination = (string)Hash::get($save, 'data.id');
+            $this->Clone->relations($source, $destination);
+            $id = $destination;
         } catch (BEditaClientException $e) {
             $this->log($e->getMessage(), LogLevel::ERROR);
             $this->Flash->error($e->getMessage(), ['params' => $e]);
-
-            return $this->redirect(['_name' => 'modules:view', 'object_type' => $this->objectType, 'id' => $id]);
         }
-        $object = [
-            'type' => $this->objectType,
-            'attributes' => $attributes,
-        ];
-        $this->History->load($id, $object);
-        $this->set(compact('object', 'schema'));
-        $this->set('properties', $this->Properties->viewGroups($object, $this->objectType));
 
-        return null;
+        return $this->redirect(['_name' => 'modules:view', 'object_type' => $this->objectType, 'id' => $id]);
     }
 
     /**

--- a/src/Locale/en_US/default.po
+++ b/src/Locale/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-05-06 08:14:16 \n"
+"POT-Creation-Date: 2022-05-20 09:50:22 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -972,26 +972,30 @@ msgid "warning"
 msgstr ""
 
 #: src/Template/Layout/js/app/app.js:175
-#: src/Template/Layout/js/app/components/history/history.js:111
+#: src/Template/Layout/js/app/components/history/history.js:110
 #, javascript-format
 msgid "Please insert a new title on \"${ title }\" clone"
 msgstr ""
 
 #: src/Template/Layout/js/app/app.js:176
-#: src/Template/Layout/js/app/components/history/history.js:112
+#: src/Template/Layout/js/app/components/history/history.js:111
 msgid "copy"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:470
+#: src/Template/Layout/js/app/app.js:186
+msgid "Clone relations"
+msgstr ""
+
+#: src/Template/Layout/js/app/app.js:472
 msgid "If you confirm, this data will be gone forever. Are you sure?"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:482
+#: src/Template/Layout/js/app/app.js:484
 msgid "Do you really want to trash the object?"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:493
-#: src/Template/Layout/js/app/components/history/history.js:101
+#: src/Template/Layout/js/app/app.js:495
+#: src/Template/Layout/js/app/components/history/history.js:100
 #: src/Template/Layout/js/app/pages/admin/index.js:19
 #: src/Template/Layout/js/app/pages/model/index.js:261
 #: src/Template/Layout/js/app/pages/modules/index.js:158
@@ -999,7 +1003,7 @@ msgstr ""
 msgid "yes, proceed"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:502
+#: src/Template/Layout/js/app/app.js:504
 msgid "There are unsaved changes, are you sure you want to leave page?"
 msgstr ""
 
@@ -1152,16 +1156,16 @@ msgstr ""
 msgid "No History data found"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/history/history.js:58
+#: src/Template/Layout/js/app/components/history/history.js:61
 #, javascript-format
 msgid "by ${ name } via ${ application }"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/history/history.js:60
+#: src/Template/Layout/js/app/components/history/history.js:64
 msgid "by ${ name }"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/history/history.js:100
+#: src/Template/Layout/js/app/components/history/history.js:99
 msgid ""
 "Restored data will replace current data (you can still check the data before "
 "saving). Are you sure?"

--- a/src/Locale/it_IT/default.po
+++ b/src/Locale/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-05-06 08:14:16 \n"
+"POT-Creation-Date: 2022-05-20 09:50:22 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -975,26 +975,30 @@ msgid "warning"
 msgstr "attenzione"
 
 #: src/Template/Layout/js/app/app.js:175
-#: src/Template/Layout/js/app/components/history/history.js:111
+#: src/Template/Layout/js/app/components/history/history.js:110
 #, javascript-format
 msgid "Please insert a new title on \"${ title }\" clone"
 msgstr "Inserisci un nuovo titolo per la copia di \"${ title }\""
 
 #: src/Template/Layout/js/app/app.js:176
-#: src/Template/Layout/js/app/components/history/history.js:112
+#: src/Template/Layout/js/app/components/history/history.js:111
 msgid "copy"
 msgstr "copia"
 
-#: src/Template/Layout/js/app/app.js:470
+#: src/Template/Layout/js/app/app.js:186
+msgid "Clone relations"
+msgstr "Clona le relazioni"
+
+#: src/Template/Layout/js/app/app.js:472
 msgid "If you confirm, this data will be gone forever. Are you sure?"
 msgstr "Questo dato verrà eliminato definitivamente. Vuoi proseguire?"
 
-#: src/Template/Layout/js/app/app.js:482
+#: src/Template/Layout/js/app/app.js:484
 msgid "Do you really want to trash the object?"
 msgstr "Vuoi davvero spostare l'oggetto nel cestino?"
 
-#: src/Template/Layout/js/app/app.js:493
-#: src/Template/Layout/js/app/components/history/history.js:101
+#: src/Template/Layout/js/app/app.js:495
+#: src/Template/Layout/js/app/components/history/history.js:100
 #: src/Template/Layout/js/app/pages/admin/index.js:19
 #: src/Template/Layout/js/app/pages/model/index.js:261
 #: src/Template/Layout/js/app/pages/modules/index.js:158
@@ -1002,7 +1006,7 @@ msgstr "Vuoi davvero spostare l'oggetto nel cestino?"
 msgid "yes, proceed"
 msgstr "sì, prosegui"
 
-#: src/Template/Layout/js/app/app.js:502
+#: src/Template/Layout/js/app/app.js:504
 msgid "There are unsaved changes, are you sure you want to leave page?"
 msgstr "Ci sono delle modifiche non salvate, vuoi comunque lasciare la pagina?"
 
@@ -1157,16 +1161,16 @@ msgstr "Rimosso"
 msgid "No History data found"
 msgstr "Nessun dato di Cronologia"
 
-#: src/Template/Layout/js/app/components/history/history.js:58
+#: src/Template/Layout/js/app/components/history/history.js:61
 #, javascript-format
 msgid "by ${ name } via ${ application }"
 msgstr "modificato da ${ name } con applicazione ${ application }"
 
-#: src/Template/Layout/js/app/components/history/history.js:60
+#: src/Template/Layout/js/app/components/history/history.js:64
 msgid "by ${ name }"
 msgstr "modificato da ${ name }"
 
-#: src/Template/Layout/js/app/components/history/history.js:100
+#: src/Template/Layout/js/app/components/history/history.js:99
 msgid ""
 "Restored data will replace current data (you can still check the data before "
 "saving). Are you sure?"

--- a/src/Locale/master.pot
+++ b/src/Locale/master.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-05-06 08:14:16 \n"
+"POT-Creation-Date: 2022-05-20 09:50:22 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -969,26 +969,30 @@ msgid "warning"
 msgstr ""
 
 #: src/Template/Layout/js/app/app.js:175
-#: src/Template/Layout/js/app/components/history/history.js:111
+#: src/Template/Layout/js/app/components/history/history.js:110
 #, javascript-format
 msgid "Please insert a new title on \"${ title }\" clone"
 msgstr ""
 
 #: src/Template/Layout/js/app/app.js:176
-#: src/Template/Layout/js/app/components/history/history.js:112
+#: src/Template/Layout/js/app/components/history/history.js:111
 msgid "copy"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:470
+#: src/Template/Layout/js/app/app.js:186
+msgid "Clone relations"
+msgstr ""
+
+#: src/Template/Layout/js/app/app.js:472
 msgid "If you confirm, this data will be gone forever. Are you sure?"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:482
+#: src/Template/Layout/js/app/app.js:484
 msgid "Do you really want to trash the object?"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:493
-#: src/Template/Layout/js/app/components/history/history.js:101
+#: src/Template/Layout/js/app/app.js:495
+#: src/Template/Layout/js/app/components/history/history.js:100
 #: src/Template/Layout/js/app/pages/admin/index.js:19
 #: src/Template/Layout/js/app/pages/model/index.js:261
 #: src/Template/Layout/js/app/pages/modules/index.js:158
@@ -996,7 +1000,7 @@ msgstr ""
 msgid "yes, proceed"
 msgstr ""
 
-#: src/Template/Layout/js/app/app.js:502
+#: src/Template/Layout/js/app/app.js:504
 msgid "There are unsaved changes, are you sure you want to leave page?"
 msgstr ""
 
@@ -1149,16 +1153,16 @@ msgstr ""
 msgid "No History data found"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/history/history.js:58
+#: src/Template/Layout/js/app/components/history/history.js:61
 #, javascript-format
 msgid "by ${ name } via ${ application }"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/history/history.js:60
+#: src/Template/Layout/js/app/components/history/history.js:64
 msgid "by ${ name }"
 msgstr ""
 
-#: src/Template/Layout/js/app/components/history/history.js:100
+#: src/Template/Layout/js/app/components/history/history.js:99
 msgid ""
 "Restored data will replace current data (you can still check the data before "
 "saving). Are you sure?"

--- a/src/Template/Layout/js/app/app.js
+++ b/src/Template/Layout/js/app/app.js
@@ -174,16 +174,18 @@ const _vueInstance = new Vue({
             const title = document.getElementById('title').value || t('Untitled');
             const msg = t`Please insert a new title on "${title}" clone`;
             const defaultTitle = title + '-' + t`copy`;
-
-            prompt(msg, defaultTitle, (cloneTitle, dialog) => {
-                const query = `?title=${cloneTitle || defaultTitle}`;
+            const confirmCallback = (cloneTitle, cloneRelations, dialog) => {
+                const query = `?title=${cloneTitle || defaultTitle}&cloneRelations=${cloneRelations || false}`;
                 const origin = window.location.origin;
                 const path = window.location.pathname.replace('/view/', '/clone/');
                 const url = `${origin}${path}${query}`;
                 const newTab = window.open(url, '_blank');
                 newTab.focus();
                 dialog.hide(true);
-            });
+            };
+            const options = { checkLabel: t`Clone relations`, checkValue: false };
+
+            prompt(msg, defaultTitle, confirmCallback, document.body, options);
         },
 
         /**

--- a/src/Template/Layout/js/app/components/dialog/dialog.js
+++ b/src/Template/Layout/js/app/components/dialog/dialog.js
@@ -20,8 +20,12 @@ export const Dialog = Vue.extend({
                 </header>
                 <div class="message mt-1 has-text-size-larger" v-if="message"><: message :></div>
                 <input class="mt-1" type="text" v-if="dialogType == 'prompt'" v-model.lazy="inputValue" />
+                <div class="mt-1" v-if="dialogType == 'prompt'" v-show="checkLabel">
+                    <input type="checkbox" id="_check" v-model.lazy="checkValue"  />
+                    <label for="_check"><: checkLabel :></label>
+                </div>
                 <div class="actions mt-2">
-                    <button class="button-outlined-white confirm mr-1" v-if="confirmMessage" @click="confirmCallback(inputValue, $root)"><: confirmMessage :></button>
+                    <button class="button-outlined-white confirm mr-1" v-if="confirmMessage" @click="confirmCallback(inputValue, checkValue, $root)"><: confirmMessage :></button>
                     <button class="button-secondary cancel" @click="hide()" v-if="cancelMessage"><: cancelMessage :></button>
                 </div>
             </div>
@@ -40,6 +44,8 @@ export const Dialog = Vue.extend({
             confirmCallback: this.hide,
             cancelMessage: t`cancel`,
             inputValue: '',
+            checkValue: '',
+            checkLabel: ''
         };
     },
     methods: {
@@ -84,10 +90,12 @@ export const Dialog = Vue.extend({
             this.confirmCallback = confirmCallback;
             this.show(message, this.dialogType, root);
         },
-        prompt(message, defaultValue, confirmCallback, root = document.body) {
+        prompt(message, defaultValue, confirmCallback, root = document.body, options = {}) {
             this.dialogType = 'prompt';
             this.icon = 'icon-info-1';
             this.inputValue = defaultValue || '';
+            this.checkValue = options?.checkValue || '';
+            this.checkLabel = options?.checkLabel || '';
             this.confirmCallback = confirmCallback;
             this.show(message, '', root);
         },
@@ -118,8 +126,8 @@ export const confirm = (message, confirmMessage, confirmCallback, type, root) =>
     return dialog;
 };
 
-export const prompt = (message, defaultValue, confirmCallback, root) => {
+export const prompt = (message, defaultValue, confirmCallback, root, options) => {
     let dialog = new Dialog();
-    dialog.prompt(message, defaultValue, confirmCallback, root);
+    dialog.prompt(message, defaultValue, confirmCallback, root, options);
     return dialog;
 };

--- a/src/Template/Layout/js/app/components/dialog/dialog.scss
+++ b/src/Template/Layout/js/app/components/dialog/dialog.scss
@@ -85,7 +85,7 @@
             }
         }
 
-        input {
+        input[type=text] {
             width: 100%;
             border: 1px solid $gray-600;
         }

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -25,6 +25,13 @@ class CloneComponentTest extends BaseControllerTest
     protected $Clone;
 
     /**
+     * Controller for test
+     *
+     * @var \Cake\Controller\Controller
+     */
+    protected $controller;
+
+    /**
      * @inheritDoc
      */
     protected function tearDown(): void
@@ -156,11 +163,11 @@ class CloneComponentTest extends BaseControllerTest
         $response = $this->client->save('documents', ['title' => 'doc 2']);
         $doc2 = $response['data'];
         $destinationId = (string)$doc2['id'];
-        $this->controller->Clone = $this->createPartialMock(CloneComponent::class, ['filterRelations', 'queryCloneRelations']);
-        $this->controller->Clone
+        $this->Clone = $this->createPartialMock(CloneComponent::class, ['filterRelations', 'queryCloneRelations']);
+        $this->Clone
             ->method('filterRelations')
             ->willReturn(['parents']);
-        $this->controller->Clone
+        $this->Clone
             ->method('queryCloneRelations')
             ->willReturn(true);
         $apiClient = $this->getMockBuilder(BEditaClient::class)
@@ -168,10 +175,10 @@ class CloneComponentTest extends BaseControllerTest
             ->getMock();
         $apiClient->method('getRelated')
             ->willReturn(['data' => []]);
-        $property = new \ReflectionProperty(get_class($this->controller->Clone), 'apiClient');
+        $property = new \ReflectionProperty(get_class($this->Clone), 'apiClient');
         $property->setAccessible(true);
-        $property->setValue($this->controller->Clone, $apiClient);
-        $result = $this->controller->Clone->relations($doc1, $destinationId);
+        $property->setValue($this->Clone, $apiClient);
+        $result = $this->Clone->relations($doc1, $destinationId);
         static::assertTrue($result);
     }
 
@@ -196,10 +203,10 @@ class CloneComponentTest extends BaseControllerTest
             ]]);
         $apiClient->method('addRelated')
                 ->willReturn([]);
-        $property = new \ReflectionProperty(get_class($this->controller->Clone), 'apiClient');
+        $property = new \ReflectionProperty(get_class($this->Clone), 'apiClient');
         $property->setAccessible(true);
-        $property->setValue($this->controller->Clone, $apiClient);
-        $result = $this->controller->Clone->relation('123', 'dummies', 'whatever', '456');
+        $property->setValue($this->Clone, $apiClient);
+        $result = $this->Clone->relation('123', 'dummies', 'whatever', '456');
         static::assertTrue($result);
     }
 
@@ -252,6 +259,5 @@ class CloneComponentTest extends BaseControllerTest
         /** @var \App\Controller\Component\CloneComponent $cloneComponent */
         $cloneComponent = $registry->load(CloneComponent::class);
         $this->Clone = $cloneComponent;
-        $this->controller->Clone = $this->Clone;
     }
 }

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -124,6 +124,41 @@ class CloneComponentTest extends BaseControllerTest
         static::assertSame($expected, $actual);
     }
 
+    /**
+     * Data provider for testFilterRelations
+     *
+     * @return array
+     */
+    public function filterRelationsProvider(): array
+    {
+        return [
+            'empty' => [
+                [],
+                [],
+            ],
+            'various relations' => [
+                ['a', 'parents', 'b', 'children', 'c', 'd', 'translations', 'e'],
+                ['a', 'b', 'c', 'd', 'e'],
+            ],
+        ];
+    }
+
+    /**
+     * Test `filterRelations`
+     *
+     * @param array $relationships
+     * @param array $expected
+     * @return void
+     * @dataProvider filterRelationsProvider()
+     * @covers ::filterRelations()
+     */
+    public function testFilterRelations(array $relationships, array $expected): void
+    {
+        $this->prepareClone(true);
+        $actual = array_values($this->Clone->filterRelations($relationships));
+        static::assertSame($expected, $actual);
+    }
+
     private function prepareClone(bool $cloneRelations): void
     {
         $config = [

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -155,7 +155,7 @@ class CloneComponentTest extends BaseControllerTest
     public function testFilterRelations(array $relationships, array $expected): void
     {
         $this->prepareClone(true);
-        $actual = array_values($this->Clone->filterRelations($relationships));
+        $actual = $this->Clone->filterRelations($relationships);
         static::assertSame($expected, $actual);
     }
 

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -85,6 +85,45 @@ class CloneComponentTest extends BaseControllerTest
         static::assertSame($expected, $actual);
     }
 
+    /**
+     * Test `relation`
+     *
+     * @return void
+     * @covers ::relation()
+     */
+    public function testRelation(): void
+    {
+        $this->prepareClone(true);
+        $this->setupApi();
+        $type = 'documents';
+        $response = $this->client->save($type, ['title' => 'doc 1']);
+        $doc1 = $response['data'];
+        $sourceId = (string)$doc1['id'];
+        $response = $this->client->save($type, ['title' => 'doc 2']);
+        $doc2 = $response['data'];
+        $destinationId = (string)$doc2['id'];
+        // empty relation case: parents
+        $this->Clone->relation($sourceId, $type, 'parents', $destinationId);
+
+        $expected = array_keys((array)Hash::extract($doc1, 'relationships'));
+        $expected = array_filter(
+            $expected,
+            function ($relationship) {
+                return !in_array($relationship, ['children', 'parents', 'translations']);
+            }
+        );
+
+        $actual = array_keys((array)Hash::extract($doc2, 'relationships'));
+        $actual = array_filter(
+            $actual,
+            function ($relationship) {
+                return !in_array($relationship, ['children', 'parents', 'translations']);
+            }
+        );
+
+        static::assertSame($expected, $actual);
+    }
+
     private function prepareClone(bool $cloneRelations): void
     {
         $config = [

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -58,7 +58,7 @@ class CloneComponentTest extends BaseControllerTest
     {
         $this->prepareClone($expected);
         $this->setupApi();
-        $actual = $this->Clone->queryCloneRelations($expected);
+        $actual = $this->Clone->queryCloneRelations();
         static::assertSame($expected, $actual);
     }
 

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Controller\Component;
+
+use App\Controller\Component\CloneComponent;
+use App\Test\TestCase\Controller\BaseControllerTest;
+use Cake\Controller\Controller;
+use Cake\Utility\Hash;
+
+/**
+ * {@see \App\Controller\Component\CloneComponent} Test Case
+ *
+ * @coversDefaultClass \App\Controller\Component\CloneComponent
+ */
+class CloneComponentTest extends BaseControllerTest
+{
+    /**
+     * Test subject
+     *
+     * @var \App\Controller\Component\CloneComponent
+     */
+    protected $Clone;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $controller = new Controller();
+        $registry = $controller->components();
+        /** @var \App\Controller\Component\CloneComponent $cloneComponent */
+        $cloneComponent = $registry->load(CloneComponent::class);
+        $this->Clone = $cloneComponent;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown(): void
+    {
+        unset($this->Clone);
+        parent::tearDown();
+    }
+
+    /**
+     * Test `relations` and `relation`.
+     *
+     * @return void
+     * @covers ::relations()
+     * @covers ::relation()
+     */
+    public function testRelations(): void
+    {
+        $this->setupApi();
+        $response = $this->client->save('documents', ['title' => 'doc 1']);
+        $doc1 = $response['data'];
+        $response = $this->client->save('documents', ['title' => 'doc 2']);
+        $doc2 = $response['data'];
+        $destinationId = (string)$doc2['id'];
+        $this->Clone->relations($doc1, $destinationId);
+        $response = $this->client->getObject($destinationId, 'documents');
+        $doc2 = $response['data'];
+
+        $expected = array_keys((array)Hash::extract($doc1, 'relationships'));
+        $expected = array_filter(
+            $expected,
+            function ($relationship) {
+                return !in_array($relationship, ['children', 'parents', 'translations']);
+            }
+        );
+
+        $actual = array_keys((array)Hash::extract($doc2, 'relationships'));
+        $actual = array_filter(
+            $actual,
+            function ($relationship) {
+                return !in_array($relationship, ['children', 'parents', 'translations']);
+            }
+        );
+
+        static::assertSame($expected, $actual);
+    }
+}

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -341,12 +341,9 @@ class ModulesControllerTest extends BaseControllerTest
         $result = $this->controller->clone($id);
 
         // verify response status code and type
-        static::assertNull($result);
-        static::assertEquals(200, $this->controller->getResponse()->getStatusCode());
+        static::assertNotNull($result);
+        static::assertEquals(302, $this->controller->getResponse()->getStatusCode());
         static::assertEquals('text/html', $this->controller->getResponse()->getType());
-
-        // verify expected vars in view
-        $this->assertExpectedViewVars(['object', 'schema', 'properties']);
     }
 
     /**


### PR DESCRIPTION
This provides the possibility to clone object with relations (excluding "children").

When you click on clone, prompt shows a new check "Clone relations". When checked, the cloning process copies relations from source object to new object.

Note: tests for `CloneComponent` use mocked api, because we found a bug (https://github.com/bedita/bedita/pull/1912) that does not allow us to create relations as we should to have a full test.