### PR TITLE
Scrutinizer config, node 18 and php 8.1

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -27,10 +27,10 @@ jobs:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1
     with:
       php_versions: '["7.4","8.0","8.1"]'
-      bedita_version: '4.9.0'
+      bedita_version: '4'
 
   unit-5:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1
     with:
       php_versions: '["7.4","8.0","8.1"]'
-      bedita_version: '5.2.0'
+      bedita_version: '5'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,10 +6,16 @@ filter:
   dependency_paths:
     - 'vendor/*'
 
-# new PHP Analysis
 build:
+  environment:
+    node: v18
   nodes:
     analysis:
+      environment:
+        php:
+          version: 8.1
+          pecl_extensions:
+            - zip
       tests:
         override:
           - php-scrutinizer-run

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,6 +7,7 @@ filter:
     - 'vendor/*'
 
 build:
+  image: default-jammy
   environment:
     node: v18
   nodes:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,7 +7,6 @@ filter:
     - 'vendor/*'
 
 build:
-  image: default-jammy
   environment:
     node: v18
   nodes:

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -9,6 +9,7 @@
  * (at your option) any later version.
  *
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ * dummy change
  */
 namespace App\Controller;
 

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -9,7 +9,6 @@
  * (at your option) any later version.
  *
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
- * dummy change
  */
 namespace App\Controller;
 


### PR DESCRIPTION
This updates scrutinizer config. Remote config on https://scrutinizer-ci.com/g/bedita/manager/ has been removed.

Bonus: update bedita_version in php workflow (latest 4 and 5)