### PR TITLE
Fix control options for `Properties.<type>.options`

### DIFF
--- a/resources/js/app/components/json-editor-input.js
+++ b/resources/js/app/components/json-editor-input.js
@@ -41,6 +41,7 @@ export default {
                 content: {
                     json,
                 },
+                readOnly: element.getAttribute('readonly') === 'readonly' ? true : false,
                 onChange: function () {
                     try {
                         const val = element.jsonEditor.get();

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -38,7 +38,7 @@ class Control
     {
         $type = $options['propertyType'];
         $format = self::format((array)$options['schema']);
-        $controlOptions = array_intersect_key($options, array_flip(['label', 'readonly', 'value']));
+        $controlOptions = array_intersect_key($options, array_flip(['label', 'disabled', 'readonly', 'value']));
         if ($type === 'text' && in_array($format, ['email', 'uri'])) {
             $result = call_user_func_array(Form::getMethod(self::class, $type, $format), [$options]);
 

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -45,7 +45,9 @@ class Control
             return array_merge($controlOptions, $result);
         }
         if (!in_array($type, self::CONTROL_TYPES)) {
-            return compact('type') + ['value' => $options['value']];
+            $result = compact('type') + ['value' => $options['value']];
+
+            return array_merge($controlOptions, $result);
         }
         $result = call_user_func_array(Form::getMethod(self::class, $type), [$options]);
 

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -71,6 +71,10 @@ class PropertyHelper extends Helper
     {
         $controlOptions = $this->Schema->controlOptions($name, $value, $this->schema($name, $type));
         $controlOptions['label'] = $this->fieldLabel($name, $type);
+        $readonly = Hash::get($controlOptions, 'readonly');
+        if ($readonly === true && array_key_exists('v-datepicker', $controlOptions)) {
+            unset($controlOptions['v-datepicker']);
+        }
         if (Hash::get($controlOptions, 'class') === 'json') {
             $jsonKeys = (array)Configure::read('_jsonKeys');
             Configure::write('_jsonKeys', array_merge($jsonKeys, [$name]));

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -61,28 +61,24 @@ class SchemaHelper extends Helper
     public function controlOptions(string $name, $value, $schema = []): array
     {
         $options = Options::customControl($name, $value);
+        $objectType = (string)$this->_View->get('objectType');
+        $ctrlOptionsPath = sprintf('Properties.%s.options.%s', $objectType, $name);
+        $ctrlOptions = (array)Configure::read($ctrlOptionsPath);
+
         if (!empty($options)) {
-            $objectType = (string)$this->_View->get('objectType');
-            $ctrlOptionsPath = sprintf('Properties.%s.options.%s', $objectType, $name);
-            $ctrlOptions = (array)Configure::read($ctrlOptionsPath);
-            $result = empty($ctrlOptions) ? $options : array_merge($options, [
+            return array_merge($options, [
                 'label' => Hash::get($ctrlOptions, 'label'),
                 'readonly' => Hash::get($ctrlOptions, 'readonly', false),
                 'disabled' => Hash::get($ctrlOptions, 'readonly', false),
             ]);
-
-            return $result;
         }
         // verify if there's an handler by $type.$name
-        $objectType = (string)$this->_View->get('objectType');
         if (!empty(Configure::read(sprintf('Control.handlers.%s.%s', $objectType, $name)))) {
             $handler = Configure::read(sprintf('Control.handlers.%s.%s', $objectType, $name));
 
             return call_user_func_array([$handler['class'], $handler['method']], [$value, $schema]);
         }
         $type = ControlType::fromSchema((array)$schema);
-        $ctrlOptionsPath = sprintf('Properties.%s.options.%s', $objectType, $name);
-        $ctrlOptions = (array)Configure::read($ctrlOptionsPath);
 
         return Control::control([
             'objectType' => $objectType,

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -62,7 +62,16 @@ class SchemaHelper extends Helper
     {
         $options = Options::customControl($name, $value);
         if (!empty($options)) {
-            return $options;
+            $objectType = (string)$this->_View->get('objectType');
+            $ctrlOptionsPath = sprintf('Properties.%s.options.%s', $objectType, $name);
+            $ctrlOptions = (array)Configure::read($ctrlOptionsPath);
+            $result = empty($ctrlOptions) ? $options : array_merge($options, [
+                'label' => Hash::get($ctrlOptions, 'label'),
+                'readonly' => Hash::get($ctrlOptions, 'readonly', false),
+                'disabled' => Hash::get($ctrlOptions, 'readonly', false),
+            ]);
+
+            return $result;
         }
         // verify if there's an handler by $type.$name
         $objectType = (string)$this->_View->get('objectType');
@@ -83,6 +92,7 @@ class SchemaHelper extends Helper
             'propertyType' => Hash::get($ctrlOptions, 'type', $type),
             'label' => Hash::get($ctrlOptions, 'label'),
             'readonly' => Hash::get($ctrlOptions, 'readonly', false),
+            'disabled' => Hash::get($ctrlOptions, 'readonly', false),
         ]);
     }
 

--- a/tests/TestCase/View/Helper/PropertyHelperTest.php
+++ b/tests/TestCase/View/Helper/PropertyHelperTest.php
@@ -134,6 +134,26 @@ class PropertyHelperTest extends TestCase
                 ],
                 '<dummy>something</dummy>',
             ],
+            'date readonly' => [
+                'expires',
+                null,
+                ['readonly' => true],
+                [
+                    'oneOf' => [
+                        [
+                            'type' => 'null',
+                        ],
+                        [
+                            'type' => 'string',
+                            'format' => 'date-time',
+                        ],
+                    ],
+                    '$id' => '/properties/expires',
+                    'title' => 'Expires',
+                    'description' => 'Expiration date',
+                ],
+                '<div class="input datepicker text"><label for="expires">Expires</label><input type="text" name="expires" readonly="readonly" disabled="disabled" date="true" time="true" id="expires"/></div>',
+            ],
         ];
     }
 
@@ -152,6 +172,10 @@ class PropertyHelperTest extends TestCase
      */
     public function testControl(string $key, $value, array $options = [], array $schema = [], string $expected = ''): void
     {
+        if (array_key_exists('readonly', $options)) {
+            unset($options['readonly']);
+            Configure::write(sprintf('Properties.dummies.options.%s.readonly', $key), true);
+        }
         $view = new View(null, null, null, []);
         if ($key === 'categories') {
             $schema = ['categories' => $schema];

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -417,6 +417,9 @@ class SchemaHelperTest extends TestCase
             ],
             'type' => 'select',
             'value' => null,
+            'label' => null,
+            'readonly' => false,
+            'disabled' => false,
         ];
         static::assertSame($expected, $actual);
     }


### PR DESCRIPTION
This fixes an unexpected behaviour with config `Properties.<type>.options`: "readonly" not applied on some types (`text` and others).