### PR TITLE
Introduce custom bulk actions

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -380,23 +380,30 @@ $routes->scope('/', function (RouteBuilder $routes) {
     )
     ->setPass(['id']);
 
+    // Bulk actions
     $routes->connect(
         '/{object_type}/bulkAttribute',
         ['controller' => 'Bulk', 'action' => 'attribute'],
         ['_name' => 'modules:bulkAttribute']
-    );
+    )->setMethods(['post']);
 
     $routes->connect(
         '/{object_type}/bulkCategories',
         ['controller' => 'Bulk', 'action' => 'categories'],
         ['_name' => 'modules:bulkCategories']
-    );
+    )->setMethods(['post']);
 
     $routes->connect(
         '/{object_type}/bulkPosition',
         ['controller' => 'Bulk', 'action' => 'position'],
         ['_name' => 'modules:bulkPosition']
-    );
+    )->setMethods(['post']);
+
+    $routes->connect(
+        '/{object_type}/bulkCustom',
+        ['controller' => 'Bulk', 'action' => 'custom'],
+        ['_name' => 'modules:bulkCustom']
+    )->setMethods(['post']);
 
     // translator service
     $routes->connect(

--- a/src/Controller/BulkController.php
+++ b/src/Controller/BulkController.php
@@ -12,7 +12,9 @@
  */
 namespace App\Controller;
 
+use App\Core\Bulk\CustomBulkActionInterface;
 use BEdita\SDK\BEditaClientException;
+use Cake\Core\App;
 use Cake\Http\Response;
 use Cake\Utility\Hash;
 use Psr\Log\LogLevel;
@@ -67,13 +69,65 @@ class BulkController extends AppController
      */
     public function attribute(): ?Response
     {
-        $this->getRequest()->allowMethod(['post']);
         $requestData = $this->getRequest()->getData();
         $this->ids = explode(',', (string)Hash::get($requestData, 'ids'));
         $this->saveAttribute($requestData['attributes']);
         $this->errors();
 
-        return $this->redirect(['_name' => 'modules:list', 'object_type' => $this->objectType, '?' => $this->getRequest()->getQuery()]);
+        return $this->modulesListRedirect();
+    }
+
+    /**
+     * Bulk custom action for selected ids.
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function custom(): ?Response
+    {
+        $requestData = $this->request->getData();
+        $this->ids = explode(',', (string)Hash::get($requestData, 'ids'));
+        $this->performCustomAction((string)Hash::get($requestData, 'custom_action'));
+        $this->errors();
+
+        return $this->modulesListRedirect();
+    }
+
+    /**
+     * Perform bulk action via custom class.
+     *
+     * @param string $bulkClass Custom action class name.
+     * @return void
+     */
+    protected function performCustomAction(string $bulkClass): void
+    {
+        $class = App::className($bulkClass);
+        if (empty($class)) {
+            $this->errors[] = __('Custom action class {0} not found', $bulkClass);
+
+            return;
+        }
+        $bulkAction = new $class();
+        if (!$bulkAction instanceof CustomBulkActionInterface) {
+            $this->errors[] = __('Custom action class {0} is not valid', $bulkClass);
+
+            return;
+        }
+
+        $this->errors = $bulkAction->bulkAction($this->ids, $this->objectType);
+    }
+
+    /**
+     * Redirect to modules index.
+     *
+     * @return \Cake\Http\Response|null
+     */
+    protected function modulesListRedirect(): ?Response
+    {
+        return $this->redirect([
+            '_name' => 'modules:list',
+            'object_type' => $this->objectType,
+            '?' => $this->request->getQuery(),
+        ]);
     }
 
     /**
@@ -83,7 +137,6 @@ class BulkController extends AppController
      */
     public function categories(): ?Response
     {
-        $this->getRequest()->allowMethod(['post']);
         $requestData = $this->getRequest()->getData();
         $this->ids = explode(',', (string)Hash::get($requestData, 'ids'));
         $this->categories = (string)Hash::get($requestData, 'categories');
@@ -91,7 +144,7 @@ class BulkController extends AppController
         $this->saveCategories();
         $this->errors();
 
-        return $this->redirect(['_name' => 'modules:list', 'object_type' => $this->objectType, '?' => $this->getRequest()->getQuery()]);
+        return $this->modulesListRedirect();
     }
 
     /**
@@ -101,7 +154,6 @@ class BulkController extends AppController
      */
     public function position(): ?Response
     {
-        $this->getRequest()->allowMethod(['post']);
         $requestData = $this->getRequest()->getData();
         $this->ids = explode(',', (string)Hash::get($requestData, 'ids'));
         $folder = (string)Hash::get($requestData, 'folderSelected');
@@ -113,7 +165,7 @@ class BulkController extends AppController
         }
         $this->errors();
 
-        return $this->redirect(['_name' => 'modules:list', 'object_type' => $this->objectType, '?' => $this->getRequest()->getQuery()]);
+        return $this->modulesListRedirect();
     }
 
     /**

--- a/src/Controller/BulkController.php
+++ b/src/Controller/BulkController.php
@@ -72,7 +72,7 @@ class BulkController extends AppController
         $requestData = $this->getRequest()->getData();
         $this->ids = explode(',', (string)Hash::get($requestData, 'ids'));
         $this->saveAttribute($requestData['attributes']);
-        $this->errors();
+        $this->showResult();
 
         return $this->modulesListRedirect();
     }
@@ -87,7 +87,7 @@ class BulkController extends AppController
         $requestData = $this->request->getData();
         $this->ids = explode(',', (string)Hash::get($requestData, 'ids'));
         $this->performCustomAction((string)Hash::get($requestData, 'custom_action'));
-        $this->errors();
+        $this->showResult();
 
         return $this->modulesListRedirect();
     }
@@ -142,7 +142,7 @@ class BulkController extends AppController
         $this->categories = (string)Hash::get($requestData, 'categories');
         $this->loadCategories();
         $this->saveCategories();
-        $this->errors();
+        $this->showResult();
 
         return $this->modulesListRedirect();
     }
@@ -163,7 +163,7 @@ class BulkController extends AppController
         } else { // move
             $this->moveToPosition($folder);
         }
-        $this->errors();
+        $this->showResult();
 
         return $this->modulesListRedirect();
     }
@@ -283,13 +283,15 @@ class BulkController extends AppController
     }
 
     /**
-     * Handle page errors.
+     * Display success or error messages.
      *
      * @return void
      */
-    protected function errors(): void
+    protected function showResult(): void
     {
         if (empty($this->errors)) {
+            $this->Flash->success(__('Bulk action performed on {0} objects', count($this->ids)));
+
             return;
         }
         $this->log('Error: ' . json_encode($this->errors), LogLevel::ERROR);

--- a/src/Core/Bulk/CustomBulkActionInterface.php
+++ b/src/Core/Bulk/CustomBulkActionInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Core\Bulk;
+
+/**
+ * Custom bulk action interface
+ */
+interface CustomBulkActionInterface
+{
+    /**
+     * Perform bulk action.
+     *
+     * @param array $ids Object IDs
+     * @param string $type Object type
+     * @return array Error details on failure, empty array on success
+     */
+    public function bulkAction(array $ids, string $type): array;
+}

--- a/src/Template/Element/Form/bulk_custom.twig
+++ b/src/Template/Element/Form/bulk_custom.twig
@@ -23,6 +23,6 @@
             </label>
             <button id="custom-bulk-{{ key }}" class="button button-outlined" @click.prevent="bulkActions('{{ bulkFormId }}')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
         </div>
-    {{ Form.end()|raw }}
+        {{ Form.end()|raw }}
     {% endif %}
 {% endfor %}

--- a/src/Template/Element/Form/bulk_custom.twig
+++ b/src/Template/Element/Form/bulk_custom.twig
@@ -1,0 +1,28 @@
+{# bulkActions set in config Properties.<type>.bulk #}
+{% for label, key in bulkActions %}
+
+    {% if schema.properties[key] is not defined %}
+
+        {% set bulkFormId = 'bulk-' ~ key|dasherize|replace({'.': '-', '/': '-', '\\': '-'}) %}
+        {{ Form.create(null, {
+                'id': bulkFormId,
+                'url': {'_name': 'modules:bulkCustom', 'object_type': objectType, '?': _view.request.getQuery()},
+        })|raw }}
+        <div class="fieldset" :disabled="!selectedRows.length">
+            <input type="hidden" name="ids" v-bind:value="selectedRows">
+            <input type="hidden" name="custom_action" value="{{ key }}">
+            {% do Form.unlockField('ids') %}
+            {% do Form.unlockField('custom_action') %}
+
+            <label for="custom-bulk-{{ key }}">
+                {%- if label matches '/^\\d+$/' -%}
+                    {{ __(key|humanize) }}
+                {%- else -%}
+                    {{ __(label|humanize) }}
+                {%- endif -%}
+            </label>
+            <button id="custom-bulk-{{ key }}" class="button button-outlined" @click.prevent="bulkActions('{{ bulkFormId }}')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
+        </div>
+    {{ Form.end()|raw }}
+    {% endif %}
+{% endfor %}

--- a/src/Template/Element/Form/bulk_properties.twig
+++ b/src/Template/Element/Form/bulk_properties.twig
@@ -1,9 +1,11 @@
 {# bulkActions set in config Properties.<type>.bulk #}
 {% for label, key in bulkActions %}
-    {{ Form.create(null, {
-        'id': 'bulk-' ~ key,
-        'url': {'_name': 'modules:bulkAttribute', 'object_type': objectType, '?': _view.request.getQuery()},
-    })|raw }}
+
+    {% if schema.properties[key] is defined %}
+        {{ Form.create(null, {
+                'id': 'bulk-' ~ key,
+                'url': {'_name': 'modules:bulkAttribute', 'object_type': objectType, '?': _view.request.getQuery()},
+        })|raw }}
         <div class="fieldset" :disabled="!selectedRows.length">
             <input type="hidden" name="ids" v-bind:value="selectedRows">
             {% do Form.unlockField('ids') %}
@@ -41,4 +43,5 @@
             <button class="button button-outlined" @click.prevent="bulkActions('bulk-{{ key }}')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
         </div>
     {{ Form.end()|raw }}
+    {% endif %}
 {% endfor %}

--- a/src/Template/Element/Form/bulk_properties.twig
+++ b/src/Template/Element/Form/bulk_properties.twig
@@ -42,6 +42,6 @@
 
             <button class="button button-outlined" @click.prevent="bulkActions('bulk-{{ key }}')" :disabled="!selectedRows.length">{{ __('Ok') }}</button>
         </div>
-    {{ Form.end()|raw }}
+        {{ Form.end()|raw }}
     {% endif %}
 {% endfor %}

--- a/src/Template/Element/Modules/index_bulk.twig
+++ b/src/Template/Element/Modules/index_bulk.twig
@@ -8,6 +8,8 @@
     <div :class="[!selectedRows.length ? 'disabled' : '', 'is-flex', 'is-flex-column']">
         {{ element('Form/bulk_properties') }}
 
+        {{ element('Form/bulk_custom') }}
+
         {{ element('Form/bulk_category') }}
 
         {{ element('Form/bulk_position') }}

--- a/tests/TestCase/Controller/BulkControllerTest.php
+++ b/tests/TestCase/Controller/BulkControllerTest.php
@@ -478,6 +478,7 @@ class BulkControllerTest extends BaseControllerTest
      *
      * @return void
      * @covers ::custom()
+     * @covers ::performCustomAction
      * @covers ::modulesListRedirect()
      */
     public function testCustomMissing(): void
@@ -509,6 +510,7 @@ class BulkControllerTest extends BaseControllerTest
      *
      * @return void
      * @covers ::custom()
+     * @covers ::performCustomAction
      */
     public function testCustomAction(): void
     {
@@ -536,6 +538,7 @@ class BulkControllerTest extends BaseControllerTest
      *
      * @return void
      * @covers ::custom()
+     * @covers ::performCustomAction
      */
     public function testCustomWrong(): void
     {

--- a/tests/TestCase/Controller/CustomBulkAction.php
+++ b/tests/TestCase/Controller/CustomBulkAction.php
@@ -1,0 +1,15 @@
+<?php
+namespace App\Test\TestCase\Controller;
+
+use App\Core\Bulk\CustomBulkActionInterface;
+
+class CustomBulkAction implements CustomBulkActionInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function bulkAction(array $ids, string $type): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
This PR introduces custom bulk actions.
These bulk actions can be configured in `Properties.{objectType}.bulk` key like this:

```php
   'bullk' => [
      'status', // property bulk action, without label
      'Change language' => 'lang', // property bulk action, with label 
      'Action Label' => '\MyApp\BulkActionClass', // custom class to perform bulk action, with label
   ],
```

When a bulk action item in the `bulk` array does not match a property name it will be treated like a custom bulk action. 
Custom bulk action item must be the name of a class implementing `CustomBulkActionInterface` interface. Its `bulkAction()` method is then called to perform the desired object manipulation.


