### PR TITLE
Data Modeling -> Object types modify: custom property type as combo + associations as list of checkboxes

### DIFF
--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -312,7 +312,7 @@ class PropertiesComponent extends Component
     /**
      * Get associations options for select multiple as list of checkboxes
      *
-     * @param array $value
+     * @param array $value The value
      * @return array
      */
     public function associationsOptions(array $value): array

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -18,6 +18,7 @@ use Cake\Cache\Cache;
 use Cake\Controller\Component;
 use Cake\Core\Configure;
 use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
 
 /**
  * Component to handle properties view in modules.
@@ -26,6 +27,23 @@ use Cake\Utility\Hash;
  */
 class PropertiesComponent extends Component
 {
+    /**
+     * Schema property types
+     */
+    public const CUSTOM_PROPERTY_TYPES = [
+        'boolean',
+        'date',
+        'datetime',
+        'email',
+        'integer',
+        'json',
+        'number',
+        'string',
+        'text',
+        'text_plain',
+        'url',
+    ];
+
     /**
      * @inheritDoc
      */
@@ -271,5 +289,23 @@ class PropertiesComponent extends Component
     public function readonlyRelationsList(string $type): array
     {
         return (array)$this->getConfig(sprintf('Properties.%s.relations._readonly', $type), []);
+    }
+
+    /**
+     * Types options for property Type select combo
+     *
+     * @return array
+     */
+    public function typesOptions(): array
+    {
+        $label = __('Type');
+        $type = 'select';
+        $options = ['' => ''];
+        foreach (self::CUSTOM_PROPERTY_TYPES as $value) {
+            $text = Inflector::humanize($value);
+            $options[] = compact('text', 'value');
+        }
+
+        return compact('label', 'type', 'options');
     }
 }

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -14,6 +14,7 @@
 namespace App\Controller\Component;
 
 use App\Utility\CacheTools;
+use BEdita\WebTools\ApiClientProvider;
 use Cake\Cache\Cache;
 use Cake\Controller\Component;
 use Cake\Core\Configure;
@@ -27,23 +28,6 @@ use Cake\Utility\Inflector;
  */
 class PropertiesComponent extends Component
 {
-    /**
-     * Schema property types
-     */
-    public const CUSTOM_PROPERTY_TYPES = [
-        'boolean',
-        'date',
-        'datetime',
-        'email',
-        'integer',
-        'json',
-        'number',
-        'string',
-        'text',
-        'text_plain',
-        'url',
-    ];
-
     /**
      * @inheritDoc
      */
@@ -301,7 +285,10 @@ class PropertiesComponent extends Component
         $label = __('Type');
         $type = 'select';
         $options = ['' => ''];
-        foreach (self::CUSTOM_PROPERTY_TYPES as $value) {
+        $apiClient = ApiClientProvider::getApiClient();
+        $response = (array)$apiClient->get('/model/property_types', []);
+        $types = (array)Hash::extract($response, 'data.{n}.attributes.name');
+        foreach ($types as $value) {
             $text = Inflector::humanize($value);
             $options[] = compact('text', 'value');
         }

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -308,4 +308,27 @@ class PropertiesComponent extends Component
 
         return compact('label', 'type', 'options');
     }
+
+    /**
+     * Get associations options for select multiple as list of checkboxes
+     *
+     * @param array $value
+     * @return array
+     */
+    public function associationsOptions(array $value): array
+    {
+        $fields = [
+            'DateRanges',
+            'Streams',
+            'Categories',
+            'Tags',
+        ];
+        $fields = array_unique(array_merge($fields, $value));
+        foreach ($fields as $text) {
+            $value = $text;
+            $options[] = compact('text', 'value');
+        }
+
+        return $options;
+    }
 }

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -286,7 +286,11 @@ class PropertiesComponent extends Component
         $type = 'select';
         $options = ['' => ''];
         $apiClient = ApiClientProvider::getApiClient();
-        $response = (array)$apiClient->get('/model/property_types', []);
+        $query = [
+            'page_size' => 100,
+            'sort' => 'id',
+        ];
+        $response = (array)$apiClient->get('/model/property_types', $query);
         $types = (array)Hash::extract($response, 'data.{n}.attributes.name');
         foreach ($types as $value) {
             $text = Inflector::humanize($value);

--- a/src/Controller/Model/ObjectTypesController.php
+++ b/src/Controller/Model/ObjectTypesController.php
@@ -76,6 +76,7 @@ class ObjectTypesController extends ModelBaseController
         $schema = $this->Schema->getSchema();
         $this->set('schema', $this->updateSchema($schema, $resource));
         $this->set('properties', $this->Properties->viewGroups($resource, $this->resourceType));
+        $this->set('propertyTypesOptions', $this->Properties->typesOptions());
 
         return null;
     }

--- a/src/Controller/Model/ObjectTypesController.php
+++ b/src/Controller/Model/ObjectTypesController.php
@@ -77,6 +77,7 @@ class ObjectTypesController extends ModelBaseController
         $this->set('schema', $this->updateSchema($schema, $resource));
         $this->set('properties', $this->Properties->viewGroups($resource, $this->resourceType));
         $this->set('propertyTypesOptions', $this->Properties->typesOptions());
+        $this->set('associationsOptions', $this->Properties->associationsOptions((array)Hash::get($resource, 'attributes.associations')));
 
         return null;
     }

--- a/src/Template/Pages/Model/ObjectTypes/view.twig
+++ b/src/Template/Pages/Model/ObjectTypes/view.twig
@@ -48,7 +48,7 @@
                     <div class="tab-container">
                         <header class="unselectable"><h2>{{ __('Add custom property') }}</h2></header>
                         {{ Property.control('prop_name', '', {'label': __('Name'), 'placeholder': 'property name'})|raw }}
-                        {{ Property.control('prop_type', '', propertyTypesOptions)|raw }}
+                        {{ Property.control('prop_type', '', propertyTypesOptions|default([]))|raw }}
                     </div>
                 </section>
 

--- a/src/Template/Pages/Model/ObjectTypes/view.twig
+++ b/src/Template/Pages/Model/ObjectTypes/view.twig
@@ -46,23 +46,9 @@
 
                 <section class="fieldset">
                     <div class="tab-container">
-                    <header class="unselectable"><h2>{{ __('Add custom property') }}</h2></header>
-                        <div class="input">
-                            <label for="prop_name">{{ __('Name') }}</label>
-                            <div>
-                                {{ Form.text('prop_name', {
-                                        'placeholder': 'property name',
-                                        'class': 'input',
-                                })|raw }}
-                            </div>
-                            <label for="prop_type">{{ __('Type') }}</label>
-                            <div>
-                                {{ Form.text('prop_type', {
-                                        'placeholder': 'property type',
-                                        'class': 'input',
-                                })|raw }}
-                            </div>
-                        </div>
+                        <header class="unselectable"><h2>{{ __('Add custom property') }}</h2></header>
+                        {{ Property.control('prop_name', '', {'label': __('Name'), 'placeholder': 'property name'})|raw }}
+                        {{ Property.control('prop_type', '', propertyTypesOptions)|raw }}
                     </div>
                 </section>
 

--- a/src/Template/Pages/Model/ObjectTypes/view.twig
+++ b/src/Template/Pages/Model/ObjectTypes/view.twig
@@ -58,9 +58,17 @@
                 <section class="fieldset">
                     <div class="tab-container">
                         {% for key, value in properties.core %}
-                            {% set options = Schema.controlOptions(key, value, schema.properties[key]) %}
-                            {% if options.class == 'json' %}
+                            {% if key == 'hidden' %}
+                                {% set options = Schema.controlOptions(key, value, schema.properties[key]) %}
                                 {{ Property.control(key, value, options|merge({'id': key}))|raw }}
+                            {% elseif key == 'associations' %}
+                                {{ Form.control(key, {
+                                    'id': key,
+                                    'value': value,
+                                    'type': 'select',
+                                    'multiple': 'checkbox',
+                                    'options': associationsOptions
+                                })|raw }}
                             {% endif %}
                         {% endfor %}
                     </div>

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -503,4 +503,20 @@ class PropertiesComponentTest extends TestCase
             static::assertEquals($v, $result[$k]);
         }
     }
+
+    /**
+     * Test `typesOptions`.
+     *
+     * @return void
+     * @covers ::typesOptions()
+     */
+    public function testTypesOptions(): void
+    {
+        $this->createComponent();
+        $actual = $this->Properties->typesOptions();
+        static::assertIsArray($actual);
+        static::assertIsArray($actual['options']);
+        static::assertEquals('Type', $actual['label']);
+        static::assertEquals('select', $actual['type']);
+    }
 }

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -519,4 +519,24 @@ class PropertiesComponentTest extends TestCase
         static::assertEquals('Type', $actual['label']);
         static::assertEquals('select', $actual['type']);
     }
+
+    /**
+     * Test `associationsOptions`
+     *
+     * @return void
+     * @covers ::associationsOptions()
+     */
+    public function testAssociationsOptions(): void
+    {
+        $this->createComponent();
+        $expected = [
+            ['text' => 'DateRanges', 'value' => 'DateRanges'],
+            ['text' => 'Streams', 'value' => 'Streams'],
+            ['text' => 'Categories', 'value' => 'Categories'],
+            ['text' => 'Tags', 'value' => 'Tags'],
+            ['text' => 'Dummy', 'value' => 'Dummy'],
+        ];
+        $actual = $this->Properties->associationsOptions(['Dummy']);
+        static::assertEquals($expected, $actual);
+    }
 }

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -139,7 +139,7 @@ class ObjectTypesControllerTest extends TestCase
     {
         $this->setupController();
         $this->ModelController->view(2);
-        $vars = ['resource', 'schema', 'properties', 'propertyTypesOptions'];
+        $vars = ['resource', 'schema', 'properties', 'propertyTypesOptions', 'associationsOptions'];
         foreach ($vars as $var) {
             static::assertNotEmpty($this->ModelController->viewBuilder()->getVar($var));
         }

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -139,7 +139,7 @@ class ObjectTypesControllerTest extends TestCase
     {
         $this->setupController();
         $this->ModelController->view(2);
-        $vars = ['resource', 'schema', 'properties'];
+        $vars = ['resource', 'schema', 'properties', 'propertyTypesOptions'];
         foreach ($vars as $var) {
             static::assertNotEmpty($this->ModelController->viewBuilder()->getVar($var));
         }


### PR DESCRIPTION
This provides 2 tasks from https://github.com/bedita/manager/issues/804:

- Single custom property Type should be a property_types select combo
- Associations should be a list of checkboxes (static list for now: DateRanges, Streams, Categories, Tags; there could be an extra value from api: show it as readonly checked)