### PR TITLE
Custom control options configuration and interface

### DIFF
--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -61,6 +61,7 @@ const _vueInstance = new Vue({
         FlashMessage: () => import(/* webpackChunkName: "flash-message" */'app/components/flash-message'),
         CoordinatesView: () => import(/* webpackChunkName: "coordinates-view" */'app/components/coordinates-view'),
         Secret: () => import(/* webpackChunkName: "secret" */'app/components/secret/secret'),
+        KeyValueList: () => import(/* webpackChunkName: "key-value-list" */'app/components/key-value-list/key-value-list'),
     },
 
     data() {

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -61,7 +61,8 @@ const _vueInstance = new Vue({
         FlashMessage: () => import(/* webpackChunkName: "flash-message" */'app/components/flash-message'),
         CoordinatesView: () => import(/* webpackChunkName: "coordinates-view" */'app/components/coordinates-view'),
         Secret: () => import(/* webpackChunkName: "secret" */'app/components/secret/secret'),
-        KeyValueList: () => import(/* webpackChunkName: "key-value-list" */'app/components/key-value-list/key-value-list'),
+        KeyValueList: () => import(/* webpackChunkName: "key-value-list" */'app/components/json-fields/key-value-list'),
+        StringList: () => import(/* webpackChunkName: "string-list" */'app/components/json-fields/string-list'),
     },
 
     data() {

--- a/resources/js/app/components/json-fields/key-value-list.js
+++ b/resources/js/app/components/json-fields/key-value-list.js
@@ -5,8 +5,8 @@ import { t } from 'ttag';
  */
 export default {
     template: `
-        <div class="input title text">
-            <label :for="name"><: label :></label>
+        <div class="input textarea text">
+            <label :for="name"><: label|humanize :></label>
             <div :id="name">
                 <div class="key-value-item mb-1" v-for="(item, index) in items">
                     <div>

--- a/resources/js/app/components/json-fields/key-value-list.js
+++ b/resources/js/app/components/json-fields/key-value-list.js
@@ -1,0 +1,104 @@
+import { t } from 'ttag';
+
+/**
+ * <key-value-list> component to handle simple JSON objects with key/values
+ */
+export default {
+    template: `
+        <div class="input title text">
+            <label :for="name"><: label :></label>
+            <div :id="name">
+                <div class="key-value-item mb-1" v-for="(item, index) in items">
+                    <div>
+                        <div>
+                            <input type="text" v-model="item.key" @change="onChanged()" :readonly="readonly"/>
+                        </div>
+                    </div>
+                    <div>
+                        <div>
+                            <input type="text" v-model="item.value" @change="onChanged()" :readonly="readonly"/>
+                        </div>
+                    </div>
+                    <div class="mb-2" v-if="!readonly">
+                        <button @click.prevent="remove(index)">${t`Remove`}</button>
+                    </div>
+                </div>
+            </div>
+
+            <button @click.prevent="add" v-if="!readonly">${t`Add`}</button>
+
+            <input type="hidden" :name="name" v-model="result" />
+        </div>
+    `,
+
+    props: {
+        value: String,
+        name: String,
+        label: String,
+        readonly: Boolean,
+    },
+
+    data() {
+        return {
+            items: [],
+            result: {},
+        }
+    },
+
+    created() {
+        this.result = this.value;
+        if (!this.value) {
+            this.result = null;
+        }
+        const v = JSON.parse(this.result) || {};
+        Object.keys(v).forEach((k) => {
+            this.items.push({
+                key: k,
+                value: v?.[k] || '',
+            })
+        });
+        if (!this.items.length) {
+            this.add();
+        }
+    },
+
+    methods: {
+        /**
+         * Update input hidden form value.
+         *
+         * @returns {void}
+         */
+        onChanged() {
+            let obj = {};
+            this.items.forEach((item) => {
+                if (item?.key) {
+                    obj[item.key] = item?.value || null;
+                }
+            })
+            this.result = JSON.stringify(obj);
+        },
+
+        /**
+         * Add an empty item to list.
+         *
+         * @returns {void}
+         */
+        add() {
+            this.items.push({
+                key: '',
+                value: '',
+            });
+        },
+
+        /**
+         * Remove item from list.
+         *
+         * @param {Integer} index The index
+         * @returns {void}
+         */
+        remove(index) {
+            this.items.splice(index, 1);
+            this.onChanged();
+        },
+    },
+}

--- a/resources/js/app/components/json-fields/string-list.js
+++ b/resources/js/app/components/json-fields/string-list.js
@@ -1,7 +1,7 @@
 import { t } from 'ttag';
 
 /**
- * <key-value-list> component to handle simple JSON objects with key/values
+ * <string-list> component to handle simple JSON array of strings
  */
 export default {
     template: `
@@ -10,21 +10,13 @@ export default {
             <div :id="name">
                 <div class="key-value-item mb-1" v-for="(item, index) in items">
                     <div>
-                        <div>
-                            <input type="text" v-model="item.key" @change="onChanged()" :readonly="readonly"/>
-                        </div>
-                    </div>
-                    <div>
-                        <div>
-                            <input type="text" v-model="item.value" @change="onChanged()" :readonly="readonly"/>
-                        </div>
+                        <input type="text" v-model="item.value" @change="onChanged()" :readonly="readonly"/>
                     </div>
                     <div class="mb-2" v-if="!readonly">
                         <button @click.prevent="remove(index)">${t`Remove`}</button>
                     </div>
                 </div>
             </div>
-
             <button @click.prevent="add" v-if="!readonly">${t`Add`}</button>
 
             <input type="hidden" :name="name" v-model="result" />
@@ -46,36 +38,31 @@ export default {
     },
 
     created() {
-        console.log(this.value);
-        let t = this.value;
+        this.result = this.value;
         if (!this.value) {
-            t = null;
+            this.result = null;
         }
-        const v = JSON.parse(t);
-        if (v) {
-            const keys = Object.keys(v);
-            keys.forEach((k) => {
-                this.items.push({
-                    key: k,
-                    value: v?.[k] || '',
-                })
-            });
-        }
+        const v = JSON.parse(this.result) || [];
+        v.forEach((k) => {
+            this.items.push({
+                value: k,
+            })
+        });
+
         if (!this.items.length) {
             this.add();
         }
-        this.onChanged();
     },
 
     methods: {
-
+        /**
+         * Update input hidden form value.
+         *
+         * @returns {void}
+         */
         onChanged() {
-            let obj = {};
-            this.items.forEach((item) => {
-                obj[item.key] = item?.value || null;
-            })
-            this.result = JSON.stringify(obj);
-            console.log(this.result);
+            const data = this.items.map((i) => i?.value || null).filter((v) => v !== null);
+            this.result = JSON.stringify(data);
         },
 
         /**
@@ -84,10 +71,7 @@ export default {
          * @returns {void}
          */
         add() {
-            this.items.push({
-                key: '',
-                value: '',
-            });
+            this.items.push({value: ''});
         },
 
         /**

--- a/resources/js/app/components/json-fields/string-list.js
+++ b/resources/js/app/components/json-fields/string-list.js
@@ -5,8 +5,8 @@ import { t } from 'ttag';
  */
 export default {
     template: `
-        <div class="input title text">
-            <label :for="name"><: label :></label>
+        <div class="input textarea text">
+            <label :for="name"><: label|humanize :></label>
             <div :id="name">
                 <div class="key-value-item mb-1" v-for="(item, index) in items">
                     <div>

--- a/resources/js/app/components/key-value-list/key-value-list.js
+++ b/resources/js/app/components/key-value-list/key-value-list.js
@@ -1,0 +1,104 @@
+import { t } from 'ttag';
+
+/**
+ * <key-value-list> component to handle simple JSON objects with key/values
+ */
+export default {
+    template: `
+        <div class="input title text">
+            <label :for="name"><: label :></label>
+            <div :id="name">
+                <div class="key-value-item mb-1" v-for="(item, index) in items">
+                    <div>
+                        <div>
+                            <input type="text" v-model="item.key" @change="onChanged()" :readonly="readonly"/>
+                        </div>
+                    </div>
+                    <div>
+                        <div>
+                            <input type="text" v-model="item.value" @change="onChanged()" :readonly="readonly"/>
+                        </div>
+                    </div>
+                    <div class="mb-2" v-if="!readonly">
+                        <button @click.prevent="remove(index)">${t`Remove`}</button>
+                    </div>
+                </div>
+            </div>
+
+            <button @click.prevent="add" v-if="!readonly">${t`Add`}</button>
+
+            <input type="hidden" :name="name" v-model="result" />
+        </div>
+    `,
+
+    props: {
+        value: String,
+        name: String,
+        label: String,
+        readonly: Boolean,
+    },
+
+    data() {
+        return {
+            items: [],
+            result: {},
+        }
+    },
+
+    created() {
+        console.log(this.value);
+        let t = this.value;
+        if (!this.value) {
+            t = null;
+        }
+        const v = JSON.parse(t);
+        if (v) {
+            const keys = Object.keys(v);
+            keys.forEach((k) => {
+                this.items.push({
+                    key: k,
+                    value: v?.[k] || '',
+                })
+            });
+        }
+        if (!this.items.length) {
+            this.add();
+        }
+        this.onChanged();
+    },
+
+    methods: {
+
+        onChanged() {
+            let obj = {};
+            this.items.forEach((item) => {
+                obj[item.key] = item?.value || null;
+            })
+            this.result = JSON.stringify(obj);
+            console.log(this.result);
+        },
+
+        /**
+         * Add an empty item to list.
+         *
+         * @returns {void}
+         */
+        add() {
+            this.items.push({
+                key: '',
+                value: '',
+            });
+        },
+
+        /**
+         * Remove item from list.
+         *
+         * @param {Integer} index The index
+         * @returns {void}
+         */
+        remove(index) {
+            this.items.splice(index, 1);
+            this.onChanged();
+        },
+    },
+}

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -33,6 +33,7 @@ export default {
         History: () => import(/* webpackChunkName: "history" */'app/components/history/history'),
         CoordinatesView: () => import(/* webpackChunkName: "coordinates-view" */'app/components/coordinates-view'),
         TagPicker: () => import(/* webpackChunkName: "tag-picker" */'app/components/tag-picker/tag-picker'),
+        KeyValueList: () => import(/* webpackChunkName: "key-value-list" */'app/components/key-value-list/key-value-list'),
     },
 
     props: {

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -33,7 +33,8 @@ export default {
         History: () => import(/* webpackChunkName: "history" */'app/components/history/history'),
         CoordinatesView: () => import(/* webpackChunkName: "coordinates-view" */'app/components/coordinates-view'),
         TagPicker: () => import(/* webpackChunkName: "tag-picker" */'app/components/tag-picker/tag-picker'),
-        KeyValueList: () => import(/* webpackChunkName: "key-value-list" */'app/components/key-value-list/key-value-list'),
+        KeyValueList: () => import(/* webpackChunkName: "key-value-list" */'app/components/json-fields/key-value-list'),
+        StringList: () => import(/* webpackChunkName: "string-list" */'app/components/json-fields/string-list'),
     },
 
     props: {

--- a/resources/js/app/helpers/text-helper.js
+++ b/resources/js/app/helpers/text-helper.js
@@ -1,0 +1,21 @@
+export function humanizeString(string) {
+    if (!string) {
+        return '';
+    }
+    string = string
+        .toLowerCase()
+        .replace(/[_-]+/g, ' ')
+        .replace(/\s{2,}/g, ' ')
+        .trim();
+    const words = string.split(' ');
+    let res = '';
+    words.forEach((entry) => {
+        res += ' ' + upperCaseFirst(entry);
+    });
+
+    return res.trim();
+}
+
+export function upperCaseFirst(input) {
+    return input.charAt(0).toUpperCase() + input.substr(1);
+}

--- a/resources/js/libs/filters.js
+++ b/resources/js/libs/filters.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import { humanizeString } from '../app/helpers/text-helper.js';
 
 /**
  * Converts a snake case string to title case.
@@ -8,9 +9,7 @@ import Vue from 'vue';
  * @return {String}
  */
 Vue.filter('humanize', function(str) {
-    return str.split('_').map(function(item) {
-        return item.charAt(0).toUpperCase() + item.substring(1);
-    }).join(' ');
+    return humanizeString(str);
 });
 
 /**

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -271,7 +271,7 @@ class AppController extends Controller
             return;
         }
 
-        $keys = explode(',', (string)$data['_jsonKeys']);
+        $keys = array_unique(explode(',', (string)$data['_jsonKeys']));
         foreach ($keys as $key) {
             $value = Hash::get($data, $key);
             $decoded = json_decode((string)$value, true);

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -166,17 +166,14 @@ class PropertiesComponent extends Component
             $list = $this->getConfig($key, $items);
             $p = [];
             foreach ($list as $item) {
-                if (array_key_exists($item, $attributes)) {
+                if (array_key_exists($item, $attributes) && !in_array($item, $used)) {
                     $p[$item] = $attributes[$item];
+                    $used[] = $item;
                 }
             }
             $properties[$group] = $p;
-            if ($group !== 'other') {
-                $used = array_merge($used, $list);
-            }
         }
         // add remaining properties to 'other' group
-        $properties['other'] = array_diff_key($properties['other'], array_flip($used));
         $properties['other'] += array_diff_key($attributes, array_flip($used));
 
         return $properties;

--- a/src/Form/CustomComponentControl.php
+++ b/src/Form/CustomComponentControl.php
@@ -34,12 +34,13 @@ class CustomComponentControl implements CustomHandlerInterface
             $value = htmlspecialchars($this->jsonValue($value));
         }
         $html = sprintf(
-            '<%s label="%s" name="%s" value="%s" :readonly=%s />',
+            '<%s label="%s" name="%s" value="%s" :readonly=%s></%s>',
             $tag,
             $label,
             $name,
             $value,
             $readonly ? 'true' : 'false',
+            $tag,
         );
 
         return compact('type', 'html');

--- a/src/Form/CustomComponentControl.php
+++ b/src/Form/CustomComponentControl.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Form;
+
+use Cake\Utility\Hash;
+
+/**
+ * Return a custom component to handle input for a JSON field
+ */
+class CustomComponentControl implements CustomHandlerInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function control(string $name, $value, array $options): array
+    {
+        // you can define a custom component via `tag` option, default is <key-value-list>
+        $tag = Hash::get($options, 'tag', 'key-value-list');
+        $label = (string)Hash::get($options, 'label', $name);
+        $readonly = (bool)Hash::get($options, 'readonly', false);
+        $json = htmlspecialchars($this->jsonValue($value));
+
+        return [
+            'class' => 'json',
+            'html' => sprintf(
+                '<%s label="%s" name="%s" value="%s" :readonly=%s />',
+                $tag,
+                $label,
+                $name,
+                $json,
+                $readonly ? 'true' : 'false',
+            ),
+        ];
+    }
+
+    /**
+     * Return a string representing the json value.
+     *
+     * @param mixed|null $value The value
+     * @return string
+     */
+    protected function jsonValue($value): string
+    {
+        if (empty($value)) {
+            return '';
+        }
+        if (is_array($value) || is_object($value)) {
+            return json_encode($value);
+        }
+
+        return json_encode(json_decode($value, true));
+    }
+}

--- a/src/Form/CustomComponentControl.php
+++ b/src/Form/CustomComponentControl.php
@@ -16,7 +16,7 @@ namespace App\Form;
 use Cake\Utility\Hash;
 
 /**
- * Return a custom component to handle input for a JSON field
+ * Return a custom component to handle input for a property
  */
 class CustomComponentControl implements CustomHandlerInterface
 {
@@ -29,19 +29,20 @@ class CustomComponentControl implements CustomHandlerInterface
         $tag = Hash::get($options, 'tag', 'key-value-list');
         $label = (string)Hash::get($options, 'label', $name);
         $readonly = (bool)Hash::get($options, 'readonly', false);
-        $json = htmlspecialchars($this->jsonValue($value));
+        $type = (string)Hash::get($options, 'type');
+        if ($type === 'json' || is_array($value) || is_object($value)) {
+            $value = htmlspecialchars($this->jsonValue($value));
+        }
+        $html = sprintf(
+            '<%s label="%s" name="%s" value="%s" :readonly=%s />',
+            $tag,
+            $label,
+            $name,
+            $value,
+            $readonly ? 'true' : 'false',
+        );
 
-        return [
-            'class' => 'json',
-            'html' => sprintf(
-                '<%s label="%s" name="%s" value="%s" :readonly=%s />',
-                $tag,
-                $label,
-                $name,
-                $json,
-                $readonly ? 'true' : 'false',
-            ),
-        ];
+        return compact('type', 'html');
     }
 
     /**

--- a/src/Form/CustomHandlerInterface.php
+++ b/src/Form/CustomHandlerInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Form;
+
+interface CustomHandlerInterface
+{
+    /**
+     * Create custom form control options for a property
+     *
+     * @param string $name Property name
+     * @param mixed $value Property value
+     * @param array $options Options array from configuration
+     * @return array
+     */
+    public function control(string $name, $value, array $options): array;
+}

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -75,7 +75,7 @@ class PropertyHelper extends Helper
         if ($readonly === true && array_key_exists('v-datepicker', $controlOptions)) {
             unset($controlOptions['v-datepicker']);
         }
-        if (Hash::get($controlOptions, 'class') === 'json') {
+        if (Hash::get($controlOptions, 'class') === 'json' || Hash::get($controlOptions, 'type') === 'json') {
             $jsonKeys = (array)Configure::read('_jsonKeys');
             Configure::write('_jsonKeys', array_merge($jsonKeys, [$name]));
         }

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -72,19 +72,21 @@ class SchemaHelper extends Helper
                 'disabled' => Hash::get($ctrlOptions, 'readonly', false),
             ]);
         }
+        if (empty($ctrlOptions['type'])) {
+            $ctrlOptions['type'] = ControlType::fromSchema((array)$schema);
+        }
         // verify if there's a custom renderer for $type and $name
         $custom = $this->customControl($name, $value, $ctrlOptions);
         if (!empty($custom)) {
             return $custom;
         }
-        $type = ControlType::fromSchema((array)$schema);
 
         return Control::control([
             'objectType' => $objectType,
             'property' => $name,
             'value' => $value,
             'schema' => (array)$schema,
-            'propertyType' => Hash::get($ctrlOptions, 'type', $type),
+            'propertyType' => (string)$ctrlOptions['type'],
             'label' => Hash::get($ctrlOptions, 'label'),
             'readonly' => Hash::get($ctrlOptions, 'readonly', false),
             'disabled' => Hash::get($ctrlOptions, 'readonly', false),

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -72,11 +72,10 @@ class SchemaHelper extends Helper
                 'disabled' => Hash::get($ctrlOptions, 'readonly', false),
             ]);
         }
-        // verify if there's an handler by $type.$name
-        if (!empty(Configure::read(sprintf('Control.handlers.%s.%s', $objectType, $name)))) {
-            $handler = Configure::read(sprintf('Control.handlers.%s.%s', $objectType, $name));
-
-            return call_user_func_array([$handler['class'], $handler['method']], [$value, $schema]);
+        // verify if there's a custom renderer for $type and $name
+        $custom = $this->customControl($name, $value, $ctrlOptions);
+        if (!empty($custom)) {
+            return $custom;
         }
         $type = ControlType::fromSchema((array)$schema);
 
@@ -90,6 +89,26 @@ class SchemaHelper extends Helper
             'readonly' => Hash::get($ctrlOptions, 'readonly', false),
             'disabled' => Hash::get($ctrlOptions, 'readonly', false),
         ]);
+    }
+
+    /**
+     * Return custom control array if a custom handler has been defined or null otherwise.
+     *
+     * @param string $name Property name
+     * @param mixed $value Property value.
+     * @param array $options Control options.
+     * @return array|null
+     */
+    protected function customControl($name, $value, array $options): ?array
+    {
+        $handlerClass = Hash::get($options, 'handler');
+        if (empty($handlerClass)) {
+            return null;
+        }
+        /** @var \App\Form\CustomHandlerInterface $handler */
+        $handler = new $handlerClass();
+
+        return $handler->control($name, $value, $options);
     }
 
     /**

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -75,7 +75,7 @@ class SchemaHelper extends Helper
         if (empty($ctrlOptions['type'])) {
             $ctrlOptions['type'] = ControlType::fromSchema((array)$schema);
         }
-        // verify if there's a custom renderer for $type and $name
+        // verify if there's a custom control handler for $type and $name
         $custom = $this->customControl($name, $value, $ctrlOptions);
         if (!empty($custom)) {
             return $custom;

--- a/tests/TestCase/Controller/Component/PropertiesComponentTest.php
+++ b/tests/TestCase/Controller/Component/PropertiesComponentTest.php
@@ -351,6 +351,7 @@ class PropertiesComponentTest extends TestCase
                     'core' => [
                         'description' => null,
                         'title' => 'A',
+                        'extra' => [],
                     ],
                     'publish' => [
                         'uname' => 'test',
@@ -367,6 +368,7 @@ class PropertiesComponentTest extends TestCase
                         'description' => null,
                         'status' => 'on',
                         'uname' => 'test',
+                        'extra' => [],
                     ],
                 ],
                 'gifts',
@@ -374,6 +376,7 @@ class PropertiesComponentTest extends TestCase
                     'core' => [
                         'description',
                         'title',
+                        'extra',
                     ],
                     'publish' => [
                         'uname',

--- a/tests/TestCase/Form/CustomComponentControlTest.php
+++ b/tests/TestCase/Form/CustomComponentControlTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Test\TestCase\Form;
+
+use App\Form\CustomComponentControl;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \App\Form\CustomComponentControl} Test Case
+ *
+ * @coversDefaultClass \App\Form\CustomComponentControl
+ */
+class CustomComponentControlTest extends TestCase
+{
+    /**
+     * Data provider for `testControl` test case.
+     *
+     * @return array
+     */
+    public function controlProvider(): array
+    {
+        return [
+            'default simple' => [
+                [
+                    'type' => '',
+                    'html' => '<key-value-list label="field1" name="field1" value="" :readonly=false></key-value-list>',
+                ],
+                'field1',
+                [],
+                [],
+            ],
+            'custom tag' => [
+                [
+                    'type' => 'json',
+                    'html' => '<my-component label="Abstract" name="subtitle" value="{&quot;a&quot;:2}" :readonly=false></my-component>',
+                ],
+                'subtitle',
+                ['a' => 2],
+                [
+                    'type' => 'json',
+                    'tag' => 'my-component',
+                    'label' => 'Abstract',
+                ],
+            ],
+            'json encoded' => [
+                [
+                    'type' => 'json',
+                    'html' => '<key-value-list label="some_field" name="some_field" value="{&quot;a&quot;:&quot;b&quot;}" :readonly=true></key-value-list>',
+                ],
+                'some_field',
+                '{"a":"b"}',
+                [
+                    'type' => 'json',
+                    'readonly' => true,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `control` method.
+     *
+     * @param array $expected Expected result.
+     * @param string $name The field name.
+     * @param mixed|null $value The field value.
+     * @param array $options Control options.
+     * @return void
+     * @dataProvider controlProvider()
+     * @covers ::control()
+     * @covers ::jsonValue()
+     */
+    public function testCustomControl(array $expected, string $name, $value, array $options = []): void
+    {
+        $control = new CustomComponentControl();
+
+        $result = $control->control($name, $value, $options);
+        ksort($expected);
+        static::assertEquals($expected, $result);
+    }
+}

--- a/tests/TestCase/View/Helper/PropertyHelperTest.php
+++ b/tests/TestCase/View/Helper/PropertyHelperTest.php
@@ -31,20 +31,17 @@ class PropertyHelperTest extends TestCase
      */
     public function setUp(): void
     {
-        Configure::write(
-            'Control.handlers',
-            array_merge(
-                (array)\Cake\Core\Configure::read('Control.handlers'),
-                [
-                    'dummies' => [ // an object type
-                        'descr' => [ // a field
-                            'class' => 'App\Test\TestCase\View\Helper\PropertyHelperTest',
-                            'method' => 'dummy',
-                        ],
-                    ],
-                ]
-            )
-        );
+        // set custom control handlers
+        $propsConf = (array)Configure::read('Properties');
+        $propsConf['dummies'] = [
+            'options' => [
+                'descr' => [
+                    'handler' => 'App\Form\CustomComponentControl',
+                    'tag' => 'dummy',
+                ],
+            ],
+        ];
+        Configure::write('Properties', $propsConf);
     }
 
     /**
@@ -132,7 +129,7 @@ class PropertyHelperTest extends TestCase
                 [
                     'name' => 'descr',
                 ],
-                '<dummy>something</dummy>',
+                '<dummy label="descr" name="descr" value="something" :readonly=false></dummy>',
             ],
             'date readonly' => [
                 'expires',

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -52,13 +52,13 @@ class SchemaHelperTest extends TestCase
         $view = new View($request, null, null, []);
         $view->set('objectType', 'dummies');
         $this->Schema = new SchemaHelper($view);
-        // set control handlers
-        $control = (array)Configure::read('Control');
-        $control['handlers'] = [
-            'dummies' => [ // an object type
-                'descr' => [ // a field
-                    'class' => 'App\Test\TestCase\View\Helper\PropertyHelperTest',
-                    'method' => 'dummy',
+        // set custom control handlers
+        $control = (array)Configure::read('Properties');
+        $control['dummies'] = [
+            'options' => [
+                'descr' => [
+                    'handler' => 'App\Form\CustomComponentControl',
+                    'tag' => 'dummy',
                 ],
             ],
         ];
@@ -348,7 +348,8 @@ class SchemaHelperTest extends TestCase
             'custom handler' => [
                 // expected result
                 [
-                    'html' => '<dummy>something</dummy>',
+                    'type' => 'string',
+                    'html' => '<dummy label="descr" name="descr" value="something" :readonly=false ></dummy>',
                 ],
                 // schema type
                 [
@@ -370,6 +371,7 @@ class SchemaHelperTest extends TestCase
      * @return void
      * @dataProvider controlOptionsSchemaProvider()
      * @covers ::controlOptions()
+     * @covers ::customControl()
      */
     public function testControlOptions(array $expected, array $schema, string $name, ?string $value): void
     {

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -53,8 +53,8 @@ class SchemaHelperTest extends TestCase
         $view->set('objectType', 'dummies');
         $this->Schema = new SchemaHelper($view);
         // set custom control handlers
-        $control = (array)Configure::read('Properties');
-        $control['dummies'] = [
+        $propsConf = (array)Configure::read('Properties');
+        $propsConf['dummies'] = [
             'options' => [
                 'descr' => [
                     'handler' => 'App\Form\CustomComponentControl',
@@ -62,7 +62,7 @@ class SchemaHelperTest extends TestCase
                 ],
             ],
         ];
-        Configure::write('Control', $control);
+        Configure::write('Properties', $propsConf);
     }
 
     /**


### PR DESCRIPTION
This PR solves #945 

Custom handler configuration has been  moved to `Properties.<type>.options` - you can define a custom handler with  a conf like:

```php
  'Properties' => [
    'documents' => [
        'options' => [
            'body' => [ 
                'handler' => '\MyApp\MyHandler',
            ],
        ],
    ],
],
```

* a new `CustomHandlerInterface` has been added, the interface that every handler MUST implmenent
* a `CustomComponentControl` handler that allow the usage of custom JS components to handle a property, where tag name can be specified via `tag` option - default is the `<key-value-list>` component for now, that can be used to handle JSON objects with simple key/value strings
* an additional `<string-list>` component has been added to handle JSON arrays of strings 
* a minor issue has also been solved in `PropertiesComponent` with duplicate properties: f. i. if the `extra` property is added to `core` group it was also repeated in the defatul `advanced` group 
  