### PR TITLE
Data Modeling -> Object types modify: parent_name and table as combo

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -408,11 +408,20 @@ return [
      */
     // 'Maintenance' => [
     //     'message' => 'This page won\'t be available for some time. Try later',
-    // ]
+    // ],
 
     /**
      * The manager application name in the API (default is `manager`).
      * This is used in reading/writing manager configuration data.
      */
     // 'ManagerAppName' => 'my-manager-app',
+
+    /**
+     * Object types to add to core types, used in Data Modeling -> Object types.
+     */
+    // 'Model' => [
+    //     'objectTypesTables' => [
+    //         'MyPlugin.MyTable',
+    //     ],
+    // ],
 ];

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -417,7 +417,7 @@ return [
     // 'ManagerAppName' => 'my-manager-app',
 
     /**
-     * Object types to add to core types, used in Data Modeling -> Object types.
+     * Object types to add to core tables, used in Data Modeling -> Object types.
      */
     // 'Model' => [
     //     'objectTypesTables' => [

--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -431,4 +431,18 @@ class SchemaComponent extends Component
         $superParent = (string)Hash::get($types, $parent . '.parent_name');
         $this->setDescendant($name, $superParent, $types, $descendants);
     }
+
+    /**
+     * Get abstract types
+     *
+     * @return array
+     */
+    public function abstractTypes(): array
+    {
+        $features = $this->objectTypesFeatures();
+        $types = array_keys($features['descendants']);
+        sort($types);
+
+        return $types;
+    }
 }

--- a/src/Controller/Model/ObjectTypesController.php
+++ b/src/Controller/Model/ObjectTypesController.php
@@ -39,7 +39,7 @@ class ObjectTypesController extends ModelBaseController
         'BEdita/Core.Objects',
         'BEdita/Core.Profiles',
         'BEdita/Core.Publications',
-        'BEdita/Core.Users'
+        'BEdita/Core.Users',
     ];
     /**
      * Resource type currently used
@@ -74,8 +74,7 @@ class ObjectTypesController extends ModelBaseController
         $objectTypeProperties = $this->prepareProperties((array)$response['data'], $name);
         $this->set(compact('objectTypeProperties'));
         $schema = $this->Schema->getSchema();
-        if ((bool)Hash::get($resource, 'meta.core_type') === false)
-        {
+        if ((bool)Hash::get($resource, 'meta.core_type') === false) {
             $schema['properties']['table'] = ['type' => 'string', 'enum' => $this->tables($resource)];
             $schema['properties']['parent_name'] = ['type' => 'string', 'enum' => [''] + $this->Schema->abstractTypes()];
         }

--- a/src/Controller/Model/ObjectTypesController.php
+++ b/src/Controller/Model/ObjectTypesController.php
@@ -94,8 +94,14 @@ class ObjectTypesController extends ModelBaseController
         if ((bool)Hash::get($resource, 'meta.core_type')) {
             return $schema;
         }
-        $schema['properties']['table'] = ['type' => 'string', 'enum' => $this->tables($resource)];
-        $schema['properties']['parent_name'] = ['type' => 'string', 'enum' => [''] + $this->Schema->abstractTypes()];
+        $schema['properties']['table'] = [
+            'type' => 'string',
+            'enum' => $this->tables($resource),
+        ];
+        $schema['properties']['parent_name'] = [
+            'type' => 'string',
+            'enum' => array_merge([''], $this->Schema->abstractTypes()),
+        ];
 
         return $schema;
     }

--- a/src/Controller/Model/ObjectTypesController.php
+++ b/src/Controller/Model/ObjectTypesController.php
@@ -74,14 +74,30 @@ class ObjectTypesController extends ModelBaseController
         $objectTypeProperties = $this->prepareProperties((array)$response['data'], $name);
         $this->set(compact('objectTypeProperties'));
         $schema = $this->Schema->getSchema();
-        if ((bool)Hash::get($resource, 'meta.core_type') === false) {
-            $schema['properties']['table'] = ['type' => 'string', 'enum' => $this->tables($resource)];
-            $schema['properties']['parent_name'] = ['type' => 'string', 'enum' => [''] + $this->Schema->abstractTypes()];
-        }
-        $this->set('schema', $schema);
+        $this->set('schema', $this->updateSchema($schema, $resource));
         $this->set('properties', $this->Properties->viewGroups($resource, $this->resourceType));
 
         return null;
+    }
+
+    /**
+     * Update schema using resource.
+     * If core type, skip.
+     * Otherwise, set table and parent_name.
+     *
+     * @param array $schema The schema
+     * @param array $resource The resource
+     * @return array
+     */
+    protected function updateSchema(array $schema, array $resource): array
+    {
+        if ((bool)Hash::get($resource, 'meta.core_type')) {
+            return $schema;
+        }
+        $schema['properties']['table'] = ['type' => 'string', 'enum' => $this->tables($resource)];
+        $schema['properties']['parent_name'] = ['type' => 'string', 'enum' => [''] + $this->Schema->abstractTypes()];
+
+        return $schema;
     }
 
     /**

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -711,4 +711,16 @@ class SchemaComponentTest extends TestCase
         $result = $this->Schema->objectTypesFeatures();
         static::assertEmpty($result);
     }
+
+    /**
+     * Test `abstractTypes`
+     *
+     * @return void
+     * @covers ::abstractTypes()
+     */
+    public function testAbstractTypes(): void
+    {
+        $actual = $this->Schema->abstractTypes();
+        static::assertIsArray($actual);
+    }
 }

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -138,7 +138,7 @@ class ObjectTypesControllerTest extends TestCase
     public function testView(): void
     {
         $this->setupController();
-        $this->ModelController->view(1);
+        $this->ModelController->view(2);
         $vars = ['resource', 'schema', 'properties'];
         foreach ($vars as $var) {
             static::assertNotEmpty($this->ModelController->viewBuilder()->getVar($var));
@@ -161,6 +161,53 @@ class ObjectTypesControllerTest extends TestCase
         $this->setupController();
         $result = $this->ModelController->view(0);
         static::assertTrue(($result instanceof Response));
+    }
+
+    /**
+     * Test `updateSchema`
+     *
+     * @return void
+     * @covers ::updateSchema()
+     */
+    public function testUpdateSchema(): void
+    {
+        $this->setupController();
+        $expected = $schema = ['whatever'];
+        $resource = ['meta' => ['core_type' => true]];
+        $reflectionClass = new \ReflectionClass($this->ModelController);
+        $method = $reflectionClass->getMethod('updateSchema');
+        $method->setAccessible(true);
+        $actual = $method->invokeArgs($this->ModelController, [$schema, $resource]);
+        static::assertSame($expected, $actual);
+
+        $resource = ['meta' => ['core_type' => false]];
+        $expected = [
+            'whatever',
+            'properties' => [
+                'table' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'BEdita/Core.Folders',
+                        'BEdita/Core.Links',
+                        'BEdita/Core.Locations',
+                        'BEdita/Core.Media',
+                        'BEdita/Core.Objects',
+                        'BEdita/Core.Profiles',
+                        'BEdita/Core.Publications',
+                        'BEdita/Core.Users',
+                    ],
+                ],
+                'parent_name' => [
+                    'type' => 'string',
+                    'enum' => [
+                        '',
+                        'objects',
+                    ],
+                ],
+            ],
+        ];
+        $actual = $method->invokeArgs($this->ModelController, [$schema, $resource]);
+        static::assertSame($expected, $actual);
     }
 
     /**

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -201,6 +201,7 @@ class ObjectTypesControllerTest extends TestCase
                     'type' => 'string',
                     'enum' => [
                         '',
+                        'media',
                         'objects',
                     ],
                 ],

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -15,7 +15,6 @@ namespace App\Test\TestCase\Controller\Model;
 
 use App\Controller\Model\ObjectTypesController;
 use BEdita\SDK\BEditaClient;
-use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Core\Configure;
 use Cake\Http\Response;
@@ -247,49 +246,5 @@ class ObjectTypesControllerTest extends TestCase
         $method->setAccessible(true);
         $actual = $method->invokeArgs($this->ModelController, []);
         static::assertSame($expected, $actual);
-    }
-
-    /**
-     * Test `abstractTypes`
-     *
-     * @return void
-     * @covers ::abstractTypes()
-     */
-    public function testAbstractTypes(): void
-    {
-        $this->setupController();
-        $reflectionClass = new \ReflectionClass($this->ModelController);
-        $method = $reflectionClass->getMethod('abstractTypes');
-        $method->setAccessible(true);
-        $actual = $method->invokeArgs($this->ModelController, []);
-        static::assertIsArray($actual);
-    }
-
-    /**
-     * Test `abstractTypes`, on exception
-     *
-     * @return void
-     * @covers ::abstractTypes()
-     */
-    public function testAbstractTypesException(): void
-    {
-        // Setup mock API client for exception.
-        $apiClient = $this->getMockBuilder(BEditaClient::class)
-            ->setConstructorArgs(['https://api.example.org'])
-            ->getMock();
-        $apiClient->method('get')
-            ->with('/model/object_types')
-            ->willThrowException(new BEditaClientException('test'));
-        ApiClientProvider::setApiClient($apiClient);
-        $this->ModelController = new ObjectTypesController(
-            new ServerRequest($this->defaultRequestConfig)
-        );
-        $reflectionClass = new \ReflectionClass($this->ModelController);
-        $method = $reflectionClass->getMethod('abstractTypes');
-        $method->setAccessible(true);
-        $actual = $method->invokeArgs($this->ModelController, []);
-        static::assertIsArray($actual);
-        $flash = $this->ModelController->getRequest()->getSession()->read('Flash.flash.0.message');
-        static::assertEquals('test', $flash);
     }
 }

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -239,12 +239,13 @@ class ObjectTypesControllerTest extends TestCase
             )
         );
         $expected = array_unique(array_merge(ObjectTypesController::TABLES, $testTables));
+        $expected = array_unique(array_merge($expected, ['dummy']));
         sort($expected);
         $this->setupController();
         $reflectionClass = new \ReflectionClass($this->ModelController);
         $method = $reflectionClass->getMethod('tables');
         $method->setAccessible(true);
-        $actual = $method->invokeArgs($this->ModelController, []);
+        $actual = $method->invokeArgs($this->ModelController, [['attributes' => ['table' => 'dummy']]]);
         static::assertSame($expected, $actual);
     }
 }


### PR DESCRIPTION
This deals with two tasks from https://github.com/bedita/manager/issues/804:

 - Parent name should be an abstract objects only select combo
 - Table should be a select combo (static list for now, result of an api call in the future)

A new configuration has been introduced: `Model.objectTypesTables`, used to fill the select combo list for `table` in data modeling (config list of tables is added to core tables). Configuration example:

```
'Model' => [
    'objectTypesTables' => [
        'MyPlugin.Cats',
        'MyPlugin.Dogs',
    ],
],
```
