### PR TITLE
Add custom sidebar links via `modules` conf

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -329,6 +329,8 @@ return [
     /**
      * Modules configuration.
      *
+     * See https://github.com/bedita/manager/wiki/Setup:-Modules-configuration
+     *
      * Keys must be actual API endpoint names like `documents`, `users` or `folders`.
      * Modules order will follow key order of this configuration.
      * In case of core or plugin modules not directly served by ModulesController
@@ -347,6 +349,8 @@ return [
      *          (default is '-id'),
      *  'icon' - icon code, f.i. `icon-article`, have a look in
      *      `webroot/css/be-icons-codes.css` for a complete list of codes
+     *  'sidebar' - additional custom sidebar links added in modules index and single item view,
+     *     defined as associative array with 'index' and 'view' keys
      */
     'Modules' => [
         'objects' => [

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -90,6 +90,8 @@ return [
     /**
      * Modules configuration.
      *
+     * See https://github.com/bedita/manager/wiki/Setup:-Modules-configuration
+     *
      * Keys must be actual API endpoint names like `documents`, `users` or `folders`.
      * Modules order will follow key order of this configuration.
      * In case of core or plugin modules not directly served by ModulesController
@@ -108,6 +110,8 @@ return [
      *          (default is '-id'),
      *  'icon' - icon code, f.i. `icon-article`, have a look in
      *      `webroot/css/be-icons-codes.css` for a complete list of codes
+     *  'sidebar' - additional custom sidebar links added in modules index and single item view,
+     *     defined as associative array with 'index' and 'view' keys
      */
     // 'Modules' => [
     //     'objects' => [

--- a/src/Template/Pages/Modules/index.twig
+++ b/src/Template/Pages/Modules/index.twig
@@ -67,5 +67,16 @@
         ) %}
         {% endif %}
 
+        {% if currentModule.sidebar.index %}
+        {% for item in currentModule.sidebar.index %}
+            {% do _view.append('module-buttons',
+                Html.link(__(item.label),
+                    item.url,
+                    {'class': 'button button-outlined button-outlined-hover-module-' ~ currentModule.name}
+                )|raw
+            ) %}
+        {% endfor %}
+        {% endif %}
+
     </div> {# end module-content #}
 </modules-index>

--- a/src/Template/Pages/Modules/index.twig
+++ b/src/Template/Pages/Modules/index.twig
@@ -72,7 +72,7 @@
             {% do _view.append('module-buttons',
                 Html.link(__(item.label),
                     item.url,
-                    {'class': 'button button-outlined button-outlined-hover-module-' ~ currentModule.name}
+                    {'class': item.class|default('button button-outlined button-outlined-hover-module-' ~ currentModule.name)}
                 )|raw
             ) %}
         {% endfor %}

--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -174,7 +174,7 @@
                     {% do _view.append('module-buttons',
                         Html.link(__(item.label),
                             url,
-                            {'class': 'button button-outlined button-outlined-hover-module-' ~ currentModule.name}
+                            {'class': item.class|default('button button-outlined button-outlined-hover-module-' ~ currentModule.name)}
                         )|raw
                     ) %}
                 {% endfor %}

--- a/src/Template/Pages/Modules/view.twig
+++ b/src/Template/Pages/Modules/view.twig
@@ -160,6 +160,25 @@
                 ) %}
             {% endif %}
 
+            {# Append custom sidebar actions #}
+            {% if currentModule.sidebar.view and object.id %}
+                {% for item in currentModule.sidebar.view %}
+                    {# if url is a named route merge with id information #}
+                    {% if item.url is iterable %}
+                        {% set url = item.url|merge({id: object.id}) %}
+                    {% else %}
+                        {# otherwise url is a string, append id in path #}
+                        {% set url = item.url ~ '/' ~ object.id %}
+                    {% endif %}
+
+                    {% do _view.append('module-buttons',
+                        Html.link(__(item.label),
+                            url,
+                            {'class': 'button button-outlined button-outlined-hover-module-' ~ currentModule.name}
+                        )|raw
+                    ) %}
+                {% endfor %}
+            {% endif %}
         </div>
     </div>
 </modules-view>


### PR DESCRIPTION
This PR adds additional custom sidebar links added in modules index and single item view.

The following examples show how this links can be added.

PHP file example (`config/app_local.php`):

```php
'Modules' => [
    'planets' => [
        'color' => '#230637',
        'sidebar' => [
            'index' => [
              [
                'label' => 'Custom Label',
                'url' => ['_name': 'custom:name'], // URL can be a named URL array
              ],
            ],
           'view' => [
              [
                'label' => 'Custom Label',
                'url' => '/custom-url', // URL can be a relative path or absolute URL
              ],
            ],
       }
    ],
],
```

JSON example (`Admin -> Appearence`):

```json
{
    "planets": {
        "color": "#230637",
        "sidebar": {
            "index": [
              {
                "label": "Custom Label",
                "url": {
                   "_name": "custom:name"
                }
              }
            ],
           "view": [
             {
               "label": "Custom Label2",
               "url": "/custom-url"
             }
           ],
       }
}
```

Custom urls in `sidebar.view` are populated with the current object id, with this rule:
* in case of relative or absolute string url a `/{id}` suffix is added with the current object id
* in case of named route and item `id: {id}` or `'id' => {id}` is added to the name route via merge
