### PR TITLE
Clear schema on model change

### DIFF
--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -462,4 +462,15 @@ class SchemaComponent extends Component
 
         return $types;
     }
+
+    /**
+     * Clear schema cache
+     *
+     * @return void
+     * @codeCoverageIgnore
+     */
+    public function clearCache(): void
+    {
+        Cache::clear(static::CACHE_CONFIG);
+    }
 }

--- a/src/Controller/Model/ModelBaseController.php
+++ b/src/Controller/Model/ModelBaseController.php
@@ -201,6 +201,7 @@ abstract class ModelBaseController extends AppController
      */
     public function save(): ?Response
     {
+        $this->Schema->clearCache();
         $id = null;
         try {
             $id = $this->doSave();
@@ -258,6 +259,7 @@ abstract class ModelBaseController extends AppController
      */
     public function remove(string $id): ?Response
     {
+        $this->Schema->clearCache();
         try {
             $this->apiClient->delete(sprintf('/model/%s/%s', $this->resourceType, $id));
         } catch (BEditaClientException $e) {

--- a/src/Controller/Model/PropertyTypesController.php
+++ b/src/Controller/Model/PropertyTypesController.php
@@ -54,6 +54,7 @@ class PropertyTypesController extends ModelBaseController
 
         $this->getRequest()->allowMethod(['post']);
         $response = [];
+        $this->Schema->clearCache();
 
         try {
             if (empty($payload)) {


### PR DESCRIPTION
This PR provides a simple schema cache clear after every model related change.
This way every model change is immediately effective.