### PR TITLE
Fix BEdita5 integration with API configuration and limit config keys 

### DIFF
--- a/src/Controller/Admin/AppearenceController.php
+++ b/src/Controller/Admin/AppearenceController.php
@@ -40,20 +40,6 @@ class AppearenceController extends AdministrationBaseController
     protected $readonly = false;
 
     /**
-     * Properties to handle for config
-     *
-     * @var array
-     */
-    protected $properties = [
-        'alert_message',
-        'export',
-        'modules',
-        'pagination',
-        'project',
-        'properties',
-    ];
-
-    /**
      * Index method
      *
      * @return \Cake\Http\Response|null
@@ -61,8 +47,8 @@ class AppearenceController extends AdministrationBaseController
     public function index(): ?Response
     {
         $configs = [];
-        foreach ($this->properties as $property) {
-            $configs[$property] = Configure::read(Inflector::camelize($property));
+        foreach (static::$configKeys as $property) {
+            $configs[Inflector::underscore($property)] = Configure::read($property);
         }
         $this->set('configs', $configs);
 

--- a/src/Utility/ApiConfigTrait.php
+++ b/src/Utility/ApiConfigTrait.php
@@ -36,7 +36,7 @@ trait ApiConfigTrait
     protected static $cacheKey = 'api_config';
 
     /**
-     * Allowed configuration keys read from API
+     * Allowed configuration keys from API
      *
      * @var array
      */

--- a/tests/TestCase/Utility/ApiConfigTraitTest.php
+++ b/tests/TestCase/Utility/ApiConfigTraitTest.php
@@ -21,6 +21,7 @@ use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
+use Cake\Http\Exception\BadRequestException;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -62,11 +63,11 @@ class ApiConfigTraitTest extends TestCase
     {
         return [
             'ok' => [
-                ['Supporto'],
+                123,
                 [
                     [
                         'id' => 1,
-                        'attributes' => ['name' => 'Gustavo', 'content' => '["Supporto"]'],
+                        'attributes' => ['name' => 'Export', 'content' => '{"limit":123}'],
                     ],
                 ],
             ],
@@ -91,20 +92,26 @@ class ApiConfigTraitTest extends TestCase
      */
     public function testReadApiCache($expected, array $content): void
     {
-        Configure::delete('Gustavo');
+        Configure::delete('Export');
         Cache::write(CacheTools::cacheKey(static::$cacheKey), $content);
         $this->readApiConfig();
-        $result = Configure::read('Gustavo');
+        $result = Configure::read('Export.limit');
         static::assertEquals($expected, $result);
     }
 
+    /**
+     * Test read single Key from API
+     *
+     * @return void
+     */
     public function testReadApiConfig(): void
     {
         $this->prepareClient();
-        Configure::delete('Gustavo');
+        Configure::delete('Export');
         $this->readApiConfig();
-        $result = Configure::read('Gustavo');
-        static::assertEquals([], $result);
+        $result = Configure::read('Export.limit');
+        static::assertEquals(666, $result);
+        static::assertNull(Configure::read('Gustavo'));
     }
 
     /**
@@ -158,16 +165,31 @@ class ApiConfigTraitTest extends TestCase
         $this->prepareClient();
 
         // PATCH
-        $this->saveApiConfig('Gustavo', ['Supporto']);
+        $this->saveApiConfig('Export', ['limit' => 123]);
         $actual = Cache::read(CacheTools::cacheKey(static::$cacheKey));
         static::assertEmpty($actual);
         $actual = Cache::read(CacheTools::cacheKey('properties'));
         static::assertEmpty($actual);
 
         // POST
-        $this->saveApiConfig('GustavoTest', ['SupportoTest']);
+        $this->saveApiConfig('AlertMessage', ['text' => 'Gustavo']);
         $actual = Cache::read(CacheTools::cacheKey(static::$cacheKey));
         static::assertEmpty($actual);
+    }
+
+    /**
+     * Test bad configuration key save
+     *
+     * @return void
+     * @covers ::saveApiConfig()
+     */
+    public function testSaveBadKey(): void
+    {
+        $expectedException = new BadRequestException('Bad configuration key "Gustavo"');
+        $this->expectException(get_class($expectedException));
+        $this->expectExceptionCode($expectedException->getCode());
+        $this->expectExceptionMessage($expectedException->getMessage());
+        $this->saveApiConfig('Gustavo', []);
     }
 
     /**
@@ -193,6 +215,13 @@ class ApiConfigTraitTest extends TestCase
                                         'attributes' => [
                                             'name' => 'Gustavo',
                                             'content' => '{}',
+                                            'context' => 'app',
+                                            'application_id' => 456,
+                                        ],
+                                        'id' => 124,
+                                        'attributes' => [
+                                            'name' => 'Export',
+                                            'content' => '{"limit":666}',
                                             'context' => 'app',
                                             'application_id' => 456,
                                         ],


### PR DESCRIPTION
This PR fixes two problems in BEdita5 integration:

* since `/config` endpoint response was changed (`application_id` and `contex` have been removed), the configuration from API was not read 
* to avoid possible conflicts with some configuration keys like `I18n` and others the list of allowed configuration keys from API has now been defined in `ApiConfigTrait` 
