### PR TITLE
Fix i18n string in index header

### DIFF
--- a/templates/Element/Modules/index_header.twig
+++ b/templates/Element/Modules/index_header.twig
@@ -16,7 +16,7 @@
 
         config-paginate-sizes="{{ config('Pagination.sizeAvailable')|json_encode|escape('html_attr') }}"
         placeholder="{{ __('Search') }}"
-        objects-label="{{ resourceType ? __(resourceType|humanize) : __(currentModule.name) }}"
+        objects-label="{{ resourceType ? __(resourceType|humanize) : __(currentModule.name|humanize) }}"
         page-size="{{ meta.pagination.page_size }}"
 
         @filter-objects="onFilterObjects"

--- a/templates/Pages/Categories/index.twig
+++ b/templates/Pages/Categories/index.twig
@@ -6,7 +6,7 @@
     </header>
 </div>
 
-{{ element('Modules/index_header') }}
+{{ element('Modules/index_header', {'resourceType': 'categories'}) }}
 
 <div class="module-index">
     {{ element('Modules/index_categories') }}


### PR DESCRIPTION
This fixes a minor issue.

Actual behaviour
=============

In a module category index, we have "{number} {object type}".
In a module index, we have "{number} {plural object type not translated}".

Expected behaviour
=============

In a module category index, we have "{number} Categories".
In a module index, we have "{number} {plural object type translated}".