### PR TITLE
Fix Control::categories notice

### DIFF
--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -143,7 +143,7 @@ class Control
     {
         $schema = (array)Hash::get($options, 'schema');
         $value = Hash::get($options, 'value');
-        $categories = $schema['categories'];
+        $categories = (array)Hash::get($schema, 'categories');
         $options = array_map(
             function ($category) {
                 return [


### PR DESCRIPTION
This fixes a possible notice in `Control::categories`, by using `Hash::get`.

The notice can be a problem for ajax call for `history`. On debug `1`, ajax call fails.