### PR TITLE
Field info if admin

### DIFF
--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -12,6 +12,7 @@ import { confirm, error, info, prompt, warning } from 'app/components/dialog/dia
 
 import datepicker from 'app/directives/datepicker';
 import email from 'app/directives/email';
+import fieldinfo from 'app/directives/fieldinfo';
 import jsoneditor from 'app/directives/jsoneditor';
 import richeditor from 'app/directives/richeditor';
 import uri from 'app/directives/uri';
@@ -117,6 +118,7 @@ const _vueInstance = new Vue({
         Vue.use(datepicker);
         Vue.use(richeditor);
         Vue.use(email);
+        Vue.use(fieldinfo);
         Vue.use(uri);
 
         // Register helpers

--- a/resources/js/app/components/field-info.vue
+++ b/resources/js/app/components/field-info.vue
@@ -1,0 +1,37 @@
+<script>
+
+export default {
+
+    props: {
+        attrs: {
+            type: Object,
+            required: true,
+        },
+        el: {
+            type: HTMLInputElement,
+        },
+    },
+
+    async mounted() {
+        const child = document.createElement('code');
+        child.classList.add('mt-05')
+        child.textContent = 'i';
+        child.setAttribute('title', JSON.stringify(this.attrs));
+        this.el.parentElement.appendChild(child);
+    },
+
+}
+</script>
+<style>
+code {
+    display: block;
+    border: dotted yellow 1px;
+    background-color: black;
+    color: yellow;
+    text-align: center;
+    height: 16px;
+    width: 18px;
+    line-height: normal;
+    font-size: small;
+}
+</style>

--- a/resources/js/app/directives/fieldinfo.vue
+++ b/resources/js/app/directives/fieldinfo.vue
@@ -1,0 +1,25 @@
+<script>
+export default {
+    install(Vue) {
+        Vue.directive('fieldinfo', {
+            inserted (el, binding, vnode) {
+                const attrs = vnode.data && vnode.data.attrs;
+                console.log(vnode);
+                console.log(attrs);
+                import(/* webpackChunkName: "field-info" */'app/components/field-info')
+                    .then(module => module.default)
+                    .then((component) => {
+                        const Constructor = Vue.extend(component);
+                        const vm = new Constructor({
+                            propsData: {
+                                attrs,
+                                el,
+                            }
+                        });
+                        vm.$mount();
+                    });
+            },
+        });
+    }
+}
+</script>

--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -23,6 +23,7 @@ use Cake\View\Helper;
  * Helper class to generate properties html
  *
  * @property \App\View\Helper\SchemaHelper $Schema The schema helper
+ * @property \App\View\Helper\PermsHelper $Perms The perms helper
  * @property \Cake\View\Helper\FormHelper $Form The form helper
  */
 class PropertyHelper extends Helper
@@ -32,7 +33,7 @@ class PropertyHelper extends Helper
      *
      * @var array
      */
-    public $helpers = ['Form', 'Schema'];
+    public $helpers = ['Form', 'Perms', 'Schema'];
 
     /**
      * Special paths to retrieve properties from related resources
@@ -72,6 +73,9 @@ class PropertyHelper extends Helper
         $forceReadonly = !empty(Hash::get($options, 'readonly'));
         $controlOptions = $this->Schema->controlOptions($name, $value, $this->schema($name, $type));
         $controlOptions['label'] = $this->fieldLabel($name, $type);
+        if ($this->Perms->userIsAdmin()) {
+            $controlOptions['v-fieldinfo'] = true;
+        }
         $readonly = Hash::get($controlOptions, 'readonly') || $forceReadonly;
         if ($readonly === true && array_key_exists('html', $controlOptions)) {
             $controlOptions['html'] = str_replace('readonly="false"', 'readonly="true"', $controlOptions['html']);

--- a/tests/TestCase/Controller/Component/HistoryComponentTest.php
+++ b/tests/TestCase/Controller/Component/HistoryComponentTest.php
@@ -4,6 +4,7 @@ namespace App\Test\TestCase\Controller\Component;
 use App\Controller\Component\HistoryComponent;
 use App\Controller\Component\SchemaComponent;
 use App\Test\TestCase\Controller\AppControllerTest;
+use Authentication\Identity;
 use BEdita\SDK\BEditaClient;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Controller\Controller;
@@ -82,6 +83,7 @@ class HistoryComponentTest extends TestCase
             'title' => 'test history controller',
         ]);
         $this->documentId = Hash::get($response, 'data.id');
+        $this->HistoryComponent->Schema->getView()->set('user', new Identity([]));
     }
 
     /**

--- a/tests/TestCase/View/Helper/AdminHelperTest.php
+++ b/tests/TestCase/View/Helper/AdminHelperTest.php
@@ -14,6 +14,7 @@
 namespace App\Test\TestCase\View\Helper;
 
 use App\View\Helper\AdminHelper;
+use Authentication\Identity;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
 
@@ -105,6 +106,7 @@ class AdminHelperTest extends TestCase
     {
         $view = new View(null, null, null, []);
         $view->set('applications', ['' => __('No application'), 1 => 'Dummy app', 2 => 'Another dummy app']);
+        $view->set('user', new Identity([]));
         $helper = new AdminHelper($view);
         $actual = $helper->control($type, $property, $value);
         static::assertEquals($expected, $actual);

--- a/tests/TestCase/View/Helper/CategoriesHelperTest.php
+++ b/tests/TestCase/View/Helper/CategoriesHelperTest.php
@@ -13,6 +13,7 @@
 namespace App\Test\TestCase\View\Helper;
 
 use App\View\Helper\CategoriesHelper;
+use Authentication\Identity;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
 
@@ -109,6 +110,7 @@ class CategoriesHelperTest extends TestCase
     {
         $view = new View(null, null, null, []);
         $view->set('schema', $schema);
+        $view->set('user', new Identity([]));
         $this->Categories = new CategoriesHelper($view);
         $actual = $this->Categories->control($name, $value);
         static::assertEquals($expected, $actual);

--- a/tests/TestCase/View/Helper/PropertyHelperTest.php
+++ b/tests/TestCase/View/Helper/PropertyHelperTest.php
@@ -15,6 +15,7 @@ namespace App\Test\TestCase\View\Helper;
 
 use App\Form\Control;
 use App\View\Helper\PropertyHelper;
+use Authentication\Identity;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
@@ -200,6 +201,7 @@ class PropertyHelperTest extends TestCase
         }
         $view->set('schema', $schema);
         $view->set('objectType', 'dummies');
+        $view->set('user', new Identity([]));
         $property = new PropertyHelper($view);
         $actual = $property->control($key, $value, $options);
         static::assertEquals($expected, $actual);
@@ -315,6 +317,7 @@ class PropertyHelperTest extends TestCase
         $view->set('schema', $schema);
         $view->set('schemasByType', $schemasByType);
         $view->set('objectType', 'dummies');
+        $view->set('user', new Identity([]));
         $property = new PropertyHelper($view);
         $actual = $property->control($key, $value, $options, $type);
         static::assertEquals($expected, $actual);
@@ -451,6 +454,7 @@ class PropertyHelperTest extends TestCase
     public function testFastCreateFields(): void
     {
         $view = new View(null, null, null, []);
+        $view->set('user', new Identity([]));
         $helper = new PropertyHelper($view);
         Configure::write('Properties.documents.fastCreate', [
             'required' => ['status'],
@@ -493,6 +497,7 @@ class PropertyHelperTest extends TestCase
     public function testDateRange(): void
     {
         $view = new View(null, null, null, []);
+        $view->set('user', new Identity([]));
         $helper = new PropertyHelper($view);
         $actual = $helper->dateRange('dummy', []);
         $expected = '<div class="date-ranges-item mb-1"><div><div class="input text"><label for="start_date_0">From</label><input type="text" name="date_ranges[0][start_date]" id="start_date_0" v-datepicker="true" date="true" time="true" daterange="true" value=""/></div><div class="input text"><label for="end_date_0">To</label><input type="text" name="date_ranges[0][end_date]" id="end_date_0" v-datepicker="true" date="true" time="true" daterange="true" value=""/></div><div class="input checkbox"><input type="hidden" name="date_ranges[0][params][all_day]" value="0"/><label for="all_day_0"><input type="checkbox" name="date_ranges[0][params][all_day]" value="" id="all_day_0" checked="checked">All Day</label></div></div></div>';

--- a/tests/TestCase/View/Helper/PropertyHelperTest.php
+++ b/tests/TestCase/View/Helper/PropertyHelperTest.php
@@ -211,6 +211,40 @@ class PropertyHelperTest extends TestCase
     }
 
     /**
+     * Test `control` method when user is admin
+     *
+     * @return void
+     * @covers ::control()
+     */
+    public function testControlUserAdmin(): void
+    {
+        $key = 'status';
+        $value = 'draft';
+        $options = [];
+        $schema = [
+            'type' => 'string',
+            'enum' => [
+                'on',
+                'off',
+                'draft',
+            ],
+            '$id' => '/properties/status',
+            'title' => 'Status',
+            'description' => 'object status: on, draft, off',
+            'default' => 'draft',
+        ];
+        $expected = '<div class="input radio"><label>Status</label><input type="hidden" name="status" id="status" value=""/><label for="status-on"><input type="radio" name="status" value="on" id="status-on" v-fieldinfo="1">On</label><label for="status-draft"><input type="radio" name="status" value="draft" id="status-draft" checked="checked" v-fieldinfo="1">Draft</label><label for="status-off"><input type="radio" name="status" value="off" id="status-off" v-fieldinfo="1">Off</label></div>';
+        $view = new View(null, null, null, []);
+        $schema = ['properties' => [$key => $schema]];
+        $view->set('schema', $schema);
+        $view->set('objectType', 'dummies');
+        $view->set('user', new Identity(['roles' => ['admin']]));
+        $property = new PropertyHelper($view);
+        $actual = $property->control($key, $value, $options);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
      * Data provider for `testSchema` test case.
      *
      * @return array


### PR DESCRIPTION
This adds extra info in module view form fields, when user has role `admin`.

The info consists of json used to build the field, shown as tooltip when mouse is over the `i` box close to the field.

An example: 
![image](https://user-images.githubusercontent.com/2227145/234546609-59e01645-95fb-4447-a471-513b295fb869.png)
