### PR TITLE
Min length 3 for category/tag name and label

### DIFF
--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2023-02-01 15:49:45 \n"
+"POT-Creation-Date: 2023-02-16 07:59:18 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1156,6 +1156,10 @@ msgid "File type not accepted"
 msgstr ""
 
 msgid "Accepted types"
+msgstr ""
+
+#, javascript-format
+msgid "At least ${ len } characters"
 msgstr ""
 
 msgid "stop"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-02-01 15:49:45 \n"
+"POT-Creation-Date: 2023-02-16 07:59:18 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1159,6 +1159,10 @@ msgid "File type not accepted"
 msgstr ""
 
 msgid "Accepted types"
+msgstr ""
+
+#, javascript-format
+msgid "At least ${ len } characters"
 msgstr ""
 
 msgid "stop"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-02-01 15:49:45 \n"
+"POT-Creation-Date: 2023-02-16 07:59:18 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1166,6 +1166,10 @@ msgstr "Tipo di file non consentito"
 
 msgid "Accepted types"
 msgstr "Tipi consentiti"
+
+#, javascript-format
+msgid "At least ${ len } characters"
+msgstr "Almeno ${ len } caratteri"
 
 msgid "stop"
 msgstr "interrompi"

--- a/resources/js/app/components/category/category.js
+++ b/resources/js/app/components/category/category.js
@@ -6,10 +6,12 @@ export default {
         <form class="table-row">
             <div class="name-cell">
                 <input type="text" name="name" autocomplete="off" autocorrect="off" autocapitalize="off" size="50" maxlength="50" @change="onChangeName($event)" v-model="name" />
+                <span class="icon-info-1" v-title="this.$helpers.minLength(3)"></span>
                 <div v-if="nameInUse()" v-text="errorAlreadyInUse"></div>
             </div>
             <div class="label-cell">
                 <input type="text" name="label" autocomplete="off" autocorrect="off" autocapitalize="off" v-model="label" />
+                <span class="icon-info-1" v-title="this.$helpers.minLength(3)"></span>
             </div>
             <div class="parent_id-cell">
                 <select v-model="parent">
@@ -29,13 +31,13 @@ export default {
                 <input type="checkbox" name="enabled" v-model="enabled" checked="!!enabled" />
             </div>
             <div v-show="!id" class="buttons-cell narrow">
-                <button :disabled="name === '' || nameInUse() || type === ''" class="icon-check-1 button button-text-white is-width-auto" @click.stop.prevent="onCreate()">${t`Create`}</button>
+                <button :disabled="name.length < 3 || label.length < 3 || nameInUse() || type === ''" class="icon-check-1 button button-text-white is-width-auto" @click.stop.prevent="onCreate()">${t`Create`}</button>
             </div>
             <div v-show="id">
                 <: id :>
             </div>
             <div v-show="id" class="buttons-cell narrow">
-                <button :disabled="name === '' || unchanged() || nameInUse()" class="icon-check-1 button button-text-white is-width-auto" @click.stop.prevent="onModify()">${t`Modify`}</button>
+                <button :disabled="name.length < 3 || label.length < 3 || unchanged() || nameInUse()" class="icon-check-1 button button-text-white is-width-auto" @click.stop.prevent="onModify()">${t`Modify`}</button>
             </div>
             <div v-show="id" class="buttons-cell narrow">
                 <button class="icon-cancel button button-text-white is-width-auto" @click.stop.prevent="onDelete()">${t`Delete`}</button>

--- a/resources/js/app/components/tag-form/tag-form.js
+++ b/resources/js/app/components/tag-form/tag-form.js
@@ -23,9 +23,11 @@ export default {
 
             <div v-if="editMode">
                 <input type="text" size="50" maxlength="50" v-model="name" @change="onChangeName($event)" />
+                <span class="icon-info-1" v-title="this.$helpers.minLength(3)"></span>
             </div>
             <div v-if="editMode">
                 <input type="text" v-model="label" />
+                <span class="icon-info-1" v-title="this.$helpers.minLength(3)"></span>
             </div>
             <div v-if="editMode">
                 <input type="checkbox" v-model="enabled" />
@@ -36,7 +38,7 @@ export default {
             </div>
             <div v-if="editMode">
                 <button @click.prevent="cancel" class="button button-outlined icon-backward-circled" v-if="obj?.id">${t`Cancel`}</button>
-                <button @click.prevent="save" class="button button-primary icon-check-1" :disabled="name === '' || label === ''">${t`Save`}</button>
+                <button @click.prevent="save" class="button button-primary icon-check-1" :disabled="name.length < 3 || label.length < 3">${t`Save`}</button>
                 <button @click.prevent="remove" class="button button-outlined icon-trash" v-if="obj?.id">${t`Remove`}</button>
             </div>
         </form>

--- a/resources/js/app/components/tag-picker/tag-picker.js
+++ b/resources/js/app/components/tag-picker/tag-picker.js
@@ -8,7 +8,7 @@ const API_OPTIONS = {
         'accept': 'application/json',
     }
 };
-const QUERY_MIN_LENGTH = 4;
+const QUERY_MIN_LENGTH = 3;
 
 export default {
     components: {

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -221,6 +221,10 @@ export default {
 
                 return str.substring(0, len - ellipsis.length) + ellipsis;
             },
+
+            minLength(len) {
+                return t`At least ${len} characters`;
+            },
         }
     }
 };


### PR DESCRIPTION
This avoids a error on category/tag save by introducing a check: name and label should be at least 3 characters long.

As long as name and label are not valid, save buttons are disabled.

This updates also `tag-picker` so that minimum length for query search is 3 characters.

Bonus: info icon with tip `At least {len} characters` (reusable in other contexts).