### PR TITLE
Attempt to improve locations autocomplete

### DIFF
--- a/resources/js/app/components/locations-view/location-view.js
+++ b/resources/js/app/components/locations-view/location-view.js
@@ -72,7 +72,7 @@ export default {
                         <autocomplete
                             autocomplete="none"
                             ref="address"
-                            class="autocomplete-address"
+                            class="autocomplete autocomplete-address"
                             :default-value="address"
                             :search="searchAddress"
                             base-class="autocomplete-address"
@@ -202,31 +202,51 @@ export default {
         onRemove() {
             this.$parent.$emit('removed', this.index);
         },
-        searchTitle(input) {
-            const requestUrl = `${BEDITA.base}/api/locations?filter[query]=${input}&sort=title`;
+        async searchTitle(input) {
+            const results = [];
+            const collected = [];
 
-            return new Promise(resolve => {
-                if (input.length < 3) {
-                    // do not search with less than 3 chars
-                    return resolve([]);
-                }
+            // do not search with less than 3 chars
+            if (input.length >= 3) {
+                let page = 1;
+                while (results.length < 20) {
+                    const url = new URL('/api/locations', BEDITA.base);
+                    url.searchParams.set('filter[query]', input.trim());
+                    url.searchParams.set('sort', 'title');
+                    url.searchParams.set('page_size', '100');
+                    url.searchParams.set('page', page++);
 
-                fetch(requestUrl, options)
-                    .then(response => response.json())
-                    .then(data => {
-                        let results = data.data;
-                        if (!results) {
-                            return resolve([]);
+                    const response = await fetch(url, options);
+                    const json = await response.json();
+                    const titles = json.data.reduce((acc, location) => {
+                        const title = location && location.attributes && location.attributes.title && location.attributes.title.trim().toLowerCase();
+                        if (!title || acc[title]) {
+                            return acc;
                         }
+                        if (collected.includes(title)) {
+                            // avoid duplicates
+                            return acc;
+                        }
+                        if (title.indexOf(input.toLowerCase()) === -1) {
+                            // only pick locations that include input string in the address
+                            return acc;
+                        }
+                        acc[title] = location;
+                        return acc;
+                    }, {});
 
-                        // only pick locations that include input string in the title
-                        results = results.filter((location) => location.attributes.title && location.attributes.title.toLowerCase().indexOf(input.toLowerCase()) !== -1);
-                        // store raw filtered data
-                        this.fetchedLocations = results.slice();
+                    collected.push(...Object.keys(titles));
+                    results.push(...Object.values(titles));
 
-                        resolve(results);
-                    });
-            })
+                    if (json.meta.pagination.page_count < page) {
+                        break;
+                    }
+                }
+            }
+
+            this.fetchedLocations = results.slice();
+
+            return results;
         },
         async searchAddress(input) {
             const results = [];
@@ -239,13 +259,13 @@ export default {
                     const url = new URL('/api/locations', BEDITA.base);
                     url.searchParams.set('filter[query]', input.trim());
                     url.searchParams.set('sort', 'address');
+                    url.searchParams.set('page_size', '100');
                     url.searchParams.set('page', page++);
 
                     const response = await fetch(url, options);
                     const json = await response.json();
                     const addresses = json.data.reduce((acc, location) => {
-                        const address = (location && location.attributes && this.cleanAddress(location.attributes.address) || '')
-                            .toLowerCase();
+                        const address = location && location.attributes && this.cleanAddress(location.attributes.address).toLowerCase();
                         if (!address || acc[address]) {
                             return acc;
                         }
@@ -295,7 +315,7 @@ export default {
                 return '';
             }
 
-            return stripHtml(`${address}`);
+            return stripHtml(`${address.trim()}`);
         },
         async geocode() {
             const retrieveGeocode = () => {

--- a/resources/js/app/components/locations-view/location-view.js
+++ b/resources/js/app/components/locations-view/location-view.js
@@ -228,34 +228,51 @@ export default {
                     });
             })
         },
-        searchAddress(input) {
-            const requestUrl = `${BEDITA.base}/api/locations?filter[query]=${input}&sort=address`;
+        async searchAddress(input) {
+            const results = [];
+            const collected = [];
 
-            return new Promise(resolve => {
-                if (input.length < 3) {
-                    // do not search with less than 3 chars
-                    return resolve([]);
-                }
+            // do not search with less than 3 chars
+            if (input.length >= 3) {
+                let page = 1;
+                while (results.length < 20) {
+                    const url = new URL('/api/locations', BEDITA.base);
+                    url.searchParams.set('filter[query]', input.trim());
+                    url.searchParams.set('sort', 'address');
+                    url.searchParams.set('page', page++);
 
-                fetch(requestUrl, options)
-                    .then(response => response.json())
-                    .then(data => {
-                        let results = data.data;
-                        if (!results) {
-                            return resolve([]);
+                    const response = await fetch(url, options);
+                    const json = await response.json();
+                    const addresses = json.data.reduce((acc, location) => {
+                        const address = (location && location.attributes && this.cleanAddress(location.attributes.address) || '')
+                            .toLowerCase();
+                        if (!address || acc[address]) {
+                            return acc;
                         }
+                        if (collected.includes(address)) {
+                            // avoid duplicates
+                            return acc;
+                        }
+                        if (address.indexOf(input.toLowerCase()) === -1) {
+                            // only pick locations that include input string in the address
+                            return acc;
+                        }
+                        acc[address] = location;
+                        return acc;
+                    }, {});
 
-                        // only pick locations that include input string in the address
-                        results = results.filter((location) => {
-                            const address = location && location.attributes && this.cleanAddress(location.attributes.address);
-                            return address && address.toLowerCase().indexOf(input.toLowerCase()) !== -1;
-                        });
-                        // store raw fetched data
-                        this.fetchedLocations = results.slice();
+                    collected.push(...Object.keys(addresses));
+                    results.push(...Object.values(addresses));
 
-                        resolve(results);
-                    });
-            });
+                    if (json.meta.pagination.page_count < page) {
+                        break;
+                    }
+                }
+            }
+
+            this.fetchedLocations = results.slice();
+
+            return results;
         },
         /**
          * Title to show in the autocomplete component.

--- a/templates/Element/Form/locations.scss
+++ b/templates/Element/Form/locations.scss
@@ -62,6 +62,30 @@
             border-bottom: 1px solid $gray-500;
         }
     }
+
+    &[data-loading='true']:after {
+        content: '';
+        border: 3px solid rgba(0,0,0,.12);
+        border-right-color: rgba(0,0,0,.48);
+        border-radius: 100%;
+        width: 20px;
+        height: 20px;
+        position: absolute;
+        right: 12px;
+        top: 50%;
+        transform: translateY(-50%);
+        animation: autocompleteSpinner 1s linear infinite;
+    }
+}
+
+@keyframes autocompleteSpinner {
+    0% {
+        transform: translateY(-50%) rotate(0deg)
+    }
+
+    100% {
+        transform: translateY(-50%) rotate(359deg)
+    }
 }
 
 .autocomplete-title-result, .autocomplete-address-result {


### PR DESCRIPTION
This PR introduces a change to the autocomplete algorithm for locations.

First of all, it uses pagination to collect at least 20 results. The current conditions are kept, and a new one is added to avoid duplicates among addresses (in case there are duplicates among the locations, which would still need to be cleaned).