### PR TITLE
Drop files upload: title from filename

### DIFF
--- a/resources/js/app/components/drop-upload.js
+++ b/resources/js/app/components/drop-upload.js
@@ -121,7 +121,9 @@ export default {
             let title = filename;
             title = title.replaceAll('-', ' ');
             title = title.replaceAll('_', ' ');
-            title = title.substring(0, title.lastIndexOf('.')) || title;
+            if (title.lastIndexOf('.') > 0) {
+                title = title.substring(0, title.lastIndexOf('.')) || title;
+            }
 
             return title.trim();
         },
@@ -130,8 +132,7 @@ export default {
         upload(file) {
             const objectType = this.getObjectType(file);
             const formData = new FormData();
-            const title = this.titleFromFileName(file.name);
-            formData.append('title', title);
+            formData.append('title', this.titleFromFileName(file?.name || ''));
             formData.append('status', 'on');
             formData.append('file', file);
             formData.append('model-type', objectType);

--- a/resources/js/app/components/drop-upload.js
+++ b/resources/js/app/components/drop-upload.js
@@ -117,11 +117,21 @@ export default {
             this.$el.classList.remove('dragover');
         },
 
+        titleFromFileName(filename) {
+            let title = filename;
+            title = title.replaceAll('-', ' ');
+            title = title.replaceAll('_', ' ');
+            title = title.substring(0, title.lastIndexOf('.')) || title;
+
+            return title.trim();
+        },
+
         // return promise
         upload(file) {
             const objectType = this.getObjectType(file);
             const formData = new FormData();
-            formData.append('title', file.name);
+            const title = this.titleFromFileName(file.name);
+            formData.append('title', title);
             formData.append('status', 'on');
             formData.append('file', file);
             formData.append('model-type', objectType);


### PR DESCRIPTION
This updates the logic of `title` from file name, on drop files in a relation area.

New image title will be the file name without extension and with some replacements:

 - ' ' instead of '-'
 - ' ' instead of '_'