### PR TITLE
Fix translations custom controls + refactor UI

### DIFF
--- a/resources/js/app/components/json-fields/string-list.vue
+++ b/resources/js/app/components/json-fields/string-list.vue
@@ -99,13 +99,3 @@ export default {
     },
 }
 </script>
-<style type="text/css">
-.tag {
-    background-color:#000;
-    color:#fff;
-    display:inline-block;
-    padding-left:8px;
-    padding-right:8px;
-    text-align:center
-}
-</style>

--- a/resources/js/app/components/json-fields/string-list.vue
+++ b/resources/js/app/components/json-fields/string-list.vue
@@ -6,9 +6,10 @@
                 <div class="is-expanded">
                     <input type="text" v-model="item.value" @change="onChanged()" :readonly="readonly"/>
                 </div>
-                <div class="mb-2" v-if="!readonly">
+                <div v-if="!readonly">
                     <button @click.prevent="remove(index)" class="button button-primary" style="min-width: 32px; border-top-left-radius: 0; border-bottom-left-radius: 0;">
                         <Icon icon="carbon:trash-can"></Icon>
+                        <span class="ml-05">{{ t('Remove') }}</span>
                     </button>
                 </div>
             </div>

--- a/resources/js/app/components/json-fields/string-list.vue
+++ b/resources/js/app/components/json-fields/string-list.vue
@@ -2,27 +2,38 @@
     <div class="input textarea text">
         <label :for="name">{{ label|humanize }}</label>
         <div :id="name">
-            <div class="key-value-item mb-1" v-for="(item, index) in items">
-                <div>
+            <div class="key-value-item mb-1 is-flex" v-for="(item, index) in items">
+                <div class="is-expanded">
                     <input type="text" v-model="item.value" @change="onChanged()" :readonly="readonly"/>
                 </div>
                 <div class="mb-2" v-if="!readonly">
-                    <button @click.prevent="remove(index)">{{  t('Remove') }}</button>
+                    <button @click.prevent="remove(index)" class="button button-primary" style="min-width: 32px; border-top-left-radius: 0; border-bottom-left-radius: 0;">
+                        <Icon icon="carbon:trash-can"></Icon>
+                    </button>
                 </div>
             </div>
         </div>
-        <button @click.prevent="add" v-if="!readonly">{{  t('Add') }}</button>
+        <button @click.prevent="add" v-if="!readonly">
+            <Icon icon="carbon:add"></Icon>
+            <span class="ml-05">{{ t('Add') }}</span>
+        </button>
 
         <input type="hidden" :name="name" v-model="result" />
     </div>
 </template>
 
 <script>
+import { Icon } from '@iconify/vue2';
 
 /**
  * <string-list> component to handle simple JSON array of strings
  */
 export default {
+
+    components: {
+        Icon,
+    },
+
     props: {
         value: String,
         name: String,
@@ -87,4 +98,13 @@ export default {
     },
 }
 </script>
-
+<style type="text/css">
+.tag {
+    background-color:#000;
+    color:#fff;
+    display:inline-block;
+    padding-left:8px;
+    padding-right:8px;
+    text-align:center
+}
+</style>

--- a/resources/js/app/pages/modules/view.js
+++ b/resources/js/app/pages/modules/view.js
@@ -20,6 +20,8 @@ export default {
         ObjectProperty: () => import(/* webpackChunkName: "object-property" */'app/components/object-property/object-property'),
         ObjectPropertyAdd: () => import(/* webpackChunkName: "object-property-add" */'app/components/object-property/object-property-add'),
         ObjectTypesList: () => import(/* webpackChunkName: "object-types-list" */'app/components/object-types-list/object-types-list'),
+        KeyValueList: () => import(/* webpackChunkName: "key-value-list" */'app/components/json-fields/key-value-list'),
+        StringList: () => import(/* webpackChunkName: "string-list" */'app/components/json-fields/string-list'),
         Icon,
     },
 

--- a/src/Form/CustomComponentControl.php
+++ b/src/Form/CustomComponentControl.php
@@ -43,7 +43,7 @@ class CustomComponentControl implements CustomHandlerInterface
             $tag,
         );
 
-        return compact('type', 'html');
+        return compact('type', 'html', 'readonly');
     }
 
     /**

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -74,16 +74,8 @@ class PropertyHelper extends Helper
         $controlOptions['label'] = $this->fieldLabel($name, $type);
         $readonly = Hash::get($controlOptions, 'readonly') || $forceReadonly;
         if ($readonly === true && array_key_exists('html', $controlOptions)) {
-            $controlOptions['html'] = str_replace(
-                'readonly="false"',
-                'readonly="true"',
-                $controlOptions['html']
-            );
-            $controlOptions['html'] = str_replace(
-                ':readonly=false',
-                ':readonly=true',
-                $controlOptions['html']
-            );
+            $controlOptions['html'] = str_replace('readonly="false"', 'readonly="true"', $controlOptions['html']);
+            $controlOptions['html'] = str_replace(':readonly=false', ':readonly=true', $controlOptions['html']);
         }
         if ($readonly === true && array_key_exists('v-datepicker', $controlOptions)) {
             unset($controlOptions['v-datepicker']);
@@ -112,11 +104,7 @@ class PropertyHelper extends Helper
         $formControlName = sprintf('translated_fields[%s]', $name);
         $controlOptions = $this->Schema->controlOptions($name, $value, $this->schema($name, null));
         if (array_key_exists('html', $controlOptions)) {
-            $controlOptions['html'] = str_replace(
-                sprintf('name="%s"', $name),
-                sprintf('name="%s"', $formControlName),
-                $controlOptions['html']
-            );
+            $controlOptions['html'] = str_replace(sprintf('name="%s"', $name), sprintf('name="%s"', $formControlName), $controlOptions['html']);
         }
         $controlOptions['label'] = $this->fieldLabel($name, null);
         $readonly = Hash::get($controlOptions, 'readonly');

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -69,7 +69,7 @@ class PropertyHelper extends Helper
      */
     public function control(string $name, $value, array $options = [], ?string $type = null): string
     {
-        $forceReadonly = Hash::get($options, 'readonly') === 'readonly';
+        $forceReadonly = !empty(Hash::get($options, 'readonly'));
         $controlOptions = $this->Schema->controlOptions($name, $value, $this->schema($name, $type));
         $controlOptions['label'] = $this->fieldLabel($name, $type);
         $readonly = Hash::get($controlOptions, 'readonly') || $forceReadonly;

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -87,6 +87,41 @@ class PropertyHelper extends Helper
     }
 
     /**
+     * Generates a form control for translation property
+     *
+     * @param string $name The property name
+     * @param mixed|null $value The property value
+     * @param array $options The form element options, if any
+     * @return string
+     */
+    public function translationControl(string $name, $value, array $options = []): string
+    {
+        $formControlName = sprintf('translated_fields[%s]', $name);
+        $controlOptions = $this->Schema->controlOptions($name, $value, $this->schema($name, null));
+        if (array_key_exists('html', $controlOptions)) {
+            $controlOptions['html'] = str_replace(
+                sprintf('name="%s"', $name),
+                sprintf('name="%s"', $formControlName),
+                $controlOptions['html']
+            );
+        }
+        $controlOptions['label'] = $this->fieldLabel($name, null);
+        $readonly = Hash::get($controlOptions, 'readonly');
+        if ($readonly === true && array_key_exists('v-datepicker', $controlOptions)) {
+            unset($controlOptions['v-datepicker']);
+        }
+        if (Hash::get($controlOptions, 'class') === 'json' || Hash::get($controlOptions, 'type') === 'json') {
+            $jsonKeys = (array)Configure::read('_jsonKeys');
+            Configure::write('_jsonKeys', array_merge($jsonKeys, [$formControlName]));
+        }
+        if (Hash::check($controlOptions, 'html')) {
+            return (string)Hash::get($controlOptions, 'html', '');
+        }
+
+        return $this->Form->control($formControlName, array_merge($controlOptions, $options));
+    }
+
+    /**
      * Return label for field by name and type.
      * If there's a config for the field and type, return it.
      * Return translation of name, otherwise.

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -69,9 +69,22 @@ class PropertyHelper extends Helper
      */
     public function control(string $name, $value, array $options = [], ?string $type = null): string
     {
+        $forceReadonly = Hash::get($options, 'readonly') === 'readonly';
         $controlOptions = $this->Schema->controlOptions($name, $value, $this->schema($name, $type));
         $controlOptions['label'] = $this->fieldLabel($name, $type);
-        $readonly = Hash::get($controlOptions, 'readonly');
+        $readonly = Hash::get($controlOptions, 'readonly') || $forceReadonly;
+        if ($readonly === true && array_key_exists('html', $controlOptions)) {
+            $controlOptions['html'] = str_replace(
+                'readonly="false"',
+                'readonly="true"',
+                $controlOptions['html']
+            );
+            $controlOptions['html'] = str_replace(
+                ':readonly=false',
+                ':readonly=true',
+                $controlOptions['html']
+            );
+        }
         if ($readonly === true && array_key_exists('v-datepicker', $controlOptions)) {
             unset($controlOptions['v-datepicker']);
         }

--- a/templates/Element/translation.twig
+++ b/templates/Element/translation.twig
@@ -52,9 +52,7 @@
                             {{ Property.control('status', translation.attributes.status|default('draft'))|raw }}
                         </div>
                         {% for key in translatable %}
-                            {% set options = Schema.controlOptions(key, translation.attributes.translated_fields[key], schema.properties[key]) %}
-                            {% set options = options|merge({'ref': key}) %}
-                            {{ Form.control('translated_fields.' ~ key, options)|raw }}
+                            {{ Property.translationControl(key, translation.attributes.translated_fields[key], {'ref': key})|raw }}
 
                             {# automatic translate button #}
                             {% if config('Translator.class') %}

--- a/templates/Element/translation.twig
+++ b/templates/Element/translation.twig
@@ -71,7 +71,7 @@
                     </div>
                     <div class="column">
                         <label>{{ __('Status') }}</label>
-                        {{ object.status|default('draft') }}
+                        {{ object.attributes.status|default('draft') }}
                     </div>
                 </div>
                 {% for key in translatable %}

--- a/templates/Element/translation.twig
+++ b/templates/Element/translation.twig
@@ -4,17 +4,15 @@
 
 <modules-view inline-template ref="moduleView">
     <div class="modules-view">
+        {{ Form.create(null, {
+            'url': {'_name': 'translations:save', 'object_type': objectType},
+            'id': 'form-translate',
+            'class': 'object-form'
+        })|raw }}
+            <section class="fieldset">
 
-        <div class="module-form">
-
-            {{ Form.create(null, {
-                'url': {'_name': 'translations:save', 'object_type': objectType},
-                'id': 'form-translate',
-            })|raw }}
-
-            <div class="main-view-column">
-                <section class="fieldset">
-                    <div class="tab-container">
+                <div class="row">
+                    <div class="column">
                         <div class="lang-header is-flex align-center">
                             {% set languageLabel = "#{__('Language')}" %}
                             {% set options = Schema.controlOptions('lang', null, [])|default({})|merge({
@@ -44,39 +42,14 @@
                                         }
                                     }) %}
                                 {% endfor %}
-                                <button class="mt-1" @click.prevent="translateAll({{ data|json_encode }}, $event)">
-                                    {{ __('Auto-translate all fields') }}
-                                </button>
+                                <a class="button has-background-module-translations" @click.prevent="translateAll({{ data|json_encode }}, $event)">
+                                    <Icon icon="carbon:translate"></Icon>
+                                    <span class="ml-05 has-text-size-smallest">{{ __('Auto-translate all fields') }}</span>
+                                </a>
                             {% endif %}
-
-                            {{ Property.control('status', translation.attributes.status|default('draft'))|raw }}
                         </div>
-                        {% for key in translatable %}
-                            {{ Property.translationControl(key, translation.attributes.translated_fields[key], {'ref': key})|raw }}
-
-                            {# automatic translate button #}
-                            {% if config('Translator.class') %}
-                                {% set translationParams = {
-                                    'field': key,
-                                    'content': object.attributes[key],
-                                    'from': object.attributes.lang,
-                                    'to': translation.attributes.lang
-                                } %}
-                                <div class="field-actions">
-                                    <button @click.prevent="translate({{ translationParams|json_encode }}, $event)">
-                                        {{ __('Auto-translate') }} {{ key }}
-                                    </button>
-                                </div>
-                            {% endif %}
-                        {% endfor %}
                     </div>
-                </section>
-                {{ element('Form/meta', { 'object' : translation }) }}
-            </div>
-
-            <div class="side-view-column original">
-                <section class="fieldset">
-                    <div class="tab-container">
+                    <div class="column">
                         <div class="lang-header is-flex align-bottom">
                             {% set languageLabel = "#{__('Original language')}" %}
                             {% set options = Schema.controlOptions('lang', null, [])|merge({
@@ -90,17 +63,52 @@
                                 <span class="ml-05">{{ __('Edit') }}</span>
                             </a>
                         </div>
-                        {% for key in translatable %}
-                            {{ Property.control(key, object.attributes[key], {'disabled': 'disabled', 'readonly': 'readonly'})|raw }}
-                            {# spacer when auto translate is available #}
-                            {% if config('Translator.class') %}
-                                <div class="field-align-aid"></div>
-                            {% endif %}
-                        {% endfor %}
                     </div>
-                </section>
-                {{ element('Form/meta', { 'object' : object }) }}
-            </div>
+                </div>
+                <div class="row">
+                    <div class="column">
+                        {{ Property.control('status', translation.attributes.status|default('draft'))|raw }}
+                    </div>
+                    <div class="column">
+                        <label>{{ __('Status') }}</label>
+                        {{ object.status|default('draft') }}
+                    </div>
+                </div>
+                {% for key in translatable %}
+                <div class="row tab-container" style="display: table">
+                    <div class="column">
+                        {{ Property.translationControl(key, translation.attributes.translated_fields[key], {'ref': key})|raw }}
+
+                        {# automatic translate button #}
+                        {% if config('Translator.class') %}
+                            {% set translationParams = {
+                                'field': key,
+                                'content': object.attributes[key],
+                                'from': object.attributes.lang,
+                                'to': translation.attributes.lang
+                            } %}
+                            <button class="mt-05" @click.prevent="translate({{ translationParams|json_encode }}, $event)">
+                                <Icon icon="carbon:translate"></Icon>
+                                <span class="ml-05 has-text-size-smallest">{{ __('Auto-translate') }} {{ key }}</span>
+                            </button>
+                        {% endif %}
+                    </div>
+                    <div class="column">
+                        {{ Property.control(key, object.attributes[key], {'disabled': 'disabled', 'readonly': 'readonly'})|raw }}
+                    </div>
+                </div>
+                {% endfor %}
+
+                <div class="row">
+                    <div class="column">
+                        {{ element('Form/meta', { 'object' : translation }) }}
+                    </div>
+                    <div class="column">
+                        {{ element('Form/meta', { 'object' : object }) }}
+                    </div>
+                </div>
+
+            </section>
 
             {# Set `_jsonKeys` hidden input from config #}
             {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': config('_jsonKeys', [])|join(',')})|raw }}
@@ -113,28 +121,25 @@
                 {{ Form.hidden('id', {'value': translation.id})|raw }}
             {% endif %}
 
-            {{ Form.end()|raw }}
-
             {# Append "Save" to sidebar #}
             {% do _view.append('app-module-buttons',
                 '<button form="form-translate" class="button button-primary button-primary-hover-module-' ~ currentModule.name ~ ' is-width-auto" onclick="this.classList.add(\'is-loading-spinner\')"><Icon icon="carbon:save"></Icon><span class="ml-05">' ~ __('Save') ~ '</span></button>'
             ) %}
 
-            {% if translation.id %}
-                {{ Form.create(null, {'id': 'form-delete-translation', 'url': Url.build({'_name': 'translations:delete', 'object_type': objectType})})|raw }}
-                    {{ Form.hidden('id', {'value': translation.id})|raw }}
-                    {{ Form.hidden('object_id', {'value': object.id})|raw }}
-                    {{ Form.hidden('lang', {'value': translation.attributes.lang})|raw }}
-                {{ Form.end()|raw }}
-                {# Append "Remove" to sidebar #}
-                {% do _view.append(
-                    'app-module-buttons',
-                    '<button form="form-delete-translation" class="button button-outlined button-outlined-hover-module-' ~ currentModule.name ~ ' is-width-auto"><Icon icon="carbon:trash-can"></Icon><span class="ml-05">' ~ __('Remove') ~ '</span></button>'
-                ) %}
-            {% endif %}
+        {{ Form.end()|raw }}
 
+        {% if translation.id %}
+            {{ Form.create(null, {'id': 'form-delete-translation', 'url': Url.build({'_name': 'translations:delete', 'object_type': objectType})})|raw }}
+                {{ Form.hidden('id', {'value': translation.id})|raw }}
+                {{ Form.hidden('object_id', {'value': object.id})|raw }}
+                {{ Form.hidden('lang', {'value': translation.attributes.lang})|raw }}
             {{ Form.end()|raw }}
-        </div>
+            {# Append "Remove" to sidebar #}
+            {% do _view.append(
+                'app-module-buttons',
+                '<button form="form-delete-translation" class="button button-outlined button-outlined-hover-module-' ~ currentModule.name ~ ' is-width-auto"><Icon icon="carbon:trash-can"></Icon><span class="ml-05">' ~ __('Remove') ~ '</span></button>'
+            ) %}
+        {% endif %}
 
     </div>
 </modules-view>

--- a/templates/Element/translation.twig
+++ b/templates/Element/translation.twig
@@ -91,7 +91,7 @@
                             </a>
                         </div>
                         {% for key in translatable %}
-                            {{ Property.control(key, object.attributes[key], {'disabled': 'disabled'})|raw }}
+                            {{ Property.control(key, object.attributes[key], {'disabled': 'disabled', 'readonly': 'readonly'})|raw }}
                             {# spacer when auto translate is available #}
                             {% if config('Translator.class') %}
                                 <div class="field-align-aid"></div>

--- a/templates/Pages/Modules/_modules-view.scss
+++ b/templates/Pages/Modules/_modules-view.scss
@@ -111,14 +111,25 @@ body.translation-module {
         opacity: .8;
     }
 
-    // TODO: refactor this css
-    .module-form form { grid-template-columns: 1fr 1fr !important; }
-
-    .main-view-column .field-actions {
-        text-align: right;
+    .column {
+        float: left;
+        width: 50%;
+        padding: 10px;
+        border-top: dashed gray 1px;
     }
-    .original .field-align-aid {
-        height: $gutter * 2; // match button on the other column
+
+    .column:first-child {
+        border-right: dashed gray 1px;
+    }
+
+    .row {
+        width: 100%;
+    }
+
+    .row:after {
+        content: '';
+        display: table;
+        clear: both;
     }
 }
 

--- a/tests/TestCase/Form/CustomComponentControlTest.php
+++ b/tests/TestCase/Form/CustomComponentControlTest.php
@@ -35,6 +35,7 @@ class CustomComponentControlTest extends TestCase
                 [
                     'type' => '',
                     'html' => '<key-value-list label="field1" name="field1" value="" :readonly=false></key-value-list>',
+                    'readonly' => false,
                 ],
                 'field1',
                 [],
@@ -44,6 +45,7 @@ class CustomComponentControlTest extends TestCase
                 [
                     'type' => 'json',
                     'html' => '<my-component label="Abstract" name="subtitle" value="{&quot;a&quot;:2}" :readonly=false></my-component>',
+                    'readonly' => false,
                 ],
                 'subtitle',
                 ['a' => 2],
@@ -57,6 +59,7 @@ class CustomComponentControlTest extends TestCase
                 [
                     'type' => 'json',
                     'html' => '<key-value-list label="some_field" name="some_field" value="{&quot;a&quot;:&quot;b&quot;}" :readonly=true></key-value-list>',
+                    'readonly' => true,
                 ],
                 'some_field',
                 '{"a":"b"}',

--- a/tests/TestCase/View/Helper/PropertyHelperTest.php
+++ b/tests/TestCase/View/Helper/PropertyHelperTest.php
@@ -66,6 +66,7 @@ class PropertyHelperTest extends TestCase
                     'description' => null,
                 ],
                 '<div class="input title text"><label for="title">Title</label><input type="text" name="title" class="title" id="title" value="something"/></div>',
+                '<div class="input title text"><label for="translated-fields-title">Title</label><input type="text" name="translated_fields[title]" class="title" id="translated-fields-title" value="something"/></div>',
             ],
             'date' => [
                 'created',
@@ -80,6 +81,7 @@ class PropertyHelperTest extends TestCase
                     'readonly' => true,
                 ],
                 '<div class="input datepicker text"><label for="created">Created</label><input type="text" name="created" v-datepicker="true" date="true" time="true" id="created" value="2020-06-15 12:35:00"/></div>',
+                '<div class="input datepicker text"><label for="translated-fields-created">Created</label><input type="text" name="translated_fields[created]" v-datepicker="true" date="true" time="true" id="translated-fields-created" value="2020-06-15 12:35:00"/></div>',
             ],
             'status' => [
                 'status',
@@ -98,6 +100,7 @@ class PropertyHelperTest extends TestCase
                     'default' => 'draft',
                 ],
                 '<div class="input radio"><label>Status</label><input type="hidden" name="status" id="status" value=""/><label for="status-on"><input type="radio" name="status" value="on" id="status-on" class="test">On</label><label for="status-draft"><input type="radio" name="status" value="draft" id="status-draft" class="test">Draft</label><label for="status-off"><input type="radio" name="status" value="off" id="status-off" class="test">Off</label></div>',
+                '<div class="input radio"><label>Status</label><input type="hidden" name="translated_fields[status]" id="translated-fields-status" value=""/><label for="translated-fields-status-on"><input type="radio" name="translated_fields[status]" value="on" id="translated-fields-status-on" class="test">On</label><label for="translated-fields-status-draft"><input type="radio" name="translated_fields[status]" value="draft" id="translated-fields-status-draft" class="test">Draft</label><label for="translated-fields-status-off"><input type="radio" name="translated_fields[status]" value="off" id="translated-fields-status-off" class="test">Off</label></div>',
             ],
             'categories' => [
                 'categories',
@@ -111,6 +114,7 @@ class PropertyHelperTest extends TestCase
                     ['name' => 'cat-5', 'label' => 'category 5', 'enabled' => true],
                 ],
                 '<div class="input select"><label for="categories">Categories</label><input type="hidden" name="categories" id="categories" value=""/><div class="checkbox"><label for="categories-cat-1" class="selected"><input type="checkbox" name="categories[]" value="cat-1" checked="checked" id="categories-cat-1" class="test">category 1</label></div><div class="checkbox"><label for="categories-cat-2"><input type="checkbox" name="categories[]" value="cat-2" id="categories-cat-2" class="test">category 2</label></div><div class="checkbox"><label for="categories-cat-3" class="selected"><input type="checkbox" name="categories[]" value="cat-3" checked="checked" id="categories-cat-3" class="test">category 3</label></div><div class="checkbox"><label for="categories-cat-4"><input type="checkbox" name="categories[]" value="cat-4" id="categories-cat-4" class="test">category 4</label></div><div class="checkbox"><label for="categories-cat-5"><input type="checkbox" name="categories[]" value="cat-5" id="categories-cat-5" class="test">category 5</label></div></div>',
+                '<div class="input select"><label for="translated-fields-categories">Categories</label><input type="hidden" name="translated_fields[categories]" id="translated-fields-categories" value=""/><div class="checkbox"><label for="translated-fields-categories-cat-1" class="selected"><input type="checkbox" name="translated_fields[categories][]" value="cat-1" checked="checked" id="translated-fields-categories-cat-1" class="test">category 1</label></div><div class="checkbox"><label for="translated-fields-categories-cat-2"><input type="checkbox" name="translated_fields[categories][]" value="cat-2" id="translated-fields-categories-cat-2" class="test">category 2</label></div><div class="checkbox"><label for="translated-fields-categories-cat-3" class="selected"><input type="checkbox" name="translated_fields[categories][]" value="cat-3" checked="checked" id="translated-fields-categories-cat-3" class="test">category 3</label></div><div class="checkbox"><label for="translated-fields-categories-cat-4"><input type="checkbox" name="translated_fields[categories][]" value="cat-4" id="translated-fields-categories-cat-4" class="test">category 4</label></div><div class="checkbox"><label for="translated-fields-categories-cat-5"><input type="checkbox" name="translated_fields[categories][]" value="cat-5" id="translated-fields-categories-cat-5" class="test">category 5</label></div></div>',
             ],
             'object' => [
                 'an object',
@@ -121,6 +125,7 @@ class PropertyHelperTest extends TestCase
                     '$id' => '/properties/object',
                 ],
                 '<div class="input textarea"><label for="an-object">An Object</label><textarea name="an object" v-jsoneditor="true" class="json" id="an-object" rows="5">{&quot;an&quot;:&quot;object&quot;}</textarea></div>',
+                '<div class="input textarea"><label for="translated-fields-an-object">An Object</label><textarea name="translated_fields[an object]" v-jsoneditor="true" class="json" id="translated-fields-an-object" rows="5">{&quot;an&quot;:&quot;object&quot;}</textarea></div>',
             ],
             'html' => [
                 'descr',
@@ -130,6 +135,7 @@ class PropertyHelperTest extends TestCase
                     'name' => 'descr',
                 ],
                 '<dummy label="descr" name="descr" value="something" :readonly=false></dummy>',
+                '<dummy label="descr" name="translated_fields[descr]" value="something" :readonly=false></dummy>',
             ],
             'date readonly' => [
                 'expires',
@@ -150,6 +156,7 @@ class PropertyHelperTest extends TestCase
                     'description' => 'Expiration date',
                 ],
                 '<div class="input datepicker text"><label for="expires">Expires</label><input type="text" name="expires" readonly="readonly" disabled="disabled" date="true" time="true" id="expires"/></div>',
+                '<div class="input datepicker text"><label for="translated-fields-expires">Expires</label><input type="text" name="translated_fields[expires]" readonly="readonly" disabled="disabled" date="true" time="true" id="translated-fields-expires"/></div>',
             ],
         ];
     }
@@ -162,12 +169,14 @@ class PropertyHelperTest extends TestCase
      * @param array $options The options
      * @param array $schema The schema
      * @param string $expected The expected result
+     * @param string $expectedTranslation The expected translation result
      * @return void
      * @dataProvider controlProvider()
      * @covers ::control()
+     * @covers ::translationControl()
      * @covers ::schema()
      */
-    public function testControl(string $key, $value, array $options = [], array $schema = [], string $expected = ''): void
+    public function testControl(string $key, $value, array $options = [], array $schema = [], string $expected = '', string $expectedTranslation = ''): void
     {
         if (array_key_exists('readonly', $options)) {
             unset($options['readonly']);
@@ -184,6 +193,9 @@ class PropertyHelperTest extends TestCase
         $property = new PropertyHelper($view);
         $actual = $property->control($key, $value, $options);
         static::assertEquals($expected, $actual);
+
+        $actual = $property->translationControl($key, $value, $options);
+        static::assertEquals($expectedTranslation, $actual);
     }
 
     /**

--- a/tests/TestCase/View/Helper/PropertyHelperTest.php
+++ b/tests/TestCase/View/Helper/PropertyHelperTest.php
@@ -137,6 +137,16 @@ class PropertyHelperTest extends TestCase
                 '<dummy label="descr" name="descr" value="something" :readonly=false></dummy>',
                 '<dummy label="descr" name="translated_fields[descr]" value="something" :readonly=false></dummy>',
             ],
+            'html readonly' => [
+                'descr',
+                'something',
+                ['readonly' => true],
+                [
+                    'name' => 'descr',
+                ],
+                '<dummy label="descr" name="descr" value="something" :readonly=true></dummy>',
+                '<dummy label="descr" name="translated_fields[descr]" value="something" :readonly=true></dummy>',
+            ],
             'date readonly' => [
                 'expires',
                 null,

--- a/tests/TestCase/View/Helper/PropertyHelperTest.php
+++ b/tests/TestCase/View/Helper/PropertyHelperTest.php
@@ -52,91 +52,91 @@ class PropertyHelperTest extends TestCase
     public function controlProvider(): array
     {
         return [
-            'text' => [
-                'title',
-                'something',
-                [],
-                [
-                    'oneOf' => [
-                        ['type' => null],
-                        ['type' => 'string', 'contentMediaType' => 'text/html'],
-                    ],
-                    '$id' => '/properties/title',
-                    'title' => 'Title',
-                    'description' => null,
-                ],
-                '<div class="input title text"><label for="title">Title</label><input type="text" name="title" class="title" id="title" value="something"/></div>',
-                '<div class="input title text"><label for="translated-fields-title">Title</label><input type="text" name="translated_fields[title]" class="title" id="translated-fields-title" value="something"/></div>',
-            ],
-            'date' => [
-                'created',
-                '2020-06-15 12:35:00',
-                [],
-                [
-                    'type' => 'string',
-                    'format' => 'date-time',
-                    '$id' => '/properties/created',
-                    'title' => 'Created',
-                    'description' => 'creation date',
-                    'readonly' => true,
-                ],
-                '<div class="input datepicker text"><label for="created">Created</label><input type="text" name="created" v-datepicker="true" date="true" time="true" id="created" value="2020-06-15 12:35:00"/></div>',
-                '<div class="input datepicker text"><label for="translated-fields-created">Created</label><input type="text" name="translated_fields[created]" v-datepicker="true" date="true" time="true" id="translated-fields-created" value="2020-06-15 12:35:00"/></div>',
-            ],
-            'status' => [
-                'status',
-                'en',
-                ['class' => 'test'],
-                [
-                    'type' => 'string',
-                    'enum' => [
-                        'on',
-                        'off',
-                        'draft',
-                    ],
-                    '$id' => '/properties/status',
-                    'title' => 'Status',
-                    'description' => 'object status: on, draft, off',
-                    'default' => 'draft',
-                ],
-                '<div class="input radio"><label>Status</label><input type="hidden" name="status" id="status" value=""/><label for="status-on"><input type="radio" name="status" value="on" id="status-on" class="test">On</label><label for="status-draft"><input type="radio" name="status" value="draft" id="status-draft" class="test">Draft</label><label for="status-off"><input type="radio" name="status" value="off" id="status-off" class="test">Off</label></div>',
-                '<div class="input radio"><label>Status</label><input type="hidden" name="translated_fields[status]" id="translated-fields-status" value=""/><label for="translated-fields-status-on"><input type="radio" name="translated_fields[status]" value="on" id="translated-fields-status-on" class="test">On</label><label for="translated-fields-status-draft"><input type="radio" name="translated_fields[status]" value="draft" id="translated-fields-status-draft" class="test">Draft</label><label for="translated-fields-status-off"><input type="radio" name="translated_fields[status]" value="off" id="translated-fields-status-off" class="test">Off</label></div>',
-            ],
-            'categories' => [
-                'categories',
-                [['name' => 'cat-1'], ['name' => 'cat-3']],
-                ['class' => 'test'],
-                [
-                    ['name' => 'cat-1', 'label' => 'category 1', 'enabled' => true],
-                    ['name' => 'cat-2', 'label' => 'category 2', 'enabled' => true],
-                    ['name' => 'cat-3', 'label' => 'category 3', 'enabled' => true],
-                    ['name' => 'cat-4', 'label' => 'category 4', 'enabled' => true],
-                    ['name' => 'cat-5', 'label' => 'category 5', 'enabled' => true],
-                ],
-                '<div class="input select"><label for="categories">Categories</label><input type="hidden" name="categories" id="categories" value=""/><div class="checkbox"><label for="categories-cat-1" class="selected"><input type="checkbox" name="categories[]" value="cat-1" checked="checked" id="categories-cat-1" class="test">category 1</label></div><div class="checkbox"><label for="categories-cat-2"><input type="checkbox" name="categories[]" value="cat-2" id="categories-cat-2" class="test">category 2</label></div><div class="checkbox"><label for="categories-cat-3" class="selected"><input type="checkbox" name="categories[]" value="cat-3" checked="checked" id="categories-cat-3" class="test">category 3</label></div><div class="checkbox"><label for="categories-cat-4"><input type="checkbox" name="categories[]" value="cat-4" id="categories-cat-4" class="test">category 4</label></div><div class="checkbox"><label for="categories-cat-5"><input type="checkbox" name="categories[]" value="cat-5" id="categories-cat-5" class="test">category 5</label></div></div>',
-                '<div class="input select"><label for="translated-fields-categories">Categories</label><input type="hidden" name="translated_fields[categories]" id="translated-fields-categories" value=""/><div class="checkbox"><label for="translated-fields-categories-cat-1" class="selected"><input type="checkbox" name="translated_fields[categories][]" value="cat-1" checked="checked" id="translated-fields-categories-cat-1" class="test">category 1</label></div><div class="checkbox"><label for="translated-fields-categories-cat-2"><input type="checkbox" name="translated_fields[categories][]" value="cat-2" id="translated-fields-categories-cat-2" class="test">category 2</label></div><div class="checkbox"><label for="translated-fields-categories-cat-3" class="selected"><input type="checkbox" name="translated_fields[categories][]" value="cat-3" checked="checked" id="translated-fields-categories-cat-3" class="test">category 3</label></div><div class="checkbox"><label for="translated-fields-categories-cat-4"><input type="checkbox" name="translated_fields[categories][]" value="cat-4" id="translated-fields-categories-cat-4" class="test">category 4</label></div><div class="checkbox"><label for="translated-fields-categories-cat-5"><input type="checkbox" name="translated_fields[categories][]" value="cat-5" id="translated-fields-categories-cat-5" class="test">category 5</label></div></div>',
-            ],
-            'object' => [
-                'an object',
-                ['an' => 'object'],
-                [],
-                [
-                    'type' => 'object',
-                    '$id' => '/properties/object',
-                ],
-                '<div class="input textarea"><label for="an-object">An Object</label><textarea name="an object" v-jsoneditor="true" class="json" id="an-object" rows="5">{&quot;an&quot;:&quot;object&quot;}</textarea></div>',
-                '<div class="input textarea"><label for="translated-fields-an-object">An Object</label><textarea name="translated_fields[an object]" v-jsoneditor="true" class="json" id="translated-fields-an-object" rows="5">{&quot;an&quot;:&quot;object&quot;}</textarea></div>',
-            ],
-            'html' => [
-                'descr',
-                'something',
-                [],
-                [
-                    'name' => 'descr',
-                ],
-                '<dummy label="descr" name="descr" value="something" :readonly=false></dummy>',
-                '<dummy label="descr" name="translated_fields[descr]" value="something" :readonly=false></dummy>',
-            ],
+            // 'text' => [
+            //     'title',
+            //     'something',
+            //     [],
+            //     [
+            //         'oneOf' => [
+            //             ['type' => null],
+            //             ['type' => 'string', 'contentMediaType' => 'text/html'],
+            //         ],
+            //         '$id' => '/properties/title',
+            //         'title' => 'Title',
+            //         'description' => null,
+            //     ],
+            //     '<div class="input title text"><label for="title">Title</label><input type="text" name="title" class="title" id="title" value="something"/></div>',
+            //     '<div class="input title text"><label for="translated-fields-title">Title</label><input type="text" name="translated_fields[title]" class="title" id="translated-fields-title" value="something"/></div>',
+            // ],
+            // 'date' => [
+            //     'created',
+            //     '2020-06-15 12:35:00',
+            //     [],
+            //     [
+            //         'type' => 'string',
+            //         'format' => 'date-time',
+            //         '$id' => '/properties/created',
+            //         'title' => 'Created',
+            //         'description' => 'creation date',
+            //         'readonly' => true,
+            //     ],
+            //     '<div class="input datepicker text"><label for="created">Created</label><input type="text" name="created" v-datepicker="true" date="true" time="true" id="created" value="2020-06-15 12:35:00"/></div>',
+            //     '<div class="input datepicker text"><label for="translated-fields-created">Created</label><input type="text" name="translated_fields[created]" v-datepicker="true" date="true" time="true" id="translated-fields-created" value="2020-06-15 12:35:00"/></div>',
+            // ],
+            // 'status' => [
+            //     'status',
+            //     'en',
+            //     ['class' => 'test'],
+            //     [
+            //         'type' => 'string',
+            //         'enum' => [
+            //             'on',
+            //             'off',
+            //             'draft',
+            //         ],
+            //         '$id' => '/properties/status',
+            //         'title' => 'Status',
+            //         'description' => 'object status: on, draft, off',
+            //         'default' => 'draft',
+            //     ],
+            //     '<div class="input radio"><label>Status</label><input type="hidden" name="status" id="status" value=""/><label for="status-on"><input type="radio" name="status" value="on" id="status-on" class="test">On</label><label for="status-draft"><input type="radio" name="status" value="draft" id="status-draft" class="test">Draft</label><label for="status-off"><input type="radio" name="status" value="off" id="status-off" class="test">Off</label></div>',
+            //     '<div class="input radio"><label>Status</label><input type="hidden" name="translated_fields[status]" id="translated-fields-status" value=""/><label for="translated-fields-status-on"><input type="radio" name="translated_fields[status]" value="on" id="translated-fields-status-on" class="test">On</label><label for="translated-fields-status-draft"><input type="radio" name="translated_fields[status]" value="draft" id="translated-fields-status-draft" class="test">Draft</label><label for="translated-fields-status-off"><input type="radio" name="translated_fields[status]" value="off" id="translated-fields-status-off" class="test">Off</label></div>',
+            // ],
+            // 'categories' => [
+            //     'categories',
+            //     [['name' => 'cat-1'], ['name' => 'cat-3']],
+            //     ['class' => 'test'],
+            //     [
+            //         ['name' => 'cat-1', 'label' => 'category 1', 'enabled' => true],
+            //         ['name' => 'cat-2', 'label' => 'category 2', 'enabled' => true],
+            //         ['name' => 'cat-3', 'label' => 'category 3', 'enabled' => true],
+            //         ['name' => 'cat-4', 'label' => 'category 4', 'enabled' => true],
+            //         ['name' => 'cat-5', 'label' => 'category 5', 'enabled' => true],
+            //     ],
+            //     '<div class="input select"><label for="categories">Categories</label><input type="hidden" name="categories" id="categories" value=""/><div class="checkbox"><label for="categories-cat-1" class="selected"><input type="checkbox" name="categories[]" value="cat-1" checked="checked" id="categories-cat-1" class="test">category 1</label></div><div class="checkbox"><label for="categories-cat-2"><input type="checkbox" name="categories[]" value="cat-2" id="categories-cat-2" class="test">category 2</label></div><div class="checkbox"><label for="categories-cat-3" class="selected"><input type="checkbox" name="categories[]" value="cat-3" checked="checked" id="categories-cat-3" class="test">category 3</label></div><div class="checkbox"><label for="categories-cat-4"><input type="checkbox" name="categories[]" value="cat-4" id="categories-cat-4" class="test">category 4</label></div><div class="checkbox"><label for="categories-cat-5"><input type="checkbox" name="categories[]" value="cat-5" id="categories-cat-5" class="test">category 5</label></div></div>',
+            //     '<div class="input select"><label for="translated-fields-categories">Categories</label><input type="hidden" name="translated_fields[categories]" id="translated-fields-categories" value=""/><div class="checkbox"><label for="translated-fields-categories-cat-1" class="selected"><input type="checkbox" name="translated_fields[categories][]" value="cat-1" checked="checked" id="translated-fields-categories-cat-1" class="test">category 1</label></div><div class="checkbox"><label for="translated-fields-categories-cat-2"><input type="checkbox" name="translated_fields[categories][]" value="cat-2" id="translated-fields-categories-cat-2" class="test">category 2</label></div><div class="checkbox"><label for="translated-fields-categories-cat-3" class="selected"><input type="checkbox" name="translated_fields[categories][]" value="cat-3" checked="checked" id="translated-fields-categories-cat-3" class="test">category 3</label></div><div class="checkbox"><label for="translated-fields-categories-cat-4"><input type="checkbox" name="translated_fields[categories][]" value="cat-4" id="translated-fields-categories-cat-4" class="test">category 4</label></div><div class="checkbox"><label for="translated-fields-categories-cat-5"><input type="checkbox" name="translated_fields[categories][]" value="cat-5" id="translated-fields-categories-cat-5" class="test">category 5</label></div></div>',
+            // ],
+            // 'object' => [
+            //     'an object',
+            //     ['an' => 'object'],
+            //     [],
+            //     [
+            //         'type' => 'object',
+            //         '$id' => '/properties/object',
+            //     ],
+            //     '<div class="input textarea"><label for="an-object">An Object</label><textarea name="an object" v-jsoneditor="true" class="json" id="an-object" rows="5">{&quot;an&quot;:&quot;object&quot;}</textarea></div>',
+            //     '<div class="input textarea"><label for="translated-fields-an-object">An Object</label><textarea name="translated_fields[an object]" v-jsoneditor="true" class="json" id="translated-fields-an-object" rows="5">{&quot;an&quot;:&quot;object&quot;}</textarea></div>',
+            // ],
+            // 'html' => [
+            //     'descr',
+            //     'something',
+            //     [],
+            //     [
+            //         'name' => 'descr',
+            //     ],
+            //     '<dummy label="descr" name="descr" value="something" :readonly=false></dummy>',
+            //     '<dummy label="descr" name="translated_fields[descr]" value="something" :readonly=false></dummy>',
+            // ],
             'html readonly' => [
                 'descr',
                 'something',
@@ -147,27 +147,27 @@ class PropertyHelperTest extends TestCase
                 '<dummy label="descr" name="descr" value="something" :readonly=true></dummy>',
                 '<dummy label="descr" name="translated_fields[descr]" value="something" :readonly=true></dummy>',
             ],
-            'date readonly' => [
-                'expires',
-                null,
-                ['readonly' => true],
-                [
-                    'oneOf' => [
-                        [
-                            'type' => 'null',
-                        ],
-                        [
-                            'type' => 'string',
-                            'format' => 'date-time',
-                        ],
-                    ],
-                    '$id' => '/properties/expires',
-                    'title' => 'Expires',
-                    'description' => 'Expiration date',
-                ],
-                '<div class="input datepicker text"><label for="expires">Expires</label><input type="text" name="expires" readonly="readonly" disabled="disabled" date="true" time="true" id="expires"/></div>',
-                '<div class="input datepicker text"><label for="translated-fields-expires">Expires</label><input type="text" name="translated_fields[expires]" readonly="readonly" disabled="disabled" date="true" time="true" id="translated-fields-expires"/></div>',
-            ],
+            // 'date readonly' => [
+            //     'expires',
+            //     null,
+            //     ['readonly' => true],
+            //     [
+            //         'oneOf' => [
+            //             [
+            //                 'type' => 'null',
+            //             ],
+            //             [
+            //                 'type' => 'string',
+            //                 'format' => 'date-time',
+            //             ],
+            //         ],
+            //         '$id' => '/properties/expires',
+            //         'title' => 'Expires',
+            //         'description' => 'Expiration date',
+            //     ],
+            //     '<div class="input datepicker text"><label for="expires">Expires</label><input type="text" name="expires" readonly="readonly" disabled="disabled" date="true" time="true" id="expires"/></div>',
+            //     '<div class="input datepicker text"><label for="translated-fields-expires">Expires</label><input type="text" name="translated_fields[expires]" readonly="readonly" disabled="disabled" date="true" time="true" id="translated-fields-expires"/></div>',
+            // ],
         ];
     }
 

--- a/tests/TestCase/View/Helper/PropertyHelperTest.php
+++ b/tests/TestCase/View/Helper/PropertyHelperTest.php
@@ -52,91 +52,91 @@ class PropertyHelperTest extends TestCase
     public function controlProvider(): array
     {
         return [
-            // 'text' => [
-            //     'title',
-            //     'something',
-            //     [],
-            //     [
-            //         'oneOf' => [
-            //             ['type' => null],
-            //             ['type' => 'string', 'contentMediaType' => 'text/html'],
-            //         ],
-            //         '$id' => '/properties/title',
-            //         'title' => 'Title',
-            //         'description' => null,
-            //     ],
-            //     '<div class="input title text"><label for="title">Title</label><input type="text" name="title" class="title" id="title" value="something"/></div>',
-            //     '<div class="input title text"><label for="translated-fields-title">Title</label><input type="text" name="translated_fields[title]" class="title" id="translated-fields-title" value="something"/></div>',
-            // ],
-            // 'date' => [
-            //     'created',
-            //     '2020-06-15 12:35:00',
-            //     [],
-            //     [
-            //         'type' => 'string',
-            //         'format' => 'date-time',
-            //         '$id' => '/properties/created',
-            //         'title' => 'Created',
-            //         'description' => 'creation date',
-            //         'readonly' => true,
-            //     ],
-            //     '<div class="input datepicker text"><label for="created">Created</label><input type="text" name="created" v-datepicker="true" date="true" time="true" id="created" value="2020-06-15 12:35:00"/></div>',
-            //     '<div class="input datepicker text"><label for="translated-fields-created">Created</label><input type="text" name="translated_fields[created]" v-datepicker="true" date="true" time="true" id="translated-fields-created" value="2020-06-15 12:35:00"/></div>',
-            // ],
-            // 'status' => [
-            //     'status',
-            //     'en',
-            //     ['class' => 'test'],
-            //     [
-            //         'type' => 'string',
-            //         'enum' => [
-            //             'on',
-            //             'off',
-            //             'draft',
-            //         ],
-            //         '$id' => '/properties/status',
-            //         'title' => 'Status',
-            //         'description' => 'object status: on, draft, off',
-            //         'default' => 'draft',
-            //     ],
-            //     '<div class="input radio"><label>Status</label><input type="hidden" name="status" id="status" value=""/><label for="status-on"><input type="radio" name="status" value="on" id="status-on" class="test">On</label><label for="status-draft"><input type="radio" name="status" value="draft" id="status-draft" class="test">Draft</label><label for="status-off"><input type="radio" name="status" value="off" id="status-off" class="test">Off</label></div>',
-            //     '<div class="input radio"><label>Status</label><input type="hidden" name="translated_fields[status]" id="translated-fields-status" value=""/><label for="translated-fields-status-on"><input type="radio" name="translated_fields[status]" value="on" id="translated-fields-status-on" class="test">On</label><label for="translated-fields-status-draft"><input type="radio" name="translated_fields[status]" value="draft" id="translated-fields-status-draft" class="test">Draft</label><label for="translated-fields-status-off"><input type="radio" name="translated_fields[status]" value="off" id="translated-fields-status-off" class="test">Off</label></div>',
-            // ],
-            // 'categories' => [
-            //     'categories',
-            //     [['name' => 'cat-1'], ['name' => 'cat-3']],
-            //     ['class' => 'test'],
-            //     [
-            //         ['name' => 'cat-1', 'label' => 'category 1', 'enabled' => true],
-            //         ['name' => 'cat-2', 'label' => 'category 2', 'enabled' => true],
-            //         ['name' => 'cat-3', 'label' => 'category 3', 'enabled' => true],
-            //         ['name' => 'cat-4', 'label' => 'category 4', 'enabled' => true],
-            //         ['name' => 'cat-5', 'label' => 'category 5', 'enabled' => true],
-            //     ],
-            //     '<div class="input select"><label for="categories">Categories</label><input type="hidden" name="categories" id="categories" value=""/><div class="checkbox"><label for="categories-cat-1" class="selected"><input type="checkbox" name="categories[]" value="cat-1" checked="checked" id="categories-cat-1" class="test">category 1</label></div><div class="checkbox"><label for="categories-cat-2"><input type="checkbox" name="categories[]" value="cat-2" id="categories-cat-2" class="test">category 2</label></div><div class="checkbox"><label for="categories-cat-3" class="selected"><input type="checkbox" name="categories[]" value="cat-3" checked="checked" id="categories-cat-3" class="test">category 3</label></div><div class="checkbox"><label for="categories-cat-4"><input type="checkbox" name="categories[]" value="cat-4" id="categories-cat-4" class="test">category 4</label></div><div class="checkbox"><label for="categories-cat-5"><input type="checkbox" name="categories[]" value="cat-5" id="categories-cat-5" class="test">category 5</label></div></div>',
-            //     '<div class="input select"><label for="translated-fields-categories">Categories</label><input type="hidden" name="translated_fields[categories]" id="translated-fields-categories" value=""/><div class="checkbox"><label for="translated-fields-categories-cat-1" class="selected"><input type="checkbox" name="translated_fields[categories][]" value="cat-1" checked="checked" id="translated-fields-categories-cat-1" class="test">category 1</label></div><div class="checkbox"><label for="translated-fields-categories-cat-2"><input type="checkbox" name="translated_fields[categories][]" value="cat-2" id="translated-fields-categories-cat-2" class="test">category 2</label></div><div class="checkbox"><label for="translated-fields-categories-cat-3" class="selected"><input type="checkbox" name="translated_fields[categories][]" value="cat-3" checked="checked" id="translated-fields-categories-cat-3" class="test">category 3</label></div><div class="checkbox"><label for="translated-fields-categories-cat-4"><input type="checkbox" name="translated_fields[categories][]" value="cat-4" id="translated-fields-categories-cat-4" class="test">category 4</label></div><div class="checkbox"><label for="translated-fields-categories-cat-5"><input type="checkbox" name="translated_fields[categories][]" value="cat-5" id="translated-fields-categories-cat-5" class="test">category 5</label></div></div>',
-            // ],
-            // 'object' => [
-            //     'an object',
-            //     ['an' => 'object'],
-            //     [],
-            //     [
-            //         'type' => 'object',
-            //         '$id' => '/properties/object',
-            //     ],
-            //     '<div class="input textarea"><label for="an-object">An Object</label><textarea name="an object" v-jsoneditor="true" class="json" id="an-object" rows="5">{&quot;an&quot;:&quot;object&quot;}</textarea></div>',
-            //     '<div class="input textarea"><label for="translated-fields-an-object">An Object</label><textarea name="translated_fields[an object]" v-jsoneditor="true" class="json" id="translated-fields-an-object" rows="5">{&quot;an&quot;:&quot;object&quot;}</textarea></div>',
-            // ],
-            // 'html' => [
-            //     'descr',
-            //     'something',
-            //     [],
-            //     [
-            //         'name' => 'descr',
-            //     ],
-            //     '<dummy label="descr" name="descr" value="something" :readonly=false></dummy>',
-            //     '<dummy label="descr" name="translated_fields[descr]" value="something" :readonly=false></dummy>',
-            // ],
+            'text' => [
+                'title',
+                'something',
+                [],
+                [
+                    'oneOf' => [
+                        ['type' => null],
+                        ['type' => 'string', 'contentMediaType' => 'text/html'],
+                    ],
+                    '$id' => '/properties/title',
+                    'title' => 'Title',
+                    'description' => null,
+                ],
+                '<div class="input title text"><label for="title">Title</label><input type="text" name="title" class="title" id="title" value="something"/></div>',
+                '<div class="input title text"><label for="translated-fields-title">Title</label><input type="text" name="translated_fields[title]" class="title" id="translated-fields-title" value="something"/></div>',
+            ],
+            'date' => [
+                'created',
+                '2020-06-15 12:35:00',
+                [],
+                [
+                    'type' => 'string',
+                    'format' => 'date-time',
+                    '$id' => '/properties/created',
+                    'title' => 'Created',
+                    'description' => 'creation date',
+                    'readonly' => true,
+                ],
+                '<div class="input datepicker text"><label for="created">Created</label><input type="text" name="created" v-datepicker="true" date="true" time="true" id="created" value="2020-06-15 12:35:00"/></div>',
+                '<div class="input datepicker text"><label for="translated-fields-created">Created</label><input type="text" name="translated_fields[created]" v-datepicker="true" date="true" time="true" id="translated-fields-created" value="2020-06-15 12:35:00"/></div>',
+            ],
+            'status' => [
+                'status',
+                'en',
+                ['class' => 'test'],
+                [
+                    'type' => 'string',
+                    'enum' => [
+                        'on',
+                        'off',
+                        'draft',
+                    ],
+                    '$id' => '/properties/status',
+                    'title' => 'Status',
+                    'description' => 'object status: on, draft, off',
+                    'default' => 'draft',
+                ],
+                '<div class="input radio"><label>Status</label><input type="hidden" name="status" id="status" value=""/><label for="status-on"><input type="radio" name="status" value="on" id="status-on" class="test">On</label><label for="status-draft"><input type="radio" name="status" value="draft" id="status-draft" class="test">Draft</label><label for="status-off"><input type="radio" name="status" value="off" id="status-off" class="test">Off</label></div>',
+                '<div class="input radio"><label>Status</label><input type="hidden" name="translated_fields[status]" id="translated-fields-status" value=""/><label for="translated-fields-status-on"><input type="radio" name="translated_fields[status]" value="on" id="translated-fields-status-on" class="test">On</label><label for="translated-fields-status-draft"><input type="radio" name="translated_fields[status]" value="draft" id="translated-fields-status-draft" class="test">Draft</label><label for="translated-fields-status-off"><input type="radio" name="translated_fields[status]" value="off" id="translated-fields-status-off" class="test">Off</label></div>',
+            ],
+            'categories' => [
+                'categories',
+                [['name' => 'cat-1'], ['name' => 'cat-3']],
+                ['class' => 'test'],
+                [
+                    ['name' => 'cat-1', 'label' => 'category 1', 'enabled' => true],
+                    ['name' => 'cat-2', 'label' => 'category 2', 'enabled' => true],
+                    ['name' => 'cat-3', 'label' => 'category 3', 'enabled' => true],
+                    ['name' => 'cat-4', 'label' => 'category 4', 'enabled' => true],
+                    ['name' => 'cat-5', 'label' => 'category 5', 'enabled' => true],
+                ],
+                '<div class="input select"><label for="categories">Categories</label><input type="hidden" name="categories" id="categories" value=""/><div class="checkbox"><label for="categories-cat-1" class="selected"><input type="checkbox" name="categories[]" value="cat-1" checked="checked" id="categories-cat-1" class="test">category 1</label></div><div class="checkbox"><label for="categories-cat-2"><input type="checkbox" name="categories[]" value="cat-2" id="categories-cat-2" class="test">category 2</label></div><div class="checkbox"><label for="categories-cat-3" class="selected"><input type="checkbox" name="categories[]" value="cat-3" checked="checked" id="categories-cat-3" class="test">category 3</label></div><div class="checkbox"><label for="categories-cat-4"><input type="checkbox" name="categories[]" value="cat-4" id="categories-cat-4" class="test">category 4</label></div><div class="checkbox"><label for="categories-cat-5"><input type="checkbox" name="categories[]" value="cat-5" id="categories-cat-5" class="test">category 5</label></div></div>',
+                '<div class="input select"><label for="translated-fields-categories">Categories</label><input type="hidden" name="translated_fields[categories]" id="translated-fields-categories" value=""/><div class="checkbox"><label for="translated-fields-categories-cat-1" class="selected"><input type="checkbox" name="translated_fields[categories][]" value="cat-1" checked="checked" id="translated-fields-categories-cat-1" class="test">category 1</label></div><div class="checkbox"><label for="translated-fields-categories-cat-2"><input type="checkbox" name="translated_fields[categories][]" value="cat-2" id="translated-fields-categories-cat-2" class="test">category 2</label></div><div class="checkbox"><label for="translated-fields-categories-cat-3" class="selected"><input type="checkbox" name="translated_fields[categories][]" value="cat-3" checked="checked" id="translated-fields-categories-cat-3" class="test">category 3</label></div><div class="checkbox"><label for="translated-fields-categories-cat-4"><input type="checkbox" name="translated_fields[categories][]" value="cat-4" id="translated-fields-categories-cat-4" class="test">category 4</label></div><div class="checkbox"><label for="translated-fields-categories-cat-5"><input type="checkbox" name="translated_fields[categories][]" value="cat-5" id="translated-fields-categories-cat-5" class="test">category 5</label></div></div>',
+            ],
+            'object' => [
+                'an object',
+                ['an' => 'object'],
+                [],
+                [
+                    'type' => 'object',
+                    '$id' => '/properties/object',
+                ],
+                '<div class="input textarea"><label for="an-object">An Object</label><textarea name="an object" v-jsoneditor="true" class="json" id="an-object" rows="5">{&quot;an&quot;:&quot;object&quot;}</textarea></div>',
+                '<div class="input textarea"><label for="translated-fields-an-object">An Object</label><textarea name="translated_fields[an object]" v-jsoneditor="true" class="json" id="translated-fields-an-object" rows="5">{&quot;an&quot;:&quot;object&quot;}</textarea></div>',
+            ],
+            'html' => [
+                'descr',
+                'something',
+                [],
+                [
+                    'name' => 'descr',
+                ],
+                '<dummy label="descr" name="descr" value="something" :readonly=false></dummy>',
+                '<dummy label="descr" name="translated_fields[descr]" value="something" :readonly=false></dummy>',
+            ],
             'html readonly' => [
                 'descr',
                 'something',
@@ -147,27 +147,27 @@ class PropertyHelperTest extends TestCase
                 '<dummy label="descr" name="descr" value="something" :readonly=true></dummy>',
                 '<dummy label="descr" name="translated_fields[descr]" value="something" :readonly=true></dummy>',
             ],
-            // 'date readonly' => [
-            //     'expires',
-            //     null,
-            //     ['readonly' => true],
-            //     [
-            //         'oneOf' => [
-            //             [
-            //                 'type' => 'null',
-            //             ],
-            //             [
-            //                 'type' => 'string',
-            //                 'format' => 'date-time',
-            //             ],
-            //         ],
-            //         '$id' => '/properties/expires',
-            //         'title' => 'Expires',
-            //         'description' => 'Expiration date',
-            //     ],
-            //     '<div class="input datepicker text"><label for="expires">Expires</label><input type="text" name="expires" readonly="readonly" disabled="disabled" date="true" time="true" id="expires"/></div>',
-            //     '<div class="input datepicker text"><label for="translated-fields-expires">Expires</label><input type="text" name="translated_fields[expires]" readonly="readonly" disabled="disabled" date="true" time="true" id="translated-fields-expires"/></div>',
-            // ],
+            'date readonly' => [
+                'expires',
+                null,
+                ['readonly' => true],
+                [
+                    'oneOf' => [
+                        [
+                            'type' => 'null',
+                        ],
+                        [
+                            'type' => 'string',
+                            'format' => 'date-time',
+                        ],
+                    ],
+                    '$id' => '/properties/expires',
+                    'title' => 'Expires',
+                    'description' => 'Expiration date',
+                ],
+                '<div class="input datepicker text"><label for="expires">Expires</label><input type="text" name="expires" readonly="readonly" disabled="disabled" date="true" time="true" id="expires"/></div>',
+                '<div class="input datepicker text"><label for="translated-fields-expires">Expires</label><input type="text" name="translated_fields[expires]" readonly="readonly" disabled="disabled" date="true" time="true" id="translated-fields-expires"/></div>',
+            ],
         ];
     }
 


### PR DESCRIPTION
This updates translation view to use a `PropertyHelper::translationControl`, to properly render custom controls.

This also refactors translation UI