### PR TITLE
ElementHelper for special template paths

### DIFF
--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -68,6 +68,7 @@ class AppView extends TwigView
         $this->loadHelper('Calendar');
         $this->loadHelper('Categories');
         $this->loadHelper('Editors');
+        $this->loadHelper('Element');
         $this->loadHelper('Layout');
         $this->loadHelper('Array');
         $this->loadHelper('Html');

--- a/src/View/Helper/ElementHelper.php
+++ b/src/View/Helper/ElementHelper.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace App\View\Helper;
+
+use Cake\Core\Configure;
+use Cake\Utility\Hash;
+use Cake\View\Helper;
+
+/**
+ * Element helper
+ */
+class ElementHelper extends Helper
+{
+    /**
+     * Return categories element via `Modules.<type>.categories._element` configuration
+     *
+     * @return string
+     */
+    public function categories(): string
+    {
+        $currentModule = (array)$this->getView()->get('currentModule');
+        $name = (string)Hash::get($currentModule, 'name');
+        $path = sprintf('Modules.%s.categories._element', $name);
+
+        return Configure::read($path, 'Modules/categories');
+    }
+
+    /**
+     * Return custom element via `Properties` configuration for
+     * a relation or property group in current module.
+     *
+     * @param string $item Relation or group name
+     * @param string $type Item type: `relation` or `group`
+     * @return string
+     */
+    public function custom(string $item, string $type = 'relation'): string
+    {
+        $currentModule = (array)$this->getView()->get('currentModule');
+        $name = (string)Hash::get($currentModule, 'name');
+        if ($type === 'relation') {
+            $path = sprintf('Properties.%s.relations._element.%s', $name, $item);
+        } else {
+            $path = sprintf('Properties.%s.view.%s._element', $name, $item);
+        }
+
+        return (string)Configure::read($path);
+    }
+
+    /**
+     * Return sidebar element via `Modules.<type>.sidebar._element` configuration
+     *
+     * @return string
+     */
+    public function sidebar(): string
+    {
+        $currentModule = (array)$this->getView()->get('currentModule');
+        $name = (string)Hash::get($currentModule, 'name');
+        $path = sprintf('Modules.%s.sidebar._element', $name);
+
+        return Configure::read($path, 'Modules/sidebar');
+    }
+}

--- a/src/View/Helper/ElementHelper.php
+++ b/src/View/Helper/ElementHelper.php
@@ -23,7 +23,7 @@ class ElementHelper extends Helper
         $name = (string)Hash::get($currentModule, 'name');
         $path = sprintf('Modules.%s.categories._element', $name);
 
-        return Configure::read($path, 'Modules/categories');
+        return (string)Configure::read($path, 'Modules/categories');
     }
 
     /**
@@ -58,6 +58,6 @@ class ElementHelper extends Helper
         $name = (string)Hash::get($currentModule, 'name');
         $path = sprintf('Modules.%s.sidebar._element', $name);
 
-        return Configure::read($path, 'Modules/sidebar');
+        return (string)Configure::read($path, 'Modules/sidebar');
     }
 }

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -13,7 +13,6 @@
 namespace App\View\Helper;
 
 use App\Utility\Translate;
-use Cake\Core\Configure;
 use Cake\Utility\Hash;
 use Cake\View\Helper;
 

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -169,27 +169,6 @@ class LayoutHelper extends Helper
     }
 
     /**
-     * Return custom element via `Properties` configuration for
-     * a relation or property group in current module.
-     *
-     * @param string $item Relation or group name
-     * @param string $type Item type: `relation` or `group`
-     * @return string
-     */
-    public function customElement(string $item, string $type = 'relation'): string
-    {
-        $currentModule = (array)$this->getView()->get('currentModule');
-        $name = (string)Hash::get($currentModule, 'name');
-        if ($type === 'relation') {
-            $path = sprintf('Properties.%s.relations._element.%s', $name, $item);
-        } else {
-            $path = sprintf('Properties.%s.view.%s._element', $name, $item);
-        }
-
-        return (string)Configure::read($path);
-    }
-
-    /**
      * Get translated val by input string, using plugins (if any) translations.
      *
      * @param string $input The input string

--- a/templates/Element/Form/group_properties.twig
+++ b/templates/Element/Form/group_properties.twig
@@ -1,5 +1,5 @@
 
-    {% set customElement = Layout.customElement(group, 'group') %}
+    {% set customElement = Element.custom(group, 'group') %}
     {% if customElement %}
         {{ element(customElement, {'properties' : properties}) }}
     {% else %}

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -14,7 +14,7 @@
         {# Lookup in properties configuration if a custom element for this relation is set
         in `Properties.{moduleName}.relations._element.{relationName}`.
         Then load custom element or use default relation view #}
-        {% set customElement = Layout.customElement(relationName) %}
+        {% set customElement = Element.custom(relationName) %}
         {% if customElement %}
             {{ element(customElement, {
                 'relationName': relationName,

--- a/templates/Element/Form/roles.twig
+++ b/templates/Element/Form/roles.twig
@@ -1,6 +1,6 @@
 {% set relationName = 'roles' %}
 
-{% set customElement = Layout.customElement(relationName) %}
+{% set customElement = Element.custom(relationName) %}
 {% if customElement %}
    {{ element(customElement) }}
 {% else %}

--- a/templates/Element/Modules/sidebar.twig
+++ b/templates/Element/Modules/sidebar.twig
@@ -1,0 +1,24 @@
+{# commands to append in side bar (commands menu) #}
+{% if Perms.canCreate() %}
+    {% do _view.append(
+        'app-module-buttons',
+        '<a href="' ~ Url.build({'_name': 'modules:create', 'object_type': objectType}) ~ '" class="button button-primary button-primary-hover-module-' ~ currentModule.name ~ '"><Icon icon="carbon:add"></Icon><span class="ml-05">' ~ __('Create') ~ '</span></a>'
+    ) %}
+{% endif %}
+
+{% if schema.properties.categories %}
+    {% do _view.append(
+        'app-module-buttons',
+        '<a href="' ~ Url.build({'_name': 'modules:categories:index', 'object_type': objectType}) ~ '" class="button button-outlined button-outlined-module-' ~ currentModule.name ~ '"><Icon icon="carbon:categories"></Icon><span class="ml-05">' ~ __('Categories') ~ '</span></a>'
+    ) %}
+{% endif %}
+
+{% if currentModule.sidebar.index %}
+{% for item in currentModule.sidebar.index %}
+    {% set url = item.url is iterable ? Url.build(item.url) : item.url %}
+    {% do _view.append(
+        'app-module-buttons',
+        '<a href="' ~ url ~ '" class="' ~ item.class|default('button button-outlined button-outlined-hover-module-' ~ currentModule.name) ~ '"><Icon icon="carbon:save"></Icon><span class="ml-05">' ~ __(item.label) ~ '</span></a>',
+    ) %}
+{% endfor %}
+{% endif %}

--- a/templates/Pages/Modules/index.twig
+++ b/templates/Pages/Modules/index.twig
@@ -50,30 +50,7 @@
             </div>
         {% endif %}
 
-        {# commands to append in side bar (commands menu) #}
-        {% if Perms.canCreate() %}
-            {% do _view.append(
-                'app-module-buttons',
-                '<a href="' ~ Url.build({'_name': 'modules:create', 'object_type': objectType}) ~ '" class="button button-primary button-primary-hover-module-' ~ currentModule.name ~ '"><Icon icon="carbon:add"></Icon><span class="ml-05">' ~ __('Create') ~ '</span></a>'
-            ) %}
-        {% endif %}
-
-        {% if schema.properties.categories %}
-            {% do _view.append(
-                'app-module-buttons',
-                '<a href="' ~ Url.build({'_name': 'modules:categories:index', 'object_type': objectType}) ~ '" class="button button-outlined button-outlined-module-' ~ currentModule.name ~ '"><Icon icon="carbon:categories"></Icon><span class="ml-05">' ~ __('Categories') ~ '</span></a>'
-            ) %}
-        {% endif %}
-
-        {% if currentModule.sidebar.index %}
-        {% for item in currentModule.sidebar.index %}
-            {% set url = item.url is iterable ? Url.build(item.url) : item.url %}
-            {% do _view.append(
-                'app-module-buttons',
-                '<a href="' ~ url ~ '" class="' ~ item.class|default('button button-outlined button-outlined-hover-module-' ~ currentModule.name) ~ '"><Icon icon="carbon:save"></Icon><span class="ml-05">' ~ __(item.label) ~ '</span></a>',
-            ) %}
-        {% endfor %}
-        {% endif %}
+        {{ element(Element.sidebar()) }}
 
     </div> {# end module-content #}
 </modules-index>

--- a/templates/Pages/Modules/view.twig
+++ b/templates/Pages/Modules/view.twig
@@ -52,7 +52,7 @@
                 {# calendar using `date_ranges` #}
                 {{ element('Form/calendar') }}
 
-                {{ element('Form/categories') }}
+                {{ element(Element.categories()) }}
 
                 {{ element('Form/tags') }}
 

--- a/tests/TestCase/View/Helper/ElementHelperTest.php
+++ b/tests/TestCase/View/Helper/ElementHelperTest.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\ElementHelper;
+use Cake\Core\Configure;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+/**
+ * {@see \App\View\Helper\ElementHelper} Test Case
+ *
+ * @coversDefaultClass \App\View\Helper\ElementHelper
+ */
+class ElementHelperTest extends TestCase
+{
+    /**
+     * Test `categories` method
+     *
+     * @return void
+     * @covers ::categories()
+     */
+    public function testCategories(): void
+    {
+        $expected = 'Modules/categories';
+        $viewVars = [
+            'currentModule' => ['name' => 'documents'],
+        ];
+        $view = new View(new ServerRequest(), null, null, compact('viewVars'));
+        $element = new ElementHelper($view);
+        $actual = $element->categories();
+        static::assertSame($expected, $actual);
+
+        Configure::write('Modules.documents.categories._element', 'another_categories');
+        $actual = $element->categories();
+        static::assertSame('another_categories', $actual);
+    }
+
+    /**
+     * Data provider for `testCustom` test case.
+     *
+     * @return array
+     */
+    public function customProvider(): array
+    {
+        return [
+            'empty' => [
+                '',
+                'test',
+            ],
+            'empty relation' => [
+                'empty',
+                'my_relation',
+                'relation',
+                [
+                    'relations' => [
+                        '_element' => [
+                            'my_relation' => 'empty',
+                        ],
+                    ],
+                ],
+            ],
+            'my_element' => [
+                'MyPlugin.my_element',
+                'my_group',
+                'group',
+                [
+                    'view' => [
+                        'my_group' => ['_element' => 'MyPlugin.my_element'],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `element` method
+     *
+     * @param string $expected The expected element
+     * @param string $item The item
+     * @param string $type The item type
+     * @param array $conf Configuration to use
+     * @return void
+     * @dataProvider customProvider()
+     * @covers ::element()
+     */
+    public function testCustom(string $expected, string $item, string $type = 'relation', array $conf = []): void
+    {
+        Configure::write('Properties.documents', $conf);
+        $view = new View();
+        $view->set('currentModule', ['name' => 'documents']);
+        $element = new ElementHelper($view);
+        $result = $element->custom($item, $type);
+        static::assertSame($expected, $result);
+    }
+
+    /**
+     * Test `sidebar` method
+     *
+     * @return void
+     * @covers ::sidebar()
+     */
+    public function testSidebar(): void
+    {
+        $expected = 'Modules/sidebar';
+        $viewVars = [
+            'currentModule' => ['name' => 'documents'],
+        ];
+        $view = new View(new ServerRequest(), null, null, compact('viewVars'));
+        $element = new ElementHelper($view);
+        $actual = $element->sidebar();
+        static::assertSame($expected, $actual);
+
+        Configure::write('Modules.documents.sidebar._element', 'another_sidebar');
+        $actual = $element->sidebar();
+        static::assertSame('another_sidebar', $actual);
+    }
+}

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -267,65 +267,6 @@ class LayoutHelperTest extends TestCase
     }
 
     /**
-     * Data provider for `testCustomElement` test case.
-     *
-     * @return array
-     */
-    public function customElementProvider(): array
-    {
-        return [
-            'empty' => [
-                '',
-                'test',
-            ],
-            'empty relation' => [
-                'empty',
-                'my_relation',
-                'relation',
-                [
-                    'relations' => [
-                        '_element' => [
-                            'my_relation' => 'empty',
-                        ],
-                    ],
-                ],
-            ],
-            'my_element' => [
-                'MyPlugin.my_element',
-                'my_group',
-                'group',
-                [
-                    'view' => [
-                        'my_group' => ['_element' => 'MyPlugin.my_element'],
-                    ],
-                ],
-            ],
-        ];
-    }
-
-    /**
-     * Test `customElement` method
-     *
-     * @param string $expected The expected element
-     * @param string $item The item
-     * @param string $type The item type
-     * @param array $conf Configuration to use
-     * @return void
-     * @dataProvider customElementProvider()
-     * @covers ::customElement()
-     */
-    public function testCustomElement(string $expected, string $item, string $type = 'relation', array $conf = []): void
-    {
-        Configure::write('Properties.documents', $conf);
-        $view = new View();
-        $view->set('currentModule', ['name' => 'documents']);
-        $layout = new LayoutHelper($view);
-
-        $result = $layout->customElement($item, $type);
-        static::assertSame($expected, $result);
-    }
-
-    /**
      * Test `tr` method
      *
      * @return void


### PR DESCRIPTION
This introduces a new helper `ElementHelper` to provide elements paths:

 - `Element::custom(string $item, string $type = 'relation')` / custom views for properties (i.e.: `Properties.<type>.relations._element.<property>` or `Properties.<type>.view.<group>._element`)
 - `Element::categories()` / categories template (i.e. `Modules.<type>.categories._element`, default `Modules/categories`)
 - `Element::sidebar()` / sidebar template (i.e. `Modules.<type>.sidebar._element`, default `Modules/sidebar`)

The refactor involved: move `LayoutHelper.customElement` logic to `ElementHelper.custom`.

You can customize a module `categories` or `sidebar` template as in the following example:
```json
"locations": {
    "categories": {
        "_element": "Modules/locations_categories"
    },
    "sidebar": {
        "_element": "Modules/locations_sidebar"
    }
}
```