### PR TITLE
Fix test for "translatable"

### DIFF
--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -188,7 +188,7 @@ class SchemaComponentTest extends TestCase
                 ],
                 [
                     'documents' => [
-                        'definitions', '$id', '$schema', 'type', 'properties', 'required', 'associations', 'relations', 'revision',
+                        'definitions', '$id', '$schema', 'type', 'properties', 'required', 'translatable', 'associations', 'relations', 'revision',
                     ],
                     'users' => [
                         'definitions', '$id', '$schema', 'type', 'properties', 'required', 'associations', 'relations', 'revision',

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -191,7 +191,7 @@ class SchemaComponentTest extends TestCase
                         'definitions', '$id', '$schema', 'type', 'properties', 'required', 'translatable', 'associations', 'relations', 'revision',
                     ],
                     'users' => [
-                        'definitions', '$id', '$schema', 'type', 'properties', 'required', 'associations', 'relations', 'revision',
+                        'definitions', '$id', '$schema', 'type', 'properties', 'required', 'translatable', 'associations', 'relations', 'revision',
                     ],
                 ],
             ],
@@ -211,9 +211,9 @@ class SchemaComponentTest extends TestCase
         if (empty($expected)) {
             static::assertEquals($expected, $schemasByType);
         } else {
-            foreach ($expected as $type => $keys) {
+            foreach ($expected as $type => $expected) {
                 $actual = array_keys($schemasByType[$type]);
-                static::assertEquals($actual, $keys);
+                static::assertEquals($expected, $actual);
             }
         }
     }


### PR DESCRIPTION
This fixes a test failing after a BEdita update (https://github.com/bedita/bedita/pull/1975 and https://github.com/bedita/bedita/pull/1978)