### PR TITLE
Fix PermsHelper possible RuntimeError

### DIFF
--- a/src/View/Helper/PermsHelper.php
+++ b/src/View/Helper/PermsHelper.php
@@ -44,7 +44,13 @@ class PermsHelper extends Helper
     public function initialize(array $config): void
     {
         $modules = (array)$this->_View->get('modules');
-        $this->allowed = Hash::combine($modules, '{s}.name', '{s}.hints.allow');
+        // using foreach instead of Hash::combine
+        // to avoid RuntimeError "Hash::combine() needs an equal number of keys + values"
+        foreach ($modules as $name => $module) {
+            if (Hash::check($module, 'hints.allow')) {
+                $this->allowed[$name] = Hash::get($module, 'hints.allow');
+            }
+        }
         $currentModule = (array)$this->_View->get('currentModule');
         $this->current = (array)Hash::get($currentModule, 'hints.allow');
     }


### PR DESCRIPTION
This fixes a possible problem in PermsHelper initialize by using `foreach` instead of `Hash::combine` to avoid RuntimeError "Hash::combine() needs an equal number of keys + values".

