### PR TITLE
Object locked by parent(s)

### DIFF
--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -111,7 +111,11 @@ class LayoutHelper extends Helper
     }
 
     /**
-     * Return module css class
+     * Return module css class(es).
+     * If object is locked by parents, return base class plus 'locked' class.
+     * If object is locked by concurrent editors, return 'concurrent-editors' class plus publish status class.
+     * If object is not locked, return base class plus publish status class.
+     * Publish status class is 'expired', 'future', 'locked' or 'draft'.
      *
      * @return string
      */

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -19,6 +19,7 @@ use Cake\View\Helper;
 /**
  * Helper for site layout
  *
+ * @property \App\View\Helper\EditorsHelper $Editors
  * @property \Cake\View\Helper\HtmlHelper $Html
  * @property \App\View\Helper\LinkHelper $Link
  * @property \App\View\Helper\PermsHelper $Perms
@@ -31,7 +32,7 @@ class LayoutHelper extends Helper
      *
      * @var array
      */
-    public $helpers = ['Html', 'Link', 'Perms', 'System'];
+    public $helpers = ['Editors', 'Html', 'Link', 'Perms', 'System'];
 
     /**
      * Is Dashboard
@@ -107,6 +108,29 @@ class LayoutHelper extends Helper
         $title = (string)Hash::get($object, 'attributes.title');
 
         return empty($title) ? $name : sprintf('%s | %s', $title, $name);
+    }
+
+    /**
+     * Return module css class
+     *
+     * @return string
+     */
+    public function moduleClass(): string
+    {
+        $moduleClasses = ['app-module-box'];
+        $object = (array)$this->getView()->get('object');
+        if (!empty($object) && $this->Perms->isLockedByParents((string)Hash::get($object, 'id'))) {
+            $moduleClasses[] = 'locked';
+
+            return trim(implode(' ', $moduleClasses));
+        }
+        $editors = $this->Editors->list();
+        if (count($editors) > 1) {
+            $moduleClasses = ['app-module-box-concurrent-editors'];
+        }
+        $moduleClasses[] = $this->publishStatus($object);
+
+        return trim(implode(' ', $moduleClasses));
     }
 
     /**

--- a/src/View/Helper/PermsHelper.php
+++ b/src/View/Helper/PermsHelper.php
@@ -208,6 +208,9 @@ class PermsHelper extends Helper
 
     /**
      * Return true if object is locked by parents.
+     * When user is admin, return false.
+     * When user is not admin, return false if at least one parent is not locked for user.
+     * Return true if all parents are locked for user.
      *
      * @param string $id The object id
      * @return bool

--- a/src/View/Helper/PermsHelper.php
+++ b/src/View/Helper/PermsHelper.php
@@ -226,9 +226,6 @@ class PermsHelper extends Helper
         $roles = $this->userRoles();
         $locked = true;
         foreach ($included as $data) {
-            if ($data['type'] !== 'folders') {
-                continue;
-            }
             if (count(array_intersect($roles, (array)Hash::get($data, 'meta.perms.roles'))) > 0) {
                 $locked = false;
             }

--- a/src/View/Helper/PermsHelper.php
+++ b/src/View/Helper/PermsHelper.php
@@ -227,13 +227,12 @@ class PermsHelper extends Helper
             return false;
         }
         $roles = $this->userRoles();
-        $locked = true;
         foreach ($included as $data) {
             if (count(array_intersect($roles, (array)Hash::get($data, 'meta.perms.roles'))) > 0) {
-                $locked = false;
+                return false;
             }
         }
 
-        return $locked;
+        return true;
     }
 }

--- a/templates/Element/Form/group_properties.twig
+++ b/templates/Element/Form/group_properties.twig
@@ -4,7 +4,7 @@
         {{ element(customElement, {'properties' : properties}) }}
     {% else %}
 
-        {% set locked = object.meta.locked or Perms.isLockedByParents(object.id) %}
+        {% set locked = object.meta.locked or (object.id and Perms.isLockedByParents(object.id)) %}
         {% for key, value in properties %}
             {% if locked and key == 'uname' %}
                 {{ Property.control(key, value, {'readonly': 'readonly'})|raw }}

--- a/templates/Element/Form/group_properties.twig
+++ b/templates/Element/Form/group_properties.twig
@@ -4,10 +4,11 @@
         {{ element(customElement, {'properties' : properties}) }}
     {% else %}
 
+        {% set locked = object.meta.locked or Perms.isLockedByParents(object.id) %}
         {% for key, value in properties %}
-            {% if object.meta.locked and key == 'uname' %}
+            {% if locked and key == 'uname' %}
                 {{ Property.control(key, value, {'readonly': 'readonly'})|raw }}
-            {% elseif object.meta.locked and key == 'status' %}
+            {% elseif locked and key == 'status' %}
                 {{ Property.control(key, value, {'disabled': 'disabled'})|raw }}
                 <input type="hidden" name="status" id="status" value="{{ value }}" />
             {% else %}

--- a/templates/Element/Menu/sidebar.twig
+++ b/templates/Element/Menu/sidebar.twig
@@ -11,8 +11,7 @@
         <div class="sidebar-module-commands">
 
         {% if not Layout.isDashboard() %}
-            {% set editors = Editors.list() %}
-            <div class="app-module-box{% if editors|length > 1 %}-concurrent-editors{% endif %} {{ Layout.publishStatus(object | default({})) }}">
+            <div class="{{ Layout.moduleClass()|raw }}">
                 {{ Layout.moduleLink()|raw }}
             </div>
 


### PR DESCRIPTION
This provides an update in object view and index. When object parents permissions roles are all different from user's roles, object is considered "locked by parent(s)", meaning that the object:

 - cannot be deleted (in object view and index, no "remove" button)
 - cannot be moved to another position (in object view, some tree nodes checkboxes are disabled)
 - its `uname` cannot be changed (in object view, uname input text field is readonly)
 - its `status` cannot be changed (in object view, status radio is readonly)
 - UI: in the object view, the module box link has a lock icon background 