### PR TITLE
Browsers data updating for browserslist

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,15 +2055,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0:
-  version "1.0.30001341"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz#59590c8ffa8b5939cf4161f00827b8873ad72498"
-  integrity sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==
-
-caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001349:
-  version "1.0.30001350"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001350.tgz#f0acc6472469d066a4357765eb73be5973eda918"
-  integrity sha512-NZBql38Pzd+rAu5SPXv+qmTWGQuFsRiemHCJCAPvkoDxWV19/xqL2YHF32fDJ9SDLdLqfax8+S0CO3ncDCp9Iw==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001349:
+  version "1.0.30001439"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz"
+  integrity sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==
 
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -5342,7 +5337,7 @@ tfunk@^4.0.0:
     chalk "^1.1.3"
     dlv "^1.1.3"
 
-tinymce@^5.10.0:
+tinymce@^5.10.7:
   version "5.10.7"
   resolved "https://registry.npmjs.org/tinymce/-/tinymce-5.10.7.tgz#d89d446f1962f2a1df6b2b70018ce475ec7ffb80"
   integrity sha512-9UUjaO0R7FxcFo0oxnd1lMs7H+D0Eh+dDVo5hKbVe1a+VB0nit97vOqlinj+YwgoBDt6/DSCUoWqAYlLI8BLYA==


### PR DESCRIPTION
This fixes a warning when launching `yarn dev`.

The warning:
```
Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
```

Fixed, as suggested:
```
$ npx browserslist@latest --update-db
Need to install the following packages:
  browserslist@4.21.4
Ok to proceed? (y) y
Latest version:     1.0.30001439
Installed versions: 1.0.30001341, 1.0.30001350
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ yarn add -W caniuse-lite
warning " > mapbox-gl-compare@0.4.0" has incorrect peer dependency "mapbox-gl@>=0.32.1 <2.0.0".
warning "mapbox-gl-compare > @mapbox/mapbox-gl-sync-move@0.3.0" has incorrect peer dependency "mapbox-gl@>=0.32.1 <2.0.0".
warning "svelte-jsoneditor > svelte-awesome@3.0.0" has unmet peer dependency "svelte@^3.43.1".
warning "svelte-jsoneditor > svelte-simple-modal@1.4.0" has unmet peer dependency "svelte@^3.31.2".
warning "svelte-jsoneditor > codemirror > @codemirror/autocomplete@6.0.2" has unmet peer dependency "@lezer/common@^1.0.0".
warning " > postcss-loader@6.2.0" has unmet peer dependency "postcss@^7.0.0 || ^8.0.1".
Cleaning package.json dependencies from caniuse-lite
$ yarn remove -W caniuse-lite
warning " > mapbox-gl-compare@0.4.0" has incorrect peer dependency "mapbox-gl@>=0.32.1 <2.0.0".
warning "mapbox-gl-compare > @mapbox/mapbox-gl-sync-move@0.3.0" has incorrect peer dependency "mapbox-gl@>=0.32.1 <2.0.0".
warning "svelte-jsoneditor > svelte-awesome@3.0.0" has unmet peer dependency "svelte@^3.43.1".
warning "svelte-jsoneditor > svelte-simple-modal@1.4.0" has unmet peer dependency "svelte@^3.31.2".
warning "svelte-jsoneditor > codemirror > @codemirror/autocomplete@6.0.2" has unmet peer dependency "@lezer/common@^1.0.0".
warning " > postcss-loader@6.2.0" has unmet peer dependency "postcss@^7.0.0 || ^8.0.1".
caniuse-lite has been successfully updated
```