### PR TITLE
Fix object types associations as empty string

### DIFF
--- a/src/Controller/Model/ObjectTypesController.php
+++ b/src/Controller/Model/ObjectTypesController.php
@@ -168,6 +168,9 @@ class ObjectTypesController extends ModelBaseController
         $this->addCustomProperty();
         $this->request = $this->request->withoutData('prop_name')
             ->withoutData('prop_type');
+        if ($this->request->getData('associations') === '') {
+            $this->request = $this->request->withData('associations', null);
+        }
 
         return parent::save();
     }

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -251,6 +251,24 @@ class ObjectTypesControllerTest extends TestCase
     }
 
     /**
+     * Test `save` method with empty associations
+     *
+     * @covers ::save()
+     * @return void
+     */
+    public function testEmptyAssocSave(): void
+    {
+        $this->saveApiMock();
+        $config = $this->saveRequestConfig;
+        $config['post'] = ['associations' => ''];
+        $controller = new ObjectTypesController(new ServerRequest($config));
+        $controller->save();
+
+        $data = $controller->getRequest()->getData();
+        static::assertEquals(['associations' => null], $data);
+    }
+
+    /**
      * API client mock for save action
      *
      * @return void


### PR DESCRIPTION
This PR fixes a bug In `Model / Object Types`: if no association is checked an empty string is saved as `associations` property causing a 500 error on API calls on the object type endpoint.