### PR TITLE
Fix save permissions considering inherited

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -280,13 +280,12 @@ class ModulesController extends AppController
 
             // save data
             $response = $this->apiClient->save($this->objectType, $requestData);
-            $objectId = (string)Hash::get($response, 'data.id');
             $this->savePermissions(
-                $objectId,
+                (array)$response,
                 (array)$this->Schema->getSchema($this->objectType),
                 (array)Hash::get($requestData, 'permissions')
             );
-            $this->Modules->saveRelated($objectId, $this->objectType, $relatedData);
+            $this->Modules->saveRelated((string)Hash::get($response, 'data.id'), $this->objectType, $relatedData);
         } catch (BEditaClientException $error) {
             $this->log($error->getMessage(), LogLevel::ERROR);
             $this->Flash->error($error->getMessage(), ['params' => $error]);

--- a/src/Utility/PermissionsTrait.php
+++ b/src/Utility/PermissionsTrait.php
@@ -102,6 +102,22 @@ trait PermissionsTrait
     }
 
     /**
+     * Return roles data (<id>:<name), using cache.
+     *
+     * @return array
+     */
+    public function roles(): array
+    {
+        return Cache::remember(RolesController::CACHE_KEY_ROLES, function () {
+            return Hash::combine(
+                (array)ApiClientProvider::getApiClient()->get('/roles'),
+                'data.{n}.id',
+                'data.{n}.attributes.name'
+            );
+        });
+    }
+
+    /**
      * Return roles data (<id>:<name) from role names
      *
      * @param array $names Role names
@@ -109,15 +125,8 @@ trait PermissionsTrait
      */
     public function rolesByNames(array $names): array
     {
-        $roles = Cache::remember(RolesController::CACHE_KEY_ROLES, function () {
-            return Hash::combine(
-                (array)ApiClientProvider::getApiClient()->get('/roles'),
-                'data.{n}.id',
-                'data.{n}.attributes.name'
-            );
-        });
         $result = [];
-        $flipped = array_flip($roles);
+        $flipped = array_flip($this->roles());
         foreach ($names as $name) {
             $result[(string)Hash::get($flipped, $name)] = $name;
         }
@@ -133,13 +142,7 @@ trait PermissionsTrait
      */
     public function rolesByIds(array $ids): array
     {
-        $roles = Cache::remember(RolesController::CACHE_KEY_ROLES, function () {
-            return Hash::combine(
-                (array)ApiClientProvider::getApiClient()->get('/roles'),
-                'data.{n}.id',
-                'data.{n}.attributes.name'
-            );
-        });
+        $roles = $this->roles();
         $result = [];
         foreach ($ids as $id) {
             $result[$id] = (string)Hash::get($roles, $id);

--- a/tests/TestCase/Utility/PermissionsTraitTest.php
+++ b/tests/TestCase/Utility/PermissionsTraitTest.php
@@ -102,6 +102,12 @@ class PermissionsTraitTest extends BaseControllerTest
      */
     public function testObjectPermissionsIds(): void
     {
+        $objectId = '114';
+        // check empty roles
+        $actual = $this->objectPermissionsIds($objectId, []);
+        static::assertEmpty($actual);
+
+        // check non empty roles
         $objectPermissions = [
             'data' => [
                 ['id' => 11, 'attributes' => ['object_id' => 111, 'role_id' => 1111]],
@@ -110,9 +116,14 @@ class PermissionsTraitTest extends BaseControllerTest
                 ['id' => 14, 'attributes' => ['object_id' => 114, 'role_id' => 1114]],
             ],
         ];
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->method('getObjects')->willReturn($objectPermissions);
+        ApiClientProvider::setApiClient($apiClient);
         $roles = [1111, 1112, 1113, 1114];
         $expected = [11, 12, 13, 14];
-        $actual = $this->objectPermissionsIds($objectPermissions, $roles);
+        $actual = $this->objectPermissionsIds($objectId, $roles);
         static::assertSame($expected, $actual);
     }
 

--- a/tests/TestCase/Utility/PermissionsTraitTest.php
+++ b/tests/TestCase/Utility/PermissionsTraitTest.php
@@ -37,10 +37,14 @@ class PermissionsTraitTest extends BaseControllerTest
     public function testSavePermissions(): void
     {
         // test with schema.associations empty
-        $folder = ['id' => '999'];
+        $response = [
+            'data' => [
+                'id' => '999',
+            ],
+        ];
         $schema = ['associations' => []];
         $permissions = [1];
-        $actual = $this->savePermissions($folder['id'], $schema, $permissions);
+        $actual = $this->savePermissions($response, $schema, $permissions);
         static::assertFalse($actual);
 
         // test with 'Permissions' in schema.associations
@@ -52,7 +56,7 @@ class PermissionsTraitTest extends BaseControllerTest
         $apiClient->method('save')->willReturn([]);
         $apiClient->method('deleteObject')->willReturn([]);
         ApiClientProvider::setApiClient($apiClient);
-        $actual = $this->savePermissions($folder['id'], $schema, $permissions);
+        $actual = $this->savePermissions($response, $schema, $permissions);
         static::assertTrue($actual);
     }
 

--- a/tests/TestCase/Utility/PermissionsTraitTest.php
+++ b/tests/TestCase/Utility/PermissionsTraitTest.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
  */
 namespace App\Test\TestCase\Utility;
 
+use App\Controller\Admin\RolesController;
 use App\Test\TestCase\Controller\BaseControllerTest;
 use App\Utility\PermissionsTrait;
 use BEdita\SDK\BEditaClient;
 use BEdita\WebTools\ApiClientProvider;
+use Cake\Cache\Cache;
 
 /**
  * {@see \App\Utility\PermissionsTrait} Test Case
@@ -27,6 +29,24 @@ use BEdita\WebTools\ApiClientProvider;
 class PermissionsTraitTest extends BaseControllerTest
 {
     use PermissionsTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        Cache::enable();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        Cache::disable();
+        parent::tearDown();
+    }
 
     /**
      * Test `savePermission` method.
@@ -128,15 +148,40 @@ class PermissionsTraitTest extends BaseControllerTest
     }
 
     /**
-     * Test `setupPermissionsRoles` method
+     * Test `rolesByNames` method
      *
      * @return void
-     * @covers ::setupPermissionsRoles()
+     * @covers ::rolesByNames()
      */
-    public function testSetupPermissionsRoles(): void
+    public function testRolesByNames(): void
     {
-        $actual = $this->setupPermissionsRoles([1,2,3]);
-        $expected = [1 => '', 2 => '', 3 => ''];
+        Cache::write(RolesController::CACHE_KEY_ROLES, [
+            1 => 'developer',
+            2 => 'business',
+            3 => 'guest',
+            4 => 'other',
+        ]);
+        $actual = $this->rolesByNames(['developer','guest']);
+        $expected = [1 => 'developer', 3 => 'guest'];
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Test `rolesByIds` method
+     *
+     * @return void
+     * @covers ::rolesByIds()
+     */
+    public function testRolesByIds(): void
+    {
+        Cache::write(RolesController::CACHE_KEY_ROLES, [
+            1 => 'developer',
+            2 => 'business',
+            3 => 'guest',
+            4 => 'other',
+        ]);
+        $actual = $this->rolesByIds([1,3]);
+        $expected = [1 => 'developer', 3 => 'guest'];
         static::assertSame($expected, $actual);
     }
 }

--- a/tests/TestCase/Utility/PermissionsTraitTest.php
+++ b/tests/TestCase/Utility/PermissionsTraitTest.php
@@ -148,6 +148,19 @@ class PermissionsTraitTest extends BaseControllerTest
     }
 
     /**
+     * Test `roles` method
+     *
+     * @return void
+     * @covers ::roles()
+     */
+    public function testRoles(): void
+    {
+        Cache::delete(RolesController::CACHE_KEY_ROLES);
+        $actual = $this->roles();
+        static::assertIsArray($actual);
+    }
+
+    /**
      * Test `rolesByNames` method
      *
      * @return void


### PR DESCRIPTION
This provides a fix to folders save when permissions are involved.

Actual Behaviour
=============
When a folder has inherited permissions, folder save override inherited permissions and create "direct" permissions on folder.

Patch Behaviour
=============
When a folder has inherited permissions, folder save override inherited permissions and create "direct" permissions on folder when user change permissions; if user doesn't change permissions, no "direct" permission is created.
