### PR TITLE
Add ancestor to allowed filters list

### DIFF
--- a/src/Template/Layout/js/app/components/filter-box.js
+++ b/src/Template/Layout/js/app/components/filter-box.js
@@ -320,8 +320,8 @@ export default {
             const filter = { ...this.queryFilter.filter };
 
             Object.entries(filter).forEach(([key, filterValue]) => {
-                // do nothing for status or type filter, if value is set
-                if ((key === 'status' || key === 'type' || key === 'history_editor') && filterValue) {
+                // do nothing allowed filters, if value is set
+                if (['status', 'type', 'ancestor', 'history_editor'].includes(key) && filterValue) {
                     return;
                 }
 


### PR DESCRIPTION
This PR adds `ancestor` to the list of allowed filters. It fixes the reset of the tree position filter when the `descendants` flag is checked.