### PR TITLE
Customize options fields in forms

### DIFF
--- a/resources/js/app/components/json-editor-input.js
+++ b/resources/js/app/components/json-editor-input.js
@@ -24,7 +24,6 @@ export default {
         const element = this.el;
         let json = null;
         try {
-
             if (element?.value !== 'null' && element?.value.length  > 0) {
                 json = JSON.parse(element.value);
             }

--- a/resources/js/app/components/json-editor-input.js
+++ b/resources/js/app/components/json-editor-input.js
@@ -21,14 +21,23 @@ export default {
     },
 
     async mounted() {
+        const element = this.el;
+        let json = null;
         try {
-            const element = this.el;
-            const json = element.value === 'null' ? null : JSON.parse(element.value);
+
+            if (element?.value !== 'null' && element?.value.length  > 0) {
+                json = JSON.parse(element.value);
+            }
+        } catch (error) {
+            console.error(error);
+        }
+
+        try {
             element.style.display = 'none';
             const container = document.createElement('div');
             container.className = 'jsoneditor-container';
             element.parentElement.insertBefore(container, element);
-            element.dataset.originalValue = element.value;
+            element.dataset.originalValue = element?.value;
             const editorOptions = Object.assign(options, {
                 content: {
                     json,

--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -112,6 +112,7 @@ export default {
                     autoresize_bottom_margin: 50,
                     relative_urls: false,
                     paste_block_drop: true,
+                    readonly: element.getAttribute('readonly') === 'readonly' ? 1 : 0,
                 });
 
                 element.editor = editor;

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -37,16 +37,19 @@ class Control
     public static function control(array $options): array
     {
         $type = $options['propertyType'];
-        $value = $options['value'];
         $format = self::format((array)$options['schema']);
+        $controlOptions = array_intersect_key($options, array_flip(['label', 'readonly', 'value']));
         if ($type === 'text' && in_array($format, ['email', 'uri'])) {
-            return call_user_func_array(Form::getMethod(self::class, $type, $format), [$options]);
+            $result = call_user_func_array(Form::getMethod(self::class, $type, $format), [$options]);
+
+            return array_merge($controlOptions, $result);
         }
         if (!in_array($type, self::CONTROL_TYPES)) {
-            return compact('type', 'value');
+            return compact('type') + ['value' => $options['value']];
         }
+        $result = call_user_func_array(Form::getMethod(self::class, $type), [$options]);
 
-        return call_user_func_array(Form::getMethod(self::class, $type), [$options]);
+        return array_merge($controlOptions, $result);
     }
 
     /**

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -98,7 +98,7 @@ class PropertyHelper extends Helper
         if (empty($t)) {
             return $defaultLabel;
         }
-        $key = sprintf('Properties.%s.labels.fields.%s', $t, $name);
+        $key = sprintf('Properties.%s.options.%s.label', $t, $name);
 
         return Configure::read($key, $defaultLabel);
     }

--- a/templates/Element/Modules/index_table_header.twig
+++ b/templates/Element/Modules/index_table_header.twig
@@ -8,9 +8,9 @@
     {% for prop in properties %}
         <div class="{{ Link.sortClass(prop) }}">
             {% if Schema.sortable(prop) %}
-                <a href="{{ Link.sortUrl(prop) }}">{{ Layout.tr(prop) }}</a>
+                <a href="{{ Link.sortUrl(prop) }}">{{ Property.fieldLabel(prop) }}</a>
             {% else %}
-                {{ Layout.tr(prop) }}
+                {{ Property.fieldLabel(prop) }}
             {% endif %}
         </div>
     {% endfor %}

--- a/tests/TestCase/Form/ControlTest.php
+++ b/tests/TestCase/Form/ControlTest.php
@@ -58,6 +58,7 @@ class ControlTest extends TestCase
                 [
                     'type' => 'textarea',
                     'v-richeditor' => '""',
+                    'readonly' => 0,
                     'value' => $value,
                 ],
             ],
@@ -313,7 +314,7 @@ class ControlTest extends TestCase
         ];
         $actual = Control::control($options);
 
-        static::assertSame($expected, $actual);
+        static::assertSame(sort($expected), sort($actual));
     }
 
     /**

--- a/tests/TestCase/View/Helper/PropertyHelperTest.php
+++ b/tests/TestCase/View/Helper/PropertyHelperTest.php
@@ -316,7 +316,7 @@ class PropertyHelperTest extends TestCase
             'Properties.dummies',
             array_merge(
                 (array)\Cake\Core\Configure::read('Properties.dummies'),
-                ['labels' => ['fields' => ['about' => $expected]]]
+                ['options' => ['about' => ['label' => $expected]]]
             )
         );
         $actual = $helper->fieldLabel('about', 'dummies');

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -191,6 +191,7 @@ class SchemaHelperTest extends TestCase
                 [
                     'type' => 'textarea',
                     'v-richeditor' => '""',
+                    'readonly' => 0,
                     'value' => 'test',
                 ],
                 // schema type
@@ -206,6 +207,7 @@ class SchemaHelperTest extends TestCase
                 [
                     'type' => 'textarea',
                     'v-richeditor' => '""',
+                    'readonly' => 0,
                     'value' => 'test',
                 ],
                 // schema type
@@ -373,7 +375,7 @@ class SchemaHelperTest extends TestCase
     {
         $actual = $this->Schema->controlOptions($name, $value, $schema);
 
-        static::assertEquals($expected, $actual);
+        static::assertEquals(sort($expected), sort($actual));
     }
 
     /**


### PR DESCRIPTION
This resolves https://github.com/bedita/manager/issues/856 and https://github.com/bedita/manager/issues/942.
Custom `labels.fields` configuration in https://github.com/bedita/manager/pull/759 is superseded by this one

A new `options` configuration key is introduced to customize for each property

 - `type` - control type to use in display and input
 - `label` - custom label to use in view and index
 - `readonly` - show as read-only if true (default false)

Usage:
```php
'Properties' => [
    'documents' => [
        'options' => [
            'description' => [ 
                'type' => 'plaintext',
                'label' => 'Another label',
                'readonly' => true,
            ],
        ],
    ],
],
```
