### PR TITLE
Use serial mode upload for dragndrop files to avoid uname error

### DIFF
--- a/resources/js/app/components/drop-upload.js
+++ b/resources/js/app/components/drop-upload.js
@@ -105,7 +105,7 @@ export default {
             this.$el.classList.remove('dragover');
             // show all files in view
             [...files].forEach(file => this.setProgressInfo(file));
-            const [uniqueFiles, duplicatesFiles] = this.filterFiles(files);
+            const [uniqueFiles, duplicatesFiles] = this.filterFiles([...files]);
             uniqueFiles.forEach((file) => {
                 // skip file not allowed by size and remove it from view
                 if (this.$helpers.checkMaxFileSize(file) === false) {
@@ -219,14 +219,14 @@ export default {
         },
 
         filterFiles(files) {
-            const duplicates = [...files]
+            const duplicates = files
                 .filter((file, index, array) =>
                     array.some((val, i) =>
                         (index !== i && this.getBaseNameFile(val) === this.getBaseNameFile(file))
                     )
                 );
 
-            const unique = [...files].filter(f => !duplicates.includes(f));
+            const unique = files.filter(f => !duplicates.includes(f));
 
             return [unique, duplicates];
         },

--- a/resources/js/app/components/drop-upload.js
+++ b/resources/js/app/components/drop-upload.js
@@ -121,7 +121,7 @@ export default {
                 // skip file not allowed by size and remove it from view
                 if (this.$helpers.checkMaxFileSize(file) === false) {
                     this.removeProgressItem(file);
-                    return;
+                    continue;
                 }
 
                 const object = await this.upload(file);
@@ -214,15 +214,11 @@ export default {
             this.removeProgressItem(file);
         },
 
-        getBaseNameFile(file) {
-            return file?.name?.split('.')[0];
-        },
-
         filterFiles(files) {
             const duplicates = files
                 .filter((file, index, array) =>
                     array.some((val, i) =>
-                        (index !== i && this.getBaseNameFile(val) === this.getBaseNameFile(file))
+                        (index !== i && this.$helpers.getBaseNameFile(val) === this.$helpers.getBaseNameFile(file))
                     )
                 );
 

--- a/resources/js/app/components/drop-upload.js
+++ b/resources/js/app/components/drop-upload.js
@@ -101,19 +101,21 @@ export default {
             this.uploadFiles(files);
         },
 
-        uploadFiles(files) {
+        async uploadFiles(files) {
             this.$el.classList.remove('dragover');
-            ([...files]).forEach(f => {
+            // add files to view
+            [...files].forEach(f => this.setProgressInfo(f));
+            // upload in serial mode
+            for (const f of [...files]) {
                 if (this.$helpers.checkMaxFileSize(f) === false) {
                     return;
                 }
-                this.upload(f)
+                await this.upload(f)
                     .then((object) => {
                         this.$emit('new-relations', [object]);
                         this.removeProgressItem(f);
                     });
-
-            });
+            }
         },
 
         onDragOver() {

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -92,6 +92,15 @@ export default {
                 return true;
             },
 
+            /**
+             * Get file name without extension
+             * @param {Object} file file
+             * @returns {String} basename file
+             */
+            getBaseNameFile(file) {
+                return file?.name?.split('.')[0];
+            },
+
             slugify(str, len) {
                 if (!str) {
                     return str;


### PR DESCRIPTION
Introducing serial mode upload for file with same basename in drag and drop area to avoid uname media error.

Ref: https://chialab.atlassian.net/browse/BEM-122