### PR TITLE
Status endpoint

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -14,6 +14,7 @@ namespace App;
 
 use App\Authentication\Identifier\ApiIdentifier;
 use App\Middleware\ProjectMiddleware;
+use App\Middleware\StatusMiddleware;
 use Authentication\AuthenticationService;
 use Authentication\AuthenticationServiceInterface;
 use Authentication\AuthenticationServiceProviderInterface;
@@ -117,6 +118,9 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
             // Load current project configuration if `multiproject` instance
             // Manager plugins will also be loaded here via `loadPluginsFromConfig()`
             ->add(new ProjectMiddleware($this))
+
+            // Provides a `GET /status` endpoint. This must be
+            ->add(new StatusMiddleware())
 
             // Handle plugin/theme assets like CakePHP normally does.
             ->add(new AssetMiddleware([

--- a/src/Middleware/StatusMiddleware.php
+++ b/src/Middleware/StatusMiddleware.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Http\Exception\MethodNotAllowedException;
+use Cake\Http\Exception\ServiceUnavailableException;
+use Cake\Log\LogTrait;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LogLevel;
+use Throwable;
+
+/**
+ * Middleware to serve a status endpoint.
+ */
+class StatusMiddleware implements MiddlewareInterface
+{
+    use LogTrait;
+
+    /**
+     * Path to the status endpoint.
+     *
+     * @var string
+     */
+    protected string $path = '/status';
+
+    /**
+     * Status middleware constructor.
+     *
+     * @param string|null $path Path to the status endpoint.
+     */
+    public function __construct(?string $path = null)
+    {
+        $this->path = $path ?? $this->path;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($request->getUri()->getPath() !== $this->path) {
+            // Request is not addressed to the status endpoint.
+            return $handler->handle($request);
+        }
+
+        if (!in_array(strtoupper($request->getMethod()), ['GET', 'HEAD', 'OPTIONS'])) {
+            // Status endpoint only supports GET and HEAD requests.
+            throw new MethodNotAllowedException();
+        }
+
+        $queryParams = $request->getQueryParams();
+        $full = filter_var($queryParams['full'] ?? null, FILTER_VALIDATE_BOOLEAN);
+        if (!$full) {
+            // Just a liveliness probe to check whether the server is up.
+            return new EmptyResponse();
+        }
+
+        try {
+            // Check if the API is reachable and up.
+            $client = ApiClientProvider::getApiClient();
+            $client->get('/status'); // Upon error, this will throw a \BEdita\SDK\BEditaClientException.
+        } catch (Throwable $e) {
+            $this->log(sprintf('API status endpoint failed or unreachable: %s', $e), LogLevel::CRITICAL);
+
+            throw new ServiceUnavailableException('API status returned an error or is unreachable');
+        }
+
+        return new EmptyResponse();
+    }
+}

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -15,6 +15,7 @@ namespace App\Test\TestCase;
 use App\Application;
 use App\Authentication\Identifier\ApiIdentifier;
 use App\Middleware\ProjectMiddleware;
+use App\Middleware\StatusMiddleware;
 use Authentication\AuthenticationService;
 use Authentication\Authenticator\AuthenticatorInterface;
 use Authentication\Identifier\IdentifierInterface;
@@ -57,6 +58,8 @@ class ApplicationTest extends TestCase
         static::assertInstanceOf(ErrorHandlerMiddleware::class, $middleware->current());
         $middleware->next();
         static::assertInstanceOf(ProjectMiddleware::class, $middleware->current());
+        $middleware->next();
+        static::assertInstanceOf(StatusMiddleware::class, $middleware->current());
         $middleware->next();
         static::assertInstanceOf(AssetMiddleware::class, $middleware->current());
         $middleware->next();

--- a/tests/TestCase/Middleware/StatusMiddlewareTest.php
+++ b/tests/TestCase/Middleware/StatusMiddlewareTest.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Middleware;
+
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Core\Configure;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * {@see \App\Middleware\StatusMiddleware} Test Case.
+ *
+ * @covers \App\Middleware\StatusMiddleware
+ */
+class StatusMiddlewareTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown(): void
+    {
+        ApiClientProvider::setApiClient(null);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Data provider for {@see StatusMiddlewareTest::testProcess()} test case.
+     *
+     * @return array[]
+     */
+    public function processProvider(): array
+    {
+        $config = function (?int $status): array {
+            return [
+                'API' => [
+                    'apiBaseUrl' => 'https://bedita.example.com',
+                    'apiKey' => 'test-api-key',
+                    'guzzleConfig' => [
+                        'handler' => MockHandler::createWithMiddleware([
+                            $status !== null ? new Response($status) : function (RequestInterface $request): void {
+                                throw new ConnectException('Connection refused for URI https://bedita.example.com', $request);
+                            },
+                        ]),
+                    ],
+                ],
+            ];
+        };
+
+        return [
+            'not status endpoint' => [200, '<title>Login | BEdita 4</title>', '/login'],
+            'method not allowed' => [405, 'Method Not Allowed', '/status', 'DELETE'],
+            'liveliness probe' => [204, null, '/status', 'GET', $config(503)],
+            'api status check (ok)' => [204, null, '/status?full=1', 'GET', $config(204)],
+            'api status check (error)' => [503, 'API status returned an error or is unreachable', '/status?full=1', 'GET', $config(503)],
+            'api status check (unreachable)' => [503, 'API status returned an error or is unreachable', '/status?full=1', 'GET', $config(null)],
+        ];
+    }
+
+    /**
+     * Test {@see \App\Middleware\StatusMiddleware::process()} method.
+     *
+     * @param int $expectedStatus Expected response status.
+     * @param string|null $expectedBody Expected response body contents, or `null` to expect an empty response.
+     * @param string $url Request URL (path and query).
+     * @param string $method Request method.
+     * @param array $config Configuration.
+     * @return void
+     * @dataProvider processProvider()
+     */
+    public function testProcess(int $expectedStatus, ?string $expectedBody, string $url, string $method = 'GET', array $config = []): void
+    {
+        Configure::write($config);
+
+        $this->_sendRequest($url, $method);
+
+        $this->assertResponseCode($expectedStatus);
+        if ($expectedBody === null) {
+            $this->assertResponseEmpty();
+        } else {
+            $this->assertResponseContains($expectedBody);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `GET /status` endpoint that can be used as a liveliness probe in distributed environments (e.g. a containerised deployment) to make auto-healing possible.

By default, the `GET /status` endpoint simply returns **204 No Content** without actually checking anything, as it is meant to be an health check to detect major issues such as fatal errors.

Additionally, the `GET /status` endpoint accepts an optional `?full=true` parameter to add an API reachability check. Although this shouldn't be used as a liveliness probe for Docker or Kubernetes (because an issue with the API would cause the manager container to restart in loop), it may be used by alerting systems to detect an issue with the connectivity between the manager and the APIs, such as a networking misconfiguration or other issues with the underlying infrastructure.

The `/status` endpoint is handled by a `StatusMiddleware`.