### PR TITLE
File upload: check file type and size. Show preview if it is an image

### DIFF
--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2023-01-26 10:48:28 \n"
+"POT-Creation-Date: 2023-01-26 17:58:40 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2023-01-26 17:58:40 \n"
+"POT-Creation-Date: 2023-01-30 10:57:43 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -854,6 +854,9 @@ msgstr ""
 msgid "Uname"
 msgstr ""
 
+msgid "Undo Change File"
+msgstr ""
+
 msgid "Unknown upload error"
 msgstr ""
 
@@ -1236,7 +1239,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Title"
 msgstr ""
 
@@ -1244,7 +1247,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Address"
 msgstr ""
 
@@ -1252,7 +1255,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "GET"
 msgstr ""
 
@@ -1263,7 +1266,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "add new"
 msgstr ""
 
@@ -1278,7 +1281,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 
@@ -1299,7 +1302,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Every day"
 msgstr ""
 
@@ -1308,7 +1311,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Sunday"
 msgstr ""
 
@@ -1317,7 +1320,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Monday"
 msgstr ""
 
@@ -1326,7 +1329,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Tuesday"
 msgstr ""
 
@@ -1335,7 +1338,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Wednesday"
 msgstr ""
 
@@ -1344,7 +1347,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Thursday"
 msgstr ""
 
@@ -1353,7 +1356,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Friday"
 msgstr ""
 
@@ -1362,7 +1365,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Saturday"
 msgstr ""
 
@@ -1371,7 +1374,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Invalid date range"
 msgstr ""
 

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2023-01-20 07:34:09 \n"
+"POT-Creation-Date: 2023-01-24 17:18:03 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -186,9 +186,6 @@ msgid "Create a new category"
 msgstr ""
 
 msgid "Create a new tag"
-msgstr ""
-
-msgid "Create new"
 msgstr ""
 
 msgid "Created"
@@ -1128,6 +1125,12 @@ msgid ""
 "less than max file size (${ maxFileSizeMb } MB)"
 msgstr ""
 
+msgid "File type not accepted"
+msgstr ""
+
+msgid "Accepted types"
+msgstr ""
+
 msgid "stop"
 msgstr ""
 
@@ -1156,12 +1159,6 @@ msgid "Items"
 msgstr ""
 
 msgid "Search text too short. Minimum length is 3. Retry"
-msgstr ""
-
-msgid "File type not accepted"
-msgstr ""
-
-msgid "Accepted types"
 msgstr ""
 
 msgid "Open Uri"

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-12-13 13:24:25 \n"
+"POT-Creation-Date: 2023-01-20 07:34:09 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -123,6 +123,9 @@ msgid "Children"
 msgstr ""
 
 msgid "Children order"
+msgstr ""
+
+msgid "Choose a file"
 msgstr ""
 
 msgid "Choose a type"
@@ -1155,6 +1158,12 @@ msgstr ""
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr ""
 
+msgid "File type not accepted"
+msgstr ""
+
+msgid "Accepted types"
+msgstr ""
+
 msgid "Open Uri"
 msgstr ""
 
@@ -1208,7 +1217,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Title"
 msgstr ""
 
@@ -1216,7 +1225,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Address"
 msgstr ""
 
@@ -1224,7 +1233,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "GET"
 msgstr ""
 
@@ -1235,7 +1244,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "add new"
 msgstr ""
 
@@ -1250,7 +1259,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 
@@ -1271,7 +1280,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Every day"
 msgstr ""
 
@@ -1280,7 +1289,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Sunday"
 msgstr ""
 
@@ -1289,7 +1298,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Monday"
 msgstr ""
 
@@ -1298,7 +1307,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Tuesday"
 msgstr ""
 
@@ -1307,7 +1316,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Wednesday"
 msgstr ""
 
@@ -1316,7 +1325,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Thursday"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Friday"
 msgstr ""
 
@@ -1334,7 +1343,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Saturday"
 msgstr ""
 
@@ -1343,7 +1352,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Invalid date range"
 msgstr ""
 

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-01-26 17:58:40 \n"
+"POT-Creation-Date: 2023-01-30 10:57:43 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -855,6 +855,9 @@ msgid "Type"
 msgstr ""
 
 msgid "Uname"
+msgstr ""
+
+msgid "Undo Change File"
 msgstr ""
 
 msgid "Unknown upload error"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-01-20 07:34:09 \n"
+"POT-Creation-Date: 2023-01-24 17:18:03 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -189,9 +189,6 @@ msgid "Create a new category"
 msgstr ""
 
 msgid "Create a new tag"
-msgstr ""
-
-msgid "Create new"
 msgstr ""
 
 msgid "Created"
@@ -1131,6 +1128,12 @@ msgid ""
 "less than max file size (${ maxFileSizeMb } MB)"
 msgstr ""
 
+msgid "File type not accepted"
+msgstr ""
+
+msgid "Accepted types"
+msgstr ""
+
 msgid "stop"
 msgstr ""
 
@@ -1159,12 +1162,6 @@ msgid "Items"
 msgstr ""
 
 msgid "Search text too short. Minimum length is 3. Retry"
-msgstr ""
-
-msgid "File type not accepted"
-msgstr ""
-
-msgid "Accepted types"
 msgstr ""
 
 msgid "Open Uri"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2022-12-13 13:24:25 \n"
+"POT-Creation-Date: 2023-01-20 07:34:09 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -126,6 +126,9 @@ msgid "Children"
 msgstr ""
 
 msgid "Children order"
+msgstr ""
+
+msgid "Choose a file"
 msgstr ""
 
 msgid "Choose a type"
@@ -1158,6 +1161,12 @@ msgstr ""
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr ""
 
+msgid "File type not accepted"
+msgstr ""
+
+msgid "Accepted types"
+msgstr ""
+
 msgid "Open Uri"
 msgstr ""
 
@@ -1211,7 +1220,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Title"
 msgstr ""
 
@@ -1219,7 +1228,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Address"
 msgstr ""
 
@@ -1227,7 +1236,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "GET"
 msgstr ""
 
@@ -1238,7 +1247,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "add new"
 msgstr ""
 
@@ -1253,7 +1262,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 
@@ -1274,7 +1283,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Every day"
 msgstr ""
 
@@ -1283,7 +1292,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Sunday"
 msgstr ""
 
@@ -1292,7 +1301,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Monday"
 msgstr ""
 
@@ -1301,7 +1310,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Tuesday"
 msgstr ""
 
@@ -1310,7 +1319,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Wednesday"
 msgstr ""
 
@@ -1319,7 +1328,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Thursday"
 msgstr ""
 
@@ -1328,7 +1337,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Friday"
 msgstr ""
 
@@ -1337,7 +1346,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Saturday"
 msgstr ""
 
@@ -1346,7 +1355,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Invalid date range"
 msgstr ""
 

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-01-26 10:48:28 \n"
+"POT-Creation-Date: 2023-01-26 17:58:40 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-01-26 17:58:40 \n"
+"POT-Creation-Date: 2023-01-30 10:57:43 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -859,6 +859,9 @@ msgstr "Tipo"
 
 msgid "Uname"
 msgstr "Nome univoco"
+
+msgid "Undo Change File"
+msgstr "Annulla Cambio File"
 
 msgid "Unknown upload error"
 msgstr "Errore sconosciuto durante caricamento"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2022-12-13 13:24:25 \n"
+"POT-Creation-Date: 2023-01-20 07:34:09 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -127,6 +127,9 @@ msgstr "Contenuti"
 
 msgid "Children order"
 msgstr "Ordinamento contenuti"
+
+msgid "Choose a file"
+msgstr "Scegli un file"
 
 msgid "Choose a type"
 msgstr "Selezionare un tipo"
@@ -1163,6 +1166,12 @@ msgstr "Elementi"
 
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr "Testo troppo breve. Lunghezza minima 3 caratteri. Riprova"
+
+msgid "File type not accepted"
+msgstr "Tipo di file non consentito"
+
+msgid "Accepted types"
+msgstr "Tipi consentiti"
 
 msgid "Open Uri"
 msgstr "Apri indirizzo"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-01-20 07:34:09 \n"
+"POT-Creation-Date: 2023-01-24 17:18:03 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -190,9 +190,6 @@ msgstr "Crea nuova categoria"
 
 msgid "Create a new tag"
 msgstr "Crea nuovo tag"
-
-msgid "Create new"
-msgstr "Crea nuovo"
 
 msgid "Created"
 msgstr "Creato"
@@ -1137,6 +1134,12 @@ msgstr ""
 "File \"${ filename }\" troppo grande (${ fileSizeMb } MB), selezionare un "
 "file che non superi la dimensione massima (${ maxFileSizeMb } MB)"
 
+msgid "File type not accepted"
+msgstr "Tipo di file non consentito"
+
+msgid "Accepted types"
+msgstr "Tipi consentiti"
+
 msgid "stop"
 msgstr "interrompi"
 
@@ -1166,12 +1169,6 @@ msgstr "Elementi"
 
 msgid "Search text too short. Minimum length is 3. Retry"
 msgstr "Testo troppo breve. Lunghezza minima 3 caratteri. Riprova"
-
-msgid "File type not accepted"
-msgstr "Tipo di file non consentito"
-
-msgid "Accepted types"
-msgstr "Tipi consentiti"
 
 msgid "Open Uri"
 msgstr "Apri indirizzo"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-01-26 10:48:28 \n"
+"POT-Creation-Date: 2023-01-26 17:58:40 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"

--- a/resources/js/app/components/drop-upload.js
+++ b/resources/js/app/components/drop-upload.js
@@ -117,22 +117,11 @@ export default {
             this.$el.classList.remove('dragover');
         },
 
-        titleFromFileName(filename) {
-            let title = filename;
-            title = title.replaceAll('-', ' ');
-            title = title.replaceAll('_', ' ');
-            if (title.lastIndexOf('.') > 0) {
-                title = title.substring(0, title.lastIndexOf('.')) || title;
-            }
-
-            return title.trim();
-        },
-
         // return promise
         upload(file) {
             const objectType = this.getObjectType(file);
             const formData = new FormData();
-            formData.append('title', this.titleFromFileName(file?.name || ''));
+            formData.append('title', this.$helpers.titleFromFileName(file?.name || ''));
             formData.append('status', 'on');
             formData.append('file', file);
             formData.append('model-type', objectType);

--- a/resources/js/app/components/form-file-upload.js
+++ b/resources/js/app/components/form-file-upload.js
@@ -40,23 +40,12 @@ export default {
         previewImage() {
             if (this.file?.name) {
                 if (document.getElementById('title') && document.getElementById('title').value === '') {
-                    document.getElementById('title').value = this.titleFromFileName(this.file.name);
+                    document.getElementById('title').value = this.$helpers.titleFromFileName(this.file.name);
                 }
                 return window.URL.createObjectURL(this.file);
             }
 
             return null;
-        },
-
-        titleFromFileName(filename) {
-            let title = filename;
-            title = title.replaceAll('-', ' ');
-            title = title.replaceAll('_', ' ');
-            if (title.lastIndexOf('.') > 0) {
-                title = title.substring(0, title.lastIndexOf('.')) || title;
-            }
-
-            return title.trim();
         },
     }
 }

--- a/resources/js/app/components/form-file-upload.js
+++ b/resources/js/app/components/form-file-upload.js
@@ -10,26 +10,56 @@
  * @prop {int} defaultActive index of the default active label in labels
  */
 
+import { t } from 'ttag';
+
 export default {
 
     data() {
         return {
-            fileName: '',
+            file: null,
+            /** accepted mime types by object type for file upload */
+            mimes: {
+                images: [
+                    'image/apng',
+                    'image/bmp',
+                    'image/jp2',
+                    'image/jpeg',
+                    'image/jpg',
+                    'image/gif',
+                    'image/png',
+                    'image/svg+xml',
+                    'image/webp',
+                ],
+            },
         }
     },
 
     methods: {
-        onFileChanged(e) {
-            this.fileName = '';
+        onFileChanged(e, type) {
+            this.file = null;
+            if (this.mimes?.[type] && !this.mimes[type].includes(e.target.files[0].type)) {
+                const msg = t`File type not accepted` + `: "${e.target.files[0].type}". ` + t`Accepted types` + `: "${this.mimes[type].join('", "')}".`;
+                BEDITA.warning(msg);
+
+                return;
+            }
             if (this.$helpers.checkMaxFileSize(e.target.files[0]) === false) {
                 return;
             }
-            this.fileName = e.target.files[0].name;
+            this.file = e.target.files[0];
         },
 
         resetFile(e) {
             e.target.parentNode.querySelector('input.file-input').value = '';
-            this.fileName = '';
-        }
+            this.file = null;
+        },
+
+        previewImage() {
+            if (this.file?.name) {
+                return window.URL.createObjectURL(this.file);
+            }
+
+            return null;
+        },
     }
 }

--- a/resources/js/app/components/form-file-upload.js
+++ b/resources/js/app/components/form-file-upload.js
@@ -38,14 +38,7 @@ export default {
         },
 
         previewImage() {
-            if (this.file?.name) {
-                if (document.getElementById('title') && document.getElementById('title').value === '') {
-                    document.getElementById('title').value = this.$helpers.titleFromFileName(this.file.name);
-                }
-                return window.URL.createObjectURL(this.file);
-            }
-
-            return null;
+            return this.$helpers.updatePreviewImage(this.file, 'title');
         },
     }
 }

--- a/resources/js/app/components/form-file-upload.js
+++ b/resources/js/app/components/form-file-upload.js
@@ -17,30 +17,13 @@ export default {
     data() {
         return {
             file: null,
-            /** accepted mime types by object type for file upload */
-            mimes: {
-                images: [
-                    'image/apng',
-                    'image/bmp',
-                    'image/jp2',
-                    'image/jpeg',
-                    'image/jpg',
-                    'image/gif',
-                    'image/png',
-                    'image/svg+xml',
-                    'image/webp',
-                ],
-            },
         }
     },
 
     methods: {
         onFileChanged(e, type) {
             this.file = null;
-            if (this.mimes?.[type] && !this.mimes[type].includes(e.target.files[0].type)) {
-                const msg = t`File type not accepted` + `: "${e.target.files[0].type}". ` + t`Accepted types` + `: "${this.mimes[type].join('", "')}".`;
-                BEDITA.warning(msg);
-
+            if (this.$helpers.checkMimeForUpload(e.target.files[0], type) === false) {
                 return;
             }
             if (this.$helpers.checkMaxFileSize(e.target.files[0]) === false) {

--- a/resources/js/app/components/form-file-upload.js
+++ b/resources/js/app/components/form-file-upload.js
@@ -56,10 +56,24 @@ export default {
 
         previewImage() {
             if (this.file?.name) {
+                if (document.getElementById('title') && document.getElementById('title').value === '') {
+                    document.getElementById('title').value = this.titleFromFileName(this.file.name);
+                }
                 return window.URL.createObjectURL(this.file);
             }
 
             return null;
+        },
+
+        titleFromFileName(filename) {
+            let title = filename;
+            title = title.replaceAll('-', ' ');
+            title = title.replaceAll('_', ' ');
+            if (title.lastIndexOf('.') > 0) {
+                title = title.substring(0, title.lastIndexOf('.')) || title;
+            }
+
+            return title.trim();
         },
     }
 }

--- a/resources/js/app/components/form-file-upload.js
+++ b/resources/js/app/components/form-file-upload.js
@@ -10,8 +10,6 @@
  * @prop {int} defaultActive index of the default active label in labels
  */
 
-import { t } from 'ttag';
-
 export default {
 
     data() {
@@ -21,7 +19,11 @@ export default {
     },
 
     methods: {
-        onFileChanged(e, type) {
+        fileAcceptMimeTypes(type) {
+            return this.$helpers.acceptMimeTypes(type);
+        },
+
+        onFileChange(e, type) {
             this.file = null;
             if (this.$helpers.checkMimeForUpload(e.target.files[0], type) === false) {
                 return;

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -199,15 +199,14 @@ export default {
             this.userInfoLoaded = true;
         },
         previewImage(thumb) {
-            if (this.file?.name) {
-                return window.URL.createObjectURL(this.file);
-            }
-
-            return thumb;
+            return this.$helpers.updatePreviewImage(this.file, 'title', thumb);
         },
         async onFileChange(e, type) {
             const files = e.target.files || e.dataTransfer.files;
             if (this.$helpers.checkMimeForUpload(files[0], type) === false) {
+                return;
+            }
+            if (this.$helpers.checkMaxFileSize(files[0]) === false) {
                 return;
             }
             this.file = files[0];

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -78,20 +78,6 @@ export default {
             totalObjects: 0,
             dataList: parseInt(this.uploadableNum) == 0,
             userInfoLoaded: false,
-            /** accepted mime types by object type for file upload */
-            mimes: {
-                images: [
-                    'image/apng',
-                    'image/bmp',
-                    'image/jp2',
-                    'image/jpeg',
-                    'image/jpg',
-                    'image/gif',
-                    'image/png',
-                    'image/svg+xml',
-                    'image/webp',
-                ],
-            },
         }
     },
 
@@ -221,10 +207,7 @@ export default {
         },
         async onFileChange(e, type) {
             const files = e.target.files || e.dataTransfer.files;
-            if (this.mimes?.[type] && !this.mimes[type].includes(files[0].type)) {
-                const msg = t`File type not accepted` + `: "${files[0].type}". ` + t`Accepted types` + `: "${this.mimes[type].join('", "')}".`;
-                BEDITA.warning(msg);
-
+            if (this.$helpers.checkMimeForUpload(files[0], type) === false) {
                 return;
             }
             this.file = files[0];

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -78,11 +78,11 @@ export default {
             totalObjects: 0,
             dataList: parseInt(this.uploadableNum) == 0,
             userInfoLoaded: false,
+            fileChanged: false,
         }
     },
 
     async mounted() {
-
         if (this.tabOpenAtStart !== null) {
             this.isOpen = this.tabOpenAtStart;
             return;
@@ -91,7 +91,6 @@ export default {
         if (this.preCount >= 0) {
             this.totalObjects = this.preCount;
         }
-
         // load user info in meta fields (created_by and modified_by )
         if (this.tabName === 'meta' && this.isOpen) {
             await this.loadInfoUsers();
@@ -201,6 +200,9 @@ export default {
         previewImage(thumb) {
             return this.$helpers.updatePreviewImage(this.file, 'title', thumb);
         },
+        fileAcceptMimeTypes(type) {
+            return this.$helpers.acceptMimeTypes(type);
+        },
         async onFileChange(e, type) {
             const files = e.target.files || e.dataTransfer.files;
             if (this.$helpers.checkMimeForUpload(files[0], type) === false) {
@@ -210,6 +212,15 @@ export default {
                 return;
             }
             this.file = files[0];
+            this.fileChanged = true;
+        },
+        resetFile(thumb) {
+            document.getElementById('fileUpload').value = '';
+            if (thumb && document.getElementById('imageThumb')) {
+                document.getElementById('imageThumb').src = thumb;
+                this.file = null;
+                this.fileChanged = false;
+            }
         },
     }
 }

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -13,6 +13,8 @@
  *
  */
 
+import { t } from 'ttag';
+
 const API_URL = new URL(BEDITA.base).pathname;
 const API_OPTIONS = {
     credentials: 'same-origin',
@@ -70,11 +72,26 @@ export default {
 
     data() {
         return {
+            file: null,
             isOpen: this.isDefaultOpen,
             isLoading: false,
             totalObjects: 0,
             dataList: parseInt(this.uploadableNum) == 0,
             userInfoLoaded: false,
+            /** accepted mime types by object type for file upload */
+            mimes: {
+                images: [
+                    'image/apng',
+                    'image/bmp',
+                    'image/jp2',
+                    'image/jpeg',
+                    'image/jpg',
+                    'image/gif',
+                    'image/png',
+                    'image/svg+xml',
+                    'image/webp',
+                ],
+            },
         }
     },
 
@@ -194,6 +211,23 @@ export default {
 
             this.isLoading = false;
             this.userInfoLoaded = true;
-        }
+        },
+        previewImage(thumb) {
+            if (this.file?.name) {
+                return window.URL.createObjectURL(this.file);
+            }
+
+            return thumb;
+        },
+        async onFileChange(e, type) {
+            const files = e.target.files || e.dataTransfer.files;
+            if (this.mimes?.[type] && !this.mimes[type].includes(files[0].type)) {
+                const msg = t`File type not accepted` + `: "${files[0].type}". ` + t`Accepted types` + `: "${this.mimes[type].join('", "')}".`;
+                BEDITA.warning(msg);
+
+                return;
+            }
+            this.file = files[0];
+        },
     }
 }

--- a/resources/js/app/components/relation-view/relations-add.js
+++ b/resources/js/app/components/relation-view/relations-add.js
@@ -364,10 +364,10 @@ export default {
             let t = type ? type : this.relationTypes.right[0];
             this.object = createData(this.relationTypes && t);
             const fields = document.querySelectorAll('.fastCreateField');
-            for (let i = 0; i < fields.length; i++) {
-                fields[i].value = '';
-                if (fields[i].jsonEditor) {
-                    fields[i].jsonEditor.update({"text": ""});
+            for (let field of fields) {
+                field.value = '';
+                if (field.jsonEditor) {
+                    field.jsonEditor.update({'text': ''});
                 }
             }
         },
@@ -461,6 +461,15 @@ export default {
             this.loading = false;
 
             return response;
+        },
+
+        onChangeType() {
+            this.file = null;
+            for (let t of this.relationTypes?.right || []) {
+                if (this.$refs[`${t}-form`]) {
+                    this.$refs[`${t}-form`].reset();
+                }
+            }
         },
 
         /**

--- a/resources/js/app/components/relation-view/relations-add.js
+++ b/resources/js/app/components/relation-view/relations-add.js
@@ -463,6 +463,10 @@ export default {
             }
         },
 
+        fileAcceptMimeTypes(type) {
+            return this.$helpers.acceptMimeTypes(type);
+        },
+
         /**
          * set file, object type and placeholder
          *

--- a/resources/js/app/components/relation-view/relations-add.js
+++ b/resources/js/app/components/relation-view/relations-add.js
@@ -485,17 +485,11 @@ export default {
                 this.object.attributes.title = this.file.name;
             }
             const titleId = `_fast_create_${type}_title`;
-            if (document.getElementById(titleId) && document.getElementById(titleId).value === '') {
-                document.getElementById(titleId).value = this.$helpers.titleFromFileName(this.file.name);
-            }
+            this.$helpers.setTitleFromFileName(titleId, this.file.name);
         },
 
         previewImage() {
-            if (this.file?.name) {
-                return window.URL.createObjectURL(this.file);
-            }
-
-            return null;
+            return this.$helpers.updatePreviewImage(this.file);
         },
     },
 };

--- a/resources/js/app/components/relation-view/relations-add.js
+++ b/resources/js/app/components/relation-view/relations-add.js
@@ -467,8 +467,15 @@ export default {
          * set file, object type and placeholder
          *
          * @param {Event} event input file change event
+         * @param {String} type The object type
          */
-        processFile(event) {
+        processFile(event, type) {
+            if (this.$helpers.checkMimeForUpload(event.target.files[0], type) === false) {
+                return;
+            }
+            if (this.$helpers.checkMaxFileSize(event.target.files[0]) === false) {
+                return false;
+            }
             this.file = event.target.files[0];
             if (!this.file) {
                 return false;
@@ -477,6 +484,29 @@ export default {
             if (!this.object.attributes.title) {
                 this.object.attributes.title = this.file.name;
             }
+            const titleId = `_fast_create_${type}_title`;
+            if (document.getElementById(titleId) && document.getElementById(titleId).value === '') {
+                document.getElementById(titleId).value = this.titleFromFileName(this.file.name);
+            }
+        },
+
+        previewImage() {
+            if (this.file?.name) {
+                return window.URL.createObjectURL(this.file);
+            }
+
+            return null;
+        },
+
+        titleFromFileName(filename) {
+            let title = filename;
+            title = title.replaceAll('-', ' ');
+            title = title.replaceAll('_', ' ');
+            if (title.lastIndexOf('.') > 0) {
+                title = title.substring(0, title.lastIndexOf('.')) || title;
+            }
+
+            return title.trim();
         },
     },
 };

--- a/resources/js/app/components/relation-view/relations-add.js
+++ b/resources/js/app/components/relation-view/relations-add.js
@@ -486,7 +486,7 @@ export default {
             }
             const titleId = `_fast_create_${type}_title`;
             if (document.getElementById(titleId) && document.getElementById(titleId).value === '') {
-                document.getElementById(titleId).value = this.titleFromFileName(this.file.name);
+                document.getElementById(titleId).value = this.$helpers.titleFromFileName(this.file.name);
             }
         },
 
@@ -496,17 +496,6 @@ export default {
             }
 
             return null;
-        },
-
-        titleFromFileName(filename) {
-            let title = filename;
-            title = title.replaceAll('-', ' ');
-            title = title.replaceAll('_', ' ');
-            if (title.lastIndexOf('.') > 0) {
-                title = title.substring(0, title.lastIndexOf('.')) || title;
-            }
-
-            return title.trim();
         },
     },
 };

--- a/resources/js/app/components/relation-view/relations-add.js
+++ b/resources/js/app/components/relation-view/relations-add.js
@@ -352,24 +352,15 @@ export default {
             ]
         },
 
-        /**
-         * clear form
-         * @return {void}
-         */
         resetForm(event, type) {
             event.preventDefault();
-
+            if (this.$refs[`${type}-form`]) {
+                this.$refs[`${type}-form`].reset();
+            }
             this.file = null;
             this.url = null;
-            let t = type ? type : this.relationTypes.right[0];
+            const t = type || this.relationTypes.right[0];
             this.object = createData(this.relationTypes && t);
-            const fields = document.querySelectorAll('.fastCreateField');
-            for (let field of fields) {
-                field.value = '';
-                if (field.jsonEditor) {
-                    field.jsonEditor.update({'text': ''});
-                }
-            }
         },
 
         resetType(type) {

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -128,6 +128,26 @@ export default {
 
                 return title.trim();
             },
+
+            setTitleFromFileName(titleId, fileName) {
+                const elem = document.getElementById(titleId);
+                if (!elem || elem.value !== '') {
+                    return;
+                }
+                elem.value = this.titleFromFileName(fileName);
+            },
+
+            updatePreviewImage(file, titleId, thumb) {
+                if (file?.name) {
+                    if (titleId) {
+                        this.setTitleFromFileName(titleId, file.name);
+                    }
+
+                    return window.URL.createObjectURL(file);
+                }
+
+                return thumb || null;
+            },
         }
     }
 };

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -117,6 +117,17 @@ export default {
 
                 return true;
             },
+
+            titleFromFileName(filename) {
+                let title = filename;
+                title = title.replaceAll('-', ' ');
+                title = title.replaceAll('_', ' ');
+                if (title.lastIndexOf('.') > 0) {
+                    title = title.substring(0, title.lastIndexOf('.')) || title;
+                }
+
+                return title.trim();
+            },
         }
     }
 };

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -92,6 +92,14 @@ export default {
                 return true;
             },
 
+            acceptMimeTypes(type) {
+                if (!BEDITA.uploadMimeTypes?.[type]) {
+                    return '';
+                }
+
+                return BEDITA.uploadMimeTypes?.[type].join(',');
+            },
+
             checkMimeForUpload(file, objectType) {
                 /** accepted mime types by object type for file upload */
                 const mimes = BEDITA.uploadMimeTypes;

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -90,7 +90,33 @@ export default {
                 }
 
                 return true;
-            }
+            },
+
+            checkMimeForUpload(file, objectType) {
+                /** accepted mime types by object type for file upload */
+                const mimes = {
+                    images: [
+                        'image/apng',
+                        'image/bmp',
+                        'image/jp2',
+                        'image/jpeg',
+                        'image/jpg',
+                        'image/gif',
+                        'image/png',
+                        'image/svg+xml',
+                        'image/webp',
+                    ],
+                };
+
+                if (mimes?.[objectType] && !mimes[objectType].includes(file.type)) {
+                    const msg = t`File type not accepted` + `: "${file.type}". ` + t`Accepted types` + `: "${mimes[objectType].join('", "')}".`;
+                    BEDITA.warning(msg);
+
+                    return false;
+                }
+
+                return true;
+            },
         }
     }
 };

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -94,20 +94,7 @@ export default {
 
             checkMimeForUpload(file, objectType) {
                 /** accepted mime types by object type for file upload */
-                const mimes = {
-                    images: [
-                        'image/apng',
-                        'image/bmp',
-                        'image/jp2',
-                        'image/jpeg',
-                        'image/jpg',
-                        'image/gif',
-                        'image/png',
-                        'image/svg+xml',
-                        'image/webp',
-                    ],
-                };
-
+                const mimes = BEDITA.uploadMimeTypes;
                 if (mimes?.[objectType] && !mimes[objectType].includes(file.type)) {
                     const msg = t`File type not accepted` + `: "${file.type}". ` + t`Accepted types` + `: "${mimes[objectType].join('", "')}".`;
                     BEDITA.warning(msg);

--- a/resources/js/app/pages/import/index.js
+++ b/resources/js/app/pages/import/index.js
@@ -43,7 +43,7 @@ export default {
     },
 
     methods: {
-        onFileChanged(e) {
+        onFileChange(e) {
             this.fileName = '';
             if (this.$helpers.checkMaxFileSize(e.target.files[0]) === false) {
                 return;

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -200,6 +200,7 @@ class LayoutHelper extends Helper
             'csrfToken' => $this->getCsrfToken(),
             'maxFileSize' => $this->System->getMaxFileSize(),
             'canReadUsers' => $this->Perms->canRead('users'),
+            'uploadMimeTypes' => $this->System->uploadMimeTypes(),
         ];
     }
 

--- a/src/View/Helper/SystemHelper.php
+++ b/src/View/Helper/SystemHelper.php
@@ -13,6 +13,25 @@ use Cake\View\Helper;
 class SystemHelper extends Helper
 {
     /**
+     * Accepted mime types for upload
+     *
+     * @var array
+     */
+    protected $defaultUploadMimeTypes = [
+        'images' => [
+            'image/apng',
+            'image/bmp',
+            'image/jp2',
+            'image/jpeg',
+            'image/jpg',
+            'image/gif',
+            'image/png',
+            'image/svg+xml',
+            'image/webp',
+        ],
+    ];
+
+    /**
      * Get the minimum value between post_max_size and upload_max_filesize.
      *
      * @return int
@@ -47,5 +66,15 @@ class SystemHelper extends Helper
         }
 
         return false;
+    }
+
+    /**
+     * Upload mime types
+     *
+     * @return array
+     */
+    public function uploadMimeTypes(): array
+    {
+        return (array)Configure::read('uploadMimeTypes', $this->defaultUploadMimeTypes);
     }
 }

--- a/templates/Element/Form/form_file_upload.twig
+++ b/templates/Element/Form/form_file_upload.twig
@@ -2,8 +2,9 @@
     <div class="file has-name">
         <label class="file-label">
             {{ Form.file('file', {
+                ':accept': 'fileAcceptMimeTypes("' ~ object.type ~ '")',
                 'class': 'file-input',
-                'v-on:change': 'onFileChanged($event, "' ~ object.type ~ '")'
+                'v-on:change': 'onFileChange($event, "' ~ object.type ~ '")'
             }) | raw }}
             <span class="file-cta icon-upload file-label" v-show="!file?.name">{{ __('Choose a file') }}</span>
             <span class="file-name" v-cloak v-show="!file?.name">

--- a/templates/Element/Form/form_file_upload.twig
+++ b/templates/Element/Form/form_file_upload.twig
@@ -3,14 +3,19 @@
         <label class="file-label">
             {{ Form.file('file', {
                 'class': 'file-input',
-                'v-on:change': 'onFileChanged',
+                'v-on:change': 'onFileChanged($event, "' ~ object.type ~ '")',
             }) | raw }}
-            <span class="file-cta icon-upload file-label">Choose a file</span>
+            <span class="file-cta icon-upload file-label">{{ __('Choose a file') }}</span>
             <span class="file-name" v-cloak>
-                <span v-bind:title="fileName" data-empty-label="{{ __('empty') }}"><: fileName :></span>
+                <span v-bind:title="file?.name" data-empty-label="{{ __('empty') }}"><: file?.name :></span>
             </span>
+            {% if object.type == 'images' %}
+            <figure class="thumb" v-if="file?.name">
+                <img :src=previewImage() alt="" />
+            </figure>
+            {% endif %}
 
-            <a class="file-reset-button" v-on:click.prevent.stop="resetFile" v-show="fileName"></a>
+            <a class="file-reset-button" v-on:click.prevent.stop="resetFile" v-show="file?.name"></a>
         </label>
     </div>
 </form-file-upload>

--- a/templates/Element/Form/form_file_upload.twig
+++ b/templates/Element/Form/form_file_upload.twig
@@ -3,15 +3,15 @@
         <label class="file-label">
             {{ Form.file('file', {
                 'class': 'file-input',
-                'v-on:change': 'onFileChanged($event, "' ~ object.type ~ '")',
+                'v-on:change': 'onFileChanged($event, "' ~ object.type ~ '")'
             }) | raw }}
-            <span class="file-cta icon-upload file-label">{{ __('Choose a file') }}</span>
-            <span class="file-name" v-cloak>
+            <span class="file-cta icon-upload file-label" v-show="!file?.name">{{ __('Choose a file') }}</span>
+            <span class="file-name" v-cloak v-show="!file?.name">
                 <span v-bind:title="file?.name" data-empty-label="{{ __('empty') }}"><: file?.name :></span>
             </span>
             {% if object.type == 'images' %}
             <figure class="thumb" v-if="file?.name">
-                <img :src=previewImage() alt="" />
+                <img :src=previewImage() alt="" style="max-width: 100%;" />
             </figure>
             {% endif %}
 

--- a/templates/Element/Form/media.twig
+++ b/templates/Element/Form/media.twig
@@ -17,6 +17,7 @@
 
                 {# Show first stream #}
                 {% set stream = streams|first %}
+                {% set thumb = null %}
 
                 {# the stream #}
                 <div class="stream">
@@ -44,7 +45,7 @@
                         {% else %}
                             <figure class="thumb">
                                 <a href={{ stream.meta.url }} title="{{ __('Open image') }}" target="_blank">
-                                    <img :src=previewImage("{{ thumb }}") alt="" />
+                                    <img :src=previewImage("{{ thumb }}") alt="" id="imageThumb" />
                                 </a>
                             </figure>
                         {% endif %}
@@ -68,19 +69,25 @@
 
                     {% if attributes.url %}
                     <a href="{{ attributes.url }}" target="_blank"
-                        class="mr-1 button button-outlined button-outlined-hover-module-{{ currentModule.name }}">
+                        class="icon-eye mr-1 button button-outlined button-outlined-hover-module-{{ currentModule.name }}">
                         {{ __('View file') }}
                     </a>
                     {% endif %}
 
                     <a href="{{ Url.build({'_name': 'stream:download', 'id': stream.id}) }}"
-                        class="mr-1 button button-outlined button-outlined-hover-module-{{ currentModule.name }}">
+                        class="icon-download-1 mr-1 button button-outlined button-outlined-hover-module-{{ currentModule.name }}">
                         {{ __('Download file') }}
                     </a>
 
-                    <div class="mr-1 has-text-size-large">{{ __('Change File') }}:</div>
-                    <div>
-                        {{ Form.control('file', { 'type': 'file', 'label': false, '@change': 'onFileChange($event, "' ~ object.type  ~ '")' }) | raw }}
+                    <a class="icon-cancel mr-1 button button-outlined button-outlined-hover-module-{{ currentModule.name }}"
+                        @click.prevent.stop=resetFile("{{ thumb }}")
+                        v-if="fileChanged">
+                        {{ __('Undo Change File') }}
+                    </a>
+
+                    <div class="mr-1 has-text-size-large" v-show="!fileChanged">{{ __('Change File') }}:</div>
+                    <div v-show="!fileChanged">
+                        {{ Form.control('file', { 'id': 'fileUpload', 'type': 'file', 'label': false, '@change': 'onFileChange($event, "' ~ object.type  ~ '")', ':accept': 'fileAcceptMimeTypes("' ~ object.type  ~ '")' }) | raw }}
                         {{ Form.hidden('MAX_FILE_SIZE', { 'value': System.getMaxFileSize() })|raw }}
                         {{ Form.control('model-type', { 'type': 'hidden', 'value': object.type}) | raw }}
                     </div>

--- a/templates/Element/Form/media.twig
+++ b/templates/Element/Form/media.twig
@@ -44,7 +44,7 @@
                         {% else %}
                             <figure class="thumb">
                                 <a href={{ stream.meta.url }} title="{{ __('Open image') }}" target="_blank">
-                                    <img src={{ thumb }} />
+                                    <img :src=previewImage("{{ thumb }}") alt="" />
                                 </a>
                             </figure>
                         {% endif %}
@@ -68,19 +68,19 @@
 
                     {% if attributes.url %}
                     <a href="{{ attributes.url }}" target="_blank"
-                            class="mr-1 button button-outlined button-outlined-hover-module-{{ currentModule.name }}">
-                            {{ __('View file') }}
+                        class="mr-1 button button-outlined button-outlined-hover-module-{{ currentModule.name }}">
+                        {{ __('View file') }}
                     </a>
                     {% endif %}
 
                     <a href="{{ Url.build({'_name': 'stream:download', 'id': stream.id}) }}"
-                            class="mr-1 button button-outlined button-outlined-hover-module-{{ currentModule.name }}">
-                            {{ __('Download file') }}
+                        class="mr-1 button button-outlined button-outlined-hover-module-{{ currentModule.name }}">
+                        {{ __('Download file') }}
                     </a>
 
                     <div class="mr-1 has-text-size-large">{{ __('Change File') }}:</div>
                     <div>
-                        {{ Form.control('file', { 'type': 'file', 'label': false}) | raw }}
+                        {{ Form.control('file', { 'type': 'file', 'label': false, '@change': 'onFileChange($event, "' ~ object.type  ~ '")' }) | raw }}
                         {{ Form.hidden('MAX_FILE_SIZE', { 'value': System.getMaxFileSize() })|raw }}
                         {{ Form.control('model-type', { 'type': 'hidden', 'value': object.type}) | raw }}
                     </div>

--- a/templates/Element/Panel/relations_add.twig
+++ b/templates/Element/Panel/relations_add.twig
@@ -76,7 +76,7 @@
                         </div>
                     </section>
                     <button @click="createObject" type="button">{{ __('create') }}</button>
-                    <button @click="resetForm">{{ __('reset') }}</button>
+                    <button @click="resetForm($event, object?.type)">{{ __('reset') }}</button>
                 {{ Form.end()|raw }}
             {% endfor %}
         </div>

--- a/templates/Element/Panel/relations_add.twig
+++ b/templates/Element/Panel/relations_add.twig
@@ -15,6 +15,7 @@
                 <select id="related_object_type"
                     name="related_object_type"
                     class="{{ selectBaseClasses }}"
+                    @change="onChangeType"
                     v-if="relationTypes"
                     v-model="object.type">
                     <option value="_choose">{{ __('Choose a type') }}</option>
@@ -29,6 +30,7 @@
                     'class': 'object-form fast-create',
                     ':disable': 'saving',
                     'id': type ~ '-form',
+                    'ref': type ~ '-form',
                     'v-if': "object.type == '" ~ type ~ "'"
                 })|raw }}
                     {{ Form.control('upload_behavior', {

--- a/templates/Element/Panel/relations_add.twig
+++ b/templates/Element/Panel/relations_add.twig
@@ -53,7 +53,7 @@
 
                             <div class="input text" v-if="isMedia">
                                 <label for="{{ prefix }}file">{{ __('File') }}</label>
-                                <input type="file" name="file" v-on:change="processFile($event, object?.type)" id="{{ prefix }}file" class="drop-file" />
+                                <input type="file" name="file" :accept="fileAcceptMimeTypes(object?.type)" v-on:change="processFile($event, object?.type)" id="{{ prefix }}file" class="drop-file" />
 
                                 <figure class="thumb" v-if="object?.type === 'images' && file?.name">
                                     <img :src=previewImage() alt="" style="max-width: 100%;" />

--- a/templates/Element/Panel/relations_add.twig
+++ b/templates/Element/Panel/relations_add.twig
@@ -51,7 +51,11 @@
 
                             <div class="input text" v-if="isMedia">
                                 <label for="{{ prefix }}file">{{ __('File') }}</label>
-                                <input type="file" name="file" v-on:change="processFile" id="{{ prefix }}file" class="drop-file" />
+                                <input type="file" name="file" v-on:change="processFile($event, object?.type)" id="{{ prefix }}file" class="drop-file" />
+
+                                <figure class="thumb" v-if="object?.type === 'images' && file?.name">
+                                    <img :src=previewImage() alt="" style="max-width: 100%;" />
+                                </figure>
                             </div>
 
                             <div class="input text" v-if="isMedia">

--- a/templates/Pages/Import/index.twig
+++ b/templates/Pages/Import/index.twig
@@ -92,7 +92,7 @@
                     {{ Form.file('file', {
                         'class': 'file-input',
                         'accept': 'text/xml,text/csv',
-                        'v-on:change': 'onFileChanged',
+                        'v-on:change': 'onFileChange',
                     }) | raw }}
                     <span class="file-cta icon-upload">
                         <span class="file-label">Choose a file</span>

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -351,6 +351,7 @@ class LayoutHelperTest extends TestCase
             'csrfToken' => 'my-token',
             'maxFileSize' => $system->getMaxFileSize(),
             'canReadUsers' => false,
+            'uploadMimeTypes' => $system->uploadMimeTypes(),
         ];
         static::assertSame($expected, $conf);
     }

--- a/tests/TestCase/View/Helper/SystemHelperTest.php
+++ b/tests/TestCase/View/Helper/SystemHelperTest.php
@@ -97,4 +97,21 @@ class SystemHelperTest extends TestCase
         $actual = $this->System->checkBeditaApiVersion();
         static::assertTrue($actual);
     }
+
+    /**
+     * Test `uploadMimeTypes`
+     *
+     * @return void
+     * @covers ::uploadMimeTypes()
+     */
+    public function testUploadMimeTypes(): void
+    {
+        // empty config, defaultUploadMimeTypes
+        $reflectionClass = new \ReflectionClass($this->System);
+        $property = $reflectionClass->getProperty('defaultUploadMimeTypes');
+        $property->setAccessible(true);
+        $expected = $property->getValue($this->System);
+        $actual = $this->System->uploadMimeTypes();
+        static::assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
This resolves https://github.com/bedita/manager/issues/922, an enhancement in Media view and other parts where upload file is involved.
When choosing a file, a check on type is performed: if file type is not among accepted mime types, the upload is not performed and the user is notified about it.
Two check are performed on save:

- check if file mime type is fine
- check if the file size is fine

If it's an image, a `figure` with the preview image is shown, on file change.
Data is saved on `Save` button click (as it was before this PR).

If media title is empty, on preview update the title value is populated with the file name (with some string replacement, to make it more friendly).

Preview + check file size + check file extension (for images) in:

 - media view for new object, upload file section
 - media view for edit object, upload file section
 - fast create form (side panel), upload file section

Accepted mime types by object type (this could be updated in future):

```
images: [
    'image/apng',
    'image/bmp',
    'image/jp2',
    'image/jpeg',
    'image/jpg',
    'image/gif',
    'image/png',
    'image/svg+xml',
    'image/webp',
],
```