### PR TITLE
Fix sidebar urls

### DIFF
--- a/templates/Pages/Modules/index.twig
+++ b/templates/Pages/Modules/index.twig
@@ -65,9 +65,13 @@
 
         {% if currentModule.sidebar.index %}
         {% for item in currentModule.sidebar.index %}
+            {% set url = item.url %}
+            {% if item.url is iterable %}
+                {% set url = Url.build(url) %}
+            {% endif %}
             {% do _view.append(
                 'app-module-buttons',
-                '<a href="' ~ item.url ~ '" class="' ~ item.class|default('button button-outlined button-outlined-hover-module-' ~ currentModule.name) ~ '"><Icon icon="carbon:save"></Icon><span class="ml-05">' ~ __(item.label) ~ '</span></a>',
+                '<a href="' ~ url ~ '" class="' ~ item.class|default('button button-outlined button-outlined-hover-module-' ~ currentModule.name) ~ '"><Icon icon="carbon:save"></Icon><span class="ml-05">' ~ __(item.label) ~ '</span></a>',
             ) %}
         {% endfor %}
         {% endif %}

--- a/templates/Pages/Modules/index.twig
+++ b/templates/Pages/Modules/index.twig
@@ -65,10 +65,7 @@
 
         {% if currentModule.sidebar.index %}
         {% for item in currentModule.sidebar.index %}
-            {% set url = item.url %}
-            {% if item.url is iterable %}
-                {% set url = Url.build(url) %}
-            {% endif %}
+            {% set url = item.url is iterable ? Url.build(url) : item.url %}
             {% do _view.append(
                 'app-module-buttons',
                 '<a href="' ~ url ~ '" class="' ~ item.class|default('button button-outlined button-outlined-hover-module-' ~ currentModule.name) ~ '"><Icon icon="carbon:save"></Icon><span class="ml-05">' ~ __(item.label) ~ '</span></a>',


### PR DESCRIPTION
This fixes a bug in sidebar urls when they are `objects` like `{'_name': ''the-route-name'}`.