### PR TITLE
Minor fix: use flash error instead of warning to show error messages

### DIFF
--- a/src/Controller/Component/ThumbsComponent.php
+++ b/src/Controller/Component/ThumbsComponent.php
@@ -87,7 +87,7 @@ class ThumbsComponent extends Component
         $errors = (array)Hash::extract($thumbs, '{*}[acceptable=false].message');
 
         if (!empty($errors)) {
-            $this->Flash->warning(__('There where errors creating the thumbnail(s)'), ['params' => $errors]);
+            $this->Flash->error(__('There where errors creating the thumbnail(s)'), ['params' => $errors]);
         }
     }
 


### PR DESCRIPTION
This MR changes `ThumbsComponent` flash message to use `error()` instead of `warning()`, because the latter doesn't show error details in the flash message.