### PR TITLE
Node 18.x in javascript workflow

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - name: 'Checkout current revision'


### PR DESCRIPTION
This adds node `18.x` to javascript github action workflow