### PR TITLE
Folders children order

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -27,7 +27,7 @@ jobs:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1
     with:
       php_versions: '["7.4","8.0","8.1"]'
-      bedita_version: '4.8.0'
+      bedita_version: '4.9.0'
 
   unit-5:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,4 +33,4 @@ jobs:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1
     with:
       php_versions: '["7.4","8.0","8.1"]'
-      bedita_version: '5.0.10'
+      bedita_version: '5.2.0'

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-12-12 14:16:42 \n"
+"POT-Creation-Date: 2022-12-13 13:24:25 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -117,6 +117,9 @@ msgid "Change password"
 msgstr ""
 
 msgid "Children"
+msgstr ""
+
+msgid "Children order"
 msgstr ""
 
 msgid "Choose a type"
@@ -723,6 +726,9 @@ msgid "Roles Modules accesses"
 msgstr ""
 
 msgid "Save"
+msgstr ""
+
+msgid "Save object to apply order change"
 msgstr ""
 
 msgid "Scheduled_from"

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2022-09-22 16:03:10 \n"
+"Project-Id-Version: BEdita 4 \n"
+"POT-Creation-Date: 2022-12-12 14:16:42 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -95,6 +95,9 @@ msgstr ""
 msgid "Bulk Action failed on: "
 msgstr ""
 
+msgid "Bulk action performed on {0} objects"
+msgstr ""
+
 msgid "Calendar"
 msgstr ""
 
@@ -183,6 +186,12 @@ msgid "Created"
 msgstr ""
 
 msgid "Current password"
+msgstr ""
+
+msgid "Custom action class {0} is not valid"
+msgstr ""
+
+msgid "Custom action class {0} not found"
 msgstr ""
 
 msgid "Custom properties"
@@ -437,6 +446,12 @@ msgstr ""
 msgid "Modified"
 msgstr ""
 
+msgid "Modified ↑ Oldest on top"
+msgstr ""
+
+msgid "Modified ↓ Newest on top"
+msgstr ""
+
 msgid "Module access not authorized"
 msgstr ""
 
@@ -608,6 +623,12 @@ msgstr ""
 msgid "Position"
 msgstr ""
 
+msgid "Position ↑"
+msgstr ""
+
+msgid "Position ↓"
+msgstr ""
+
 msgid "Preferences and Tools"
 msgstr ""
 
@@ -768,6 +789,12 @@ msgid "Thumb not ready: coming soon"
 msgstr ""
 
 msgid "Thumbnail is not ready"
+msgstr ""
+
+msgid "Title ↑"
+msgstr ""
+
+msgid "Title ↓"
 msgstr ""
 
 msgid "To"
@@ -1077,7 +1104,7 @@ msgid "Moving ${ number } item(s) to trash. Are you sure?"
 msgstr ""
 
 #, javascript-format
-msgid "Do you really want to trash these property types? ${ types }"
+msgid "Do you really want to remove these property types? ${ types }"
 msgstr ""
 
 msgid "Remove item. Are you sure?"
@@ -1138,6 +1165,9 @@ msgid "Search existing tags"
 msgstr ""
 
 msgid "Add new tag"
+msgstr ""
+
+msgid "Error on deleting tag"
 msgstr ""
 
 msgid "copied in the clipboard"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2022-12-12 14:16:42 \n"
+"POT-Creation-Date: 2022-12-13 13:24:25 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -120,6 +120,9 @@ msgid "Change password"
 msgstr ""
 
 msgid "Children"
+msgstr ""
+
+msgid "Children order"
 msgstr ""
 
 msgid "Choose a type"
@@ -726,6 +729,9 @@ msgid "Roles Modules accesses"
 msgstr ""
 
 msgid "Save"
+msgstr ""
+
+msgid "Save object to apply order change"
 msgstr ""
 
 msgid "Scheduled_from"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2022-09-22 16:03:10 \n"
+"POT-Creation-Date: 2022-12-12 14:16:42 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -98,6 +98,9 @@ msgstr ""
 msgid "Bulk Action failed on: "
 msgstr ""
 
+msgid "Bulk action performed on {0} objects"
+msgstr ""
+
 msgid "Calendar"
 msgstr ""
 
@@ -186,6 +189,12 @@ msgid "Created"
 msgstr ""
 
 msgid "Current password"
+msgstr ""
+
+msgid "Custom action class {0} is not valid"
+msgstr ""
+
+msgid "Custom action class {0} not found"
 msgstr ""
 
 msgid "Custom properties"
@@ -440,6 +449,12 @@ msgstr ""
 msgid "Modified"
 msgstr ""
 
+msgid "Modified ↑ Oldest on top"
+msgstr ""
+
+msgid "Modified ↓ Newest on top"
+msgstr ""
+
 msgid "Module access not authorized"
 msgstr ""
 
@@ -611,6 +626,12 @@ msgstr ""
 msgid "Position"
 msgstr ""
 
+msgid "Position ↑"
+msgstr ""
+
+msgid "Position ↓"
+msgstr ""
+
 msgid "Preferences and Tools"
 msgstr ""
 
@@ -771,6 +792,12 @@ msgid "Thumb not ready: coming soon"
 msgstr ""
 
 msgid "Thumbnail is not ready"
+msgstr ""
+
+msgid "Title ↑"
+msgstr ""
+
+msgid "Title ↓"
 msgstr ""
 
 msgid "To"
@@ -1080,7 +1107,7 @@ msgid "Moving ${ number } item(s) to trash. Are you sure?"
 msgstr ""
 
 #, javascript-format
-msgid "Do you really want to trash these property types? ${ types }"
+msgid "Do you really want to remove these property types? ${ types }"
 msgstr ""
 
 msgid "Remove item. Are you sure?"
@@ -1141,6 +1168,9 @@ msgid "Search existing tags"
 msgstr ""
 
 msgid "Add new tag"
+msgstr ""
+
+msgid "Error on deleting tag"
 msgstr ""
 
 msgid "copied in the clipboard"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2022-09-22 16:03:10 \n"
+"POT-Creation-Date: 2022-12-12 14:16:42 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -98,6 +98,9 @@ msgstr "Data di nascita"
 msgid "Bulk Action failed on: "
 msgstr "Operazione massiva non riuscita:"
 
+msgid "Bulk action performed on {0} objects"
+msgstr "Operazione massiva eseguita su {n} oggetti"
+
 msgid "Calendar"
 msgstr "Calendario"
 
@@ -187,6 +190,12 @@ msgstr "Creato"
 
 msgid "Current password"
 msgstr "Password corrente"
+
+msgid "Custom action class {0} is not valid"
+msgstr "Classe action personalizzata {0} non valida"
+
+msgid "Custom action class {0} not found"
+msgstr "Classe action personalizzata {0} non trovata"
 
 msgid "Custom properties"
 msgstr "Proprietà personalizzate"
@@ -440,6 +449,12 @@ msgstr "Url miniatura mancante"
 msgid "Modified"
 msgstr "Modificato"
 
+msgid "Modified ↑ Oldest on top"
+msgstr "Data di modifica ↑ Meno recenti in testa"
+
+msgid "Modified ↓ Newest on top"
+msgstr "Data di modifica ↓ Più recenti in testa"
+
 msgid "Module access not authorized"
 msgstr "Accesso al modulo non autorizzato"
 
@@ -613,6 +628,12 @@ msgstr ""
 msgid "Position"
 msgstr "Posizione"
 
+msgid "Position ↑"
+msgstr "Posizione ↑"
+
+msgid "Position ↓"
+msgstr "Posizione ↓"
+
 msgid "Preferences and Tools"
 msgstr "Preferenze e Strumenti"
 
@@ -775,6 +796,12 @@ msgstr "Miniatura non pronta: in lavorazione"
 
 msgid "Thumbnail is not ready"
 msgstr "La miniatura non è pronta"
+
+msgid "Title ↑"
+msgstr "Titolo ↑"
+
+msgid "Title ↓"
+msgstr "Titolo ↓"
 
 msgid "To"
 msgstr "A"
@@ -1084,7 +1111,7 @@ msgid "Moving ${ number } item(s) to trash. Are you sure?"
 msgstr "Stai per spostare ${ number } elementi nel cestino. Vuoi procedere?"
 
 #, javascript-format
-msgid "Do you really want to trash these property types? ${ types }"
+msgid "Do you really want to remove these property types? ${ types }"
 msgstr "Vuoi davvero cancellare questi tipi di proprietà? ${ types }"
 
 msgid "Remove item. Are you sure?"
@@ -1148,6 +1175,9 @@ msgstr "Cerca tag esistenti"
 
 msgid "Add new tag"
 msgstr "Aggiungi un nuovo tag"
+
+msgid "Error on deleting tag"
+msgstr "Errore nell'eliminazione del tag"
 
 msgid "copied in the clipboard"
 msgstr "copiato negli appunti"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2022-12-12 14:16:42 \n"
+"POT-Creation-Date: 2022-12-13 13:24:25 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -121,6 +121,9 @@ msgstr "Cambia password"
 
 msgid "Children"
 msgstr "Contenuti"
+
+msgid "Children order"
+msgstr "Ordinamento contenuti"
 
 msgid "Choose a type"
 msgstr "Selezionare un tipo"
@@ -729,6 +732,9 @@ msgstr "Accessi Ruoli Moduli"
 
 msgid "Save"
 msgstr "Salva"
+
+msgid "Save object to apply order change"
+msgstr "Salva per applicare cambiamenti di ordinamento"
 
 msgid "Scheduled_from"
 msgstr "Partenza"

--- a/resources/js/app/components/relation-view/relation-view.js
+++ b/resources/js/app/components/relation-view/relation-view.js
@@ -753,6 +753,21 @@ export default {
         },
 
         /**
+         * Get position value
+         *
+         * @param {Object} related The related folder
+         * @param {String} defaultPosition The default position
+         * @returns
+         */
+        position(related, defaultPosition) {
+            if (related?.meta?.relation?.position) {
+                return related.meta.relation.position;
+            }
+
+            return defaultPosition;
+        },
+
+        /**
          * Return true when related object has streams data.
          *
          * @param {Object} related The object

--- a/resources/js/app/components/relation-view/relation-view.js
+++ b/resources/js/app/components/relation-view/relation-view.js
@@ -302,13 +302,8 @@ export default {
             this.objects.splice(newIndex, 0, this.objects.splice(oldIndex, 1)[0]);
 
             this.objects = this.objects.map((object, index) => {
-                if (ascending) {
-                    object.meta.relation.position = index + 1;
-                    object.meta.relation.position += this.pagination.page_size * (this.pagination.page - 1);
-                } else {
-                    object.meta.relation.position = this.pagination.count - index;
-                    object.meta.relation.position += this.pagination.page_size * (this.pagination.page - 1);
-                }
+                object.meta.relation.position = ascending ? index + 1 : this.pagination.count - index;
+                object.meta.relation.position += this.pagination.page_size * (this.pagination.page - 1);
                 this.modifyRelation(object);
 
                 return object;

--- a/resources/js/app/components/relation-view/relation-view.js
+++ b/resources/js/app/components/relation-view/relation-view.js
@@ -288,15 +288,29 @@ export default {
 
         // children position
         updatePositions(movedObject, newIndex) {
+            let ascending = true;
+            let order = 'position';
+            if (document.getElementById('children-order')) {
+                order = document.getElementById('children-order').value;
+            }
+            if (order.indexOf('position') >= 0) {
+                ascending = order === 'position';
+            }
             const oldIndex = this.objects.findIndex((object) => movedObject.id === object.id);
 
             // moves the object in the objects array from the old index to the new index
             this.objects.splice(newIndex, 0, this.objects.splice(oldIndex, 1)[0]);
 
             this.objects = this.objects.map((object, index) => {
-                object.meta.relation.position = index + 1;
-                object.meta.relation.position += this.pagination.page_size * (this.pagination.page - 1);
+                if (ascending) {
+                    object.meta.relation.position = index + 1;
+                    object.meta.relation.position += this.pagination.page_size * (this.pagination.page - 1);
+                } else {
+                    object.meta.relation.position = this.pagination.count - index;
+                    object.meta.relation.position += this.pagination.page_size * (this.pagination.page - 1);
+                }
                 this.modifyRelation(object);
+
                 return object;
             });
         },

--- a/resources/js/app/mixins/paginated-content.js
+++ b/resources/js/app/mixins/paginated-content.js
@@ -71,6 +71,7 @@ export const PaginatedContentMixin = {
                 }
 
                 options.signal = this.requestController.signal;
+                const isChildren = requestUrl.indexOf('/related/children') > 0;
 
                 let currentRequest = fetch(requestUrl, options)
                     .then((response) => response.json())
@@ -80,6 +81,20 @@ export const PaginatedContentMixin = {
                         let objects = [];
                         if (json && 'data' in json) {
                             objects = (Array.isArray(json.data) ? json.data : [json.data]) || [];
+                        }
+                        if (isChildren) {
+                            let order = 'position';
+                            if (document.getElementById('children-order')) {
+                                order = document.getElementById('children-order').value;
+                            }
+                            if (order.indexOf('position') >= 0) {
+                                const ascending = order === 'position';
+                                let i = order === 'position' ? 1 : json.meta.pagination.count;
+                                for (let obj of objects) {
+                                    obj.meta.relation.position = i;
+                                    i = ascending ? i+1 : i-1;
+                                }
+                            }
                         }
 
                         // if requestQueue is empty it means that this request is the last of the queue

--- a/resources/js/app/mixins/paginated-content.js
+++ b/resources/js/app/mixins/paginated-content.js
@@ -89,7 +89,7 @@ export const PaginatedContentMixin = {
                             }
                             if (order.indexOf('position') >= 0) {
                                 const ascending = order === 'position';
-                                let i = order === 'position' ? 1 : json.meta.pagination.count;
+                                let i = ascending ? 1 : json.meta.pagination.count;
                                 for (let obj of objects) {
                                     obj.meta.relation.position = i;
                                     i = ascending ? i+1 : i-1;

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -88,6 +88,7 @@ class PropertiesComponent extends Component
         'date_ranges',
         'tags',
         'lang',
+        'children_order',
     ];
 
     /**

--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -35,6 +35,7 @@ class Options
         'status',
         'title',
         'coords',
+        'children_order',
     ];
 
     /**
@@ -222,6 +223,30 @@ class Options
             'class' => 'coordinates',
             'templates' => [
                 'inputContainer' => sprintf('<div class="input coordinates {{type}}{{required}}">%s%s</div>', $label, $coordinatesView),
+            ],
+        ];
+    }
+
+    /**
+     * Children order
+     *
+     * @param mixed|null $value The field value.
+     * @return array
+     */
+    public static function childrenOrder($value): array
+    {
+        return compact('value') + [
+            'type' => 'select',
+            'options' => [
+                ['value' => 'position', 'text' => __('Position ↑')],
+                ['value' => '-position', 'text' => __('Position ↓')],
+                ['value' => 'title', 'text' => __('Title ↑')],
+                ['value' => '-title', 'text' => __('Title ↓')],
+                ['value' => 'modified', 'text' => __('Modified ↑ Oldest on top')],
+                ['value' => '-modified', 'text' => __('Modified ↓ Newest on top')],
+            ],
+            'templateVars' => [
+                'containerClass' => 'childrenOrder',
             ],
         ];
     }

--- a/templates/Element/Form/related_item.twig
+++ b/templates/Element/Form/related_item.twig
@@ -19,7 +19,7 @@
 
 
     {# PRIORITY (or position) #}
-    {% if common or (children and object.attributes.children_order in ['position', '-position']) %}
+    {% if common or (children and object.attributes.children_order in [null, 'position', '-position']) %}
         <div class="priority">
             {% if children %}
                 <span class="badge" v-html="position(related, index + 1)"></span>
@@ -143,9 +143,8 @@
     </div>
     {% endif %}
 
-
     {# CHILDREN position #}
-    {% if children and object.attributes.children_order in ['position', '-position'] %}
+    {% if children and object.attributes.children_order in [null, 'position', '-position'] %}
         <div class="children-position container-grid p-05">
             <dl>
                 <dt>{{ __('Move to position') }}:</dt>

--- a/templates/Element/Form/related_item.twig
+++ b/templates/Element/Form/related_item.twig
@@ -7,6 +7,8 @@
     • children    (translations.twig)
 #}
 
+{% set positionInUse = children and object.attributes.children_order in [null, 'position', '-position'] %}
+
 <article class="box"
     {%- if add %}
         :class="selectClasses(related)"
@@ -19,7 +21,7 @@
 
 
     {# PRIORITY (or position) #}
-    {% if common or (children and object.attributes.children_order in [null, 'position', '-position']) %}
+    {% if common or positionInUse %}
         <div class="priority">
             {% if children %}
                 <span class="badge" v-html="position(related, index + 1)"></span>
@@ -144,7 +146,7 @@
     {% endif %}
 
     {# CHILDREN position #}
-    {% if children and object.attributes.children_order in [null, 'position', '-position'] %}
+    {% if positionInUse %}
         <div class="children-position container-grid p-05">
             <dl>
                 <dt>{{ __('Move to position') }}:</dt>

--- a/templates/Element/Form/related_item.twig
+++ b/templates/Element/Form/related_item.twig
@@ -19,10 +19,10 @@
 
 
     {# PRIORITY (or position) #}
-    {% if common or children %}
+    {% if common or (children and object.attributes.children_order in ['position', '-position']) %}
         <div class="priority">
             {% if children %}
-                <span class="badge" v-html="index + 1"><: related.meta.relation.priority :></span>
+                <span class="badge" v-html="position(related, index + 1)"></span>
             {% else %}
                 <span class="badge"><: related.meta.relation.priority :></span>
             {% endif %}
@@ -145,7 +145,7 @@
 
 
     {# CHILDREN position #}
-    {% if children %}
+    {% if children and object.attributes.children_order in ['position', '-position'] %}
         <div class="children-position container-grid p-05">
             <dl>
                 <dt>{{ __('Move to position') }}:</dt>

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -55,16 +55,20 @@
                 </filter-box-view>
             </div>
 
+            {% set dragAndDrop = relationName != 'children' or (relationName == 'children' and mainObject.attributes.children_order in [null, 'position', '-position']) %}
             {# RELATED OBJECTS #}
             <div class="related-objects mb-1" v-show="objects.length || addedRelations.length">
-                <div :data-list="dataList" class="columns" droppable sortable>
+                <div :data-list="dataList" class="columns" {%- if dragAndDrop %}droppable sortable{%- endif %}>
                     <div
                         class="related-item-column column is-3 is-one-half-mobile is-one-third-tablet is-one-quarter-desktop is-one-fifth-widescreen is-one-sixth-fullhd"
                         v-for="(related, index) in objects"
                         :key="related.id"
                         :class="containsId(removedRelated, related.id)? 'removed' : ''"
+                        {%- if dragAndDrop %}
                         draggable
-                        :drag-data="JSON.stringify(related)">
+                        :drag-data="JSON.stringify(related)"
+                        {%- endif %}
+                        >
 
                         {% if relationName == 'children' %}
                             {{ element('Form/related_item', { 'children': true }) }}

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -55,6 +55,22 @@
                 </filter-box-view>
             </div>
 
+            {% if relationName == 'children' %}
+            <div class="related-objects ml-1 mb-1">
+                <div class="columns">
+                    {{ Property.control(
+                        'children_order',
+                        mainObject.attributes.children_order|default('position'),
+                        {
+                            'label': __('Children order'),
+                            'class': 'icon-info-1',
+                        }
+                    )|raw }}
+                    <span class="icon-info-1" title="{{ __('Save object to apply order change') }}"></span>
+                </div>
+            </div>
+            {% endif %}
+
             {% set dragAndDrop = relationName != 'children' or (relationName == 'children' and mainObject.attributes.children_order in [null, 'position', '-position']) %}
             {# RELATED OBJECTS #}
             <div class="related-objects mb-1" v-show="objects.length || addedRelations.length">

--- a/templates/Element/Form/relations.twig
+++ b/templates/Element/Form/relations.twig
@@ -34,6 +34,7 @@
                         'readonly': relationsSchema[relationName].readonly,
                         'preCount': preCount,
                         'uploadableNum': uploadableNum,
+                        'mainObject': mainObject,
                     }) }}
                 </div>
 

--- a/templates/Pages/Modules/view.twig
+++ b/templates/Pages/Modules/view.twig
@@ -79,11 +79,11 @@
                 {{ element('Form/resource_relations') }}
 
                 {# aside relations view #}
-                {{ element('Form/relations', {'relations': objectRelations.aside}) }}
+                {{ element('Form/relations', {'relations': objectRelations.aside, 'mainObject': object}) }}
             </div>
 
             {# main relations view #}
-            {{ element('Form/relations', {'relations': objectRelations.main}) }}
+            {{ element('Form/relations', {'relations': objectRelations.main, 'mainObject': object}) }}
 
             {% if object.id %}
                 {{ element('Form/history') }}

--- a/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -91,6 +91,8 @@ class PropertyTypesControllerTest extends TestCase
      */
     public function saveProvider(): array
     {
+        $nextId = $this->nextId();
+
         return [
             // test with empty object
             'emptyRequest' => [
@@ -101,7 +103,7 @@ class PropertyTypesControllerTest extends TestCase
             'addPropertyTypesRequest' => [
                 [
                     [
-                        // 'id' => '14',
+                        // 'id' => $nextId,
                         'type' => 'property_types',
                         'attributes' => [
                                 'name' => 'giovanni',
@@ -126,7 +128,7 @@ class PropertyTypesControllerTest extends TestCase
             'editPropertyTypesRequest' => [
                 [
                     [
-                        'id' => '14',
+                        'id' => $nextId,
                         'type' => 'property_types',
                         'attributes' => [
                             'name' => 'enrico',
@@ -139,7 +141,7 @@ class PropertyTypesControllerTest extends TestCase
                 [
                     'editPropertyTypes' => [
                         [
-                            'id' => '14',
+                            'id' => $nextId,
                             'attributes' => [
                                 'name' => 'enrico',
                                 'params' => [
@@ -152,10 +154,10 @@ class PropertyTypesControllerTest extends TestCase
                 'edited',
             ],
             'removePropertyTypesRequest' => [
-                [ '14' ],
+                [ $nextId ],
                 [
                     'removePropertyTypes' => [
-                        '14',
+                        $nextId,
                     ],
                 ],
                 'removed',
@@ -240,5 +242,19 @@ class PropertyTypesControllerTest extends TestCase
         $this->ModelController->setResourceType($expected);
         $actual = $this->ModelController->getResourceType();
         static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Next ID for test
+     *
+     * @return string
+     */
+    private function nextId(): string
+    {
+        $this->setupController();
+        $response = $this->client->get('/model/property_types');
+        $maxId = (int)Hash::get($response, 'data.%d.id', count($response['data']));
+
+        return $maxId + 1;
     }
 }

--- a/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -106,7 +106,7 @@ class PropertyTypesControllerTest extends TestCase
                         // 'id' => $nextId,
                         'type' => 'property_types',
                         'attributes' => [
-                                'name' => 'dummy_property_one',
+                                'name' => 'dummyone',
                                 'params' => [
                                         'type' => 'string',
                                 ],
@@ -116,7 +116,7 @@ class PropertyTypesControllerTest extends TestCase
                 [
                     'addPropertyTypes' => [
                         [
-                            'name' => 'dummy_property_one',
+                            'name' => 'dummyone',
                             'params' => json_encode([
                                 'type' => 'string',
                             ]),
@@ -131,7 +131,7 @@ class PropertyTypesControllerTest extends TestCase
                         'id' => $nextId,
                         'type' => 'property_types',
                         'attributes' => [
-                            'name' => 'dummy_property_two',
+                            'name' => 'dummytwo',
                             'params' => [
                                 'type' => 'object',
                             ],
@@ -143,7 +143,7 @@ class PropertyTypesControllerTest extends TestCase
                         [
                             'id' => $nextId,
                             'attributes' => [
-                                'name' => 'dummy_property_two',
+                                'name' => 'dummytwo',
                                 'params' => [
                                     'type' => 'object',
                                 ],

--- a/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -106,7 +106,7 @@ class PropertyTypesControllerTest extends TestCase
                         // 'id' => $nextId,
                         'type' => 'property_types',
                         'attributes' => [
-                                'name' => 'giovanni',
+                                'name' => 'dummy_property_one',
                                 'params' => [
                                         'type' => 'string',
                                 ],
@@ -116,7 +116,7 @@ class PropertyTypesControllerTest extends TestCase
                 [
                     'addPropertyTypes' => [
                         [
-                            'name' => 'giovanni',
+                            'name' => 'dummy_property_one',
                             'params' => json_encode([
                                 'type' => 'string',
                             ]),
@@ -131,7 +131,7 @@ class PropertyTypesControllerTest extends TestCase
                         'id' => $nextId,
                         'type' => 'property_types',
                         'attributes' => [
-                            'name' => 'enrico',
+                            'name' => 'dummy_property_two',
                             'params' => [
                                 'type' => 'object',
                             ],
@@ -143,7 +143,7 @@ class PropertyTypesControllerTest extends TestCase
                         [
                             'id' => $nextId,
                             'attributes' => [
-                                'name' => 'enrico',
+                                'name' => 'dummy_property_two',
                                 'params' => [
                                     'type' => 'object',
                                 ],

--- a/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -101,7 +101,7 @@ class PropertyTypesControllerTest extends TestCase
             'addPropertyTypesRequest' => [
                 [
                     [
-                        // 'id' => '13',
+                        // 'id' => '14',
                         'type' => 'property_types',
                         'attributes' => [
                                 'name' => 'giovanni',
@@ -126,7 +126,7 @@ class PropertyTypesControllerTest extends TestCase
             'editPropertyTypesRequest' => [
                 [
                     [
-                        'id' => '13',
+                        'id' => '14',
                         'type' => 'property_types',
                         'attributes' => [
                             'name' => 'enrico',
@@ -139,7 +139,7 @@ class PropertyTypesControllerTest extends TestCase
                 [
                     'editPropertyTypes' => [
                         [
-                            'id' => '13',
+                            'id' => '14',
                             'attributes' => [
                                 'name' => 'enrico',
                                 'params' => [
@@ -152,10 +152,10 @@ class PropertyTypesControllerTest extends TestCase
                 'edited',
             ],
             'removePropertyTypesRequest' => [
-                [ '13' ],
+                [ '14' ],
                 [
                     'removePropertyTypes' => [
-                        '13',
+                        '14',
                     ],
                 ],
                 'removed',

--- a/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -255,6 +255,6 @@ class PropertyTypesControllerTest extends TestCase
         $response = $this->client->get('/model/property_types');
         $maxId = (int)Hash::get($response, 'data.%d.id', count($response['data']));
 
-        return $maxId + 1;
+        return strval($maxId + 1);
     }
 }

--- a/tests/TestCase/Form/OptionsTest.php
+++ b/tests/TestCase/Form/OptionsTest.php
@@ -196,6 +196,25 @@ class OptionsTest extends TestCase
                     'type' => 'readonly',
                 ],
             ],
+            'children_order' => [
+                'children_order',
+                '-title',
+                [
+                    'type' => 'select',
+                    'options' => [
+                        ['value' => 'position', 'text' => __('Position ↑')],
+                        ['value' => '-position', 'text' => __('Position ↓')],
+                        ['value' => 'title', 'text' => __('Title ↑')],
+                        ['value' => '-title', 'text' => __('Title ↓')],
+                        ['value' => 'modified', 'text' => __('Modified ↑ Oldest on top')],
+                        ['value' => '-modified', 'text' => __('Modified ↓ Newest on top')],
+                    ],
+                    'templateVars' => [
+                        'containerClass' => 'childrenOrder',
+                    ],
+                    'value' => '-title',
+                ],
+            ],
         ];
     }
 
@@ -219,6 +238,7 @@ class OptionsTest extends TestCase
      * @covers ::confirmPassword
      * @covers ::title
      * @covers ::coords
+     * @covers ::childrenOrder
      */
     public function testCustomControl(string $name, $value, array $expected, array $config = []): void
     {


### PR DESCRIPTION
With BEdita 4.9.0 (https://github.com/bedita/bedita/releases/tag/v4.9.0) and 5.2.0 (https://github.com/bedita/bedita/releases/tag/v5.2.0) folders children can be ordered using a property "children_order".

This provides an update in the folder's view:

 - drop down to handle children_order
 - in the children items:
   - when children_order value is not default (`null`) nor  `position` or `-position`, do not show position numbers and the input field "move to position"
   - when children order is not default (`null`) nor  `position` or `-position` disable drag and drop
   - when children order is `-position` use numbers in descending order
  
![children_order](https://user-images.githubusercontent.com/2227145/207085009-73920e3e-478b-4b32-b2f9-eac29277bb4f.png)

![children_order-ita](https://user-images.githubusercontent.com/2227145/207085380-0ec30a5f-7b60-41d8-a34a-f908c204dfb7.png)

Bonus: use bedita_version 4.9.0 and 5.2.0 in php workflow
