### PR TITLE
Fix tree-view defaults

### DIFF
--- a/resources/js/app/components/tree-view/tree-view.vue
+++ b/resources/js/app/components/tree-view/tree-view.vue
@@ -97,7 +97,7 @@ export default {
         },
         parent: {
             type: Object,
-            default: () => ({}),
+            default: null,
         },
         parents: {
             type: Array,
@@ -114,7 +114,7 @@ export default {
         },
         object: {
             type: Object,
-            default: () => ({}),
+            default: null,
         },
         relationName: {
             type: String,


### PR DESCRIPTION
This fixes a problem in `tree-view`component rendering, when `parent` and `object` props are `{}`.