### PR TITLE
Build main app and plugins with `yarn build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     },
     "homepage": "https://github.com/bedita/manager#README",
     "scripts": {
-        "build": "webpack --mode production",
+        "build": "webpack --mode production && webpack --config ./webpack.config.plugin.js --mode production",
         "bundle-report": "webpack --mode production --report",
         "develop": "webpack --mode development --hot",
         "dev": "webpack --mode development --hot",

--- a/webpack.config.environment.js
+++ b/webpack.config.environment.js
@@ -11,8 +11,13 @@ const dotenv = require('dotenv').config({path: __dirname + '/config/.env'});
 const { readdirSync, statSync, existsSync } = require('fs')
 const { join } = require('path')
 
-const readDirs = p => readdirSync(p).filter(f => statSync(join(p, f)).isDirectory());
 const fileExists = p => existsSync(p);
+const readDirs = (p) => {
+    if (!fileExists(p)) {
+        return [];
+    }
+    return readdirSync(p).filter(f => statSync(join(p, f)).isDirectory());
+}
 
 // Environment: default development
 // from Node env

--- a/webpack.config.plugin.js
+++ b/webpack.config.plugin.js
@@ -5,10 +5,12 @@ const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
 
+// auto load installed plugins
+const pluginsFound = readDirs(BUNDLE.beditaPluginsRoot);
+
 let entries = {};
 let aliases = {};
 
-const pluginsFound = readDirs(BUNDLE.beditaPluginsRoot);
 pluginsFound.forEach(plugin => {
     let jsRoot = BUNDLE.jsRoot;
     if (!fileExists(`${BUNDLE.beditaPluginsRoot}/${plugin}/${jsRoot}`)) {

--- a/webpack.config.plugin.js
+++ b/webpack.config.plugin.js
@@ -6,7 +6,19 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
 
 // auto load installed plugins
-const pluginsFound = readDirs(BUNDLE.beditaPluginsRoot);
+const { readdir } = require('fs')
+
+let pluginsFound = [];
+let noPlugins = true;
+readdir(BUNDLE.beditaPluginsRoot, function(err, files) {
+    noPlugins = !err && files.length > 0;
+});
+
+if (noPlugins) {
+    console.log('No plugins to build');
+} else {
+    pluginsFound = readDirs(BUNDLE.beditaPluginsRoot);
+}
 
 let entries = {};
 let aliases = {};

--- a/webpack.config.plugin.js
+++ b/webpack.config.plugin.js
@@ -5,24 +5,10 @@ const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
 
-// auto load installed plugins
-const { readdir } = require('fs')
-
-let pluginsFound = [];
-let noPlugins = true;
-readdir(BUNDLE.beditaPluginsRoot, function(err, files) {
-    noPlugins = !err && files.length > 0;
-});
-
-if (noPlugins) {
-    console.log('No plugins to build');
-} else {
-    pluginsFound = readDirs(BUNDLE.beditaPluginsRoot);
-}
-
 let entries = {};
 let aliases = {};
 
+const pluginsFound = readDirs(BUNDLE.beditaPluginsRoot);
 pluginsFound.forEach(plugin => {
     let jsRoot = BUNDLE.jsRoot;
     if (!fileExists(`${BUNDLE.beditaPluginsRoot}/${plugin}/${jsRoot}`)) {


### PR DESCRIPTION
This provides a change on `build` so that it also perform plugins build.

`yarn build-plugins` is left for retrocompatibility.