### PR TITLE
chore: prevent iframes in placeholders from downloading files

### DIFF
--- a/src/Template/Layout/js/app/plugins/tinymce/placeholders.js
+++ b/src/Template/Layout/js/app/plugins/tinymce/placeholders.js
@@ -49,7 +49,7 @@ function loadPreview(editor, node, id) {
                         break;
                     default:
                         if (data.meta.media_url) {
-                            content = `<iframe src="${data.meta.media_url}"></iframe>`;
+                            content = `<iframe src="${data.meta.media_url}" sandbox=""></iframe>`;
                         } else {
                             content = `<div class="embed-card">
                                 <div class="title">${data.attributes.title || t('Untitled')}</div>


### PR DESCRIPTION
Added an [emtpy `sandbox` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe?retiredLocale=it#attr-sandbox) to the iframe inside placeholders in order to prevent the iframe from downloading files, for example when adding a 3d model file as placeholder in a BEdita document.