### PR TITLE
Fix `modified_by` meta display

### DIFF
--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -186,7 +186,7 @@ export default {
                         document.querySelector(`td[name='created_by']`).innerHTML = `<a href="${href}">${userInfo}</a>`;
                     }
 
-                    if (user.id == modifierId != undefined) {
+                    if (user.id == modifierId && userInfo!= undefined) {
                         document.querySelector(`td[name='modified_by']`).innerHTML = `<a href="${href}">${userInfo}</a>`;
                     }
                 });


### PR DESCRIPTION
This PR solves a problem with `modified_by` meta field display that has currently always same display of `created_by` field
