### PR TITLE
Fix CSRF cookie error on login

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -206,6 +206,7 @@ ServerRequest::addDetector('tablet', function ($request) {
  * Array having `controller` as key and actions array as value.
  */
 Configure::write('CsrfExceptions', [
+    'Login' => ['login'],
     'PropertyTypes' => ['save'],
     'Modules' => ['save'],
     'Translator' => ['translate'],


### PR DESCRIPTION
This PR fixes #860 

Solution is trivial, in this particular case a `CSRF` exception makes more sense than the other current cases...
