### PR TITLE
Review object properties modeling layout

### DIFF
--- a/config/properties.php
+++ b/config/properties.php
@@ -153,10 +153,10 @@ return [
                     'description',
                     'enabled',
                     'is_abstract',
-                    'hidden',
                     'associations',
                     'table',
                     'parent_name',
+                    'is_translatable',
                 ],
             ],
             'index' => [

--- a/config/schema_properties.php
+++ b/config/schema_properties.php
@@ -90,6 +90,26 @@ return [
                 'title' => 'Hidden',
                 'description' => 'Object type hidden properties',
             ],
+            'is_translatable' => [
+                'type' => 'boolean',
+                '$id' => '/properties/is_translatable',
+                'title' => 'Is translatable',
+                'description' => 'this object type is translatable?',
+                'default' => true,
+            ],
+            'translation_rules' => [
+                'oneOf' => [
+                    [
+                        'type' => 'null',
+                    ],
+                    [
+                        'type' => 'object',
+                    ],
+                ],
+                '$id' => '/properties/translation_rules',
+                'title' => 'Translation Rules',
+                'description' => 'rules to use when translating an object: properties always and never translatable	',
+            ],
         ],
 
         // model/property_types

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -45,6 +45,7 @@ const _vueInstance = new Vue({
         ModulesIndex: () => import(/* webpackChunkName: "modules-index" */'app/pages/modules/index'),
         ModulesView: () => import(/* webpackChunkName: "modules-view" */'app/pages/modules/view'),
         ObjectProperty: () => import(/* webpackChunkName: "object-property" */'app/components/object-property/object-property'),
+        ObjectPropertyAdd: () => import(/* webpackChunkName: "object-property-add" */'app/components/object-property/object-property-add'),
         ObjectTypesList: () => import(/* webpackChunkName: "object-types-list" */'app/components/object-types-list/object-types-list'),
         TrashIndex: () => import(/* webpackChunkName: "trash-index" */'app/pages/trash/index'),
         TrashView: () => import(/* webpackChunkName: "trash-view" */'app/pages/trash/view'),

--- a/resources/js/app/components/object-property/object-properties.vue
+++ b/resources/js/app/components/object-property/object-properties.vue
@@ -29,7 +29,6 @@ export default {
 
     components: {
         ObjectProperty: () => import(/* webpackChunkName: "object-property" */'app/components/object-property/object-property'),
-        ObjectPropertyAdd: () => import(/* webpackChunkName: "object-property-add" */'app/components/object-property/object-property-add'),
     },
 
     data() {
@@ -41,6 +40,15 @@ export default {
 
     mounted() {
         this.properties = this.initProperties;
+        if (this.type !== 'custom') {
+            return;
+        }
+        this.$eventBus.$on('prop-added', (item) => {
+            this.properties.push({
+                id: 0,
+                attributes: item,
+            });
+        });
     },
 }
 </script>

--- a/resources/js/app/components/object-property/object-properties.vue
+++ b/resources/js/app/components/object-property/object-properties.vue
@@ -15,26 +15,6 @@
             {{ t('No properties') }}
         </p>
 
-        <div class="fieldset tab-container" v-if="type == 'custom'">
-            <header class="unselectable">
-                <h2>{{ t('Add custom property') }}</h2>
-            </header>
-            <div class="input text">
-                <label>{{ t('Name') }}
-                    <input type="text" :placeholder="t('Property name')" v-model="propName">
-                </label>
-            </div>
-            <div class="input select">
-                <label for="prop-type">{{ t('Type') }}
-                    <select name="prop_type" v-model="propType">
-                        <option v-for="(t,idx) in propTypes" :value="t.value" :key="idx">{{ t.text }}</option>
-                    </select>
-                </label>
-            </div>
-
-            <button @click.prevent="add">{{ t('Add') }}</button>
-        </div>
-
     </div>
 
 </template>
@@ -45,52 +25,22 @@ export default {
         initProperties: [],
         type: '',
         hidden: [],
-        propTypes: [],
     },
 
     components: {
         ObjectProperty: () => import(/* webpackChunkName: "object-property" */'app/components/object-property/object-property'),
+        ObjectPropertyAdd: () => import(/* webpackChunkName: "object-property-add" */'app/components/object-property/object-property-add'),
     },
 
     data() {
         return {
             properties: [],
-            propName: '',
-            propType: '',
             immutable: ['created', 'id', 'lang', 'locked', 'modified', 'status', 'uname'],
         };
     },
 
     mounted() {
         this.properties = this.initProperties;
-    },
-
-    methods: {
-        add() {
-            if (!this.propName || !this.propType) {
-                return;
-            }
-            this.properties.push({
-                id: 0,
-                attributes: {
-                    name: this.propName,
-                    property_type_name: this.propType,
-                },
-            });
-            this.updateAdded();
-            this.propName = '';
-            this.propType = '';
-        },
-
-        updateAdded() {
-            let addedProperties = JSON.parse(document.getElementById('addedProperties').value || '[]') || [];
-            addedProperties.push({
-                name: this.propName,
-                type: this.propType,
-            });
-            const newVal = JSON.stringify(addedProperties);
-            document.getElementById('addedProperties').value = newVal;
-        }
     },
 }
 </script>

--- a/resources/js/app/components/object-property/object-properties.vue
+++ b/resources/js/app/components/object-property/object-properties.vue
@@ -1,0 +1,96 @@
+<template>
+
+    <div class="properties-container">
+
+        <object-property v-for="(prop, index) in properties"
+            :key="prop.id"
+            :prop="prop"
+            :type="type"
+            :is-hidden="hidden.includes(prop.attributes?.name)"
+            :is-new="prop.id == 0"
+            :nobuttonsfor="immutable">
+        </object-property>
+
+        <p v-if="properties.length == 0">
+            {{ t('No properties') }}
+        </p>
+
+        <div class="fieldset tab-container" v-if="type == 'custom'">
+            <header class="unselectable">
+                <h2>{{ t('Add custom property') }}</h2>
+            </header>
+            <div class="input text">
+                <label>{{ t('Name') }}
+                    <input type="text" :placeholder="t('Property name')" v-model="propName">
+                </label>
+            </div>
+            <div class="input select">
+                <label for="prop-type">{{ t('Type') }}
+                    <select name="prop_type" v-model="propType">
+                        <option v-for="(t,idx) in propTypes" :value="t.value" :key="idx">{{ t.text }}</option>
+                    </select>
+                </label>
+            </div>
+
+            <button @click.prevent="add">{{ t('Add') }}</button>
+        </div>
+
+    </div>
+
+</template>
+<script>
+
+export default {
+    props: {
+        initProperties: [],
+        type: '',
+        hidden: [],
+        propTypes: [],
+    },
+
+    components: {
+        ObjectProperty: () => import(/* webpackChunkName: "object-property" */'app/components/object-property/object-property'),
+    },
+
+    data() {
+        return {
+            properties: [],
+            propName: '',
+            propType: '',
+            immutable: ['created', 'id', 'lang', 'locked', 'modified', 'status', 'uname'],
+        };
+    },
+
+    mounted() {
+        this.properties = this.initProperties;
+    },
+
+    methods: {
+        add() {
+            if (!this.propName || !this.propType) {
+                return;
+            }
+            this.properties.push({
+                id: 0,
+                attributes: {
+                    name: this.propName,
+                    property_type_name: this.propType,
+                },
+            });
+            this.updateAdded();
+            this.propName = '';
+            this.propType = '';
+        },
+
+        updateAdded() {
+            let addedProperties = JSON.parse(document.getElementById('addedProperties').value || '[]') || [];
+            addedProperties.push({
+                name: this.propName,
+                type: this.propType,
+            });
+            const newVal = JSON.stringify(addedProperties);
+            document.getElementById('addedProperties').value = newVal;
+        }
+    },
+}
+</script>

--- a/resources/js/app/components/object-property/object-property-add.vue
+++ b/resources/js/app/components/object-property/object-property-add.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="mt-25" v-if="type == 'custom'">
+    <div class="mt-25">
         <h3>{{ t('Create') }}</h3>
-        <input id="newPropName" type="text" :placeholder="t('Name')" v-model="propName" />
-        <select id="newPropType" name="prop_type" v-model="propType">
+        <input type="text" :placeholder="t('Name')" v-model="propName" />
+        <select v-model="propType">
             <option v-for="(t,idx) in propTypes" :value="t.value" :key="idx">{{ t.text }}</option>
         </select>
         <input type="text" v-model="propDescription" :placeholder="t('Description')" />
@@ -16,7 +16,6 @@ export default {
 
     props: {
         propTypes: [],
-        type: '',
     },
 
     data() {
@@ -24,29 +23,20 @@ export default {
             propDescription: '',
             propName: '',
             propType: 'string',
-            properties: [],
         };
     },
 
     methods: {
         add() {
-            if (!this.propName || !this.propType) {
-                return;
-            }
-            this.properties.push({
-                id: 0,
-                attributes: {
-                    name: this.propName,
-                    property_type_name: this.propType,
-                },
-            });
             this.updateAdded();
+            this.$eventBus.$emit('prop-added', {
+                name: this.propName,
+                property_type_name: this.propType,
+                description: this.propDescription,
+            });
             this.propDescription = '';
             this.propName = '';
             this.propType = '';
-            const button = document.querySelector('button[form=form-main]');
-            button.classList.add('is-loading-spinner');
-            button.click();
         },
 
         updateAdded() {

--- a/resources/js/app/components/object-property/object-property-add.vue
+++ b/resources/js/app/components/object-property/object-property-add.vue
@@ -5,6 +5,7 @@
         <select id="newPropType" name="prop_type" v-model="propType">
             <option v-for="(t,idx) in propTypes" :value="t.value" :key="idx">{{ t.text }}</option>
         </select>
+        <input type="text" v-model="propDescription" />
         <button @click.prevent="add" :disabled="!propName || !propType">{{ t('Add') }}</button>
     </div>
 </template>
@@ -20,6 +21,7 @@ export default {
 
     data() {
         return {
+            propDescription: '',
             propName: '',
             propType: 'string',
             properties: [],
@@ -39,6 +41,7 @@ export default {
                 },
             });
             this.updateAdded();
+            this.propDescription = '';
             this.propName = '';
             this.propType = '';
             const button = document.querySelector('button[form=form-main]');
@@ -49,6 +52,7 @@ export default {
         updateAdded() {
             let addedProperties = JSON.parse(document.getElementById('addedProperties').value || '[]') || [];
             addedProperties.push({
+                description: this.propDescription,
                 name: this.propName,
                 type: this.propType,
             });

--- a/resources/js/app/components/object-property/object-property-add.vue
+++ b/resources/js/app/components/object-property/object-property-add.vue
@@ -1,11 +1,11 @@
 <template>
     <div class="mt-25" v-if="type == 'custom'">
         <h3>{{ t('Create') }}</h3>
-        <input id="newPropName" type="text" :placeholder="t('Property name')" v-model="propName" />
+        <input id="newPropName" type="text" :placeholder="t('Name')" v-model="propName" />
         <select id="newPropType" name="prop_type" v-model="propType">
             <option v-for="(t,idx) in propTypes" :value="t.value" :key="idx">{{ t.text }}</option>
         </select>
-        <input type="text" v-model="propDescription" />
+        <input type="text" v-model="propDescription" :placeholder="t('Description')" />
         <button @click.prevent="add" :disabled="!propName || !propType">{{ t('Add') }}</button>
     </div>
 </template>

--- a/resources/js/app/components/object-property/object-property-add.vue
+++ b/resources/js/app/components/object-property/object-property-add.vue
@@ -1,0 +1,60 @@
+<template>
+    <div class="mt-25" v-if="type == 'custom'">
+        <h3>{{ t('Create') }}</h3>
+        <input id="newPropName" type="text" :placeholder="t('Property name')" v-model="propName" />
+        <select id="newPropType" name="prop_type" v-model="propType">
+            <option v-for="(t,idx) in propTypes" :value="t.value" :key="idx">{{ t.text }}</option>
+        </select>
+        <button @click.prevent="add" :disabled="!propName || !propType">{{ t('Add') }}</button>
+    </div>
+</template>
+
+<script>
+
+export default {
+
+    props: {
+        propTypes: [],
+        type: '',
+    },
+
+    data() {
+        return {
+            propName: '',
+            propType: 'string',
+            properties: [],
+        };
+    },
+
+    methods: {
+        add() {
+            if (!this.propName || !this.propType) {
+                return;
+            }
+            this.properties.push({
+                id: 0,
+                attributes: {
+                    name: this.propName,
+                    property_type_name: this.propType,
+                },
+            });
+            this.updateAdded();
+            this.propName = '';
+            this.propType = '';
+            const button = document.querySelector('button[form=form-main]');
+            button.classList.add('is-loading-spinner');
+            button.click();
+        },
+
+        updateAdded() {
+            let addedProperties = JSON.parse(document.getElementById('addedProperties').value || '[]') || [];
+            addedProperties.push({
+                name: this.propName,
+                type: this.propType,
+            });
+            const newVal = JSON.stringify(addedProperties);
+            document.getElementById('addedProperties').value = newVal;
+        }
+    },
+}
+</script>

--- a/resources/js/app/components/object-property/object-property.vue
+++ b/resources/js/app/components/object-property/object-property.vue
@@ -41,6 +41,7 @@ export default {
 
     data() {
         return {
+            confirm: null,
             hidden: false,
             display: true,
         };
@@ -99,7 +100,7 @@ export default {
             }
         },
         remove() {
-            BEDITA.confirm(
+            this.confirm = BEDITA.confirm(
                 t`If you confirm, this resource will be gone forever. Are you sure?`,
                 t`yes, proceed`,
                 () => {
@@ -132,6 +133,8 @@ export default {
                 }
             } catch (error) {
                 BEDITA.showError(`${prefix}: ${error}`);
+            } finally {
+                this.confirm.hide();
             }
         },
     },

--- a/resources/js/app/components/object-property/object-property.vue
+++ b/resources/js/app/components/object-property/object-property.vue
@@ -1,54 +1,62 @@
-import { t } from 'ttag';
-
-export default {
-    template: `<div :class="boxClass()">
+<template>
+    <div :class="boxClass()" v-show="display">
         <div class="columns">
             <div class="column">
-                <span :class="tagClass()"><: prop.attributes.name :></span>
-                <p>${t`Label`}: <: prop.attributes.label || '-' :></p>
-                <p>${t`Type`}: <: prop.attributes.property_type_name :></p>
-                <p>${t`Hidden`}:
-                    <span v-if="hidden">${t`Yes`}</span>
-                    <span v-if="!hidden">${t`No`}</span>
+                <span :class="tagClass()">{{ prop.attributes.name }}</span>
+                <p>{{ t('Label') }}: {{ prop.attributes.label || '-' }}</p>
+                <p>{{ t('Type') }}: {{ prop.attributes.property_type_name }}</p>
+                <p>{{ t('Hidden') }}:
+                    <span v-if="hidden">{{ t('Yes') }}</span>
+                    <span v-if="!hidden">{{ t('No') }}</span>
                 </p>
                 <p v-if="type === 'inherited'">
-                    ${t`Inherited from`}:
-                    <: prop.attributes.object_type_name :>
+                    {{ t('Inherited from') }}:
+                    {{ prop.attributes.object_type_name }}
                 </p>
                 <p v-if="prop.attributes.description">&nbsp;</p>
-                <p v-if="prop.attributes.description"><: prop.attributes.description :></p>
+                <p v-if="prop.attributes.description">{{ prop.attributes.description }}</p>
             </div>
-            <div v-if="!(prop.attributes.name in nobuttonsfor)" class="column is-narrow">
+            <div v-if="!nobuttonsfor.includes(prop.attributes.name)" class="column is-narrow">
                 <div class="buttons-container">
-                    <button v-if="type === 'custom'" @click.prevent="remove()" class="icon-cancel button button-outlined button-text-white is-expanded">${t`Delete`}</button>
-                    <button v-if="hidden" @click.prevent="toggle(false)" class="icon-eye button button-outlined button-text-white is-expanded">${t`Show`}</button>
-                    <button v-if="!hidden" @click.prevent="toggle(true)" class="icon-eye-off button button-outlined button-text-white is-expanded">${t`Hide`}</button>
+                    <button v-if="type === 'custom'" @click.prevent="remove()" class="icon-cancel button button-outlined button-text-white is-expanded">{{ t('Delete') }}</button>
+                    <button v-if="hidden" @click.prevent="toggle(false)" class="icon-eye button button-outlined button-text-white is-expanded">{{ t('Show') }}</button>
+                    <button v-if="!hidden" @click.prevent="toggle(true)" class="icon-eye-off button button-outlined button-text-white is-expanded">{{ t('Hide') }}</button>
                 </div>
             </div>
         </div>
-    </div>`,
+    </div>
+</template>
+<script>
 
+import { t } from 'ttag';
+
+export default {
     props: {
         prop: [],
         nobuttonsfor: [],
         type: '',
-        ishidden: false,
+        isHidden: false,
+        isNew: false,
     },
 
     data() {
         return {
             hidden: false,
+            display: true,
         };
     },
 
     mounted() {
         this.$nextTick(() => {
-            this.hidden = this.ishidden || false;
+            this.hidden = this.isHidden || false;
         });
     },
 
     methods: {
         boxClass() {
+            if (this.hidden) {
+                return 'box pb-05 has-background-gray-600 has-text-white';
+            }
             if (this.type === 'custom') {
                 return 'box pb-05 has-background-info has-text-white';
             }
@@ -77,7 +85,7 @@ export default {
                 hiddenProperties.splice(index, 1);
                 const newVal = JSON.stringify(hiddenProperties);
                 document.getElementById('hidden').value = newVal;
-                document.getElementById('hidden').setAttribute('data-original-value', newVal);
+                // document.getElementById('hidden').setAttribute('data-original-value', newVal);
 
                 return;
             }
@@ -87,7 +95,7 @@ export default {
                 hiddenProperties.sort();
                 const newVal = JSON.stringify(hiddenProperties);
                 document.getElementById('hidden').value = newVal;
-                document.getElementById('hidden').setAttribute('data-original-value', newVal);
+                // document.getElementById('hidden').setAttribute('data-original-value', newVal);
             }
         },
         remove() {
@@ -100,6 +108,11 @@ export default {
             );
         },
         async delete() {
+            if (this.isNew) {
+                this.display = false;
+
+                return;
+            }
             const prefix = t`Error on deleting property`;
             try {
                 const options = {
@@ -112,11 +125,8 @@ export default {
                 };
                 const response = await fetch(`${BEDITA.base}/api/model/properties/${this.prop.id}`, options);
                 if (response.status === 200) {
-                    document.location.reload();
-
-                    return;
-                }
-                if (response.error) {
+                    this.display = false;
+                } else if (response.error) {
                     BEDITA.showError(`${prefix}: ${response.error}`);
                     this.handleError(response.error, prefix);
                 }
@@ -126,3 +136,4 @@ export default {
         },
     },
 }
+</script>

--- a/resources/js/app/components/object-property/object-property.vue
+++ b/resources/js/app/components/object-property/object-property.vue
@@ -86,7 +86,6 @@ export default {
                 hiddenProperties.splice(index, 1);
                 const newVal = JSON.stringify(hiddenProperties);
                 document.getElementById('hidden').value = newVal;
-                // document.getElementById('hidden').setAttribute('data-original-value', newVal);
 
                 return;
             }
@@ -96,7 +95,6 @@ export default {
                 hiddenProperties.sort();
                 const newVal = JSON.stringify(hiddenProperties);
                 document.getElementById('hidden').value = newVal;
-                // document.getElementById('hidden').setAttribute('data-original-value', newVal);
             }
         },
         remove() {

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -36,6 +36,7 @@ export default {
         KeyValueList: () => import(/* webpackChunkName: "key-value-list" */'app/components/json-fields/key-value-list'),
         StringList: () => import(/* webpackChunkName: "string-list" */'app/components/json-fields/string-list'),
         ObjectProperties: () => import(/* webpackChunkName: "string-list" */'app/components/object-property/object-properties'),
+        ObjectPropertyAdd: () => import(/* webpackChunkName: "object-property-add" */'app/components/object-property/object-property-add'),
     },
 
     props: {

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -35,6 +35,7 @@ export default {
         TagPicker: () => import(/* webpackChunkName: "tag-picker" */'app/components/tag-picker/tag-picker'),
         KeyValueList: () => import(/* webpackChunkName: "key-value-list" */'app/components/json-fields/key-value-list'),
         StringList: () => import(/* webpackChunkName: "string-list" */'app/components/json-fields/string-list'),
+        ObjectProperties: () => import(/* webpackChunkName: "string-list" */'app/components/object-property/object-properties'),
     },
 
     props: {

--- a/resources/js/app/pages/modules/view.js
+++ b/resources/js/app/pages/modules/view.js
@@ -16,6 +16,7 @@ export default {
         PropertyView: () => import(/* webpackChunkName: "property-view" */'app/components/property-view/property-view'),
         HorizontalTabView: () => import(/* webpackChunkName: "horizontal-tab-view" */'app/components/horizontal-tab-view'),
         ObjectProperty: () => import(/* webpackChunkName: "object-property" */'app/components/object-property/object-property'),
+        ObjectPropertyAdd: () => import(/* webpackChunkName: "object-property-add" */'app/components/object-property/object-property-add'),
         ObjectTypesList: () => import(/* webpackChunkName: "object-types-list" */'app/components/object-types-list/object-types-list'),
     },
 

--- a/src/Controller/Model/ObjectTypesController.php
+++ b/src/Controller/Model/ObjectTypesController.php
@@ -51,6 +51,17 @@ class ObjectTypesController extends ModelBaseController
     /**
      * @inheritDoc
      */
+    public function create(): ?Response
+    {
+        parent::create();
+        $this->set('propertyTypesOptions', $this->Properties->typesOptions());
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function view($id): ?Response
     {
         parent::view($id);
@@ -197,6 +208,7 @@ class ObjectTypesController extends ModelBaseController
             $data = [
                 'type' => 'properties',
                 'attributes' => [
+                    'description' => Hash::get($prop, 'description'),
                     'name' => Hash::get($prop, 'name'),
                     'property_type_name' => Hash::get($prop, 'type'),
                     'object_type_name' => $objectTypeName,

--- a/templates/Pages/Model/ObjectTypes/view.twig
+++ b/templates/Pages/Model/ObjectTypes/view.twig
@@ -20,66 +20,67 @@
 
             {{ Form.hidden('id', {'value': (object) ? object.id : resource.id})|raw }}
             {{ Form.hidden('_actualAttributes', {'value': currentAttributes})|raw }}
+            {# Handle `hidden` and `translation_rules` via hidden input for now #}
+            {{ Form.hidden('hidden', {
+                id: 'hidden',
+                value: resource.attributes.hidden|default([])|json_encode,
+            })|raw }}
+            {% do Form.unlockField('hidden') %}
+            {# TODO: handle translation rules in properties directly, like `hidden` #}
+            {# {{ Form.hidden('translation_rules', {
+                id: 'translation_rules',
+                value: resource.attributes.translation_rules|default({})|json_encode,
+            })|raw }}
+            {% do Form.unlockField('translation_rules') %} #}
 
-            <div class="main-view-column">
-                <section class="fieldset">
-                    <div class="tab-container">
-                        {% for key, value in properties.core %}
-                            {% set options = Schema.controlOptions(key, value, schema.properties[key]) %}
-                            {% if options.class != 'json' %}
-                                {% if resource.meta.core_type %}
-                                    {% if key in ['name', 'singular', 'table', 'is_abstract', 'parent_name'] %}
-                                        {% set options = options|merge({
-                                            'readonly' : true,
-                                        }) %}
-                                     {% endif %}
+            {# Handle newly created custom props via `addedProperties` hidden input for now #}
+            {{ Form.hidden('addedProperties', {
+                id: 'addedProperties',
+                value: []|json_encode,
+            })|raw }}
+            {% do Form.unlockField('addedProperties') %}
+
+                <property-view inline-template :tab-open="tabsOpen" :is-default-open=true tab-name="general">
+                    <section class="fieldset">
+                        <header @click.prevent="toggleVisibility()"
+                            class="tab unselectable"
+                            :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                            <h2>{{ __('General') }}</h2>
+                        </header>
+                        <div v-show="isOpen" class="tab-container">
+                            {% for key, value in properties.core %}
+                                {% if key == 'associations' %}
+                                    {{ Form.control(key, {
+                                        'id': key,
+                                        'value': value,
+                                        'type': 'select',
+                                        'multiple': 'checkbox',
+                                        'options': associationsOptions
+                                    })|raw }}
+                                {% else %}
+
+                                    {% set options = Schema.controlOptions(key, value, schema.properties[key]) %}
+                                    {% if resource.meta.core_type %}
+                                        {% if key in ['name', 'singular', 'table', 'is_abstract', 'parent_name'] %}
+                                            {% set options = options|merge({
+                                                'readonly' : true,
+                                            }) %}
+                                        {% endif %}
+                                    {% endif %}
+
+                                    {{ Property.control(key, value, options)|raw }}
+
+                                    {% if key == 'parent_name' %}
+                                        <a href="{{ Url.build({'_name': 'model:view:object_types', 'id': value}) }}" class="link-to-parent">› {{ __('view parent') }}</a>
+                                    {% endif %}
                                 {% endif %}
-
-                                {{ Property.control(key, value, options)|raw }}
-
-                                {% if key == 'parent_name' %}
-                                    <a href="{{ Url.build({'_name': 'model:view:object_types', 'id': value}) }}" class="link-to-parent">› {{ __('view parent') }}</a>
-                                {% endif %}
-                            {% endif %}
-                        {% endfor %}
-                    </div>
-                </section>
-
-                <section class="fieldset">
-                    <div class="tab-container">
-                        <header class="unselectable"><h2>{{ __('Add custom property') }}</h2></header>
-                        {{ Property.control('prop_name', '', {'label': __('Name'), 'placeholder': 'property name'})|raw }}
-                        {{ Property.control('prop_type', '', propertyTypesOptions|default([]))|raw }}
-                    </div>
-                </section>
-
-            </div>
-
-            <div class="side-view-column">
-                <section class="fieldset">
-                    <div class="tab-container">
-                        {% for key, value in properties.core %}
-                            {% if key == 'hidden' %}
-                                {% set options = Schema.controlOptions(key, value, schema.properties[key]) %}
-                                {{ Property.control(key, value, options|merge({'id': key}))|raw }}
-                            {% elseif key == 'associations' %}
-                                {{ Form.control(key, {
-                                    'id': key,
-                                    'value': value,
-                                    'type': 'select',
-                                    'multiple': 'checkbox',
-                                    'options': associationsOptions
-                                })|raw }}
-                            {% endif %}
-                        {% endfor %}
-                    </div>
-                </section>
-
-                {{ element('Form/meta') }}
-            </div>
+                            {% endfor %}
+                        </div>
+                    </section>
+                </property-view>
 
         {# Set `_jsonKeys` hidden input from config #}
-        {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': config('_jsonKeys', [])|join(',')})|raw }}
+        {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': config('_jsonKeys', [])|merge(['hidden'])|join(',')})|raw }}
 
         {{ Form.end()|raw }}
 
@@ -100,75 +101,81 @@
         {% endif %}
     </div>
 
+    <property-view inline-template :tab-open="tabsOpen" :is-default-open=true tab-name="relations">
+        <section class="fieldset">
+            <header @click.prevent="toggleVisibility()"
+                class="tab unselectable"
+                :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                <h2>{{ __('Relations') }}</h2>
+            </header>
+            <div v-show="isOpen" class="relations-container">
+                {% if resource.meta.relations %}
+                    <div class="relations-group">
+                    {% for relation in resource.meta.relations %}
+                        <a class="tag is-black" href="{{ Url.build({'_name': 'model:view:relations', 'id': relation}) }}">{{ relation }}</a>
+                    {% endfor %}
+                    </ul>
+                {% else %}
+                    <p>No Relations</p>
+                {% endif %}
+            </div>
+        </section>
+    </property-view>
 
-    <section class="relations">
-        <header class="unselectable"><h2>{{ __('Relations') }}</h2></header>
-        <div class="relations-container">
-        {% if resource.meta.relations %}
-            <div class="relations-group">
-            {% for relation in resource.meta.relations %}
-                <a class="tag is-black" href="{{ Url.build({'_name': 'model:view:relations', 'id': relation}) }}">{{ relation }}</a>
-            {% endfor %}
-            </ul>
-        {% else %}
-            <p>No Relations</p>
-        {% endif %}
-        </div>
-    </section>
+    <property-view inline-template :tab-open="tabsOpen" :is-default-open=true tab-name="core-props">
+        <section class="fieldset">
+            <header @click.prevent="toggleVisibility()"
+                class="tab unselectable"
+                :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                <h2>{{ __('Core properties') }}</h2>
+            </header>
+            <div v-show="isOpen">
+                <object-properties
+                    :init-properties="{{ objectTypeProperties.core|json_encode }}"
+                    type="core"
+                    :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
+                >
+                </object-properties>
+            </div>
+        </section>
+    </property-view>
 
+    <property-view inline-template :tab-open="tabsOpen" :is-default-open=true tab-name="inherited-props">
+        <section class="fieldset">
+            <header @click.prevent="toggleVisibility()"
+                class="tab unselectable"
+                :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                <h2>{{ __('Inherited properties') }}</h2>
+            </header>
+            <div v-show="isOpen">
+                <object-properties
+                    :init-properties="{{ objectTypeProperties.inherited|json_encode }}"
+                    type="inherited"
+                    :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
+                >
+                </object-properties>
+            </div>
+        </section>
+    </property-view>
 
-    <section class="properties">
-        <header class="unselectable"><h2>{{ __('Core properties') }}</h2></header>
-        <div class="properties-container">
-            {% for prop in objectTypeProperties.core %}
-                {% set h = prop.attributes.name in properties.core.hidden|default([]) %}
-                <object-property
-                    :prop="{{ prop|json_encode }}"
-                    :type="{{ 'core'|json_encode }}"
-                    :ishidden="{{ h|json_encode }}"
-                    :nobuttonsfor="{{ []|json_encode }}">
-                </object-property>
-            {% else %}
-                <p>{{ __('No core properties') }}</p>
-            {% endfor %}
-        </div>
-    </section>
-
-
-    <section class="properties">
-        <header class="unselectable"><h2>{{ __('Inherited properties') }}</h2></header>
-        <div class="properties-container">
-            {% for prop in objectTypeProperties.inherited %}
-                {% set h = prop.attributes.name in properties.core.hidden|default([]) %}
-                <object-property
-                    :prop="{{ prop|json_encode }}"
-                    :type="{{ 'inherited'|json_encode }}"
-                    :ishidden="{{ h|json_encode }}"
-                    :nobuttonsfor="{{ ['id', 'status', 'uname']|json_encode }}">
-                </object-property>
-            {% else %}
-                <p>{{ __('No inherited properties') }}</p>
-            {% endfor %}
-        </div>
-    </section>
-
-
-    <section class="properties">
-        <header class="unselectable"><h2>{{ __('Custom properties') }}</h2></header>
-        <div class="properties-container">
-            {% for prop in objectTypeProperties.custom %}
-                {% set h = prop.attributes.name in properties.core.hidden|default([]) %}
-                <object-property
-                    :prop="{{ prop|json_encode }}"
-                    :type="{{ 'custom'|json_encode }}"
-                    :ishidden="{{ h|json_encode }}"
-                    :nobuttonsfor="{{ []|json_encode }}">
-                </object-property>
-            {% else %}
-                <p>{{ __('No custom properties') }}</p>
-            {% endfor %}
-        </div>
-    </section>
+    <property-view inline-template :tab-open="tabsOpen" :is-default-open=true tab-name="custom-props">
+        <section class="fieldset">
+            <header @click.prevent="toggleVisibility()"
+                class="tab unselectable"
+                :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                <h2>{{ __('Custom properties') }}</h2>
+            </header>
+            <div v-show="isOpen">
+                <object-properties
+                    :init-properties="{{ objectTypeProperties.custom|json_encode }}"
+                    type="custom"
+                    :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
+                    :prop-types="{{ propertyTypesOptions.options|default([])|json_encode }}"
+                >
+                </object-properties>
+            </div>
+        </section>
+    </property-view>
 
     {{ element('Model/sidebar_links') }}
 

--- a/templates/Pages/Model/ObjectTypes/view.twig
+++ b/templates/Pages/Model/ObjectTypes/view.twig
@@ -131,7 +131,7 @@
             </header>
             <div v-show="isOpen">
                 <object-properties
-                    :init-properties="{{ objectTypeProperties.core|json_encode }}"
+                    :init-properties="{{ objectTypeProperties.core|default([])|json_encode }}"
                     type="core"
                     :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
                 >
@@ -149,7 +149,7 @@
             </header>
             <div v-show="isOpen">
                 <object-properties
-                    :init-properties="{{ objectTypeProperties.inherited|json_encode }}"
+                    :init-properties="{{ objectTypeProperties.inherited|default([])|json_encode }}"
                     type="inherited"
                     :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
                 >
@@ -167,7 +167,7 @@
             </header>
             <div v-show="isOpen">
                 <object-properties
-                    :init-properties="{{ objectTypeProperties.custom|json_encode }}"
+                    :init-properties="{{ objectTypeProperties.custom|default([])|json_encode }}"
                     type="custom"
                     :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
                 >

--- a/templates/Pages/Model/ObjectTypes/view.twig
+++ b/templates/Pages/Model/ObjectTypes/view.twig
@@ -170,9 +170,12 @@
                     :init-properties="{{ objectTypeProperties.custom|json_encode }}"
                     type="custom"
                     :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
-                    :prop-types="{{ propertyTypesOptions.options|default([])|json_encode }}"
                 >
                 </object-properties>
+                <object-property-add
+                    type="custom"
+                    :prop-types="{{ propertyTypesOptions.options|default([])|json_encode }}">
+                </object-property-add>
             </div>
         </section>
     </property-view>

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -128,6 +128,22 @@ class ObjectTypesControllerTest extends TestCase
     }
 
     /**
+     * Test `create` method
+     *
+     * @covers ::create()
+     * @return void
+     */
+    public function testCreate(): void
+    {
+        $this->setupController();
+        $this->ModelController->create();
+        $vars = ['resource', 'schema', 'properties', 'propertyTypesOptions'];
+        foreach ($vars as $var) {
+            static::assertNotEmpty($this->ModelController->viewBuilder()->getVar($var));
+        }
+    }
+
+    /**
      * Test `view` method
      *
      * @covers ::view()

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -92,10 +92,7 @@ class ObjectTypesControllerTest extends TestCase
             'REQUEST_METHOD' => 'POST',
         ],
         'post' => [
-            'addedProperties' => [
-                'name' => 'my_prop',
-                'type' => 'datetime',
-            ],
+            'addedProperties' => '[{"name": "my_prop", "type": "datetime"}]',
         ],
         'params' => [
             'resource_type' => 'object_types',

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -92,8 +92,10 @@ class ObjectTypesControllerTest extends TestCase
             'REQUEST_METHOD' => 'POST',
         ],
         'post' => [
-            'prop_name' => 'my_prop',
-            'prop_type' => 'datetime',
+            'addedProperties' => [
+                'name' => 'my_prop',
+                'type' => 'datetime',
+            ],
         ],
         'params' => [
             'resource_type' => 'object_types',
@@ -215,7 +217,7 @@ class ObjectTypesControllerTest extends TestCase
      * Test `save` method
      *
      * @covers ::save()
-     * @covers ::addCustomProperty()
+     * @covers ::addCustomProperties()
      * @return void
      */
     public function testSave(): void
@@ -227,27 +229,25 @@ class ObjectTypesControllerTest extends TestCase
         $controller->save();
 
         $data = $controller->getRequest()->getData();
-        static::assertArrayNotHasKey('prop_name', $data);
-        static::assertArrayNotHasKey('prop_type', $data);
+        static::assertArrayNotHasKey('addedProperties', $data);
     }
 
     /**
      * Test `save` method with empty data
      *
-     * @covers ::addCustomProperty()
+     * @covers ::addCustomProperties()
      * @return void
      */
     public function testSaveEmpty(): void
     {
         $this->saveApiMock();
         $config = $this->saveRequestConfig;
-        $config['post'] = ['prop_name' => '', 'prop_type' => ''];
+        $config['post'] = ['addedProperties' => '[]'];
         $controller = new ObjectTypesController(new ServerRequest($config));
         $controller->save();
 
         $data = $controller->getRequest()->getData();
-        static::assertArrayNotHasKey('prop_name', $data);
-        static::assertArrayNotHasKey('prop_type', $data);
+        static::assertArrayNotHasKey('addedProperties', $data);
     }
 
     /**


### PR DESCRIPTION
This PR is an initial review of the single object type view layout mainly on object type properties. 

* tabs to open properties section, using the same pattern as in single object view 
* `hidden` properties are now highlighted and can be selected only via hide/show buttons (JSON editor is hidden) 
* `is_translatable` property available
* new `object-properties.vue` and `object-property-add.vue` components - `object-property` moved to `.vue` format
 
TODO: handle `translation_rules` via action button like `hidden` props selection 
