### PR TITLE
Fix `PermsHelper::canLock()`

### DIFF
--- a/src/View/Helper/PermsHelper.php
+++ b/src/View/Helper/PermsHelper.php
@@ -56,9 +56,10 @@ class PermsHelper extends Helper
      */
     public function canLock(): bool
     {
-        $roles = (array)Hash::get((array)$this->_View->get('user'), 'roles');
+        /** @var \Authentication\Identity $identity */
+        $identity = $this->_View->get('user');
 
-        return in_array('admin', $roles);
+        return in_array('admin', (array)$identity->get('roles'));
     }
 
     /**

--- a/tests/TestCase/View/Helper/PermsHelperTest.php
+++ b/tests/TestCase/View/Helper/PermsHelperTest.php
@@ -14,6 +14,7 @@
 namespace App\Test\TestCase\View\Helper;
 
 use App\View\Helper\PermsHelper;
+use Authentication\Identity;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
 
@@ -128,10 +129,13 @@ class PermsHelperTest extends TestCase
      */
     public function testCanLock(): void
     {
-        $actual = $this->Perms->canLock();
-        $expected = false;
+        $this->Perms->getView()->set('user', new Identity([]));
+        $result = $this->Perms->canLock();
+        static::assertFalse($result);
 
-        static::assertEquals($expected, $actual);
+        $this->Perms->getView()->set('user', new Identity(['roles' => ['admin']]));
+        $result = $this->Perms->canLock();
+        static::assertTrue($result);
     }
 
     /**


### PR DESCRIPTION
Since the introduction of the authentication plugin and component in #691 the method `PermsHelper::canLock()` has always returned `false` => the `Lock` button was never available in the object detail

