### PR TITLE
Pagination current page as input

### DIFF
--- a/src/Template/Element/FilterBox/filter_box_page_toolbar.twig
+++ b/src/Template/Element/FilterBox/filter_box_page_toolbar.twig
@@ -30,9 +30,10 @@
             {# prev page #}
             <button v-if="pagination.page > 2" class="{{ pageButton }}" @click.prevent="onChangePage(pagination.page - 1)"><: pagination.page - 1:></button>
             {# current page #}
-            <button class="is-dark current-page has-text-size-smallest" @click.prevent="onChangePage(pagination.page)"><: pagination.page :></button>
+            <input v-show="pagination.page === 1" size="2" class="ml-05 mr-05" :value="pagination.page" @change="onChangePageNumber($event)" />
+            <input v-show="pagination.page > 1" size="2" class="ml-05" :value="pagination.page" @change="onChangePageNumber($event)" />
             {# next page #}
-            <button v-if="pagination.page < pagination.page_count-1" class="{{ pageButton }}" @click.prevent="onChangePage(pagination.page + 1)"><: pagination.page + 1:></button>
+            <button v-if="pagination.page < pagination.page_count-1" class="ml-05 {{ pageButton }}" @click.prevent="onChangePage(pagination.page + 1)"><: pagination.page + 1:></button>
             {# delimiter #}
             <span v-if="pagination.page < pagination.page_count-2" class="pages-delimiter"></span>
             {# last page #}

--- a/src/Template/Element/FilterBox/filter_box_page_toolbar.twig
+++ b/src/Template/Element/FilterBox/filter_box_page_toolbar.twig
@@ -33,7 +33,7 @@
             <input v-show="pagination.page === 1" size="2" class="ml-05 mr-05" :value="pagination.page" @change="onChangePageNumber($event)" />
             <input v-show="pagination.page > 1" size="2" class="ml-05" :value="pagination.page" @change="onChangePageNumber($event)" />
             {# next page #}
-            <button v-if="pagination.page < pagination.page_count-1" class="ml-05 {{ pageButton }}" @click.prevent="onChangePage(pagination.page + 1)"><: pagination.page + 1:></button>
+            <button v-if="pagination.page < pagination.page_count-1" class="{{ pageButton }}" @click.prevent="onChangePage(pagination.page + 1)"><: pagination.page + 1:></button>
             {# delimiter #}
             <span v-if="pagination.page < pagination.page_count-2" class="pages-delimiter"></span>
             {# last page #}

--- a/src/Template/Element/FilterBox/filter_box_page_toolbar.twig
+++ b/src/Template/Element/FilterBox/filter_box_page_toolbar.twig
@@ -30,8 +30,7 @@
             {# prev page #}
             <button v-if="pagination.page > 2" class="{{ pageButton }}" @click.prevent="onChangePage(pagination.page - 1)"><: pagination.page - 1:></button>
             {# current page #}
-            <input v-show="pagination.page === 1" size="2" class="ml-05 mr-05" :value="pagination.page" @change="onChangePageNumber($event)" />
-            <input v-show="pagination.page > 1" size="2" class="ml-05" :value="pagination.page" @change="onChangePageNumber($event)" />
+            <input size="2" class="ml-05" :class="pagination.page === 1 ? 'mr-05' : 'ml-05'" :value="pagination.page" @change="onChangePageNumber($event)" />
             {# next page #}
             <button v-if="pagination.page < pagination.page_count-1" class="{{ pageButton }}" @click.prevent="onChangePage(pagination.page + 1)"><: pagination.page + 1:></button>
             {# delimiter #}

--- a/src/Template/Element/FilterBox/filter_box_page_toolbar.twig
+++ b/src/Template/Element/FilterBox/filter_box_page_toolbar.twig
@@ -30,7 +30,7 @@
             {# prev page #}
             <button v-if="pagination.page > 2" class="{{ pageButton }}" @click.prevent="onChangePage(pagination.page - 1)"><: pagination.page - 1:></button>
             {# current page #}
-            <input size="2" class="ml-05" :class="pagination.page === 1 ? 'mr-05' : 'ml-05'" :value="pagination.page" @change="onChangePageNumber($event)" />
+            <input size="2" class="ml-05" :class="pagination.page === 1 ? 'mr-05' : 'ml-05'" :value="pagination.page" @change="onChangePageNumber($event)" @keydown="onPageKeydown($event)"/>
             {# next page #}
             <button v-if="pagination.page < pagination.page_count-1" class="{{ pageButton }}" @click.prevent="onChangePage(pagination.page + 1)"><: pagination.page + 1:></button>
             {# delimiter #}

--- a/src/Template/Layout/js/app/components/filter-box.js
+++ b/src/Template/Layout/js/app/components/filter-box.js
@@ -390,6 +390,15 @@ export default {
             }
             this.onChangePage(val);
         },
+        onPageKeydown(e) {
+            if (e.key === 'Enter' || e.keyCode === 13) {
+                e.preventDefault();
+                e.stopPropagation();
+                this.onChangePageNumber(e);
+
+                return false;
+            }
+        },
         onCategoryChange(categories) {
             this.queryFilter.filter.categories = categories?.map((cat) => cat.name).join(',');
         },

--- a/src/Template/Layout/js/app/components/filter-box.js
+++ b/src/Template/Layout/js/app/components/filter-box.js
@@ -376,7 +376,20 @@ export default {
         onChangePage(index) {
             this.$emit("filter-update-current-page", index);
         },
+        onChangePageNumber(e) {
+            let val = e.target.value;
+            val = val.trim();
+            if (!val) {
+                return;
+            }
+            val = parseFloat(val);
+            if (!val || val > this.pagination.page_count) {
+                e.target.value = '';
 
+                return;
+            }
+            this.onChangePage(val);
+        },
         onCategoryChange(categories) {
             this.queryFilter.filter.categories = categories?.map((cat) => cat.name).join(',');
         },

--- a/src/Template/Layout/styles/_elements.scss
+++ b/src/Template/Layout/styles/_elements.scss
@@ -130,6 +130,11 @@ nav.pagination {
                 }
             }
 
+            input {
+                min-width: 2.5em;
+                text-align: center;
+            }
+
             .pages-delimiter {
                 &:after {
                     content: '…';


### PR DESCRIPTION
This provides a change to pagination block: current page is an editable input text.

This allows user to jump to a desired page, avoiding multiple clicks on prev or next button.

On input change, if value is not an integer or greater than pagination count, it's cleared.

It looks like follows:
![pagination](https://user-images.githubusercontent.com/2227145/171878002-ecc01632-4a59-4741-8416-52cfdf0b164b.png)

