### PR TITLE
Pass only changed attributes in object types API calls

### DIFF
--- a/config/schema_properties.php
+++ b/config/schema_properties.php
@@ -36,7 +36,7 @@ return [
                     ],
                     [
                         'type' => 'string',
-                        'contentMediaType' => 'text/html',
+                        'contentMediaType' => 'text/plain',
                     ],
                 ],
                 '$id' => '/properties/description',
@@ -165,7 +165,7 @@ return [
                     ],
                     [
                         'type' => 'string',
-                        'contentMediaType' => 'text/html',
+                        'contentMediaType' => 'text/plain',
                     ],
                 ],
                 '$id' => '/properties/description',
@@ -288,7 +288,7 @@ return [
                     ],
                     [
                         'type' => 'string',
-                        'contentMediaType' => 'text/html',
+                        'contentMediaType' => 'text/plain',
                     ],
                 ],
                 '$id' => '/properties/description',
@@ -421,7 +421,7 @@ return [
                     ],
                     [
                         'type' => 'string',
-                        'contentMediaType' => 'text/html',
+                        'contentMediaType' => 'text/plain',
                     ],
                 ],
                 '$id' => '/properties/description',

--- a/src/Controller/Model/ObjectTypesController.php
+++ b/src/Controller/Model/ObjectTypesController.php
@@ -78,6 +78,8 @@ class ObjectTypesController extends ModelBaseController
         $this->set('properties', $this->Properties->viewGroups($resource, $this->resourceType));
         $this->set('propertyTypesOptions', $this->Properties->typesOptions());
         $this->set('associationsOptions', $this->Properties->associationsOptions((array)Hash::get($resource, 'attributes.associations')));
+        // setup `currentAttributes`
+        $this->Modules->setupAttributes($resource);
 
         return null;
     }

--- a/templates/Pages/Model/ObjectTypes/view.twig
+++ b/templates/Pages/Model/ObjectTypes/view.twig
@@ -19,6 +19,7 @@
         })|raw }}
 
             {{ Form.hidden('id', {'value': (object) ? object.id : resource.id})|raw }}
+            {{ Form.hidden('_actualAttributes', {'value': currentAttributes})|raw }}
 
             <div class="main-view-column">
                 <section class="fieldset">


### PR DESCRIPTION
This PR solves a problem updating some object types like `folders`: only actually changed attributes are now saved using `currentAttributes`/`_actualAttributes` pattern. 

Bonus: some model description fields are moved to plain text to avoid HTML tags in this context 