### PR TITLE
Fix relations add

### DIFF
--- a/resources/js/app/components/relation-view/relations-add.js
+++ b/resources/js/app/components/relation-view/relations-add.js
@@ -478,5 +478,20 @@ export default {
                 this.object.attributes.title = this.file.name;
             }
         },
+
+        datesInfo(obj) {
+            const created = new Date(obj.meta.created).toLocaleDateString() + ' ' + new Date(obj.meta.created).toLocaleTimeString();
+            const modified = new Date(obj.meta.modified).toLocaleDateString() + ' ' + new Date(obj.meta.modified).toLocaleTimeString();
+            if (!obj?.attributes?.publish_start) {
+                return t`Created on ${created}.` + ' ' + t`Modified on ${modified}.`;
+            }
+            const published = new Date(obj.meta.publish_start).toLocaleDateString() + ' ' + new Date(obj.attributes.publish_start).toLocaleTimeString();
+
+            return t`Created on ${created}.` + ' ' + t`Modified on ${modified}.` + ' ' + t`Publish start on ${published}.`;
+        },
+
+        truncate(str, len) {
+            return this.$helpers.truncate(str, len);
+        },
     },
 };


### PR DESCRIPTION
This fixes a bug in relations add.

Expected behaviour
===============

Click on "add objects", side panel opens and show relationable items.

Actual behaviour
=============

Click on "add objects", side panel opens, no items shown and loader spins.

The cause of the bug: 2 missing functions in `relations-add.js`