### PR TITLE
Improve thumbs component

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -460,4 +460,14 @@ return [
     //     'clientId' => '####',
     //     'clientSecret' => '####',
     // ],
+
+    /**
+     * Configuration for thumbnails component.
+     */
+    // 'Thumbs' => [
+    //     // Query parameters used for calling API to generate the thumbnail
+    //     'queryParams' => ['preset' => 'default'],
+    //     // Object types for which to call API to generate the thumbnails
+    //     'objectTypes' => ['images', 'videos'],
+    // ],
 ];

--- a/config/bedita-api-version.ini
+++ b/config/bedita-api-version.ini
@@ -1,3 +1,3 @@
 [BEditaAPI]
-versions[]=4.9.2
-versions[]=5.5.1
+versions[]=4.9.5
+versions[]=5.5.7

--- a/src/Controller/Component/ThumbsComponent.php
+++ b/src/Controller/Component/ThumbsComponent.php
@@ -20,6 +20,7 @@ use Cake\Utility\Hash;
 /**
  * Handles thumbs.
  *
+ * @property-read \App\Controller\Component\FlashComponent $Flash
  * @property-read \App\Controller\Component\QueryComponent $Query
  */
 class ThumbsComponent extends Component
@@ -48,6 +49,7 @@ class ThumbsComponent extends Component
      */
     public function urls(?array &$response, ?array &$errors): void
     {
+        Flash
         if (empty($response) || empty($response['data'])) {
             return;
         }

--- a/src/Controller/Component/ThumbsComponent.php
+++ b/src/Controller/Component/ThumbsComponent.php
@@ -49,7 +49,6 @@ class ThumbsComponent extends Component
      */
     public function urls(?array &$response, ?array &$errors): void
     {
-        Flash
         if (empty($response) || empty($response['data'])) {
             return;
         }

--- a/src/Controller/Component/ThumbsComponent.php
+++ b/src/Controller/Component/ThumbsComponent.php
@@ -37,7 +37,7 @@ class ThumbsComponent extends Component
      *
      * @var array
      */
-    protected $components = ['Query'];
+    protected $components = ['Flash', 'Query'];
 
     /**
      * Retrieve thumbnails URL of related objects in `meta.url` if present.
@@ -85,6 +85,10 @@ class ThumbsComponent extends Component
 
         // Extract possible errors in creation of thumbnail(s)
         $errors = (array)Hash::extract($thumbs, '{*}[acceptable=false].message');
+
+        if (!empty($errors)) {
+            $this->Flash->warning(__('There where errors creating the thumbnail(s)'), ['params' => $errors]);
+        }
     }
 
     /**

--- a/src/Controller/Component/ThumbsComponent.php
+++ b/src/Controller/Component/ThumbsComponent.php
@@ -43,9 +43,10 @@ class ThumbsComponent extends Component
      * Retrieve thumbnails URL of related objects in `meta.url` if present.
      *
      * @param array|null $response Related objects response.
+     * @param array|null $errors Array to store possible error messages from API.
      * @return void
      */
-    public function urls(?array &$response): void
+    public function urls(?array &$response, ?array &$errors): void
     {
         if (empty($response) || empty($response['data'])) {
             return;
@@ -76,11 +77,14 @@ class ThumbsComponent extends Component
             }
 
             // extract url of the matching objectid's thumb
-            $thumbnail = Hash::get($thumbs, $object['id']);
+            $thumbnail = Hash::get($thumbs, sprintf('%d.url', $object['id']));
             if ($thumbnail !== null) {
                 $object['meta']['thumb_url'] = $thumbnail;
             }
         }
+
+        // Extract possible errors in creation of thumbnail(s)
+        $errors = (array)Hash::extract($thumbs, '{*}[acceptable=false].message');
     }
 
     /**
@@ -100,7 +104,7 @@ class ThumbsComponent extends Component
             $apiClient = ApiClientProvider::getApiClient();
             $res = (array)$apiClient->get($url, $query);
 
-            return (array)Hash::combine($res, 'meta.thumbnails.{*}.id', 'meta.thumbnails.{*}.url');
+            return (array)Hash::combine($res, 'meta.thumbnails.{*}.id', 'meta.thumbnails.{*}');
         } catch (BEditaClientException $e) {
             $this->getController()->log($e, 'error');
 

--- a/src/Controller/Component/ThumbsComponent.php
+++ b/src/Controller/Component/ThumbsComponent.php
@@ -25,6 +25,14 @@ use Cake\Utility\Hash;
 class ThumbsComponent extends Component
 {
     /**
+     * @inheritDoc
+     */
+    protected $_defaultConfig = [
+        'queryParams' => ['preset' => 'default'],
+        'objectTypes' => ['images', 'videos'],
+    ];
+
+    /**
      * Components
      *
      * @var array
@@ -44,7 +52,8 @@ class ThumbsComponent extends Component
         }
 
         // extract ids of objects
-        $ids = (array)Hash::extract($response, 'data.{n}[type=/images|videos/].id');
+        $types = $this->getConfig('objectTypes', []);
+        $ids = (array)Hash::extract($response, sprintf('data.{n}[type=/%s/].id', join('|', $types)));
         if (empty($ids)) {
             return;
         }
@@ -87,8 +96,7 @@ class ThumbsComponent extends Component
             $query = $this->Query->prepare($params);
             $url = sprintf('/media/thumbs?%s', http_build_query([
                 'ids' => implode(',', $ids),
-                'options' => ['w' => 400],
-            ]));
+            ] + $this->getConfig('queryParams', [])));
             $apiClient = ApiClientProvider::getApiClient();
             $res = (array)$apiClient->get($url, $query);
 

--- a/src/Controller/Component/ThumbsComponent.php
+++ b/src/Controller/Component/ThumbsComponent.php
@@ -44,10 +44,9 @@ class ThumbsComponent extends Component
      * Retrieve thumbnails URL of related objects in `meta.url` if present.
      *
      * @param array|null $response Related objects response.
-     * @param array|null $errors Array to store possible error messages from API.
      * @return void
      */
-    public function urls(?array &$response, ?array &$errors): void
+    public function urls(?array &$response): void
     {
         if (empty($response) || empty($response['data'])) {
             return;

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -294,7 +294,10 @@ class ModulesController extends AppController
             $response['data'] = [ $response['data'] ];
         }
 
-        $this->Thumbs->urls($response);
+        $this->Thumbs->urls($response, $errors);
+        if (!empty($errors)) {
+            $this->Flash->warning(__('There where errors creating the thumbnail(s)'), ['params' => $errors]);
+        }
 
         $this->set((array)$response);
         $this->setSerialize(array_keys($response));
@@ -402,7 +405,10 @@ class ModulesController extends AppController
             return;
         }
 
-        $this->Thumbs->urls($response);
+        $this->Thumbs->urls($response, $errors);
+        if (!empty($errors)) {
+            $this->Flash->warning(__('There where errors creating the thumbnail(s)'), ['params' => $errors]);
+        }
 
         $this->set((array)$response);
         $this->setSerialize(array_keys($response));
@@ -452,7 +458,10 @@ class ModulesController extends AppController
             $query = $this->Query->prepare($this->getRequest()->getQueryParams());
             $response = $this->apiClient->get($available, $query);
 
-            $this->Thumbs->urls($response);
+            $this->Thumbs->urls($response, $errors);
+            if (!empty($errors)) {
+                $this->Flash->warning(__('There where errors creating the thumbnail(s)'), ['params' => $errors]);
+            }
         } catch (BEditaClientException $ex) {
             $this->log($ex->getMessage(), LogLevel::ERROR);
 

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -294,10 +294,7 @@ class ModulesController extends AppController
             $response['data'] = [ $response['data'] ];
         }
 
-        $this->Thumbs->urls($response, $errors);
-        if (!empty($errors)) {
-            $this->Flash->warning(__('There where errors creating the thumbnail(s)'), ['params' => $errors]);
-        }
+        $this->Thumbs->urls($response);
 
         $this->set((array)$response);
         $this->setSerialize(array_keys($response));
@@ -405,10 +402,7 @@ class ModulesController extends AppController
             return;
         }
 
-        $this->Thumbs->urls($response, $errors);
-        if (!empty($errors)) {
-            $this->Flash->warning(__('There where errors creating the thumbnail(s)'), ['params' => $errors]);
-        }
+        $this->Thumbs->urls($response);
 
         $this->set((array)$response);
         $this->setSerialize(array_keys($response));
@@ -458,10 +452,7 @@ class ModulesController extends AppController
             $query = $this->Query->prepare($this->getRequest()->getQueryParams());
             $response = $this->apiClient->get($available, $query);
 
-            $this->Thumbs->urls($response, $errors);
-            if (!empty($errors)) {
-                $this->Flash->warning(__('There where errors creating the thumbnail(s)'), ['params' => $errors]);
-            }
+            $this->Thumbs->urls($response);
         } catch (BEditaClientException $ex) {
             $this->log($ex->getMessage(), LogLevel::ERROR);
 

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -13,6 +13,7 @@
 namespace App\Controller;
 
 use BEdita\SDK\BEditaClientException;
+use Cake\Core\Configure;
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
 use Cake\Utility\Hash;
@@ -54,7 +55,7 @@ class ModulesController extends AppController
         $this->loadComponent('Properties');
         $this->loadComponent('ProjectConfiguration');
         $this->loadComponent('Query');
-        $this->loadComponent('Thumbs');
+        $this->loadComponent('Thumbs', Configure::read('Thumbs', []));
         $this->loadComponent('BEdita/WebTools.ApiFormatter');
         if ($this->getRequest()->getParam('object_type')) {
             $this->objectType = $this->getRequest()->getParam('object_type');

--- a/templates/Element/Form/media.twig
+++ b/templates/Element/Form/media.twig
@@ -24,7 +24,7 @@
                     {# thumb #}
                     {% if object.type == 'images' %}
                         {# TODO process below #}
-                        {% set thumb = Thumb.getUrl(object, { 'options': { 'w': 960, 'fit': 'max' } } ) %}
+                        {% set thumb = Thumb.getUrl(object) %}
                         {% if thumb == constant('BEdita\\WebTools\\View\\Helper\\ThumbHelper::NOT_ACCEPTABLE') %}
                             <p>{{ __('Cannot produce a thumbnail for this file') }}</p>
                         {% elseif thumb == constant('BEdita\\WebTools\\View\\Helper\\ThumbHelper::NOT_AVAILABLE') %}

--- a/tests/TestCase/Controller/Component/ThumbsComponentTest.php
+++ b/tests/TestCase/Controller/Component/ThumbsComponentTest.php
@@ -163,7 +163,7 @@ class ThumbsComponentTest extends TestCase
         $registry = $controller->components();
         $registry->load(QueryComponent::class);
         $registry->load(ThumbsComponent::class);
-        $this->Thumbs->urls($data, $errors);
+        $this->Thumbs->urls($data);
         static::assertEquals($expected, $data);
     }
 
@@ -268,7 +268,7 @@ class ThumbsComponentTest extends TestCase
         $registry = $controller->components();
         $registry->load(QueryComponent::class);
         $registry->load(ThumbsComponent::class);
-        $this->Thumbs->urls($data, $errors);
+        $this->Thumbs->urls($data);
         static::assertEquals($expected, $data);
     }
 }

--- a/tests/TestCase/Controller/Component/ThumbsComponentTest.php
+++ b/tests/TestCase/Controller/Component/ThumbsComponentTest.php
@@ -219,13 +219,14 @@ class ThumbsComponentTest extends TestCase
             ->with('/media/thumbs?ids=45&preset=default')
             ->willReturn($mockApiResponse);
         ApiClientProvider::setApiClient($apiClient);
-
         $registry = $controller->components();
-        $registry->load(QueryComponent::class);
-        $registry->load(ThumbsComponent::class);
-        $this->Thumbs->urls($data, $errors);
+        /** @var \App\Controller\Component\ThumbsComponent $thumbsComponent */
+        $thumbsComponent = $registry->load(ThumbsComponent::class);
+        $this->Thumbs = $thumbsComponent;
+        $this->Thumbs->urls($data);
         static::assertEquals($expected, $data);
-        static::assertEquals($expectedErrors, $errors);
+        $actual = $this->Thumbs->getController()->getRequest()->getSession()->read('Flash.flash.0.params.0');
+        static::assertEquals($expectedErrors[0], $actual);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/ThumbsComponentTest.php
+++ b/tests/TestCase/Controller/Component/ThumbsComponentTest.php
@@ -156,15 +156,76 @@ class ThumbsComponentTest extends TestCase
                 ->setConstructorArgs(['https://media.example.com'])
                 ->getMock();
             $apiClient->method('get')
-                ->with('/media/thumbs?ids=43%2C45&options%5Bw%5D=400')
+                ->with('/media/thumbs?ids=43%2C45&preset=default')
                 ->willReturn($mockResponse);
             ApiClientProvider::setApiClient($apiClient);
         }
         $registry = $controller->components();
         $registry->load(QueryComponent::class);
         $registry->load(ThumbsComponent::class);
-        $this->Thumbs->urls($data);
+        $this->Thumbs->urls($data, $errors);
         static::assertEquals($expected, $data);
+    }
+
+    /**
+     * Test `urls` method, with errors from thumbnail generation API.
+     *
+     * @return void
+     * @covers ::urls()
+     * @covers ::getThumbs()
+     */
+    public function testUrlsThumbErrors(): void
+    {
+        $data = [
+            'data' => [
+                [
+                    'id' => '45',
+                    'type' => 'images',
+                    'meta' => [],
+                ],
+            ],
+        ];
+        $expected = [
+            'data' => [
+                [
+                    'id' => '45',
+                    'type' => 'images',
+                    'meta' =>
+                        [
+                            'thumb_url' => 'https://media.example.com/be4-media-test/test-thumbs/thumb2.png',
+                        ],
+                ],
+            ],
+        ];
+        $expectedErrors = ['Corrupted file'];
+        $mockApiResponse = [
+            'meta' => [
+                'thumbnails' => [
+                    [
+                        'url' => 'https://media.example.com/be4-media-test/test-thumbs/thumb2.png',
+                        'acceptable' => false,
+                        'message' => 'Corrupted file',
+                        'id' => 45,
+                    ],
+                ],
+            ],
+        ];
+
+        $controller = new Controller(new ServerRequest([]));
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://media.example.com'])
+            ->getMock();
+        $apiClient->method('get')
+            ->with('/media/thumbs?ids=45&preset=default')
+            ->willReturn($mockApiResponse);
+        ApiClientProvider::setApiClient($apiClient);
+
+        $registry = $controller->components();
+        $registry->load(QueryComponent::class);
+        $registry->load(ThumbsComponent::class);
+        $this->Thumbs->urls($data, $errors);
+        static::assertEquals($expected, $data);
+        static::assertEquals($expectedErrors, $errors);
     }
 
     /**
@@ -206,7 +267,7 @@ class ThumbsComponentTest extends TestCase
         $registry = $controller->components();
         $registry->load(QueryComponent::class);
         $registry->load(ThumbsComponent::class);
-        $this->Thumbs->urls($data);
+        $this->Thumbs->urls($data, $errors);
         static::assertEquals($expected, $data);
     }
 }

--- a/tests/TestCase/View/Helper/LinkHelperTest.php
+++ b/tests/TestCase/View/Helper/LinkHelperTest.php
@@ -495,24 +495,6 @@ class LinkHelperTest extends TestCase
     }
 
     /**
-     * Get webroot/js/app.bundle.<number>.js file and return <number>
-     *
-     * @return string
-     */
-    private function getBundle(): string
-    {
-        $files = preg_grep('~^app.bundle.*\.js$~', scandir(WWW_ROOT . 'js' . DS));
-        foreach ($files as $filename) {
-            $filename = basename($filename, '.js');
-            $bundle = substr($filename, strlen('app.bundle.'));
-
-            return $bundle;
-        }
-
-        return '';
-    }
-
-    /**
      * Data provider for `testJsBundle` test case.
      *
      * @return array
@@ -576,11 +558,6 @@ class LinkHelperTest extends TestCase
                 ['abcdefg'], // filter
                 '', // expected
             ],
-            // this test case works only locally, where there's a bundle
-            // 'existing css' => [
-            //     ['app'], // filter
-            //     sprintf('<link rel="stylesheet" href="css/app.%s.css"/>', $this->getBundle()), // expected
-            // ],
         ];
     }
 

--- a/tests/TestCase/View/Helper/SystemHelperTest.php
+++ b/tests/TestCase/View/Helper/SystemHelperTest.php
@@ -87,13 +87,13 @@ class SystemHelperTest extends TestCase
         $actual = $this->System->checkBeditaApiVersion();
         static::assertFalse($actual);
 
-        // project version 4.9.2
-        $this->System->getView()->set('project', ['version' => '4.9.2']);
+        // project version 4.9.5
+        $this->System->getView()->set('project', ['version' => '4.9.5']);
         $actual = $this->System->checkBeditaApiVersion();
         static::assertTrue($actual);
 
-        // project version 5.5.1
-        $this->System->getView()->set('project', ['version' => '5.5.1']);
+        // project version 5.5.7
+        $this->System->getView()->set('project', ['version' => '5.5.7']);
         $actual = $this->System->checkBeditaApiVersion();
         static::assertTrue($actual);
     }


### PR DESCRIPTION
This PR implements some QoL improvements to `ThumbsComponent`:

- allow configuration of the component
- handle errors in thumbnail generation returned from BEdita API
- change calls to `/media/thumb` so that it works out of the box; previously calls where made with parameters not allowed by API's default configuration

Related: https://github.com/bedita/bedita/pull/1983