### PR TITLE
Refactor: register component Icon in app.js

### DIFF
--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -557,3 +557,6 @@ const _vueInstance = new Vue({
 });
 
 window._vueInstance = _vueInstance;
+
+// use component everywhere in Manager
+Vue.component('Icon', Icon);

--- a/resources/js/app/components/category/category.js
+++ b/resources/js/app/components/category/category.js
@@ -1,4 +1,3 @@
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 import { error as showError } from 'app/components/dialog/dialog';
 
@@ -54,10 +53,6 @@ export default {
             </div>
         </form>
     `,
-
-    components: {
-        Icon,
-    },
 
     props: {
         source: Object,

--- a/resources/js/app/components/date-ranges-list/date-ranges-list.js
+++ b/resources/js/app/components/date-ranges-list/date-ranges-list.js
@@ -4,13 +4,7 @@
  *
  * <date-ranges-list> component used for ModulesPage -> Index
  */
-import { Icon } from '@iconify/vue2';
-
 export default {
-
-    components: {
-        Icon,
-    },
 
     data() {
         return {

--- a/resources/js/app/components/dialog/dialog.js
+++ b/resources/js/app/components/dialog/dialog.js
@@ -1,4 +1,3 @@
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 import Vue from 'vue';
 
@@ -54,10 +53,6 @@ export const Dialog = Vue.extend({
             </div>
         </transition>
     </div>`,
-
-    components: {
-        Icon,
-    },
 
     data() {
         return {

--- a/resources/js/app/components/drop-upload.js
+++ b/resources/js/app/components/drop-upload.js
@@ -6,7 +6,6 @@
  */
 
 import { FetchMixin } from 'app/mixins/fetch';
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 
 export default {
@@ -59,10 +58,6 @@ export default {
             </div>
         </div>
     `,
-
-    components: {
-        Icon,
-    },
 
     props: {
         placeholder: {

--- a/resources/js/app/components/filter-box.js
+++ b/resources/js/app/components/filter-box.js
@@ -19,7 +19,6 @@
 
 import { DEFAULT_PAGINATION, getDefaultFilter } from 'app/mixins/paginated-content';
 import merge from 'deepmerge';
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 import { warning } from 'app/components/dialog/dialog';
 
@@ -29,7 +28,6 @@ export default {
         CategoryPicker: () => import(/* webpackChunkName: "category-picker" */'app/components/category-picker/category-picker'),
         FolderPicker: () => import(/* webpackChunkName: "folder-picker" */'app/components/folder-picker/folder-picker'),
         TagPicker: () => import(/* webpackChunkName: "tag-picker" */'app/components/tag-picker/tag-picker'),
-        Icon,
     },
 
     props: {

--- a/resources/js/app/components/flash-message.vue
+++ b/resources/js/app/components/flash-message.vue
@@ -30,14 +30,10 @@
 </template>
 
 <script>
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 import { error, warning, info, success } from 'app/components/dialog/dialog';
 
 export default {
-    components: {
-        Icon,
-    },
 
     props: {
         level: {

--- a/resources/js/app/components/form-file-upload.js
+++ b/resources/js/app/components/form-file-upload.js
@@ -9,14 +9,7 @@
  * @prop {Array} labels
  * @prop {int} defaultActive index of the default active label in labels
  */
-
-import { Icon } from '@iconify/vue2';
-
 export default {
-
-    components: {
-        Icon,
-    },
 
     data() {
         return {

--- a/resources/js/app/components/horizontal-tab-view.js
+++ b/resources/js/app/components/horizontal-tab-view.js
@@ -10,13 +10,9 @@
  * @prop {int} defaultActive index of the default active label in labels
  *
  */
-
-import { Icon } from '@iconify/vue2';
-
 export default {
     components: {
         FormFileUpload: () => import(/* webpackChunkName: "form-file-upload" */'app/components/form-file-upload'),
-        Icon,
     },
 
     props: {

--- a/resources/js/app/components/index-cell/index-cell.js
+++ b/resources/js/app/components/index-cell/index-cell.js
@@ -1,4 +1,3 @@
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 
 export default {
@@ -11,10 +10,6 @@ export default {
         <div v-if="msg" v-text="msg" style="color: gray"></div>
     </div>
     `,
-
-    components: {
-        Icon,
-    },
 
     props: {
         settings: {},

--- a/resources/js/app/components/json-fields/string-list.vue
+++ b/resources/js/app/components/json-fields/string-list.vue
@@ -24,16 +24,11 @@
 </template>
 
 <script>
-import { Icon } from '@iconify/vue2';
 
 /**
  * <string-list> component to handle simple JSON array of strings
  */
 export default {
-
-    components: {
-        Icon,
-    },
 
     props: {
         value: String,

--- a/resources/js/app/components/locations-view/location-view.js
+++ b/resources/js/app/components/locations-view/location-view.js
@@ -1,4 +1,3 @@
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 
 const options = {
@@ -132,10 +131,6 @@ export default {
             </div>
         </div>
     </div>`,
-
-    components: {
-        Icon,
-    },
 
     props: {
         index: Number,

--- a/resources/js/app/components/login-password/login-password.js
+++ b/resources/js/app/components/login-password/login-password.js
@@ -1,4 +1,3 @@
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 
 export default {
@@ -27,10 +26,6 @@ export default {
         </div>
     </div>
     `,
-
-    components: {
-        Icon,
-    },
 
     data() {
         return {

--- a/resources/js/app/components/menu.js
+++ b/resources/js/app/components/menu.js
@@ -5,12 +5,8 @@
  * <menu> component
  *
  */
-import { Icon } from '@iconify/vue2';
-
 export default {
-    components: {
-        Icon,
-    },
+
     data() {
         return {
             popUpAction: '',

--- a/resources/js/app/components/object-nav/object-nav.vue
+++ b/resources/js/app/components/object-nav/object-nav.vue
@@ -19,13 +19,7 @@
 </template>
 
 <script>
-import { Icon } from '@iconify/vue2';
-
 export default {
-
-    components: {
-        Icon,
-    },
 
     props: {
         obj: {},

--- a/resources/js/app/components/panel-view.js
+++ b/resources/js/app/components/panel-view.js
@@ -22,16 +22,13 @@
 *
 */
 
-import { Icon } from '@iconify/vue2';
 import Vue from 'vue';
 
 /**
  * Event bus to communicate from/to PanelView
  */
 export const PanelEvents = new Vue({
-    components: {
-        Icon,
-    },
+
     methods: {
         /**
          * set listener for events and if "from" is set, it extract its _uid and use it to match the evant signature

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -12,8 +12,6 @@
  * @prop {String} label label of the property view
  *
  */
-import { Icon } from '@iconify/vue2';
-
 const API_URL = new URL(BEDITA.base).pathname;
 const API_OPTIONS = {
     credentials: 'same-origin',
@@ -39,7 +37,6 @@ export default {
         ObjectProperties: () => import(/* webpackChunkName: "string-list" */'app/components/object-property/object-properties'),
         ObjectPropertyAdd: () => import(/* webpackChunkName: "object-property-add" */'app/components/object-property/object-property-add'),
         Thumbnail:() => import(/* webpackChunkName: "thumbnail" */'app/components/thumbnail/thumbnail'),
-        Icon,
     },
 
     props: {

--- a/resources/js/app/components/relation-view/relation-view.js
+++ b/resources/js/app/components/relation-view/relation-view.js
@@ -16,7 +16,6 @@
  */
 
 import flatpickr from 'flatpickr';
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 
 import { PaginatedContentMixin } from 'app/mixins/paginated-content';
@@ -38,7 +37,6 @@ export default {
         DropUpload: () => import(/* webpackChunkName: "drop-upload" */'app/components/drop-upload'),
         LocationsView: () => import(/* webpackChunkName: "locations-view" */'app/components/locations-view/locations-view'),
         Thumbnail:() => import(/* webpackChunkName: "thumbnail" */'app/components/thumbnail/thumbnail'),
-        Icon,
     },
 
     props: {

--- a/resources/js/app/components/relation-view/relations-add.js
+++ b/resources/js/app/components/relation-view/relations-add.js
@@ -17,7 +17,6 @@ import { PaginatedContentMixin } from 'app/mixins/paginated-content';
 import { PanelEvents } from 'app/components/panel-view';
 import { DragdropMixin } from 'app/mixins/dragdrop';
 import { error as showError } from 'app/components/dialog/dialog';
-import { Icon } from '@iconify/vue2';
 import sleep from 'sleep-promise';
 import { t } from 'ttag';
 import { warning } from 'app/components/dialog/dialog';
@@ -36,7 +35,6 @@ export default {
 
     components: {
         FilterBoxView: () => import(/* webpackChunkName: "filter-box-view" */'app/components/filter-box'),
-        Icon,
     },
 
     props: {

--- a/resources/js/app/components/secret/secret.js
+++ b/resources/js/app/components/secret/secret.js
@@ -1,4 +1,3 @@
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 
 export default {
@@ -24,10 +23,6 @@ export default {
 
 
     </div>`,
-
-    components: {
-        Icon,
-    },
 
     props: {
         val: '',

--- a/resources/js/app/components/tag-form/tag-form.js
+++ b/resources/js/app/components/tag-form/tag-form.js
@@ -1,4 +1,3 @@
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 import { confirm, error as showError, info as showInfo } from 'app/components/dialog/dialog';
 
@@ -56,10 +55,6 @@ export default {
             </div>
         </form>
     `,
-
-    components: {
-        Icon,
-    },
 
     props: {
         cansave: Boolean,

--- a/resources/js/app/components/thumbnail/thumbnail.vue
+++ b/resources/js/app/components/thumbnail/thumbnail.vue
@@ -7,13 +7,8 @@
     </div>
 </template>
 <script>
-import { Icon } from '@iconify/vue2';
 
 export default {
-
-    components: {
-        Icon,
-    },
 
     props: {
         related: {

--- a/resources/js/app/pages/admin/appearance.js
+++ b/resources/js/app/pages/admin/appearance.js
@@ -1,9 +1,4 @@
-import { Icon } from '@iconify/vue2';
-
 export default {
-    components: {
-        Icon,
-    },
     props: {
         configkey: {
             type: String,

--- a/resources/js/app/pages/admin/index.js
+++ b/resources/js/app/pages/admin/index.js
@@ -6,12 +6,10 @@
  */
 
 import { confirm } from 'app/components/dialog/dialog';
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 
 export default {
     components: {
-        Icon,
         PropertyView: () => import(/* webpackChunkName: "property-view" */'app/components/property-view/property-view'),
         Secret: () => import(/* webpackChunkName: "secret" */'app/components/secret/secret'),
     },

--- a/resources/js/app/pages/dashboard/index.js
+++ b/resources/js/app/pages/dashboard/index.js
@@ -5,13 +5,7 @@
  * <dashboard> component used for Dashboard -> Index
  *
  */
-import { Icon } from '@iconify/vue2';
-
 export default {
-
-    components: {
-        Icon,
-    },
 
     props: {
         q: {

--- a/resources/js/app/pages/import/index.js
+++ b/resources/js/app/pages/import/index.js
@@ -5,13 +5,7 @@
  * <import-view> component
  */
 
-import { Icon } from '@iconify/vue2';
-
 export default {
-
-    components: {
-        Icon,
-    },
 
     props: {
         jobs: {

--- a/resources/js/app/pages/model/index.js
+++ b/resources/js/app/pages/model/index.js
@@ -9,7 +9,6 @@
 
 import ModulesIndex from 'app/pages/modules/index';
 import { confirm, error as showError} from 'app/components/dialog/dialog';
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 
 export default {
@@ -18,7 +17,6 @@ export default {
     components: {
         AutosizeTextarea: () => import(/* webpackChunkName: "autosize-textarea" */'app/components/autosize-textarea'),
         TagForm: () => import(/* webpackChunkName: "tag-form" */'app/components/tag-form/tag-form'),
-        Icon,
     },
 
     props: {

--- a/resources/js/app/pages/modules/index.js
+++ b/resources/js/app/pages/modules/index.js
@@ -6,7 +6,6 @@
  *
  */
 import { confirm } from 'app/components/dialog/dialog';
-import { Icon } from '@iconify/vue2';
 import { t } from 'ttag';
 
 export default {
@@ -18,7 +17,6 @@ export default {
         TreeView: () => import(/* webpackChunkName: "tree-view" */'app/components/tree-view/tree-view'),
         FilterBoxView: () => import(/* webpackChunkName: "tree-view" */'app/components/filter-box'),
         IndexCell: () => import(/* webpackChunkName: "index-cell" */'app/components/index-cell/index-cell'),
-        Icon,
     },
 
     /**

--- a/resources/js/app/pages/modules/view.js
+++ b/resources/js/app/pages/modules/view.js
@@ -1,6 +1,5 @@
 import { AjaxLogin } from '../../components/ajax-login/ajax-login.js';
 import Vue from 'vue';
-import { Icon } from '@iconify/vue2';
 
 /**
  * Templates that uses this component (directly or indirectly):
@@ -22,7 +21,6 @@ export default {
         ObjectTypesList: () => import(/* webpackChunkName: "object-types-list" */'app/components/object-types-list/object-types-list'),
         KeyValueList: () => import(/* webpackChunkName: "key-value-list" */'app/components/json-fields/key-value-list'),
         StringList: () => import(/* webpackChunkName: "string-list" */'app/components/json-fields/string-list'),
-        Icon,
     },
 
     props: {


### PR DESCRIPTION
This provides a refactor to have `Icon` component available in all twig, vue and js files (manager plugins included), without the need to import it every time. This is done by registering component `Icon` in app.js with `Vue.component('Icon', Icon);`