### PR TITLE
Fix auto translate string-list and enhance auto translate logic

### DIFF
--- a/resources/js/app/components/json-fields/string-list.vue
+++ b/resources/js/app/components/json-fields/string-list.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="input textarea text">
-        <label :for="name">{{ label|humanize }}</label>
-        <div :id="name">
+        <label :for="`container-${name}`">{{ label|humanize }}</label>
+        <div :id="`container-${name}`">
             <div class="key-value-item mb-1 is-flex" v-for="(item, index) in items">
                 <div class="is-expanded">
                     <input type="text" v-model="item.value" @change="onChanged()" :readonly="readonly"/>
@@ -19,7 +19,7 @@
             <span class="ml-05">{{ t('Add') }}</span>
         </button>
 
-        <input type="hidden" :name="name" v-model="result" />
+        <input type="hidden" :id="getId(name)" :name="name" v-model="result" @change="updateList($event)" />
     </div>
 </template>
 
@@ -95,6 +95,19 @@ export default {
         remove(index) {
             this.items.splice(index, 1);
             this.onChanged();
+        },
+
+        getId(name) {
+            return name.replaceAll('_', '-').replaceAll('[', '-').replaceAll(']', '');
+        },
+
+        updateList(event) {
+            this.items = [];
+            this.result = event?.target?.value || '';
+            const items = this.result.split(',') || [];
+            for (let item of items) {
+                this.items.push({value: item});
+            }
         },
     },
 }

--- a/resources/js/app/components/json-fields/string-list.vue
+++ b/resources/js/app/components/json-fields/string-list.vue
@@ -104,10 +104,11 @@ export default {
         updateList(event) {
             this.items = [];
             this.result = event?.target?.value || '';
-            const items = this.result.split(',') || [];
+            const items = this.result.split('|||') || [];
             for (let item of items) {
                 this.items.push({value: item});
             }
+            this.onChanged();
         },
     },
 }

--- a/resources/js/app/helpers/api-translation.js
+++ b/resources/js/app/helpers/api-translation.js
@@ -22,7 +22,13 @@ const methods = {
         const formData = new FormData();
         formData.append('from', from);
         formData.append('to', to);
-        formData.append('text', text);
+        if (Array.isArray(text)) {
+            for (let t of text) {
+                formData.append('text[]', t);
+            }
+        } else {
+            formData.append('text', text);
+        }
         const options = {
             method: 'POST',
             credentials: 'same-origin',

--- a/resources/js/app/pages/modules/view.js
+++ b/resources/js/app/pages/modules/view.js
@@ -212,6 +212,10 @@ export default {
                     if (!input) {
                         input = document.getElementById('translated-fields-' + object.field.replaceAll('_', '-'));
                     }
+                    if (Array.isArray(r.translation)) {
+                        // this to avoid "," could be problematic as separator for contents
+                        r.translation = r.translation.join('|||');
+                    }
                     input.value = r.translation;
                     input.dispatchEvent(new CustomEvent('change'));
                 });

--- a/resources/js/app/pages/modules/view.js
+++ b/resources/js/app/pages/modules/view.js
@@ -164,10 +164,13 @@ export default {
                     )
                 );
             } catch (error) {
-                alert(error);
-                console.log(error);
+                BEDITA.error(error);
             }
             el.classList.remove('is-loading-spinner');
+        },
+
+        isTranslatable(content) {
+            return content && content.length > 0;
         },
 
         translate(object, e) {
@@ -176,8 +179,7 @@ export default {
 
             this.fetchTranslation(object)
                 .catch((error) => {
-                    alert(error);
-                    console.log(error);
+                    BEDITA.error(error);
                 })
                 .finally(() => {
                     el.classList.remove('is-loading-spinner');
@@ -185,8 +187,10 @@ export default {
         },
 
         fetchTranslation(object) {
-            if (!object.content) {
-                return;
+            if (!object || !this.isTranslatable(object?.content)) {
+                // skip translation, content empty
+
+                return Promise.resolve();
             }
             if (!object.to) {
                 // use `value` from select on new translations
@@ -205,6 +209,9 @@ export default {
                     }
 
                     let input = this.$refs[object.field];
+                    if (!input) {
+                        input = document.getElementById('translated-fields-' + object.field.replaceAll('_', '-'));
+                    }
                     input.value = r.translation;
                     input.dispatchEvent(new CustomEvent('change'));
                 });

--- a/templates/Element/translation.twig
+++ b/templates/Element/translation.twig
@@ -87,7 +87,7 @@
                                 'from': object.attributes.lang,
                                 'to': translation.attributes.lang
                             } %}
-                            <button class="mt-05" @click.prevent="translate({{ translationParams|json_encode }}, $event)">
+                            <button class="mt-05" :disabled="!isTranslatable({{ object.attributes[key]|json_encode }})" @click.prevent="translate({{ translationParams|json_encode }}, $event)">
                                 <Icon icon="carbon:translate"></Icon>
                                 <span class="ml-05 has-text-size-smallest">{{ __('Auto-translate') }} {{ key }}</span>
                             </button>


### PR DESCRIPTION
This provides:

 - a fix in "auto-translate" of `string-list` components
 - some enhancements in translation page:
   - "empty" contents are not translatable, thus buttons are disabled
   - auto translate all skips empty contents with no errors
   - translation error is shown with modal `BEDITA.error` instead of javascript `alert`