### PR TITLE
Clone relations - 100 related

### DIFF
--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -107,7 +107,7 @@ class CloneComponent extends Component
      */
     public function relation(string $sourceId, string $type, string $relation, string $destinationId): bool
     {
-        $related = $this->apiClient->getRelated($sourceId, $type, $relation);
+        $related = $this->apiClient->getRelated($sourceId, $type, $relation, ['page_size' => 100]);
         if (empty($related['data'])) {
             return false;
         }


### PR DESCRIPTION
When cloning an object, if "related" is checked the system clone relations with related data too, using PAGE_SIZE (20) as limit for related objects.
This changes the limit to 100 (per relation).