### PR TITLE
Validate uri on change

### DIFF
--- a/src/Locale/default.pot
+++ b/src/Locale/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-06-15 09:39:56 \n"
+"POT-Creation-Date: 2022-07-01 14:12:22 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -18,6 +18,9 @@ msgid "Actions on selected items"
 msgstr ""
 
 msgid "Add"
+msgstr ""
+
+msgid "Add custom property"
 msgstr ""
 
 msgid "Add translation"
@@ -95,7 +98,13 @@ msgstr ""
 msgid "Change File"
 msgstr ""
 
+msgid "Change left types"
+msgstr ""
+
 msgid "Change password"
+msgstr ""
+
+msgid "Change right types"
 msgstr ""
 
 msgid "Children"
@@ -456,6 +465,15 @@ msgid "No"
 msgstr ""
 
 msgid "No application"
+msgstr ""
+
+msgid "No core properties"
+msgstr ""
+
+msgid "No custom properties"
+msgstr ""
+
+msgid "No inherited properties"
 msgstr ""
 
 msgid "No items found"
@@ -987,6 +1005,9 @@ msgstr ""
 msgid "Do you really want to trash the object?"
 msgstr ""
 
+msgid "If you confirm, this resource will be gone forever. Are you sure?"
+msgstr ""
+
 msgid "yes, proceed"
 msgstr ""
 
@@ -1047,6 +1068,12 @@ msgstr ""
 msgid "Open Uri"
 msgstr ""
 
+msgid "Uri is valid"
+msgstr ""
+
+msgid "Uri is not valid"
+msgstr ""
+
 msgid "edit"
 msgstr ""
 
@@ -1073,7 +1100,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Title"
 msgstr ""
 
@@ -1081,7 +1108,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Address"
 msgstr ""
 
@@ -1089,7 +1116,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "GET"
 msgstr ""
 
@@ -1100,7 +1127,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "add new"
 msgstr ""
 
@@ -1115,7 +1142,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 
@@ -1136,7 +1163,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Every day"
 msgstr ""
 
@@ -1145,7 +1172,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Sunday"
 msgstr ""
 
@@ -1154,7 +1181,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Monday"
 msgstr ""
 
@@ -1163,7 +1190,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Tuesday"
 msgstr ""
 
@@ -1172,7 +1199,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Wednesday"
 msgstr ""
 
@@ -1181,7 +1208,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Thursday"
 msgstr ""
 
@@ -1190,7 +1217,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Friday"
 msgstr ""
 
@@ -1199,7 +1226,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Saturday"
 msgstr ""
 

--- a/src/Locale/en_US/default.po
+++ b/src/Locale/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-06-15 09:39:56 \n"
+"POT-Creation-Date: 2022-07-01 14:12:22 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -21,6 +21,9 @@ msgid "Actions on selected items"
 msgstr ""
 
 msgid "Add"
+msgstr ""
+
+msgid "Add custom property"
 msgstr ""
 
 msgid "Add translation"
@@ -98,7 +101,13 @@ msgstr ""
 msgid "Change File"
 msgstr ""
 
+msgid "Change left types"
+msgstr ""
+
 msgid "Change password"
+msgstr ""
+
+msgid "Change right types"
 msgstr ""
 
 msgid "Children"
@@ -459,6 +468,15 @@ msgid "No"
 msgstr ""
 
 msgid "No application"
+msgstr ""
+
+msgid "No core properties"
+msgstr ""
+
+msgid "No custom properties"
+msgstr ""
+
+msgid "No inherited properties"
 msgstr ""
 
 msgid "No items found"
@@ -990,6 +1008,9 @@ msgstr ""
 msgid "Do you really want to trash the object?"
 msgstr ""
 
+msgid "If you confirm, this resource will be gone forever. Are you sure?"
+msgstr ""
+
 msgid "yes, proceed"
 msgstr ""
 
@@ -1050,6 +1071,12 @@ msgstr ""
 msgid "Open Uri"
 msgstr ""
 
+msgid "Uri is valid"
+msgstr ""
+
+msgid "Uri is not valid"
+msgstr ""
+
 msgid "edit"
 msgstr ""
 
@@ -1076,7 +1103,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Title"
 msgstr ""
 
@@ -1084,7 +1111,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Address"
 msgstr ""
 
@@ -1092,7 +1119,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "GET"
 msgstr ""
 
@@ -1103,7 +1130,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "add new"
 msgstr ""
 
@@ -1118,7 +1145,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 
@@ -1139,7 +1166,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Every day"
 msgstr ""
 
@@ -1148,7 +1175,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Sunday"
 msgstr ""
 
@@ -1157,7 +1184,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Monday"
 msgstr ""
 
@@ -1166,7 +1193,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Tuesday"
 msgstr ""
 
@@ -1175,7 +1202,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Wednesday"
 msgstr ""
 
@@ -1184,7 +1211,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Thursday"
 msgstr ""
 
@@ -1193,7 +1220,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Friday"
 msgstr ""
 
@@ -1202,7 +1229,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Saturday"
 msgstr ""
 

--- a/src/Locale/it_IT/default.po
+++ b/src/Locale/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-06-15 09:39:56 \n"
+"POT-Creation-Date: 2022-07-01 14:12:22 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -22,6 +22,9 @@ msgstr "Azioni sugli oggetti selezionati"
 
 msgid "Add"
 msgstr "Aggiungi"
+
+msgid "Add custom property"
+msgstr "Aggiungi proprietà custom"
 
 msgid "Add translation"
 msgstr "Aggiungi traduzione"
@@ -98,8 +101,14 @@ msgstr "Categorie"
 msgid "Change File"
 msgstr "Cambia File"
 
+msgid "Change left types"
+msgstr "Cambia tipi di sinistra"
+
 msgid "Change password"
 msgstr "Cambia password"
+
+msgid "Change right types"
+msgstr "Cambia tipi di destra"
 
 msgid "Children"
 msgstr "Contenuti"
@@ -460,6 +469,15 @@ msgstr "No"
 
 msgid "No application"
 msgstr "Nessuna applicazione"
+
+msgid "No core properties"
+msgstr "Nessuna proprietà di base"
+
+msgid "No custom properties"
+msgstr "Nessuna proprietà personalizzata"
+
+msgid "No inherited properties"
+msgstr "Nessuna proprietà ereditata"
 
 msgid "No items found"
 msgstr "Nessun elemento trovato"
@@ -993,6 +1011,9 @@ msgstr "Questo dato verrà eliminato definitivamente. Vuoi proseguire?"
 msgid "Do you really want to trash the object?"
 msgstr "Vuoi davvero spostare l'oggetto nel cestino?"
 
+msgid "If you confirm, this resource will be gone forever. Are you sure?"
+msgstr "Se confermi, questa risorsa verrà eliminata definitivamente. Vuoi continuare?"
+
 msgid "yes, proceed"
 msgstr "sì, prosegui"
 
@@ -1054,6 +1075,12 @@ msgstr "Testo troppo breve. Lunghezza minima 3 caratteri. Riprova"
 
 msgid "Open Uri"
 msgstr "Apri indirizzo"
+
+msgid "Uri is valid"
+msgstr "Indirizzo valido"
+
+msgid "Uri is not valid"
+msgstr "Indirizzo non valido"
 
 msgid "edit"
 msgstr "modifica"

--- a/src/Template/Layout/js/app/components/uri-input.js
+++ b/src/Template/Layout/js/app/components/uri-input.js
@@ -43,6 +43,9 @@ export default {
         onChange(ev) {
             ev.preventDefault()
             ev.stopPropagation();
+            const span = document.getElementById(`valid_${this.el.id}`);
+            span.classList.remove('icon-check-1');
+            span.classList.remove('icon-error');
             this.el.value = this.el.value.trim();
             if (this.el.value.length === 0) {
                 return;
@@ -54,9 +57,6 @@ export default {
             if (!this.isValid) {
                 this.el.value = '';
             }
-            const span = document.getElementById(`valid_${this.el.id}`);
-            span.classList.remove('icon-check-1');
-            span.classList.remove('icon-error');
             span.classList.add(this.isValid ? 'icon-check-1' : 'icon-error');
             const message = this.isValid ? t`Uri is valid` : t`Uri is not valid`;
             span.innerHTML = message;

--- a/src/Template/Layout/js/app/components/uri-input.js
+++ b/src/Template/Layout/js/app/components/uri-input.js
@@ -63,7 +63,7 @@ export default {
         },
 
         isURLValid(url) {
-            const regex = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi;;
+            const regex = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi;
 
             return regex.test(url);
         }

--- a/src/Template/Layout/js/app/components/uri-input.js
+++ b/src/Template/Layout/js/app/components/uri-input.js
@@ -32,5 +32,40 @@ export default {
             window.open(this.el.value, '_blank').focus();
         });
         this.el.parentElement.appendChild(anchor);
+        const span = document.createElement('span');
+        span.id = `valid_${this.el.id}`;
+        span.style = 'padding-left: 10px';
+        this.el.parentElement.appendChild(span);
+        this.el.onchange = this.onChange.bind(this);
     },
+
+    methods: {
+        onChange(ev) {
+            ev.preventDefault()
+            ev.stopPropagation();
+            this.el.value = this.el.value.trim();
+            if (this.el.value.length === 0) {
+                return;
+            }
+            if (!this.el.value.startsWith('http')) {
+                this.el.value = `https://${this.el.value}`;
+            }
+            this.isValid = this.isURLValid(this.el.value);
+            if (!this.isValid) {
+                this.el.value = '';
+            }
+            const span = document.getElementById(`valid_${this.el.id}`);
+            span.classList.remove('icon-check-1');
+            span.classList.remove('icon-error');
+            span.classList.add(this.isValid ? 'icon-check-1' : 'icon-error');
+            const message = this.isValid ? t`Uri is valid` : t`Uri is not valid`;
+            span.innerHTML = message;
+        },
+
+        isURLValid(url) {
+            const regex = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi;;
+
+            return regex.test(url);
+        }
+    }
 };


### PR DESCRIPTION
This provides a validation on `uri` fields.
If uri doesn't start with `http`, on change it is updated to `https://{previuos val}`.
If uri is valid, a feedback message appears and you can continue.
If uri is not valid, the system empty it and shows a feedback message.

Bonus: translate some i18n strings