### PR TITLE
Avoid unwanted `format-{relation}` items in form data

### DIFF
--- a/src/Template/Element/Form/relation.twig
+++ b/src/Template/Element/Form/relation.twig
@@ -128,7 +128,7 @@
                 'MS Excel': 'xlsx'
             }) %}
 
-            <select name="format-{{ relationName }}" v-model="exportFormat">
+            <select v-model="exportFormat">
             {% for label,format in formats %}
                 <option value="{{ format }}" {% if format == defaultFormat %}selected="selected"{% endif %}>{{ label }}</option>
             {% endfor %}


### PR DESCRIPTION
This PR removes some form data from the object properties being saved. 

Currently on every object save some fields like `"format-{relation}": "csv"` (one for every relation) are being added to the object properties saved via API.

