### PR TITLE
Feat/media detail layout

### DIFF
--- a/src/Locale/default.pot
+++ b/src/Locale/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-07-27 08:08:30 \n"
+"POT-Creation-Date: 2022-08-10 07:15:19 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -30,6 +30,9 @@ msgid "Administration"
 msgstr ""
 
 msgid "Advanced"
+msgstr ""
+
+msgid "Advanced Data"
 msgstr ""
 
 msgid "Alert Message"
@@ -699,6 +702,12 @@ msgid "Sign in"
 msgstr ""
 
 msgid "Size"
+msgstr ""
+
+msgid "Sorry, your browser does not support embedded %s element"
+msgstr ""
+
+msgid "Sorry, your browser does not support embedded {0} element"
 msgstr ""
 
 msgid "State Name"

--- a/src/Locale/default.pot
+++ b/src/Locale/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-08-10 07:15:19 \n"
+"POT-Creation-Date: 2022-08-10 07:30:34 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -707,9 +707,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-msgid "Sorry, your browser does not support embedded %s element"
-msgstr ""
-
 msgid "Sorry, your browser does not support embedded {0} element"
 msgstr ""
 
@@ -1154,7 +1151,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Title"
 msgstr ""
 
@@ -1162,7 +1159,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Address"
 msgstr ""
 
@@ -1170,7 +1167,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "GET"
 msgstr ""
 
@@ -1181,7 +1178,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "add new"
 msgstr ""
 
@@ -1196,7 +1193,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 
@@ -1217,7 +1214,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Every day"
 msgstr ""
 
@@ -1226,7 +1223,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Sunday"
 msgstr ""
 
@@ -1235,7 +1232,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Monday"
 msgstr ""
 
@@ -1244,7 +1241,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Tuesday"
 msgstr ""
 
@@ -1253,7 +1250,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Wednesday"
 msgstr ""
 
@@ -1262,7 +1259,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Thursday"
 msgstr ""
 
@@ -1271,7 +1268,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Friday"
 msgstr ""
 
@@ -1280,7 +1277,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Saturday"
 msgstr ""
 

--- a/src/Locale/en_US/default.po
+++ b/src/Locale/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-07-27 08:08:30 \n"
+"POT-Creation-Date: 2022-08-10 07:15:19 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -33,6 +33,9 @@ msgid "Administration"
 msgstr ""
 
 msgid "Advanced"
+msgstr ""
+
+msgid "Advanced Data"
 msgstr ""
 
 msgid "Alert Message"
@@ -704,6 +707,12 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
+msgid "Sorry, your browser does not support embedded %s element"
+msgstr ""
+
+msgid "Sorry, your browser does not support embedded {0} element"
+msgstr ""
+
 msgid "State Name"
 msgstr ""
 
@@ -1145,7 +1154,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Title"
 msgstr ""
 
@@ -1153,7 +1162,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Address"
 msgstr ""
 
@@ -1161,7 +1170,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "GET"
 msgstr ""
 
@@ -1172,7 +1181,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "add new"
 msgstr ""
 
@@ -1187,7 +1196,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 
@@ -1208,7 +1217,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Every day"
 msgstr ""
 
@@ -1217,7 +1226,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Sunday"
 msgstr ""
 
@@ -1226,7 +1235,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Monday"
 msgstr ""
 
@@ -1235,7 +1244,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Tuesday"
 msgstr ""
 
@@ -1244,7 +1253,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Wednesday"
 msgstr ""
 
@@ -1253,7 +1262,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Thursday"
 msgstr ""
 
@@ -1262,7 +1271,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Friday"
 msgstr ""
 
@@ -1271,7 +1280,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Saturday"
 msgstr ""
 

--- a/src/Locale/en_US/default.po
+++ b/src/Locale/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-08-10 07:15:19 \n"
+"POT-Creation-Date: 2022-08-10 07:30:34 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -710,9 +710,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-msgid "Sorry, your browser does not support embedded %s element"
-msgstr ""
-
 msgid "Sorry, your browser does not support embedded {0} element"
 msgstr ""
 
@@ -1157,7 +1154,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Title"
 msgstr ""
 
@@ -1165,7 +1162,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Address"
 msgstr ""
 
@@ -1173,7 +1170,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "GET"
 msgstr ""
 
@@ -1184,7 +1181,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "add new"
 msgstr ""
 
@@ -1199,7 +1196,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 
@@ -1220,7 +1217,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Every day"
 msgstr ""
 
@@ -1229,7 +1226,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Sunday"
 msgstr ""
 
@@ -1238,7 +1235,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Monday"
 msgstr ""
 
@@ -1247,7 +1244,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Tuesday"
 msgstr ""
 
@@ -1256,7 +1253,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Wednesday"
 msgstr ""
 
@@ -1265,7 +1262,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Thursday"
 msgstr ""
 
@@ -1274,7 +1271,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Friday"
 msgstr ""
 
@@ -1283,7 +1280,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Saturday"
 msgstr ""
 

--- a/src/Locale/it_IT/default.po
+++ b/src/Locale/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-08-10 07:15:19 \n"
+"POT-Creation-Date: 2022-08-10 07:30:34 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -712,9 +712,6 @@ msgstr "Accedi"
 msgid "Size"
 msgstr "Dimensione"
 
-msgid "Sorry, your browser does not support embedded %s element"
-msgstr ""
-
 msgid "Sorry, your browser does not support embedded {0} element"
 msgstr "Spiacenti, il tuo browser non supporta l'elemento {0} incorporato"
 
@@ -1163,7 +1160,7 @@ msgstr "Password"
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Title"
 msgstr "Titolo"
 
@@ -1171,7 +1168,7 @@ msgstr "Titolo"
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Address"
 msgstr "Indirizzo"
 
@@ -1179,7 +1176,7 @@ msgstr "Indirizzo"
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "GET"
 msgstr ""
 
@@ -1190,7 +1187,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "add new"
 msgstr "aggiungi nuovo"
 
@@ -1205,7 +1202,7 @@ msgstr "Rimosso"
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr "Nessun dato di Cronologia"
 
@@ -1228,7 +1225,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Every day"
 msgstr "Tutti i giorni"
 
@@ -1237,7 +1234,7 @@ msgstr "Tutti i giorni"
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Sunday"
 msgstr "Domenica"
 
@@ -1246,7 +1243,7 @@ msgstr "Domenica"
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Monday"
 msgstr "Lunedì"
 
@@ -1255,7 +1252,7 @@ msgstr "Lunedì"
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Tuesday"
 msgstr "Martedì"
 
@@ -1264,7 +1261,7 @@ msgstr "Martedì"
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Wednesday"
 msgstr "Mercoledì"
 
@@ -1273,7 +1270,7 @@ msgstr "Mercoledì"
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Thursday"
 msgstr "Giovedì"
 
@@ -1282,7 +1279,7 @@ msgstr "Giovedì"
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Friday"
 msgstr "Venerdì"
 
@@ -1291,7 +1288,7 @@ msgstr "Venerdì"
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Saturday"
 msgstr "Sabato"
 

--- a/src/Locale/it_IT/default.po
+++ b/src/Locale/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-07-27 08:08:30 \n"
+"POT-Creation-Date: 2022-08-10 07:15:19 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -34,6 +34,9 @@ msgstr "Amministrazione"
 
 msgid "Advanced"
 msgstr "Avanzate"
+
+msgid "Advanced Data"
+msgstr "Dati Avanzati"
 
 msgid "Alert Message"
 msgstr "Messaggio di Attenzione"
@@ -705,6 +708,12 @@ msgstr "Accedi"
 
 msgid "Size"
 msgstr "Dimensione"
+
+msgid "Sorry, your browser does not support embedded %s element"
+msgstr ""
+
+msgid "Sorry, your browser does not support embedded {0} element"
+msgstr "Spiacenti, il tuo browser non supporta l'elemento {0} incorporato"
 
 msgid "State Name"
 msgstr "Provincia"

--- a/src/Template/Element/Form/media.twig
+++ b/src/Template/Element/Form/media.twig
@@ -1,15 +1,12 @@
 {% if streams or object.attributes.provider_extra.html %}
 <property-view inline-template :tab-open="tabsOpen" :is-default-open=true :tab-open-at-start=true>
-
     <section class="fieldset">
         <header @click.prevent="toggleVisibility()"
             class="tab unselectable"
             :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
             <h2>{{ __('Media') }}</h2>
         </header>
-
         <div v-show="isOpen" class="tab-container">
-
             {# Display embedded video if available #}
             {% if object.attributes.provider_extra.html %}
                 <div class="embedded-container"
@@ -54,13 +51,48 @@
                     {% endif %}
                 </div>
 
-                <div>
-                    {# Stream properties #}
-                    {# Display properties list without edit inputs, they're not changeable #}
-                    {% set attributes = stream.attributes|merge(stream.meta) %}
-                    <table>
-                        <tbody>
-                            {% for k, val in attributes %}
+                {# Stream properties #}
+                {# Display properties list without edit inputs, they're not changeable #}
+                {% set attributes = stream.attributes|merge(stream.meta) %}
+
+                <div class="mt-1 grid-span-full is-flex align-center">
+
+                    {% if attributes.url %}
+                    <a href="{{ attributes.url }}" target="_blank"
+                            class="mr-1 button button-outlined button-outlined-hover-module-{{ currentModule.name }}">
+                            {{ __('View file') }}
+                    </a>
+                    {% endif %}
+
+                    <a href="{{ Url.build({'_name': 'stream:download', 'id': stream.id}) }}"
+                            class="mr-1 button button-outlined button-outlined-hover-module-{{ currentModule.name }}">
+                            {{ __('Download file') }}
+                    </a>
+
+                    <div class="mr-1 has-text-size-large">{{ __('Change File') }}:</div>
+                    <div>
+                        {{ Form.control('file', { 'type': 'file', 'label': false}) | raw }}
+                        {{ Form.hidden('MAX_FILE_SIZE', { 'value': System.getMaxFileSize() })|raw }}
+                        {{ Form.control('model-type', { 'type': 'hidden', 'value': object.type}) | raw }}
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+    </section>
+</property-view>
+
+<property-view inline-template :tab-open="tabsOpen" :is-default-open=false :tab-open-at-start=false>
+    <section class="fieldset">
+        <header @click.prevent="toggleVisibility()"
+            class="tab unselectable"
+            :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+            <h2>{{ __('Advanced Data') }}</h2>
+        </header>
+        <div v-show="isOpen" class="tab-container">
+            <div class="grid-span-full mt-1">
+                <table class="inside-bordered">
+                    <tbody>
+                        {% for k, val in attributes %}
                             {% if val and k != 'file_metadata' %}
                                 <tr>
                                     <th class="nowrap">{{ k|humanize }} :</th>
@@ -81,48 +113,19 @@
                                     </td>
                                 </tr>
                             {% endif %}
-                            {% endfor %}
-                        </tbody>
-                    </table>
-
-                </div>
-
-                <div class="grid-span-full mt-1">
-
-                    {% if attributes.url %}
-                    <a href="{{ attributes.url }}" target="_blank"
-                            class="button button-outlined button-outlined-hover-module-{{ currentModule.name }}">
-                            {{ __('View file') }}
-                    </a>
-                    {% endif %}
-
-                    <a href="{{ Url.build({'_name': 'stream:download', 'id': stream.id}) }}"
-                            class="button button-outlined button-outlined-hover-module-{{ currentModule.name }}">
-                            {{ __('Download file') }}
-                    </a>
-
-                </div>
+                        {% endfor %}
+                    </tbody>
+                </table>
                 {% if attributes.file_metadata %}
-                <div class="grid-span-full mt-1">
-                    <h3>{{ __('Metadata') }}</h3>
-                    <div>
-                        <textarea style="min-height: 10rem; resize: none;" readonly>{{ attributes.file_metadata|json_encode(constant('JSON_PRETTY_PRINT')) }}</textarea>
+                    <div class="grid-span-full mt-1">
+                        <h3>{{ __('Metadata') }}</h3>
+                        <div>
+                            <textarea style="min-height: 10rem; resize: none;" readonly>{{ attributes.file_metadata|json_encode(constant('JSON_PRETTY_PRINT')) }}</textarea>
+                        </div>
                     </div>
-                </div>
                 {% endif %}
-
-                <div class="grid-span-full mt-1">
-                    <h3>{{ __('Change File') }}</h3>
-                    <div>
-                        {{ Form.control('file', { 'type': 'file', 'label': false }) | raw }}
-                        {{ Form.hidden('MAX_FILE_SIZE', { 'value': System.getMaxFileSize() })|raw }}
-                        {{ Form.control('model-type', { 'type': 'hidden', 'value': object.type}) | raw }}
-                    </div>
-                </div>
-            {% endif %}
-
+            </div>
         </div>
     </section>
-
 </property-view>
 {% endif %}

--- a/src/Template/Element/Form/media.twig
+++ b/src/Template/Element/Form/media.twig
@@ -48,6 +48,15 @@
                                 </a>
                             </figure>
                         {% endif %}
+                    {% elseif object.type == 'videos' %}
+                            <video controls width="100%">
+                                <source src="{{ stream.meta.url }}" type="{{ stream.attributes.mime_type }}">
+                                Sorry, your browser does not support embedded <code>video</code> element.
+                            </video>
+                    {% elseif object.type == 'audio' %}
+                        <audio controls src="{{ stream.meta.url }}">
+                                Sorry, your browser does not support the <code>audio</code> element.
+                        </audio>
                     {% endif %}
                 </div>
 
@@ -81,51 +90,53 @@
     </section>
 </property-view>
 
-<property-view inline-template :tab-open="tabsOpen" :is-default-open=false :tab-open-at-start=false>
-    <section class="fieldset">
-        <header @click.prevent="toggleVisibility()"
-            class="tab unselectable"
-            :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
-            <h2>{{ __('Advanced Data') }}</h2>
-        </header>
-        <div v-show="isOpen" class="tab-container">
-            <div class="grid-span-full mt-1">
-                <table class="inside-bordered">
-                    <tbody>
-                        {% for k, val in attributes %}
-                            {% if val and k != 'file_metadata' %}
-                                <tr>
-                                    <th class="nowrap">{{ k|humanize }} :</th>
-                                    <td>
-                                        {% if k == 'url' %}
-                                            <a href={{ val }} target="_blank">{{ val }}</a>
-                                        {% elseif in_array(k, ['created', 'modified']) %}
-                                            {{ Schema.format(val, {'type': 'string', 'format': 'date-time'}) }}
-                                        {% elseif k == 'file_size' %}
-                                            {{ Schema.format(val, {'type': 'byte'}) }}
-                                        {% elseif k == 'duration' %}
-                                            {{ val|date('H:i:s', '+00:00 GMT') }}
-                                        {% elseif k == 'private_url' %}
-                                            {{ Schema.format(val, {'type': 'boolean'}) }}
-                                        {% else %}
-                                            {{ val }}
-                                        {% endif %}
-                                    </td>
-                                </tr>
-                            {% endif %}
-                        {% endfor %}
-                    </tbody>
-                </table>
-                {% if attributes.file_metadata %}
-                    <div class="grid-span-full mt-1">
-                        <h3>{{ __('Metadata') }}</h3>
-                        <div>
-                            <textarea style="min-height: 10rem; resize: none;" readonly>{{ attributes.file_metadata|json_encode(constant('JSON_PRETTY_PRINT')) }}</textarea>
+    {% if attributes %}
+    <property-view inline-template :tab-open="tabsOpen" :is-default-open=false :tab-open-at-start=false>
+        <section class="fieldset">
+            <header @click.prevent="toggleVisibility()"
+                class="tab unselectable"
+                :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                <h2>{{ __('Advanced Data') }}</h2>
+            </header>
+            <div v-show="isOpen" class="tab-container">
+                <div class="grid-span-full mt-1">
+                    <table class="inside-bordered">
+                        <tbody>
+                            {% for k, val in attributes %}
+                                {% if val and k != 'file_metadata' %}
+                                    <tr>
+                                        <th class="nowrap">{{ k|humanize }} :</th>
+                                        <td>
+                                            {% if k == 'url' %}
+                                                <a href={{ val }} target="_blank">{{ val }}</a>
+                                            {% elseif in_array(k, ['created', 'modified']) %}
+                                                {{ Schema.format(val, {'type': 'string', 'format': 'date-time'}) }}
+                                            {% elseif k == 'file_size' %}
+                                                {{ Schema.format(val, {'type': 'byte'}) }}
+                                            {% elseif k == 'duration' %}
+                                                {{ val|date('H:i:s', '+00:00 GMT') }}
+                                            {% elseif k == 'private_url' %}
+                                                {{ Schema.format(val, {'type': 'boolean'}) }}
+                                            {% else %}
+                                                {{ val }}
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                {% endif %}
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% if attributes.file_metadata %}
+                        <div class="grid-span-full mt-1">
+                            <h3>{{ __('Metadata') }}</h3>
+                            <div>
+                                <textarea style="min-height: 10rem; resize: none;" readonly>{{ attributes.file_metadata|json_encode(constant('JSON_PRETTY_PRINT')) }}</textarea>
+                            </div>
                         </div>
-                    </div>
-                {% endif %}
+                    {% endif %}
+                </div>
             </div>
-        </div>
-    </section>
-</property-view>
+        </section>
+    </property-view>
+    {% endif %}
 {% endif %}

--- a/src/Template/Element/Form/media.twig
+++ b/src/Template/Element/Form/media.twig
@@ -49,13 +49,13 @@
                             </figure>
                         {% endif %}
                     {% elseif object.type == 'videos' %}
-                            <video controls width="100%">
-                                <source src="{{ stream.meta.url }}" type="{{ stream.attributes.mime_type }}">
-                                Sorry, your browser does not support embedded <code>video</code> element.
-                            </video>
+                        <video controls width="100%">
+                            <source src="{{ stream.meta.url }}" type="{{ stream.attributes.mime_type }}">
+                            {{ __('Sorry, your browser does not support embedded {0} element', '<code>video</code>')|raw }}.
+                        </video>
                     {% elseif object.type == 'audio' %}
                         <audio controls src="{{ stream.meta.url }}">
-                                Sorry, your browser does not support the <code>audio</code> element.
+                            {{ __('Sorry, your browser does not support embedded {0} element', '<code>audio</code>')|raw }}.
                         </audio>
                     {% endif %}
                 </div>

--- a/src/Template/Element/Form/upload.twig
+++ b/src/Template/Element/Form/upload.twig
@@ -38,6 +38,7 @@
                             'autocorrect': 'off',
                             'autocapitalize': 'off',
                             'spellcheck': 'false',
+                            'class':'is-width-full',
                             'placeholder': __('Remote URL') ~ ieLabel }) | raw }}
                     </div>
 

--- a/src/Template/Layout/styles/_utility_classes.scss
+++ b/src/Template/Layout/styles/_utility_classes.scss
@@ -215,3 +215,13 @@
 .order-7          { order: 7 !important; }
 .order-8          { order: 8 !important; }
 .order-bottom     { order: 100 !important; }
+
+
+table.inside-bordered {
+    border-collapse: collapse;
+
+    th, td {
+        border: 1px solid $gray-600;
+        padding: $gutter * 0.5;
+    }
+}

--- a/src/Template/Layout/styles/_utility_classes.scss
+++ b/src/Template/Layout/styles/_utility_classes.scss
@@ -225,3 +225,7 @@ table.inside-bordered {
         padding: $gutter * 0.5;
     }
 }
+
+.is-width-full {
+    width: 100% !important;
+}


### PR DESCRIPTION
Minor enhancement to media module.
- player video and audio
- split readonly metadata in a different tab "Advanced data"
- minor styles for some input

Suggested modules configuration:

```
  "images": {
    "view": {
      "core": [
        "title",
        "description",
        "license"
      ],
      "provider": [
        "provider",
        "provider_uid",
        "provider_url",
        "provider_thumbnail",
        "provider_extra"
      ],
      "_hide": [
        "body",
        "name"
      ]
    },
    "relations": {
      "_hide": [
        "poster"
      ]
    }
  },
```
 ```
 "videos": {
    "view": {
      "core": [
        "title",
        "description",
        "license"
      ],
      "provider": [
        "provider",
        "provider_uid",
        "provider_url",
        "provider_thumbnail",
        "provider_extra"
      ],
      "_hide": [
        "body",
        "name"
      ]
    }
  },
```
```
  "audio": {
    "view": {
      "core": [
        "title",
        "description",
        "license"
      ],
      "provider": [
        "provider",
        "provider_uid",
        "provider_url",
        "provider_thumbnail",
        "provider_extra"
      ],
      "_hide": [
        "body",
        "name"
      ]
    }
  },
```