### PR TITLE
Handle empty schema as 'json'

### DIFF
--- a/src/Form/ControlType.php
+++ b/src/Form/ControlType.php
@@ -62,7 +62,7 @@ class ControlType
         if (empty($schema)) {
             return 'json';
         }
-        $schemaType = Hash::get($schema, 'type', null);
+        $schemaType = (string)Hash::get($schema, 'type');
         if ($schemaType === 'categories') {
             return $schemaType;
         }

--- a/src/Form/ControlType.php
+++ b/src/Form/ControlType.php
@@ -59,7 +59,7 @@ class ControlType
         if (!is_array($schema)) {
             return 'text';
         }
-        if ($schema === []) {
+        if (empty($schema)) {
             return 'json';
         }
         $schemaType = Hash::get($schema, 'type', null);

--- a/src/Form/ControlType.php
+++ b/src/Form/ControlType.php
@@ -51,12 +51,12 @@ class ControlType
      *   'richtext'
      *   'text'
      *
-     * @param mixed $schema The property schema
+     * @param array $schema The property schema
      * @return string
      */
-    public static function fromSchema($schema): string
+    public static function fromSchema(?array $schema): string
     {
-        if (!is_array($schema)) {
+        if ($schema === null) {
             return 'text';
         }
         if (empty($schema)) {
@@ -75,7 +75,7 @@ class ControlType
                 return ControlType::fromSchema($subSchema);
             }
         }
-        if (empty($schemaType) || !in_array($schemaType, ControlType::SCHEMA_PROPERTY_TYPES)) {
+        if (!in_array($schemaType, ControlType::SCHEMA_PROPERTY_TYPES)) {
             return 'text';
         }
         $method = Form::getMethod(ControlType::class, sprintf('from%s', ucfirst($schemaType)));

--- a/src/Form/ControlType.php
+++ b/src/Form/ControlType.php
@@ -59,6 +59,9 @@ class ControlType
         if (!is_array($schema)) {
             return 'text';
         }
+        if ($schema === []) {
+            return 'json';
+        }
         $schemaType = Hash::get($schema, 'type', null);
         if ($schemaType === 'categories') {
             return $schemaType;

--- a/src/Form/ControlType.php
+++ b/src/Form/ControlType.php
@@ -51,7 +51,7 @@ class ControlType
      *   'richtext'
      *   'text'
      *
-     * @param array $schema The property schema
+     * @param array|null $schema The property schema
      * @return string
      */
     public static function fromSchema(?array $schema): string

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -64,7 +64,7 @@ class PropertyHelper extends Helper
      * @param string $name The property name
      * @param mixed|null $value The property value
      * @param array $options The form element options, if any
-     * @param string|null $type The object type, for others schemas
+     * @param string|null $type The object or resource type, for others schemas
      * @return string
      */
     public function control(string $name, $value, array $options = [], ?string $type = null): string

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -64,7 +64,7 @@ class PropertyHelper extends Helper
      * @param string $name The property name
      * @param mixed|null $value The property value
      * @param array $options The form element options, if any
-     * @param string|null $type The type, for others schemas
+     * @param string|null $type The object type, for others schemas
      * @return string
      */
     public function control(string $name, $value, array $options = [], ?string $type = null): string
@@ -111,26 +111,29 @@ class PropertyHelper extends Helper
      * JSON Schema array of property name
      *
      * @param string $name The property name
-     * @param string|null $type The type, for others schemas
-     * @return array
+     * @param string|null $objectType The object or resource type to use as schema
+     * @return array|null
      */
-    public function schema(string $name, ?string $type = null): array
+    public function schema(string $name, ?string $objectType = null): ?array
     {
         $schema = (array)$this->_View->get('schema');
-        if (!empty($type)) {
+        if (!empty($objectType)) {
             $schemas = (array)$this->_View->get('schemasByType');
-            $schema = (array)Hash::get($schemas, $type);
+            $schema = (array)Hash::get($schemas, $objectType);
         }
-        $res = (array)Hash::get($schema, sprintf('properties.%s', $name));
-        $default = array_filter([
-            'type' => Hash::get(self::SPECIAL_PROPS_TYPE, $name),
-            $name => Hash::get($schema, sprintf('%s', $name)),
-        ]);
-        if (in_array($name, self::SPECIAL_PROPS_TYPE)) {
-            return $default;
+        $res = Hash::get($schema, sprintf('properties.%s', $name));
+        if ($res === null) {
+            if (Hash::check(self::SPECIAL_PROPS_TYPE, $name)) {
+                return array_filter([
+                    'type' => Hash::get(self::SPECIAL_PROPS_TYPE, $name),
+                    $name => Hash::get($schema, sprintf('%s', $name)),
+                ]);
+            }
+
+            return null;
         }
 
-        return !empty($res) ? $res : $default;
+        return $res;
     }
 
     /**

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -133,7 +133,7 @@ class PropertyHelper extends Helper
             return null;
         }
 
-        return $res;
+        return (array)$res;
     }
 
     /**

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -55,7 +55,7 @@ class SchemaHelper extends Helper
      *
      * @param string $name Property name.
      * @param mixed $value Property value.
-     * @param array|null $schema Object schema array.
+     * @param array|null $schema Property schema.
      * @return array
      */
     public function controlOptions(string $name, $value, ?array $schema = null): array

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -55,10 +55,10 @@ class SchemaHelper extends Helper
      *
      * @param string $name Property name.
      * @param mixed $value Property value.
-     * @param array $schema Object schema array.
+     * @param array|null $schema Object schema array.
      * @return array
      */
-    public function controlOptions(string $name, $value, $schema = []): array
+    public function controlOptions(string $name, $value, ?array $schema = null): array
     {
         $options = Options::customControl($name, $value);
         $objectType = (string)$this->_View->get('objectType');
@@ -78,7 +78,7 @@ class SchemaHelper extends Helper
 
             return call_user_func_array([$handler['class'], $handler['method']], [$value, $schema]);
         }
-        $type = ControlType::fromSchema((array)$schema);
+        $type = ControlType::fromSchema($schema);
 
         return Control::control([
             'objectType' => $objectType,

--- a/tests/TestCase/Form/ControlTypeTest.php
+++ b/tests/TestCase/Form/ControlTypeTest.php
@@ -99,7 +99,7 @@ class ControlTypeTest extends TestCase
             ],
             'not an array' => [
                 'text',
-                false,
+                null,
             ],
             'no type' => [
                 'text',
@@ -163,7 +163,7 @@ class ControlTypeTest extends TestCase
      * Test `fromSchema()` method.
      *
      * @param string $expected Expected result.
-     * @param array|bool $schema Schema.
+     * @param array|null $schema Schema.
      * @return void
      * @dataProvider fromSchemaProvider()
      * @covers ::fromSchema()

--- a/tests/TestCase/Form/ControlTypeTest.php
+++ b/tests/TestCase/Form/ControlTypeTest.php
@@ -107,10 +107,15 @@ class ControlTypeTest extends TestCase
                     'const' => 13,
                 ],
             ],
-            'json' => [
+            'json object' => [
                 'json',
                 [
                     'type' => 'object',
+                ],
+            ],
+            'json' => [
+                'json',
+                [
                 ],
             ],
             'unknown' => [


### PR DESCRIPTION
This PR fixes a problem in JSON Schema: an empty schema like `{}` MUST be interpreted as pure JSON 
