### PR TITLE
Fix property bulk action label

### DIFF
--- a/src/Template/Element/Form/bulk_properties.twig
+++ b/src/Template/Element/Form/bulk_properties.twig
@@ -14,7 +14,11 @@
                 'v-model': 'bulkValue',
                 ':disabled': '!selectedRows.length'
             }) %}
-            {% if label %}
+
+            {# use key as label if index is numeric (no actual label was specified) #}
+            {% if label matches '/^\\d+$/' %}
+                {% set options = options|merge({'label': __(key|humanize)}) %}
+            {% else %}
                 {% set options = options|merge({'label': __(label)}) %}
             {% endif %}
 


### PR DESCRIPTION
This PR fix labels on custom property bulk actions: if no label was set in configuration the property name has to be used not the numeric index.

Example `'Properties'` configuration: 

```php
  'documents' => [
     'view' => [
       // .... view details conf
     ],
     'bulk' => [
        'status', 
        'Change language' => 'lang', 
     ]
 ],
```

With the configuration above we will get two property change bulk actions: the first will have `Status` as label, the second will have `Change language`.