### PR TITLE
View core properties on first access

### DIFF
--- a/src/Template/Element/Form/core_properties.twig
+++ b/src/Template/Element/Form/core_properties.twig
@@ -1,4 +1,4 @@
-<property-view inline-template :tab-open="tabsOpen" tab-name="general">
+<property-view inline-template :tab-open="tabsOpen" :is-default-open=true tab-name="general">
     <section class="fieldset">
         <header @click.prevent="toggleVisibility()"
             class="tab unselectable"

--- a/src/Template/Layout/js/app/components/property-view/property-view.js
+++ b/src/Template/Layout/js/app/components/property-view/property-view.js
@@ -134,11 +134,17 @@ export default {
             return (tabs.indexOf(this.tabName) >= 0);
         },
         readTabsOpen() {
-            let tabs = [];
             if (localStorage.getItem(STORAGE_TABS_KEY)) {
-                tabs = JSON.parse(localStorage.getItem(STORAGE_TABS_KEY));
+                return JSON.parse(localStorage.getItem(STORAGE_TABS_KEY));
             }
-            return tabs;
+            // if `isDefaultOpen` is true, on the first access, this tab is saved as open
+            // Note: there can be only one tab having `tabName` and `isDefaultOpen` set as true
+            if (this.isDefaultOpen) {
+                localStorage.setItem(STORAGE_TABS_KEY, JSON.stringify([this.tabName]));
+                return [this.tabName];
+            };
+
+            return [];
         },
         updateStorage() {
             if (!this.tabName) {


### PR DESCRIPTION
At the first access to view item in a module `core` properties should be visible

Note: there can be only one tab having `tabName` and `isDefaultOpen` set as true