### PR TITLE
Avoid error when saving a relation with `params`

### DIFF
--- a/src/Controller/Model/RelationsController.php
+++ b/src/Controller/Model/RelationsController.php
@@ -84,12 +84,19 @@ class RelationsController extends ModelBaseController
     public function save(): ?Response
     {
         $data = (array)$this->request->getData();
+
+        // remove 'definitions' from JSON-SCHEMA relation 'params' attribute to avoid validation errors
+        $params = (array)json_decode((string)Hash::get($data, 'params'), true);
+        unset($params['definitions']);
+        $params = empty($params) ? null : json_encode($params);
+
         $this->updateRelatedTypes($data, 'left');
         $this->updateRelatedTypes($data, 'right');
         $this->request = $this->request->withoutData('change_left')
             ->withoutData('change_right')
             ->withoutData('current_left')
-            ->withoutData('current_right');
+            ->withoutData('current_right')
+            ->withData('params', $params);
 
         return parent::save();
     }


### PR DESCRIPTION
This PR fixes a problem saving a `relation` in modeling module: when `params` attribute is populated a JSON-SCHEMA validation error is raised because `definitions` becomes and empty array instead of an empty object in a JSON to PHP conversion.

 