### PR TITLE
Avoid API client creation in component initialize

### DIFF
--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -24,6 +24,22 @@ use Cake\Utility\Hash;
 class CloneComponent extends Component
 {
     /**
+     * BEdita Api client
+     *
+     * @var \BEdita\SDK\BEditaClient
+     */
+    protected $apiClient = null;
+
+    /**
+     * {@inheritDoc}
+     * {@codeCoverageIgnore}
+     */
+    public function startup(): void
+    {
+        $this->apiClient = ApiClientProvider::getApiClient();
+    }
+
+    /**
      * Get the value of query 'cloneRelations'.
      * Return true when cloneRelations is not false.
      *
@@ -91,13 +107,12 @@ class CloneComponent extends Component
      */
     public function relation(string $sourceId, string $type, string $relation, string $destinationId): bool
     {
-        $apiClient = ApiClientProvider::getApiClient();
-        $related = $apiClient->getRelated($sourceId, $type, $relation);
+        $related = $this->apiClient->getRelated($sourceId, $type, $relation);
         if (empty($related['data'])) {
             return false;
         }
         foreach ($related['data'] as $obj) {
-            $apiClient->addRelated($destinationId, $type, $relation, [
+            $this->apiClient->addRelated($destinationId, $type, $relation, [
                 [
                     'id' => (string)Hash::get($obj, 'id'),
                     'type' => (string)Hash::get($obj, 'type'),

--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -24,23 +24,6 @@ use Cake\Utility\Hash;
 class CloneComponent extends Component
 {
     /**
-     * BEdita Api client
-     *
-     * @var \BEdita\SDK\BEditaClient
-     */
-    protected $apiClient = null;
-
-    /**
-     * {@inheritDoc}
-     * {@codeCoverageIgnore}
-     */
-    public function initialize(array $config): void
-    {
-        $this->apiClient = ApiClientProvider::getApiClient();
-        parent::initialize($config);
-    }
-
-    /**
      * Get the value of query 'cloneRelations'.
      * Return true when cloneRelations is not false.
      *
@@ -108,12 +91,13 @@ class CloneComponent extends Component
      */
     public function relation(string $sourceId, string $type, string $relation, string $destinationId): bool
     {
-        $related = $this->apiClient->getRelated($sourceId, $type, $relation);
+        $apiClient = ApiClientProvider::getApiClient();
+        $related = $apiClient->getRelated($sourceId, $type, $relation);
         if (empty($related['data'])) {
             return false;
         }
         foreach ($related['data'] as $obj) {
-            $this->apiClient->addRelated($destinationId, $type, $relation, [
+            $apiClient->addRelated($destinationId, $type, $relation, [
                 [
                     'id' => (string)Hash::get($obj, 'id'),
                     'type' => (string)Hash::get($obj, 'type'),

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -127,6 +127,7 @@ class CloneComponentTest extends BaseControllerTest
         $doc2 = $response['data'];
         $destinationId = (string)$doc2['id'];
         // empty relation case: parents
+        $this->Clone->startup();
         $this->Clone->relation($sourceId, $type, 'parents', $destinationId);
 
         $expected = array_keys((array)Hash::extract($doc1, 'relationships'));


### PR DESCRIPTION
This PR fixes an error in `ApiClientProvider::getApiClient()` call when session is expired