### PR TITLE
Show object title, module name and project name in `<title>`

### DIFF
--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -107,7 +107,7 @@ class LayoutHelper extends Helper
         $title = '';
         if (!empty($currentModule) && !empty($currentModule['name'])) {
             $currentModuleName = $currentModule['name'];
-            if (!empty($object) && !empty($object['attributes']['title'])) {
+            if (Hash::check($object, 'attributes.title')) {
                 $title = $object['attributes']['title'] . ' | ';
             }
             $title = $title . $currentModuleName;

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -96,6 +96,27 @@ class LayoutHelper extends Helper
     }
 
     /**
+     * Return title with object title and current module name
+     *
+     * @return string title with object title and current module name separated by '|'
+     */
+    public function title(): string
+    {
+        $currentModule = (array)$this->getView()->get('currentModule');
+        $object = (array)$this->getView()->get('object');
+        $title = '';
+        if (!empty($currentModule) && !empty($currentModule['name'])) {
+            $currentModuleName = $currentModule['name'];
+            if (!empty($object) && !empty($object['attributes']['title'])) {
+                $title = $object['attributes']['title'] . ' | ';
+            }
+            $title = $title . $currentModuleName;
+        }
+
+        return $title;
+    }
+
+    /**
      * Module main link
      *
      * @return string The link

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -102,18 +102,12 @@ class LayoutHelper extends Helper
      */
     public function title(): string
     {
-        $currentModule = (array)$this->getView()->get('currentModule');
+        $module = (array)$this->getView()->get('currentModule');
+        $name = (string)Hash::get($module, 'name');
         $object = (array)$this->getView()->get('object');
-        $title = '';
-        if (!empty($currentModule) && !empty($currentModule['name'])) {
-            $currentModuleName = $currentModule['name'];
-            if (Hash::check($object, 'attributes.title')) {
-                $title = $object['attributes']['title'] . ' | ';
-            }
-            $title = $title . $currentModuleName;
-        }
+        $title = (string)Hash::get($object, 'attributes.title');
 
-        return $title;
+        return empty($title) ? $name : sprintf('%s | %s', $title, $name);
     }
 
     /**

--- a/templates/Pages/Modules/view.twig
+++ b/templates/Pages/Modules/view.twig
@@ -1,4 +1,4 @@
-{% do _view.assign('title', currentModule.name|humanize) %}
+{% do _view.assign('title', Layout.title()) %}
 
 <modules-view inline-template ref="moduleView" :object="{{ object|json_encode }}">
     <div class="modules-view">

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -253,7 +253,7 @@ class LayoutHelperTest extends TestCase
      * @dataProvider titleProvider()
      * @covers ::title()
      */
-    public function testTitle($expected, $name, array $viewVars = []): void
+    public function testTitle(string $expected, string $name, array $viewVars = []): void
     {
         $request = $response = $events = null;
         $data = ['name' => $name];

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -198,6 +198,75 @@ class LayoutHelperTest extends TestCase
     }
 
     /**
+     * Data provider for `testTitle` test case.
+     *
+     * @return array
+     */
+    public function titleProvider(): array
+    {
+        return [
+            'empty' => [
+                '',
+                'Module',
+                [],
+            ],
+            'only module' => [
+                'objects',
+                'Module',
+                [
+                    'currentModule' => ['name' => 'objects'],
+                ],
+            ],
+            'objects' => [
+                'Object title | objects',
+                'Module',
+                [
+                    'object' => [
+                        'attributes' => [
+                            'title' => 'Object title',
+                        ],
+                    ],
+                    'currentModule' => ['name' => 'objects'],
+                ],
+            ],
+            'video' => [
+                'Video title | video',
+                'Module',
+                [
+                    'object' => [
+                        'attributes' => [
+                            'title' => 'Video title',
+                        ],
+                    ],
+                    'currentModule' => ['name' => 'video'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `title` method
+     *
+     * @param string $expected The expected title
+     * @param string $name The view name
+     * @param array $viewVars The view vars
+     * @dataProvider titleProvider()
+     * @covers ::title()
+     */
+    public function testTitle($expected, $name, array $viewVars = []): void
+    {
+        $request = $response = $events = null;
+        $data = ['name' => $name];
+        $view = new View($request, $response, $events, $data);
+        foreach ($viewVars as $key => $value) {
+            $view->set($key, $value);
+        }
+        $layout = new LayoutHelper($view);
+        $result = $layout->title();
+        static::assertSame($expected, $result);
+    }
+
+    /**
      * Data provider for `testCustomElement` test case.
      *
      * @return array


### PR DESCRIPTION
This provides an update in pages `<title>`, introducing a new function `LayoutHelper::title`.
When `$object['attributes']['title']` is available, title starts with it.

Ref: https://chialab.atlassian.net/browse/ZEB-12