### PR TITLE
bootstrap_cli: fix for command line exceptions and bake usage

### DIFF
--- a/config/bootstrap_cli.php
+++ b/config/bootstrap_cli.php
@@ -15,7 +15,7 @@
  */
 use Cake\Core\Configure;
 use Cake\Database\Connection;
-use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
 use Cake\Error\ExceptionTrap;
 use Cake\Error\Renderer\ConsoleExceptionRenderer;
@@ -40,7 +40,7 @@ if (Configure::check('Log.error')) {
 // this is for using "bin/cake bake"
 ConnectionManager::setConfig(['default' => [
     'className' => Connection::class,
-    'driver' => Mysql::class,
+    'driver' => Sqlite::class,
 ]]);
 
 // override Error.exceptionRenderer to ConsoleExceptionRenderer

--- a/config/bootstrap_cli.php
+++ b/config/bootstrap_cli.php
@@ -14,6 +14,11 @@
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 use Cake\Core\Configure;
+use Cake\Database\Connection;
+use Cake\Database\Driver\Mysql;
+use Cake\Datasource\ConnectionManager;
+use Cake\Error\ExceptionTrap;
+use Cake\Error\Renderer\ConsoleExceptionRenderer;
 
 /**
  * Additional bootstrapping and configuration for CLI environments should
@@ -31,3 +36,16 @@ if (Configure::check('Log.debug')) {
 if (Configure::check('Log.error')) {
     Configure::write('Log.error.file', 'cli-error');
 }
+
+// this is for using "bin/cake bake"
+ConnectionManager::setConfig(['default' => [
+    'className' => Connection::class,
+    'driver' => Mysql::class,
+    'persistent' => false,
+    'timezone' => 'UTC',
+]]);
+
+// override Error.exceptionRenderer to ConsoleExceptionRenderer
+$errorConfig = Configure::read('Error');
+$errorConfig['exceptionRenderer'] = ConsoleExceptionRenderer::class;
+(new ExceptionTrap($errorConfig))->register();

--- a/config/bootstrap_cli.php
+++ b/config/bootstrap_cli.php
@@ -41,8 +41,6 @@ if (Configure::check('Log.error')) {
 ConnectionManager::setConfig(['default' => [
     'className' => Connection::class,
     'driver' => Mysql::class,
-    'persistent' => false,
-    'timezone' => 'UTC',
 ]]);
 
 // override Error.exceptionRenderer to ConsoleExceptionRenderer


### PR DESCRIPTION
This provides:

 - fix to use `bin/cake bake controller|model|...` in manager, by adding a datasource (not used, but required by cakephp)
 - fix to use `Cake\Error\Renderer\ConsoleExceptionRenderer` when exception is raised on cli command