### PR TITLE
Add created and publish_date to children_order combo

### DIFF
--- a/config/bedita-api-version.ini
+++ b/config/bedita-api-version.ini
@@ -1,3 +1,3 @@
 [BEditaAPI]
-versions[]=4.8.0
-versions[]=5.1.0
+versions[]=4.9.2
+versions[]=5.5.1

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2022-12-13 13:24:25 \n"
+"POT-Creation-Date: 2023-01-26 10:48:28 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -185,10 +185,13 @@ msgstr ""
 msgid "Create a new tag"
 msgstr ""
 
-msgid "Create new"
+msgid "Created"
 msgstr ""
 
-msgid "Created"
+msgid "Created ↑ Oldest on top"
+msgstr ""
+
+msgid "Created ↓ Newest on top"
 msgstr ""
 
 msgid "Current password"
@@ -666,6 +669,12 @@ msgid "Publish End"
 msgstr ""
 
 msgid "Publish Start"
+msgstr ""
+
+msgid "Publish date ↑ Oldest on top"
+msgstr ""
+
+msgid "Publish date ↓ Newest on top"
 msgstr ""
 
 msgid "Publishing properties"
@@ -1183,6 +1192,16 @@ msgid "copied in the clipboard"
 msgstr ""
 
 #, javascript-format
+msgid "Created on ${ created }."
+msgstr ""
+
+msgid "Modified on ${ modified }."
+msgstr ""
+
+#, javascript-format
+msgid "Publish start on ${ published }."
+msgstr ""
+
 msgid "Missing required data \"${ required }\". Retry"
 msgstr ""
 
@@ -1208,7 +1227,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Title"
 msgstr ""
 
@@ -1216,7 +1235,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Address"
 msgstr ""
 
@@ -1224,7 +1243,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "GET"
 msgstr ""
 
@@ -1235,7 +1254,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "add new"
 msgstr ""
 
@@ -1250,7 +1269,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 
@@ -1271,7 +1290,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Every day"
 msgstr ""
 
@@ -1280,7 +1299,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Sunday"
 msgstr ""
 
@@ -1289,7 +1308,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Monday"
 msgstr ""
 
@@ -1298,7 +1317,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Tuesday"
 msgstr ""
 
@@ -1307,7 +1326,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Wednesday"
 msgstr ""
 
@@ -1316,7 +1335,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Thursday"
 msgstr ""
 
@@ -1325,7 +1344,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Friday"
 msgstr ""
 
@@ -1334,7 +1353,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Saturday"
 msgstr ""
 
@@ -1343,7 +1362,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Invalid date range"
 msgstr ""
 

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2022-12-13 13:24:25 \n"
+"POT-Creation-Date: 2023-01-26 10:48:28 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -188,10 +188,13 @@ msgstr ""
 msgid "Create a new tag"
 msgstr ""
 
-msgid "Create new"
+msgid "Created"
 msgstr ""
 
-msgid "Created"
+msgid "Created ↑ Oldest on top"
+msgstr ""
+
+msgid "Created ↓ Newest on top"
 msgstr ""
 
 msgid "Current password"
@@ -669,6 +672,12 @@ msgid "Publish End"
 msgstr ""
 
 msgid "Publish Start"
+msgstr ""
+
+msgid "Publish date ↑ Oldest on top"
+msgstr ""
+
+msgid "Publish date ↓ Newest on top"
 msgstr ""
 
 msgid "Publishing properties"
@@ -1186,6 +1195,16 @@ msgid "copied in the clipboard"
 msgstr ""
 
 #, javascript-format
+msgid "Created on ${ created }."
+msgstr ""
+
+msgid "Modified on ${ modified }."
+msgstr ""
+
+#, javascript-format
+msgid "Publish start on ${ published }."
+msgstr ""
+
 msgid "Missing required data \"${ required }\". Retry"
 msgstr ""
 
@@ -1211,7 +1230,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Title"
 msgstr ""
 
@@ -1219,7 +1238,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "Address"
 msgstr ""
 
@@ -1227,7 +1246,7 @@ msgstr ""
 #.  * <location-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "GET"
 msgstr ""
 
@@ -1238,7 +1257,7 @@ msgstr ""
 #.  * <locations-view> component used for ModulesPage -> View
 #.  *
 #.  * Handle Locations and reverse geocoding from addresses
-#.
+#.  
 msgid "add new"
 msgstr ""
 
@@ -1253,7 +1272,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 
@@ -1274,7 +1293,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Every day"
 msgstr ""
 
@@ -1283,7 +1302,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Sunday"
 msgstr ""
 
@@ -1292,7 +1311,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Monday"
 msgstr ""
 
@@ -1301,7 +1320,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Tuesday"
 msgstr ""
 
@@ -1310,7 +1329,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Wednesday"
 msgstr ""
 
@@ -1319,7 +1338,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Thursday"
 msgstr ""
 
@@ -1328,7 +1347,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Friday"
 msgstr ""
 
@@ -1337,7 +1356,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Saturday"
 msgstr ""
 
@@ -1346,7 +1365,7 @@ msgstr ""
 #.  *  Template/Elements/calendar.twig
 #.  *
 #.  * <date-ranges-view> component used for ModulesPage -> View
-#.
+#.  
 msgid "Invalid date range"
 msgstr ""
 

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2022-12-13 13:24:25 \n"
+"POT-Creation-Date: 2023-01-26 10:48:28 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -188,11 +188,14 @@ msgstr "Crea nuova categoria"
 msgid "Create a new tag"
 msgstr "Crea nuovo tag"
 
-msgid "Create new"
-msgstr "Crea nuovo"
-
 msgid "Created"
 msgstr "Creato"
+
+msgid "Created ↑ Oldest on top"
+msgstr "Creazione ↑ Meno recenti in testa"
+
+msgid "Created ↓ Newest on top"
+msgstr "Creazione ↓ Più recenti in testa"
 
 msgid "Current password"
 msgstr "Password corrente"
@@ -672,6 +675,12 @@ msgstr "Data revoca pubblicazione"
 
 msgid "Publish Start"
 msgstr "Data inizio pubblicazione"
+
+msgid "Publish date ↑ Oldest on top"
+msgstr "Pubblicazione ↑ Meno recenti in testa"
+
+msgid "Publish date ↓ Newest on top"
+msgstr "Pubblicazione ↓ Più recenti in testa"
 
 msgid "Publishing properties"
 msgstr "Proprietà di pubblicazione"
@@ -1192,6 +1201,16 @@ msgid "copied in the clipboard"
 msgstr "copiato negli appunti"
 
 #, javascript-format
+msgid "Created on ${ created }."
+msgstr "Creato il ${ created }."
+
+msgid "Modified on ${ modified }."
+msgstr "Modificato il ${ modified }."
+
+#, javascript-format
+msgid "Publish start on ${ published }."
+msgstr "Pubblicato il ${ published }."
+
 msgid "Missing required data \"${ required }\". Retry"
 msgstr "Dato obbligatorio mancante \"${ required }\". Riprovare"
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "tinymce": "^5.10.7",
         "ttag": "^1.7.24",
         "vue": "^2.5.16",
+        "vuejs-title": "^1.0.16",
         "webpack-manifest-plugin": "^5.0.0"
     },
     "devDependencies": {

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -23,6 +23,8 @@ import merge from 'deepmerge';
 import { t } from 'ttag';
 import { buildSearchParams } from '../libs/urlUtils.js';
 
+import vTitle from 'vuejs-title';
+
 const _vueInstance = new Vue({
     el: 'main',
 
@@ -111,6 +113,8 @@ const _vueInstance = new Vue({
         Vue.use(viewHelper);
         Vue.use(autoTranslation);
         Vue.use(Autocomplete);
+
+        Vue.use(vTitle);
 
         // load BEplugins's components
         BELoader.loadBeditaPlugins();

--- a/resources/js/app/components/relation-view/relation-view.js
+++ b/resources/js/app/components/relation-view/relation-view.js
@@ -16,6 +16,7 @@
  */
 
 import flatpickr from 'flatpickr';
+import { t } from 'ttag';
 
 import { PaginatedContentMixin } from 'app/mixins/paginated-content';
 import { RelationSchemaMixin } from 'app/mixins/relation-schema';
@@ -849,7 +850,22 @@ export default {
             let i = size == 0 ? 0 : Math.floor( Math.log(size) / Math.log(1024) );
 
             return ( size / Math.pow(1024, i) ).toFixed(2) * 1 + ' ' + ['B', 'kB', 'MB', 'GB', 'TB'][i];
-        }
+        },
+
+        datesInfo(obj) {
+            const created = new Date(obj.meta.created).toLocaleDateString() + ' ' + new Date(obj.meta.created).toLocaleTimeString();
+            const modified = new Date(obj.meta.modified).toLocaleDateString() + ' ' + new Date(obj.meta.modified).toLocaleTimeString();
+            if (!obj?.attributes?.publish_start) {
+                return t`Created on ${created}.` + ' ' + t`Modified on ${modified}.`;
+            }
+            const published = new Date(obj.meta.publish_start).toLocaleDateString() + ' ' + new Date(obj.attributes.publish_start).toLocaleTimeString();
+
+            return t`Created on ${created}.` + ' ' + t`Modified on ${modified}.` + ' ' + t`Publish start on ${published}.`;
+        },
+
+        truncate(str, len) {
+            return this.$helpers.truncate(str, len);
+        },
     }
 
 }

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -90,7 +90,16 @@ export default {
                 }
 
                 return true;
-            }
+            },
+
+            truncate(str, len) {
+                if (str.length <= len) {
+                    return str;
+                }
+                const ellipsis = '[...]';
+
+                return str.substring(0, len - ellipsis.length) + ellipsis;
+            },
         }
     }
 };

--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -242,8 +242,12 @@ class Options
                 ['value' => '-position', 'text' => __('Position ↓')],
                 ['value' => 'title', 'text' => __('Title ↑')],
                 ['value' => '-title', 'text' => __('Title ↓')],
+                ['value' => 'created', 'text' => __('Created ↑ Oldest on top')],
+                ['value' => '-created', 'text' => __('Created ↓ Newest on top')],
                 ['value' => 'modified', 'text' => __('Modified ↑ Oldest on top')],
                 ['value' => '-modified', 'text' => __('Modified ↓ Newest on top')],
+                ['value' => 'publish_start', 'text' => __('Publish date ↑ Oldest on top')],
+                ['value' => '-publish_start', 'text' => __('Publish date ↓ Newest on top')],
             ],
             'templateVars' => [
                 'containerClass' => 'childrenOrder',

--- a/templates/Element/Form/related_item.twig
+++ b/templates/Element/Form/related_item.twig
@@ -68,6 +68,8 @@
                 <span class="tag is-dark"><: related.attributes.lang :></span>
             {% else %}
                 <span class="tag" v-bind:class="'has-background-module-' + related.type"><: related.type :></span>
+
+                <span class="icon-calendar-check-o" v-title="datesInfo(related)"></span>
             {% endif %}
 
             <span class="status is-uppercase has-text-size-smallest" v-if="related.attributes.status"><: related.attributes.status :></span>
@@ -78,11 +80,13 @@
 
                 <h3 class="title m-0 has-text-size-small" style="padding-bottom: 7px;">
                     {% if translation %}
-                        <span v-if="related.attributes.translated_fields && related.attributes.translated_fields.title ">
-                            <: related.attributes.translated_fields.title :>
+                        <span :title="related.attributes.translated_fields.title" v-if="related.attributes.translated_fields && related.attributes.translated_fields.title ">
+                            <: truncate(related.attributes.translated_fields.title, 50) :>
                         </span>
                     {% else %}
-                        <: related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-' :>
+                        <span :title="related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-'">
+                            <: truncate(related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-', 50) :>
+                        </span>
                     {% endif %}
                 </h3>
 
@@ -105,12 +109,6 @@
             {% endif %}
 
             </div>
-
-            {% if not translation %}
-                <span class="modified">
-                    <: new Date(related.meta.modified).toLocaleDateString() :>
-                </span>
-            {% endif %}
 
         </header>
     </div>

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -66,9 +66,9 @@
                                     'label': __('Children order'),
                                     'class': 'icon-info-1',
                                     'id': 'children-order',
+                                    'v-title': '`' ~ __('Save object to apply order change') ~ '`',
                                 }
                             )|raw }}
-                            <span class="icon-info-1" title="{{ __('Save object to apply order change') }}"></span>
                         </div>
                     </div>
                 {% else %}

--- a/tests/TestCase/Form/OptionsTest.php
+++ b/tests/TestCase/Form/OptionsTest.php
@@ -206,8 +206,12 @@ class OptionsTest extends TestCase
                         ['value' => '-position', 'text' => __('Position ↓')],
                         ['value' => 'title', 'text' => __('Title ↑')],
                         ['value' => '-title', 'text' => __('Title ↓')],
+                        ['value' => 'created', 'text' => __('Created ↑ Oldest on top')],
+                        ['value' => '-created', 'text' => __('Created ↓ Newest on top')],
                         ['value' => 'modified', 'text' => __('Modified ↑ Oldest on top')],
                         ['value' => '-modified', 'text' => __('Modified ↓ Newest on top')],
+                        ['value' => 'publish_start', 'text' => __('Publish date ↑ Oldest on top')],
+                        ['value' => '-publish_start', 'text' => __('Publish date ↓ Newest on top')],
                     ],
                     'templateVars' => [
                         'containerClass' => 'childrenOrder',

--- a/tests/TestCase/View/Helper/SystemHelperTest.php
+++ b/tests/TestCase/View/Helper/SystemHelperTest.php
@@ -87,13 +87,13 @@ class SystemHelperTest extends TestCase
         $actual = $this->System->checkBeditaApiVersion();
         static::assertFalse($actual);
 
-        // project version 4.9.0
-        $this->System->getView()->set('project', ['version' => '4.9.0']);
+        // project version 4.9.2
+        $this->System->getView()->set('project', ['version' => '4.9.2']);
         $actual = $this->System->checkBeditaApiVersion();
         static::assertTrue($actual);
 
-        // project version 5.2.0
-        $this->System->getView()->set('project', ['version' => '5.2.0']);
+        // project version 5.5.1
+        $this->System->getView()->set('project', ['version' => '5.5.1']);
         $actual = $this->System->checkBeditaApiVersion();
         static::assertTrue($actual);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5586,6 +5586,11 @@ vue@^2.5.16:
     "@vue/compiler-sfc" "2.7.14"
     csstype "^3.1.0"
 
+vuejs-title@^1.0.16:
+  version "1.0.16"
+  resolved "https://registry.npmjs.org/vuejs-title/-/vuejs-title-1.0.16.tgz#6eef2656e8c85e5ac7b07c112e08e474cc67505c"
+  integrity sha512-HQTsbutGyW1QiEKDL5lPH0ryKS2szpv0dQaoR/6LnW4IKfKHcloe3vkvvLjxehbP7ldjh6vJX40odgCzeJNwJg==
+
 w3c-keyname@^2.2.4:
   version "2.2.6"
   resolved "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz#8412046116bc16c5d73d4e612053ea10a189c85f"


### PR DESCRIPTION
This updates `children_order` field possible values, for a single folder, by adding `created`, `-created`, `publish_start` and `-publish_start` as possible values.

This is possible with BEdita API versions 4.9.2 and 5.5.1:

 - https://github.com/bedita/bedita/releases/tag/v4.9.2, https://github.com/bedita/bedita/pull/1966
 - https://github.com/bedita/bedita/releases/tag/v5.5.1, https://github.com/bedita/bedita/pull/1967