### PR TITLE
Fix user profile change password

### DIFF
--- a/src/Controller/UserProfileController.php
+++ b/src/Controller/UserProfileController.php
@@ -81,6 +81,7 @@ class UserProfileController extends AppController
     public function save(): void
     {
         $data = $this->getRequest()->getData();
+        unset($data['id']);
         $this->changedAttributes($data);
         try {
             $this->changePassword($data);
@@ -122,8 +123,7 @@ class UserProfileController extends AppController
      */
     protected function changeData(array $data): void
     {
-        // only id? skip
-        if (!empty($data['id']) && count($data) < 2) {
+        if (empty($data)) {
             return;
         }
         $this->apiClient->patch('/auth/user', json_encode($data));

--- a/src/Controller/UserProfileController.php
+++ b/src/Controller/UserProfileController.php
@@ -81,6 +81,15 @@ class UserProfileController extends AppController
     {
         $data = $this->getRequest()->getData();
         try {
+            if (
+                empty(Hash::get($data, 'password')) &&
+                Hash::get($data, 'password') === Hash::get($data, 'old_password') &&
+                Hash::get($data, 'password') === Hash::get($data, 'confirm-password')
+            ) {
+                unset($data['password']);
+                unset($data['old_password']);
+                unset($data['confirm-password']);
+            }
             $this->apiClient->patch('/auth/user', json_encode($data));
             $this->Flash->success(__('User profile saved'));
         } catch (BEditaClientException $e) {

--- a/templates/Pages/UserProfile/view.twig
+++ b/templates/Pages/UserProfile/view.twig
@@ -17,6 +17,7 @@
         })|raw }}
 
             {{ Form.hidden('id', {'value': object.id})|raw }}
+            {{ Form.hidden('_actualAttributes', {'value': currentAttributes})|raw }}
             <div class="main-view-column">
 
                 {% set jsonKeys = [] %}

--- a/tests/TestCase/Controller/UserProfileControllerTest.php
+++ b/tests/TestCase/Controller/UserProfileControllerTest.php
@@ -154,6 +154,7 @@ class UserProfileControllerTest extends TestCase
         ]);
         $this->UserProfileController = new class ($request) extends UserProfileController
         {
+            public $apiClient;
         };
 
         // mock api patch /auth/user
@@ -180,6 +181,7 @@ class UserProfileControllerTest extends TestCase
         ]);
         $this->UserProfileController = new class ($request) extends UserProfileController
         {
+            public $apiClient;
         };
         $apiClient->method('patch')
             ->with('/auth/user')
@@ -201,6 +203,7 @@ class UserProfileControllerTest extends TestCase
         ]);
         $this->UserProfileController = new class ($request) extends UserProfileController
         {
+            public $apiClient;
         };
         $apiClient->method('patch')
             ->with('/auth/user')


### PR DESCRIPTION
This fixes some unexpected issues in user profile save:

# buggy behaviour

 - save with no changes or changing fields [but not password] => a PATCH /auth/user is performed and password is changed  (DOH!)
 - save new password => a PATCH /auth/user is performed and password is not changed (DOH!)

# patched behaviour

 - save with no changes => no PATCH /auth/user is called
 - save changing data (but not password) => perform PATCH /auth/user (excluding password fields from payload)
 - save changing password (but not data) => perform PATCH /auth/user (with only password fields in payload)
 - save changing data and password => perform a PATCH /auth/user (with only password fields in payload), and perform another PATCH /auth/user (with only changed data in payload)