### PR TITLE
Default lang for combo language in object view

### DIFF
--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -69,7 +69,7 @@ class Options
         if (empty($languages)) {
             return compact('value') + ['type' => 'text'];
         }
-        $options = [];
+        $options[] = ['value' => '', 'text' => ''];
         foreach ($languages as $key => $description) {
             $options[] = ['value' => $key, 'text' => __($description)];
         }

--- a/src/Template/Element/Form/related_translations.twig
+++ b/src/Template/Element/Form/related_translations.twig
@@ -17,7 +17,7 @@
             <div v-show="isOpen" class="tab-container">
 
                 <div>
-                    {% set lang = object.id ? object.attributes.lang : config('I18n.default')|default('en') %}
+                    {% set lang = object.id ? object.attributes.lang : config('Project.config.I18n.default') %}
                     {{ Property.control('lang', lang, { 'label': __('The main language is') })|raw }}
 
                     {% if object.relationships.translations %}

--- a/src/Template/Element/Form/related_translations.twig
+++ b/src/Template/Element/Form/related_translations.twig
@@ -17,7 +17,8 @@
             <div v-show="isOpen" class="tab-container">
 
                 <div>
-                    {{ Property.control('lang', object.attributes.lang, { 'label': __('The main language is') })|raw }}
+                    {% set lang = object.id ? object.attributes.lang : config('I18n.default')|default('en') %}
+                    {{ Property.control('lang', lang, { 'label': __('The main language is') })|raw }}
 
                     {% if object.relationships.translations %}
                         {{ Html.link(__('Add translation'), {

--- a/src/Utility/ApiConfigTrait.php
+++ b/src/Utility/ApiConfigTrait.php
@@ -105,7 +105,7 @@ trait ApiConfigTrait
     {
         $attr = (array)Hash::get($config, 'attributes');
         if (
-            (isset($attr['application_id']) && $attr['application_id'] === null) ||
+            (isset($attr['application_id']) && $attr['application_id'] == null) ||
             (isset($attr['context']) && $attr['context'] !== 'app') ||
             !in_array((string)Hash::get($attr, 'name'), static::$configKeys)
         ) {

--- a/tests/TestCase/Form/OptionsTest.php
+++ b/tests/TestCase/Form/OptionsTest.php
@@ -55,6 +55,10 @@ class OptionsTest extends TestCase
                     'type' => 'select',
                     'options' => [
                         [
+                            'value' => '',
+                            'text' => '',
+                        ],
+                        [
                             'value' => 'en',
                             'text' => 'English',
                         ],

--- a/tests/TestCase/Utility/ApiConfigTraitTest.php
+++ b/tests/TestCase/Utility/ApiConfigTraitTest.php
@@ -218,6 +218,8 @@ class ApiConfigTraitTest extends TestCase
                                             'context' => 'app',
                                             'application_id' => 456,
                                         ],
+                                    ],
+                                    [
                                         'id' => 124,
                                         'attributes' => [
                                             'name' => 'Export',

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -401,6 +401,10 @@ class SchemaHelperTest extends TestCase
         $expected = [
             'options' => [
                 [
+                    'value' => '',
+                    'text' => '',
+                ],
+                [
                     'value' => 'en',
                     'text' => 'English',
                 ],


### PR DESCRIPTION
This fixes a buggy behaviour in object view (new or edit):

 - (new) first language is selected, not the default one (config `Project.config.I18n.default`).
 - (edit) when object.attributes.lang is null or empty, first language is selected

Expected behaviour:

 - (new) default language is selected ('en' when there's no config `Project.config.I18n.default`)
 - (edit) when object.attributes.lang is null or empty, show empty option; user can change it to proper language

Note: in "edit" case, it's dangerous to set a default language... objects with "null" language would be treated as they have a language. This could confuse the user

Bonus: fix `ApiConfigTrait` and `ApiConfigTraitTest` (phpstan found some issues)