### PR TITLE
Fix translations module types filter

### DIFF
--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -46,6 +46,17 @@ class TranslationsController extends ModulesController
     }
 
     /**
+     * @inheritDoc
+     */
+    public function index(): ?Response
+    {
+        parent::index();
+        $this->set('types', ['right' => $this->Modules->objectTypes(false)]);
+
+        return null;
+    }
+
+    /**
      * Display data to add a translation.
      *
      * @param string|int $id Object ID.

--- a/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -623,4 +623,20 @@ class TranslationsControllerTest extends TestCase
             static::assertArrayHasKey($varName, $this->controller->viewBuilder()->getVars());
         }
     }
+
+    /**
+     * Test `index` method
+     *
+     * @return void
+     * @covers ::index()
+     */
+    public function testIndex(): void
+    {
+        $request = new ServerRequest($this->defaultRequestConfig);
+        $this->controller = new TranslationsController($request);
+        $this->controller->index();
+        $types = $this->controller->viewBuilder()->getVar('types');
+        static::assertIsArray($types);
+        static::assertNotEmpty($types);
+    }
 }


### PR DESCRIPTION
This PR fixes a problem with `types` filter in `Translations` module where `types` variable is currently empty