### PR TITLE
Clone streams when cloning media objects

### DIFF
--- a/config/bedita-api-version.ini
+++ b/config/bedita-api-version.ini
@@ -1,3 +1,3 @@
 [BEditaAPI]
-versions[]=4.9.5
-versions[]=5.5.7
+versions[]=4.12.0
+versions[]=5.9.0

--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -124,7 +124,7 @@ class CloneComponent extends Component
     }
 
     /**
-     * Clone stream if schema has Streams in associations.
+     * Clone stream if schema has Streams in associations and source object has a related stream.
      * Return media ID, or null.
      *
      * @param array $schema The object schema

--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -135,6 +135,7 @@ class CloneComponent extends Component
         $filename = basename($filepath);
         $response = $this->apiClient->post(sprintf('/streams/clone/%s', $filename), $filepath);
         $streamId = (string)Hash::get($response, 'data.id');
+        $data = compact('type');
         $response = $this->apiClient->createMediaFromStream($streamId, $type, compact('data'));
 
         return (string)Hash::get($response, 'data.id');

--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -124,16 +124,15 @@ class CloneComponent extends Component
     }
 
     /**
-     * Clone stream for object type and filepath, return new media ID
+     * Clone stream for object type and stream ID, return new media ID
      *
      * @param string $type The object type
-     * @param string $filepath The file path
+     * @param string $uuid The stream ID
      * @return string The media ID
      */
-    public function stream(string $type, string $filepath): string
+    public function stream(string $type, string $uuid): string
     {
-        $filename = basename($filepath);
-        $response = $this->apiClient->post(sprintf('/streams/clone/%s', $filename), $filepath);
+        $response = $this->apiClient->post(sprintf('/streams/clone/%s', $uuid), '');
         $streamId = (string)Hash::get($response, 'data.id');
         $data = compact('type');
         $response = $this->apiClient->createMediaFromStream($streamId, $type, compact('data'));

--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -122,4 +122,21 @@ class CloneComponent extends Component
 
         return true;
     }
+
+    /**
+     * Clone stream for object type and filepath, return new media ID
+     *
+     * @param string $type The object type
+     * @param string $filepath The file path
+     * @return string The media ID
+     */
+    public function stream(string $type, string $filepath): string
+    {
+        $filename = basename($filepath);
+        $response = $this->apiClient->post(sprintf('/streams/clone/%s', $filename), $filepath);
+        $streamId = (string)Hash::get($response, 'data.id');
+        $response = $this->apiClient->createMediaFromStream($streamId, $type, compact('data'));
+
+        return (string)Hash::get($response, 'data.id');
+    }
 }

--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -141,7 +141,7 @@ class CloneComponent extends Component
         $uuid = (string)Hash::get($source, 'data.relationships.streams.data.0.id');
         $response = $this->apiClient->post(sprintf('/streams/clone/%s', $uuid), '');
         $streamId = (string)Hash::get($response, 'data.id');
-        $type = $source['type'];
+        $type = (string)Hash::get($source, 'data.type');
         $data = compact('type');
         $response = $this->apiClient->createMediaFromStream($streamId, $type, compact('data'));
         $attributes['id'] = (string)Hash::get($response, 'data.id');

--- a/src/Controller/Component/CloneComponent.php
+++ b/src/Controller/Component/CloneComponent.php
@@ -137,8 +137,10 @@ class CloneComponent extends Component
         if (!in_array('Streams', (array)Hash::get($schema, 'associations'))) {
             return null;
         }
-
         $uuid = (string)Hash::get($source, 'data.relationships.streams.data.0.id');
+        if (empty($uuid)) {
+            return null;
+        }
         $response = $this->apiClient->post(sprintf('/streams/clone/%s', $uuid), '');
         $streamId = (string)Hash::get($response, 'data.id');
         $type = (string)Hash::get($source, 'data.type');

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -324,12 +324,7 @@ class ModulesController extends AppController
             unset($attributes['relationships']);
             $attributes['title'] = $this->getRequest()->getQuery('title');
             $attributes['status'] = 'draft';
-            if (in_array('Streams', (array)Hash::get($schema, 'associations'))) {
-                $attributes['id'] = $this->Clone->stream(
-                    $this->objectType,
-                    (string)Hash::get($source, 'data.relationships.streams.data.0.id')
-                );
-            }
+            $this->Clone->stream($schema, $source, $attributes);
             $save = $this->apiClient->save($this->objectType, $attributes);
             $destination = (string)Hash::get($save, 'data.id');
             $this->Clone->relations($source, $destination);

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -327,7 +327,7 @@ class ModulesController extends AppController
             if (in_array('Streams', (array)Hash::get($schema, 'associations'))) {
                 $attributes['id'] = $this->Clone->stream(
                     $this->objectType,
-                    (string)Hash::get($source, 'data.meta.media_url')
+                    (string)Hash::get($source, 'data.relationships.streams.data.0.id')
                 );
             }
             $save = $this->apiClient->save($this->objectType, $attributes);

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -319,11 +319,17 @@ class ModulesController extends AppController
         }
         try {
             $source = $this->apiClient->getObject($id, $this->objectType);
-            $attributes = $source['data']['attributes'];
+            $attributes = (array)Hash::get($source, 'data.attributes');
             $attributes['uname'] = '';
             unset($attributes['relationships']);
             $attributes['title'] = $this->getRequest()->getQuery('title');
             $attributes['status'] = 'draft';
+            if (in_array('Streams', (array)Hash::get($schema, 'associations'))) {
+                $attributes['id'] = $this->Clone->stream(
+                    $this->objectType,
+                    (string)Hash::get($source, 'data.meta.media_url')
+                );
+            }
             $save = $this->apiClient->save($this->objectType, $attributes);
             $destination = (string)Hash::get($save, 'data.id');
             $this->Clone->relations($source, $destination);

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -247,30 +247,14 @@ class CloneComponentTest extends BaseControllerTest
     }
 
     /**
-     * Data provider for `testStream` test case.
-     *
-     * @return array
-     */
-    public function streamProvider(): array
-    {
-        return [
-            'clone image' => [
-                'images',
-                'abcdefghi',
-            ],
-        ];
-    }
-
-    /**
      * Test `stream` method
      *
      * @param string $type The object type
      * @param string $uuid The stream uuid
      * @return void
      * @covers ::stream()
-     * @dataProvider streamProvider()
      */
-    public function testStream(string $type, string $uuid): void
+    public function testStream(): void
     {
         $this->prepareClone(true);
         $apiClient = $this->getMockBuilder(BEditaClient::class)->setConstructorArgs(['https://media.example.com'])->getMock();
@@ -279,8 +263,20 @@ class CloneComponentTest extends BaseControllerTest
         $property = new \ReflectionProperty(get_class($this->Clone), 'apiClient');
         $property->setAccessible(true);
         $property->setValue($this->Clone, $apiClient);
-        $actual = $this->Clone->stream($type, $uuid);
+        $schema = ['associations' => ['Streams']];
+        $source = ['type' => 'files'];
+        $attributes = [];
+        $actual = $this->Clone->stream($schema, $source, $attributes);
         static::assertNotEmpty($actual);
+        static::assertArrayHasKey('id', $attributes);
+
+        // test clone, not a stream
+        $schema = ['associations' => []];
+        $source = ['type' => 'documents'];
+        $attributes = [];
+        $actual = $this->Clone->stream($schema, $source, $attributes);
+        static::assertNull($actual);
+        static::assertArrayNotHasKey('id', $attributes);
     }
 
     private function prepareClone(bool $cloneRelations): void

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -293,9 +293,9 @@ class CloneComponentTest extends BaseControllerTest
         static::assertNull($actual);
         static::assertArrayNotHasKey('id', $attributes);
 
-        // test clone, uuid null
-        $schema = ['associations' => []];
-        $source = ['type' => 'documents'];
+        // test clone stream with uuid null
+        $schema = ['associations' => ['Streams']];
+        $source = ['type' => 'images'];
         $attributes = [];
         $actual = $this->Clone->stream($schema, $source, $attributes);
         static::assertNull($actual);

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -256,7 +256,7 @@ class CloneComponentTest extends BaseControllerTest
         return [
             'clone image' => [
                 'images',
-                sprintf('%s/tests/files/%s', getcwd(), 'test.png'),
+                'abcdefghi',
             ],
         ];
     }
@@ -265,12 +265,12 @@ class CloneComponentTest extends BaseControllerTest
      * Test `stream` method
      *
      * @param string $type The object type
-     * @param string $url The url
+     * @param string $uuid The stream uuid
      * @return void
      * @covers ::stream()
      * @dataProvider streamProvider()
      */
-    public function testStream(string $type, string $url): void
+    public function testStream(string $type, string $uuid): void
     {
         $this->prepareClone(true);
         $apiClient = $this->getMockBuilder(BEditaClient::class)->setConstructorArgs(['https://media.example.com'])->getMock();
@@ -279,7 +279,7 @@ class CloneComponentTest extends BaseControllerTest
         $property = new \ReflectionProperty(get_class($this->Clone), 'apiClient');
         $property->setAccessible(true);
         $property->setValue($this->Clone, $apiClient);
-        $actual = $this->Clone->stream($type, $url);
+        $actual = $this->Clone->stream($type, $uuid);
         static::assertNotEmpty($actual);
     }
 

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -262,13 +262,38 @@ class CloneComponentTest extends BaseControllerTest
         $property->setAccessible(true);
         $property->setValue($this->Clone, $apiClient);
         $schema = ['associations' => ['Streams']];
-        $source = ['type' => 'files'];
+        $source = [
+            'data' => [
+                'type' => 'files',
+                'relationships' => [
+                    'streams' => [
+                        'data' => [
+                            [
+                                'id' => 'abcdefg',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
         $attributes = [];
         $actual = $this->Clone->stream($schema, $source, $attributes);
         static::assertNotEmpty($actual);
         static::assertArrayHasKey('id', $attributes);
 
         // test clone, not a stream
+        $schema = ['associations' => []];
+        $source = [
+            'data' => [
+                'type' => 'documents',
+            ],
+        ];
+        $attributes = [];
+        $actual = $this->Clone->stream($schema, $source, $attributes);
+        static::assertNull($actual);
+        static::assertArrayNotHasKey('id', $attributes);
+
+        // test clone, uuid null
         $schema = ['associations' => []];
         $source = ['type' => 'documents'];
         $attributes = [];

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -246,6 +246,43 @@ class CloneComponentTest extends BaseControllerTest
         static::assertSame($expected, $actual);
     }
 
+    /**
+     * Data provider for `testStream` test case.
+     *
+     * @return array
+     */
+    public function streamProvider(): array
+    {
+        return [
+            'clone image' => [
+                'images',
+                sprintf('%s/tests/files/%s', getcwd(), 'test.png'),
+            ],
+        ];
+    }
+
+    /**
+     * Test `stream` method
+     *
+     * @param string $type The object type
+     * @param string $url The url
+     * @return void
+     * @covers ::stream()
+     * @dataProvider streamProvider()
+     */
+    public function testStream(string $type, string $url): void
+    {
+        $this->prepareClone(true);
+        $apiClient = $this->getMockBuilder(BEditaClient::class)->setConstructorArgs(['https://media.example.com'])->getMock();
+        $apiClient->method('post')->willReturn(['data' => ['id' => 999, 'type' => 'streams']]);
+        $apiClient->method('createMediaFromStream')->willReturn(['data' => ['id' => 99999, 'type' => 'images']]);
+        $property = new \ReflectionProperty(get_class($this->Clone), 'apiClient');
+        $property->setAccessible(true);
+        $property->setValue($this->Clone, $apiClient);
+        $actual = $this->Clone->stream($type, $url);
+        static::assertNotEmpty($actual);
+    }
+
     private function prepareClone(bool $cloneRelations): void
     {
         $config = [

--- a/tests/TestCase/Controller/Component/CloneComponentTest.php
+++ b/tests/TestCase/Controller/Component/CloneComponentTest.php
@@ -249,8 +249,6 @@ class CloneComponentTest extends BaseControllerTest
     /**
      * Test `stream` method
      *
-     * @param string $type The object type
-     * @param string $uuid The stream uuid
      * @return void
      * @covers ::stream()
      */

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -371,6 +371,30 @@ class ModulesControllerTest extends BaseControllerTest
      * @covers ::clone()
      * @return void
      */
+    public function testCloneMedia(): void
+    {
+        // Setup controller for test
+        $this->setupController();
+
+        // get object ID for test
+        $media = $this->createTestMedia();
+        $id = (string)Hash::get($media, 'id');
+
+        // do controller call
+        $result = $this->controller->clone($id);
+
+        // verify response status code and type
+        static::assertNotNull($result);
+        static::assertEquals(302, $this->controller->getResponse()->getStatusCode());
+        static::assertEquals('text/html', $this->controller->getResponse()->getType());
+    }
+
+    /**
+     * Test `clone` method
+     *
+     * @covers ::clone()
+     * @return void
+     */
     public function testClone302(): void
     {
         // test 1 clone abstract type

--- a/tests/TestCase/View/Helper/SystemHelperTest.php
+++ b/tests/TestCase/View/Helper/SystemHelperTest.php
@@ -87,13 +87,13 @@ class SystemHelperTest extends TestCase
         $actual = $this->System->checkBeditaApiVersion();
         static::assertFalse($actual);
 
-        // project version 4.9.5
-        $this->System->getView()->set('project', ['version' => '4.9.5']);
+        // project version 4.12.0
+        $this->System->getView()->set('project', ['version' => '4.12.0']);
         $actual = $this->System->checkBeditaApiVersion();
         static::assertTrue($actual);
 
-        // project version 5.5.7
-        $this->System->getView()->set('project', ['version' => '5.5.7']);
+        // project version 5.9.0
+        $this->System->getView()->set('project', ['version' => '5.9.0']);
         $actual = $this->System->checkBeditaApiVersion();
         static::assertTrue($actual);
     }


### PR DESCRIPTION
This provides a new behaviour when cloning a media object, cloning related stream as well.

This requires https://github.com/bedita/bedita/pull/2006 and https://github.com/bedita/bedita/pull/2007

BEdita API version update:

 - 4.12.0
 - 5.9.0