### PR TITLE
Fix module Links UI by refactoring modules classes

### DIFF
--- a/templates/Element/Admin/sidebar.twig
+++ b/templates/Element/Admin/sidebar.twig
@@ -3,10 +3,10 @@
 {% set controllerAction = _view.request.getparam('controller')|default('') %}
 {% for action in actions %}
     {% if action == controllerAction|underscore %}
-        {% do _view.append('module-anchors', '<span class="active-action">' ~ __(action|underscore|humanize) ~ '</span>') %}
+        {% do _view.append('app-module-links', '<span class="active-action">' ~ __(action|underscore|humanize) ~ '</span>') %}
     {% else %}
-        {% do _view.append('module-anchors', Html.link(__(action|underscore|humanize), {'_name': 'admin:list:' ~ action}, {})|raw) %}
+        {% do _view.append('app-module-links', Html.link(__(action|underscore|humanize), {'_name': 'admin:list:' ~ action}, {})|raw) %}
     {% endif %}
 {% endfor %}
 
-{% do _view.append('module-anchors', '<a style="width: 170px;" href="' ~ Url.build({'_name': 'admin:cache:clear'}) ~ '" class="icon-cancel button button-primary button-primary-hover-module-admin is-width-auto">' ~ __('Clear cache') ~ '</a>') %}
+{% do _view.append('app-module-links', '<a style="width: 170px;" href="' ~ Url.build({'_name': 'admin:cache:clear'}) ~ '" class="icon-cancel button button-primary button-primary-hover-module-admin is-width-auto">' ~ __('Clear cache') ~ '</a>') %}

--- a/templates/Element/Admin/sidebar.twig
+++ b/templates/Element/Admin/sidebar.twig
@@ -3,10 +3,10 @@
 {% set controllerAction = _view.request.getparam('controller')|default('') %}
 {% for action in actions %}
     {% if action == controllerAction|underscore %}
-        {% do _view.append('module-links', '<span class="active-action">' ~ __(action|underscore|humanize) ~ '</span>') %}
+        {% do _view.append('module-anchors', '<span class="active-action">' ~ __(action|underscore|humanize) ~ '</span>') %}
     {% else %}
-        {% do _view.append('module-links', Html.link(__(action|underscore|humanize), {'_name': 'admin:list:' ~ action}, {})|raw) %}
+        {% do _view.append('module-anchors', Html.link(__(action|underscore|humanize), {'_name': 'admin:list:' ~ action}, {})|raw) %}
     {% endif %}
 {% endfor %}
 
-{% do _view.append('module-links', '<a style="width: 170px;" href="' ~ Url.build({'_name': 'admin:cache:clear'}) ~ '" class="icon-cancel button button-primary button-primary-hover-module-admin is-width-auto">' ~ __('Clear cache') ~ '</a>') %}
+{% do _view.append('module-anchors', '<a style="width: 170px;" href="' ~ Url.build({'_name': 'admin:cache:clear'}) ~ '" class="icon-cancel button button-primary button-primary-hover-module-admin is-width-auto">' ~ __('Clear cache') ~ '</a>') %}

--- a/templates/Element/Menu/sidebar.scss
+++ b/templates/Element/Menu/sidebar.scss
@@ -140,7 +140,7 @@ ul.concurrent-editors {
 
         > *:not(:empty) { margin-bottom: $gutter; }
 
-        .module-buttons, .module-anchors {
+        .app-module-buttons, .app-module-links {
             display: flex;
             flex-direction: column;
             > *:not(:last-child) { margin-bottom: $gutter; }

--- a/templates/Element/Menu/sidebar.scss
+++ b/templates/Element/Menu/sidebar.scss
@@ -1,4 +1,4 @@
-.module-box a {
+.app-module-box a {
     position: relative;
     display: flex;
     height: $dashboard-item-height;
@@ -25,7 +25,7 @@
     }
 }
 
-.module-box {
+.app-module-box {
 
     a {
         position: relative;
@@ -52,7 +52,7 @@
     }
 }
 
-.module-box-concurrent-editors a {
+.app-module-box-concurrent-editors a {
     position: relative;
     display: flex;
     height: $dashboard-item-height;
@@ -98,7 +98,7 @@ ul.concurrent-editors {
         height: 0;
         padding-bottom: $dashboard-items-ratio;
     }
-    .module-box a {
+    .app-module-box a {
         background-color: $gray-strange;
         font: $font-weight-normal $font-size-lg $font-family-serif;
     }

--- a/templates/Element/Menu/sidebar.scss
+++ b/templates/Element/Menu/sidebar.scss
@@ -140,7 +140,7 @@ ul.concurrent-editors {
 
         > *:not(:empty) { margin-bottom: $gutter; }
 
-        .module-buttons, .module-links {
+        .module-buttons, .module-anchors {
             display: flex;
             flex-direction: column;
             > *:not(:last-child) { margin-bottom: $gutter; }

--- a/templates/Element/Menu/sidebar.twig
+++ b/templates/Element/Menu/sidebar.twig
@@ -34,8 +34,8 @@
                 {% endif %}
             </div>
 
-            <div class="module-links">
-                {{ _view.fetch('module-links')|raw }}
+            <div class="module-anchors">
+                {{ _view.fetch('module-anchors')|raw }}
             </div>
         </div>
     {% endif %}

--- a/templates/Element/Menu/sidebar.twig
+++ b/templates/Element/Menu/sidebar.twig
@@ -27,15 +27,15 @@
             {% endif %}
         {% endif %}
 
-            <div class="module-buttons">
-                {{ _view.fetch('module-buttons')|raw }}
+            <div class="app-module-buttons">
+                {{ _view.fetch('app-module-buttons')|raw }}
                 {% if currentModule.hints.multiple_types and types.right is iterable %}
                     {{ element('filter_type') }}
                 {% endif %}
             </div>
 
-            <div class="module-anchors">
-                {{ _view.fetch('module-anchors')|raw }}
+            <div class="app-module-links">
+                {{ _view.fetch('app-module-links')|raw }}
             </div>
         </div>
     {% endif %}

--- a/templates/Element/Menu/sidebar.twig
+++ b/templates/Element/Menu/sidebar.twig
@@ -1,7 +1,7 @@
 <div class="sidebar">
 
     <div class="project-title">
-        <div class="module-box">
+        <div class="app-module-box">
             {{ Html.link( (project.name ?: 'BEdita Manager'), '/' ) | raw }}
         </div>
     </div>
@@ -12,7 +12,7 @@
 
         {% if not Layout.isDashboard() %}
             {% set editors = Editors.list() %}
-            <div class="module-box{% if editors|length > 1 %}-concurrent-editors{% endif %} {{ Layout.publishStatus(object | default({})) }}">
+            <div class="app-module-box{% if editors|length > 1 %}-concurrent-editors{% endif %} {{ Layout.publishStatus(object | default({})) }}">
                 {{ Layout.moduleLink()|raw }}
             </div>
 

--- a/templates/Element/Model/sidebar_links.twig
+++ b/templates/Element/Model/sidebar_links.twig
@@ -14,9 +14,9 @@
     ) %}
 
     {# append links to sidebar #}
-    {% do _view.append('module-links', Html.link(__('Object types'), {'_name': 'model:list:object_types'}, { 'class': 'icon-th-2' })|raw) %}
-    {% do _view.append('module-links', Html.link(__('Relations'), {'_name': 'model:list:relations'}, { 'class': 'icon-resize-full' })|raw) %}
-    {% do _view.append('module-links', Html.link(__('Property types'), {'_name': 'model:list:property_types'}, { 'class': 'icon-tasks' })|raw) %}
-    {% do _view.append('module-links', Html.link(__('Categories'), {'_name': 'model:list:categories'}, { 'class': 'icon-check' })|raw) %}
-    {% do _view.append('module-links', Html.link(__('Tags'), {'_name': 'model:list:tags'}, { 'class': 'icon-check' })|raw) %}
+    {% do _view.append('module-anchors', Html.link(__('Object types'), {'_name': 'model:list:object_types'}, { 'class': 'icon-th-2' })|raw) %}
+    {% do _view.append('module-anchors', Html.link(__('Relations'), {'_name': 'model:list:relations'}, { 'class': 'icon-resize-full' })|raw) %}
+    {% do _view.append('module-anchors', Html.link(__('Property types'), {'_name': 'model:list:property_types'}, { 'class': 'icon-tasks' })|raw) %}
+    {% do _view.append('module-anchors', Html.link(__('Categories'), {'_name': 'model:list:categories'}, { 'class': 'icon-check' })|raw) %}
+    {% do _view.append('module-anchors', Html.link(__('Tags'), {'_name': 'model:list:tags'}, { 'class': 'icon-check' })|raw) %}
 

--- a/templates/Element/Model/sidebar_links.twig
+++ b/templates/Element/Model/sidebar_links.twig
@@ -1,12 +1,12 @@
     {% if in_array(resourceType, ['object_types', 'relations']) %}
-    {% do _view.append('module-buttons',
+    {% do _view.append('app-module-buttons',
         Html.link(__('Create'),
             {'_name': 'model:create:' ~ resourceType},
             {'class': 'icon-link-ext button button-primary button-primary-hover-module-model'}
         )|raw) %}
     {% endif %}
 
-    {% do _view.append('module-buttons',
+    {% do _view.append('app-module-buttons',
         Html.link(__('Export'),
             {'_name': 'model:export'},
             {'class': 'icon-export button button-outlined'}
@@ -14,9 +14,9 @@
     ) %}
 
     {# append links to sidebar #}
-    {% do _view.append('module-anchors', Html.link(__('Object types'), {'_name': 'model:list:object_types'}, { 'class': 'icon-th-2' })|raw) %}
-    {% do _view.append('module-anchors', Html.link(__('Relations'), {'_name': 'model:list:relations'}, { 'class': 'icon-resize-full' })|raw) %}
-    {% do _view.append('module-anchors', Html.link(__('Property types'), {'_name': 'model:list:property_types'}, { 'class': 'icon-tasks' })|raw) %}
-    {% do _view.append('module-anchors', Html.link(__('Categories'), {'_name': 'model:list:categories'}, { 'class': 'icon-check' })|raw) %}
-    {% do _view.append('module-anchors', Html.link(__('Tags'), {'_name': 'model:list:tags'}, { 'class': 'icon-check' })|raw) %}
+    {% do _view.append('app-module-links', Html.link(__('Object types'), {'_name': 'model:list:object_types'}, { 'class': 'icon-th-2' })|raw) %}
+    {% do _view.append('app-module-links', Html.link(__('Relations'), {'_name': 'model:list:relations'}, { 'class': 'icon-resize-full' })|raw) %}
+    {% do _view.append('app-module-links', Html.link(__('Property types'), {'_name': 'model:list:property_types'}, { 'class': 'icon-tasks' })|raw) %}
+    {% do _view.append('app-module-links', Html.link(__('Categories'), {'_name': 'model:list:categories'}, { 'class': 'icon-check' })|raw) %}
+    {% do _view.append('app-module-links', Html.link(__('Tags'), {'_name': 'model:list:tags'}, { 'class': 'icon-check' })|raw) %}
 

--- a/templates/Element/translation.twig
+++ b/templates/Element/translation.twig
@@ -117,7 +117,7 @@
             {{ Form.end()|raw }}
 
             {# Append "Save" to sidebar #}
-            {% do _view.append('module-buttons', Form.button( __('Save'),
+            {% do _view.append('app-module-buttons', Form.button( __('Save'),
                 {
                     'form': 'form-translate',
                     'class': 'icon-check-1 button button-primary button-primary-hover-module-' ~ currentModule.name ~ ' is-width-auto',
@@ -127,7 +127,7 @@
 
             {% if translation.id %}
                 {# Append "Remove" to sidebar #}
-                {% do _view.append('module-buttons', Form.postButton(__('Remove'),
+                {% do _view.append('app-module-buttons', Form.postButton(__('Remove'),
                     {
                         '_name': 'translations:delete',
                         'object_type': objectType

--- a/templates/Pages/Admin/_admin.scss
+++ b/templates/Pages/Admin/_admin.scss
@@ -16,7 +16,7 @@ body.view-admin {
     }
 }
 
-.module-links {
+.module-anchors {
     a:not(.button), span {
         border-bottom: 1px solid $gray-600;
         padding: calc($gutter * 0.5);

--- a/templates/Pages/Admin/_admin.scss
+++ b/templates/Pages/Admin/_admin.scss
@@ -16,7 +16,7 @@ body.view-admin {
     }
 }
 
-.module-anchors {
+.app-module-links {
     a:not(.button), span {
         border-bottom: 1px solid $gray-600;
         padding: calc($gutter * 0.5);

--- a/templates/Pages/Categories/index.twig
+++ b/templates/Pages/Categories/index.twig
@@ -11,7 +11,7 @@
 <div class="module-index">
     {{ element('Modules/index_categories') }}
 
-    {% do _view.append('module-buttons',
+    {% do _view.append('app-module-buttons',
         Html.link(__('List'),
             {
                 '_name': 'modules:list',

--- a/templates/Pages/Import/index.twig
+++ b/templates/Pages/Import/index.twig
@@ -86,7 +86,7 @@
 
         <section class="fieldset">
             {# Append "Upload" to commands in commands menu. Must stay here, before the form end. #}
-            {# {% do _view.append('module-buttons', Form.submit(__('Upload'), {'form': 'form-import'})) %} #}
+            {# {% do _view.append('app-module-buttons', Form.submit(__('Upload'), {'form': 'form-import'})) %} #}
             <div class="file has-name">
                 <label class="file-label">
                     {{ Form.file('file', {

--- a/templates/Pages/Login/login.twig
+++ b/templates/Pages/Login/login.twig
@@ -10,7 +10,7 @@
         </div>
 
          <div class="project-title">
-            <div class="module-box">
+            <div class="app-module-box">
                 {{ Html.link( (config('Project.name') ?: 'BEdita Content Manager'), '/' ) | raw }}
             </div>
         </div>

--- a/templates/Pages/Model/ObjectTypes/view.twig
+++ b/templates/Pages/Model/ObjectTypes/view.twig
@@ -82,14 +82,14 @@
 
         {{ Form.end()|raw }}
 
-        {% do _view.append('module-buttons', Form.button( __('Save'),
+        {% do _view.append('app-module-buttons', Form.button( __('Save'),
             {
                 'form': 'form-main',
                 'class': 'icon-check-1 button button-primary button-primary-hover-module-' ~ currentModule.name ~ ' is-width-auto',
             }
         )) %}
         {% if not resource.meta.core_type %}
-            {% do _view.append('module-buttons', Form.postButton(__('Remove'),
+            {% do _view.append('app-module-buttons', Form.postButton(__('Remove'),
                 {
                     '_name': 'model:remove:object_types',
                     'id': resource.id,

--- a/templates/Pages/Model/Relations/view.twig
+++ b/templates/Pages/Model/Relations/view.twig
@@ -37,13 +37,13 @@
 
         {{ Form.end()|raw }}
 
-        {% do _view.append('module-buttons', Form.button(__('Save'),
+        {% do _view.append('app-module-buttons', Form.button(__('Save'),
             {
                 'form': 'form-main',
                 'class': 'icon-check-1 button button-primary button-primary-hover-module-' ~ currentModule.name ~ ' is-width-auto'
             }
         )) %}
-        {% do _view.append('module-buttons', Form.postButton(__('Remove'),
+        {% do _view.append('app-module-buttons', Form.postButton(__('Remove'),
             {
                 '_name': 'model:remove:relations',
                 'id': resource.id,

--- a/templates/Pages/Modules/index.twig
+++ b/templates/Pages/Modules/index.twig
@@ -50,7 +50,7 @@
 
         {# commands to append in side bar (commands menu) #}
         {% if Perms.canCreate() %}
-            {% do _view.append('module-buttons',
+            {% do _view.append('app-module-buttons',
                 Html.link(__('Create'),
                     {'_name': 'modules:create', 'object_type': objectType},
                     {'class': 'icon-check-1 button button-primary button-primary-hover-module-' ~ currentModule.name}
@@ -59,7 +59,7 @@
         {% endif %}
 
         {% if schema.properties.categories %}
-        {% do _view.append('module-buttons',
+        {% do _view.append('app-module-buttons',
             Html.link(__('Categories'),
                 {'_name': 'modules:categories:index', 'object_type': objectType},
                 {'class': 'icon-check-1 button button-outlined button-outlined-hover-module-' ~ currentModule.name}
@@ -69,7 +69,7 @@
 
         {% if currentModule.sidebar.index %}
         {% for item in currentModule.sidebar.index %}
-            {% do _view.append('module-buttons',
+            {% do _view.append('app-module-buttons',
                 Html.link(__(item.label),
                     item.url,
                     {'class': item.class|default('icon-check-1 button button-outlined button-outlined-hover-module-' ~ currentModule.name)}

--- a/templates/Pages/Modules/view.twig
+++ b/templates/Pages/Modules/view.twig
@@ -100,7 +100,7 @@
             {# append buttons to sidebar #}
             {# Append "Save" #}
             {% if Perms.canSave() %}
-                {% do _view.append('module-buttons', Form.button( __('Save'),
+                {% do _view.append('app-module-buttons', Form.button( __('Save'),
                     {
                         'form': 'form-main',
                         'class': 'icon-check-1 button button-primary button-primary-hover-module-' ~ currentModule.name ~ ' is-width-auto',
@@ -110,7 +110,7 @@
 
             {# Append "Clone" #}
             {% if object.id and Perms.canCreate() %}
-                {% do _view.append('module-buttons', Html.link(
+                {% do _view.append('app-module-buttons', Html.link(
                     __('Clone'),
                     {'_name': 'modules:clone', 'object_type': objectType, 'id': object.id},
                     {'@click.prevent': 'clone', 'class': 'icon-link-ext button button-outlined button-outlined-hover-module-' ~ currentModule.name }
@@ -120,13 +120,13 @@
             {# Append "Lock/Unlock" #}
             {% if object.id and Perms.canLock() %}
                 {% if object.meta.locked %}
-                    {% do _view.append('module-buttons', Html.link(
+                    {% do _view.append('app-module-buttons', Html.link(
                         __('Unlock'),
                         {'_name': 'lock:remove', 'object_type': objectType, 'id': object.id},
                         {'class': 'icon-lock-open button button-outlined button-outlined-hover-module-' ~ currentModule.name }
                     )) %}
                 {% else %}
-                    {% do _view.append('module-buttons', Html.link(
+                    {% do _view.append('app-module-buttons', Html.link(
                         __('Lock'),
                         {'_name': 'lock:add', 'object_type': objectType, 'id': object.id},
                         {'class': 'icon-lock button button-outlined button-outlined-hover-module-' ~ currentModule.name }
@@ -136,7 +136,7 @@
 
             {# Append "Trash (move to)" #}
             {% if object.id and Perms.canDelete(object) %}
-                {% do _view.append('module-buttons',
+                {% do _view.append('app-module-buttons',
                     Form.postButton(
                         __('Trash-verb'),
                         {'_name': 'modules:delete', 'object_type': objectType},
@@ -147,12 +147,12 @@
 
             {# Append "Prev" and "Next" #}
             {% if object.id and objectNav %}
-                {% do _view.append('module-buttons', Link.objectNav(objectNav)) %}
+                {% do _view.append('app-module-buttons', Link.objectNav(objectNav)) %}
             {% endif %}
 
             {# Append "new" button #}
             {% if object.id and Perms.canCreate() %}
-                {% do _view.append('module-buttons',
+                {% do _view.append('app-module-buttons',
                     Html.link(__('Create'),
                         {'_name': 'modules:create', 'object_type': objectType},
                         {'class': 'icon-link-ext button button-outlined button-outlined-hover-module-' ~ currentModule.name}
@@ -171,7 +171,7 @@
                         {% set url = item.url ~ '/' ~ object.id %}
                     {% endif %}
 
-                    {% do _view.append('module-buttons',
+                    {% do _view.append('app-module-buttons',
                         Html.link(__(item.label),
                             url,
                             {'class': item.class|default('button button-outlined button-outlined-hover-module-' ~ currentModule.name)}

--- a/templates/Pages/Password/reset.twig
+++ b/templates/Pages/Password/reset.twig
@@ -10,7 +10,7 @@
         </div>
 
          <div class="project-title">
-            <div class="module-box">
+            <div class="app-module-box">
                 {{ Html.link( (config('Project.name') ?: 'BEdita Content Manager'), '/' ) | raw }}
             </div>
         </div>

--- a/templates/Pages/Trash/index.twig
+++ b/templates/Pages/Trash/index.twig
@@ -52,7 +52,7 @@
         {% endif %}
 
         {# Append "Empty" button in commands menu. #}
-        {% do _view.append('module-buttons',
+        {% do _view.append('app-module-buttons',
             Form.postButton(__('Empty-verb'), {'_name': 'trash:empty'}, {
                 'data': {'query': q},
                 'class': 'icon-cancel button button-primary button-primary-hover-module-' ~ currentModule.name ~ ' is-width-auto'

--- a/templates/Pages/Trash/view.twig
+++ b/templates/Pages/Trash/view.twig
@@ -41,8 +41,8 @@
         {{ Form.end()|raw }}
 
         {# Append "Delete" and "Restore" to commands in commands menu. #}
-        {% do _view.append('module-buttons', Form.postButton(__('Restore'), {'_name': 'trash:restore'}, {'data': {'id': object.id}})) %}
-        {% do _view.append('module-buttons', Form.postButton(__('Delete'), {'_name': 'trash:delete'}, {'data': {'id': object.id}})) %}
+        {% do _view.append('app-module-buttons', Form.postButton(__('Restore'), {'_name': 'trash:restore'}, {'data': {'id': object.id}})) %}
+        {% do _view.append('app-module-buttons', Form.postButton(__('Delete'), {'_name': 'trash:delete'}, {'data': {'id': object.id}})) %}
     </div>
 
 </div>

--- a/templates/Pages/UserProfile/view.twig
+++ b/templates/Pages/UserProfile/view.twig
@@ -65,7 +65,7 @@
         {{ Form.end()|raw }}
 
         {# append "save" to sidebar #}
-        {% do _view.append('module-buttons', Form.button( __('Save'),
+        {% do _view.append('app-module-buttons', Form.button( __('Save'),
             {
                 'form': 'form-main',
                 'class': 'icon-check-1 button button-primary button-primary-hover-module-' ~ currentModule.name ~ ' is-width-auto',


### PR DESCRIPTION
This fixes an UI problem in Links module.

In Manager templates `module-{type}` is a dynamic class that is used to represent the current module data.
The problem: `module-links` is explicitely referenced as a block of DOM, with its own styles, and when `{type}` is `links`, there is a collision of styles.
The solution applied:

 - replace `module-links` with `app-module-links`
 - replace `module-buttons` with `app-module-buttons`
 - replace `module-box` with `app-module-box`
 - replace `module-box{var}` with `app-module-box{var}`

An example of the UI problem:

![links](https://user-images.githubusercontent.com/2227145/216537291-1be16a42-4e6a-4643-a8d6-a1f4d6394df4.png)
