### PR TITLE
String properties are translatable fields (except for "special" properties)

### DIFF
--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -230,10 +230,10 @@ class SchemaHelper extends Helper
             return $property['translatable'] === true;
         });
         $translatable = array_keys($properties);
-        $translatable = array_merge(
+        $translatable = array_unique(array_merge(
             (array)Configure::read(sprintf('Properties.%s.translatable', (string)$objectType)),
             $translatable
-        );
+        ));
         usort($translatable, function ($item1, $item2) {
             if ($item1 === 'title') {
                 return -1;

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -168,27 +168,6 @@ class SchemaHelper extends Helper
     }
 
     /**
-     * Infer format from property schema in JSON-SCHEMA format.
-     *
-     * @param array $schema The property schema
-     * @return string
-     */
-    public static function formatFromSchema(array $schema): string
-    {
-        if (!empty($schema['oneOf'])) {
-            foreach ($schema['oneOf'] as $subSchema) {
-                if (!empty($subSchema['format']) && $subSchema['format'] === 'null') {
-                    continue;
-                }
-
-                return static::formatFromSchema($subSchema);
-            }
-        }
-
-        return (string)Hash::get($schema, 'format');
-    }
-
-    /**
      * Infer type from property schema in JSON-SCHEMA format
      * Possible return values:
      *

--- a/templates/Pages/Translations/index.twig
+++ b/templates/Pages/Translations/index.twig
@@ -47,7 +47,7 @@
                             <input type="checkbox" name="oneItem" value="{{ object.id }}" v-model="selectedRows" {% if not Perms.canRead(object.type) %}disabled="disabled"{% endif %}>
                         </div>
                         <div class="narrow">
-                            {{ object.attributes.translated_fields.title|default('no title') }}
+                            {{ object.attributes.translated_fields.title|truncate(50)|default('no title') }}
                         </div>
                         <div class="narrow">
                             {% if translated.attributes.lang %}

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -648,7 +648,6 @@ class SchemaHelperTest extends TestCase
      * @return void
      * @dataProvider translatableFieldsProvider()
      * @covers ::translatableFields()
-     * @covers ::formatFromSchema()
      */
     public function testTranslatableFields(array $properties, array $expected): void
     {

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -556,6 +556,7 @@ class SchemaHelperTest extends TestCase
      * @return void
      * @dataProvider translatableFieldsProvider()
      * @covers ::translatableFields()
+     * @covers ::formatFromSchema()
      */
     public function testTranslatableFields(array $properties, array $expected): void
     {

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -545,6 +545,98 @@ class SchemaHelperTest extends TestCase
                     'dummy',
                 ],
             ],
+            'properties sort 1' => [
+                [
+                    'title' => ['type' => 'string'],
+                    'description' => ['type' => 'string'],
+                    'body' => ['type' => 'string'],
+                ],
+                [
+                    'title',
+                    'description',
+                    'body',
+                ],
+            ],
+            'properties sort 1' => [
+                [
+                    'description' => ['type' => 'string'],
+                    'title' => ['type' => 'string'],
+                    'body' => ['type' => 'string'],
+                ],
+                [
+                    'title',
+                    'description',
+                    'body',
+                ],
+            ],
+            'properties sort 2' => [
+                [
+                    'body' => ['type' => 'string'],
+                    'title' => ['type' => 'string'],
+                    'description' => ['type' => 'string'],
+                ],
+                [
+                    'title',
+                    'description',
+                    'body',
+                ],
+            ],
+            'properties sort 3' => [
+                [
+                    'body' => ['type' => 'string'],
+                    'description' => ['type' => 'string'],
+                    'title' => ['type' => 'string'],
+                ],
+                [
+                    'title',
+                    'description',
+                    'body',
+                ],
+            ],
+            'properties sort 4' => [
+                [
+                    'description' => ['type' => 'string'],
+                    'title' => ['type' => 'string'],
+                    'body' => ['type' => 'string'],
+                ],
+                [
+                    'title',
+                    'description',
+                    'body',
+                ],
+            ],
+            'properties sort 5' => [
+                [
+                    'description' => ['type' => 'string'],
+                    'body' => ['type' => 'string'],
+                    'title' => ['type' => 'string'],
+                ],
+                [
+                    'title',
+                    'description',
+                    'body',
+                ],
+            ],
+            'properties sort 6' => [
+                [
+                    'something' => ['type' => 'string'],
+                    'body' => ['type' => 'string'],
+                ],
+                [
+                    'body',
+                    'something',
+                ],
+            ],
+            'properties sort 7' => [
+                [
+                    'body' => ['type' => 'string'],
+                    'something' => ['type' => 'string'],
+                ],
+                [
+                    'body',
+                    'something',
+                ],
+            ],
         ];
     }
 

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -449,12 +449,71 @@ class SchemaHelperTest extends TestCase
             ],
             'not translatable' => [
                 [
-                    'field1' => [
+                    'field_boolean' => [
+                        'type' => 'boolean',
+                    ],
+                    'field_date' => [
+                        'type' => 'string',
+                        'format' => 'date',
+                    ],
+                    'field_datetime' => [
+                        'type' => 'string',
+                        'format' => 'date-time',
+                    ],
+                    'field_integer' => [
+                        'type' => 'integer',
+                    ],
+                    'field_number' => [
+                        'type' => 'integer',
+                    ],
+                    'id' => [
+                        'type' => 'integer',
+                    ],
+                    'uname' => [
                         'type' => 'string',
                     ],
-                    'field2' => [
+                    'status' => [
                         'type' => 'string',
-                        'contentMediaType' => 'text/css',
+                    ],
+                    'lang' => [
+                        'type' => 'string',
+                    ],
+                    'locked' => [
+                        'type' => 'boolean',
+                    ],
+                    'published' => [
+                        'type' => 'boolean',
+                    ],
+                    'created' => [
+                        'type' => 'string',
+                        'format' => 'date-time',
+                    ],
+                    'modified' => [
+                        'type' => 'string',
+                        'format' => 'date-time',
+                    ],
+                    'created_by' => [
+                        'type' => 'integer',
+                    ],
+                    'modified_by' => [
+                        'type' => 'integer',
+                    ],
+                    'publish_start' => [
+                        'type' => 'string',
+                        'format' => 'date-time',
+                    ],
+                    'publish_end' => [
+                        'type' => 'string',
+                        'format' => 'date-time',
+                    ],
+                    'categories' => [
+                        'type' => 'array',
+                    ],
+                    'tags' => [
+                        'type' => 'array',
+                    ],
+                    'extra' => [
+                        'type' => 'object',
                     ],
                 ],
                 [],
@@ -468,7 +527,6 @@ class SchemaHelperTest extends TestCase
                             ],
                             [
                                 'type' => 'string',
-                                'contentMediaType' => 'text/plain',
                             ],
                         ],
                     ],
@@ -498,7 +556,6 @@ class SchemaHelperTest extends TestCase
      * @return void
      * @dataProvider translatableFieldsProvider()
      * @covers ::translatableFields()
-     * @covers ::translatableType()
      */
     public function testTranslatableFields(array $properties, array $expected): void
     {
@@ -519,11 +576,11 @@ class SchemaHelperTest extends TestCase
             ],
         ];
         $actual = $this->Schema->translatableFields($properties);
-        static::assertEmpty($actual);
+        static::assertNotEmpty($actual);
 
-        Configure::write('Properties.documents.translatable', ['field1']);
+        Configure::write('Properties.documents.translatable', ['field2']);
         $actual = $this->Schema->translatableFields($properties, 'documents');
-        static::assertEquals(['field1'], $actual);
+        static::assertEquals(['field1', 'field2'], $actual);
     }
 
     /**

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -545,7 +545,7 @@ class SchemaHelperTest extends TestCase
                     'dummy',
                 ],
             ],
-            'properties sort 1' => [
+            'properties sort 0' => [
                 [
                     'title' => ['type' => 'string'],
                     'description' => ['type' => 'string'],


### PR DESCRIPTION
This fixes https://github.com/bedita/manager/issues/682 by refactoring `SchemaHelper`.

Translatable fields are all properties of type `object` or `string`, except for `SchemaHelper::UNTRASLATABLE` fields and fields whose format is `date` or `date-time`.

