### PR TITLE
Use `async_jobs` endpoint

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -204,7 +204,9 @@ class ModulesComponent extends Component
      */
     protected function modulesFromMeta(): array
     {
-        $meta = $this->getMeta();
+        /** @var \Authentication\Identity $user */
+        $user = $this->Authentication->getIdentity();
+        $meta = $this->getMeta($user);
         $modules = collection(Hash::get($meta, 'resources', []))
             ->map(function (array $data, $endpoint) {
                 $name = substr($endpoint, 1);
@@ -226,7 +228,9 @@ class ModulesComponent extends Component
      */
     public function getProject(): array
     {
-        $meta = $this->getMeta();
+        /** @var \Authentication\Identity $user */
+        $user = $this->Authentication->getIdentity();
+        $meta = $this->getMeta($user);
         $project = (array)Configure::read('Project');
         $name = (string)Hash::get($project, 'name', Hash::get($meta, 'project.name'));
         $version = Hash::get($meta, 'version', '');

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -14,7 +14,7 @@ namespace App\Controller\Component;
 
 use App\Core\Exception\UploadException;
 use App\Utility\OEmbed;
-use BEdita\SDK\BEditaClientException;
+use App\Utility\SchemaTrait;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Cache\Cache;
 use Cake\Controller\Component;
@@ -22,7 +22,6 @@ use Cake\Core\Configure;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Utility\Hash;
-use Psr\Log\LogLevel;
 
 /**
  * Component to load available modules.
@@ -33,6 +32,13 @@ use Psr\Log\LogLevel;
  */
 class ModulesComponent extends Component
 {
+    use SchemaTrait;
+
+    /**
+     * Fixed relationships to be loaded for each object
+     *
+     * @var array
+     */
     public const FIXED_RELATIONSHIPS = [
         'parent',
         'children',
@@ -106,33 +112,6 @@ class ModulesComponent extends Component
         if (!empty($currentModule)) {
             $this->getController()->set(compact('currentModule'));
         }
-    }
-
-    /**
-     * Getter for home endpoint metadata.
-     *
-     * @return array
-     */
-    protected function getMeta(): array
-    {
-        try {
-            /** @var \Authentication\Identity|null $user */
-            $user = $this->Authentication->getIdentity();
-            $home = Cache::remember(
-                sprintf('home_%d', $user->get('id')),
-                function () {
-                    return ApiClientProvider::getApiClient()->get('/home');
-                }
-            );
-        } catch (BEditaClientException $e) {
-            // Something bad happened. Returning an empty array instead.
-            // The exception is being caught _outside_ of `Cache::remember()` to avoid caching the fallback.
-            $this->log($e->getMessage(), LogLevel::ERROR);
-
-            return [];
-        }
-
-        return !empty($home['meta']) ? $home['meta'] : [];
     }
 
     /**

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -12,6 +12,7 @@
  */
 namespace App\Controller;
 
+use App\Utility\SchemaTrait;
 use Cake\Utility\Hash;
 
 /**
@@ -19,6 +20,8 @@ use Cake\Utility\Hash;
  */
 class DashboardController extends AppController
 {
+    use SchemaTrait;
+
     /**
      * @inheritDoc
      */
@@ -39,6 +42,10 @@ class DashboardController extends AppController
     {
         $this->getRequest()->allowMethod(['get']);
         $this->set('recentItems', $this->recentItems());
+        $this->set(
+            'jobsAllow',
+            (array)Hash::extract($this->getMeta(), 'resources./async_jobs.hints.allow')
+        );
     }
 
     /**

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -42,9 +42,12 @@ class DashboardController extends AppController
     {
         $this->getRequest()->allowMethod(['get']);
         $this->set('recentItems', $this->recentItems());
+
+        /** @var \Authentication\Identity $user */
+        $user = $this->Authentication->getIdentity();
         $this->set(
             'jobsAllow',
-            (array)Hash::extract($this->getMeta(), 'resources./async_jobs.hints.allow')
+            (array)Hash::extract($this->getMeta($user), 'resources./async_jobs.hints.allow')
         );
     }
 

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -12,6 +12,7 @@
  */
 namespace App\Controller;
 
+use App\Utility\SchemaTrait;
 use BEdita\SDK\BEditaClientException;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
@@ -25,6 +26,8 @@ use Exception;
  */
 class ImportController extends AppController
 {
+    use SchemaTrait;
+
     /**
      * @inheritDoc
      */
@@ -62,6 +65,10 @@ class ImportController extends AppController
         $result = $this->getRequest()->getSession()->consume('Import.result');
         $this->set(compact('result'));
         $this->loadFilters();
+        $this->set(
+            'jobsAllow',
+            (array)Hash::extract($this->getMeta(), 'resources./async_jobs.hints.allow')
+        );
     }
 
     /**

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -189,7 +189,7 @@ class ImportController extends AppController
             'filter' => ['service' => implode(',', $this->services)],
         ];
         try {
-            $response = $this->apiClient->get('/admin/async_jobs', $query);
+            $response = $this->apiClient->get('/async_jobs', $query);
         } catch (BEditaClientException $e) {
             $this->log($e->getMessage(), 'error');
             $this->Flash->error($e->getMessage(), ['params' => $e]);

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -65,9 +65,11 @@ class ImportController extends AppController
         $result = $this->getRequest()->getSession()->consume('Import.result');
         $this->set(compact('result'));
         $this->loadFilters();
+        /** @var \Authentication\Identity $user */
+        $user = $this->Authentication->getIdentity();
         $this->set(
             'jobsAllow',
-            (array)Hash::extract($this->getMeta(), 'resources./async_jobs.hints.allow')
+            (array)Hash::extract($this->getMeta($user), 'resources./async_jobs.hints.allow')
         );
     }
 

--- a/src/Core/Filter/ImportFilter.php
+++ b/src/Core/Filter/ImportFilter.php
@@ -115,7 +115,7 @@ abstract class ImportFilter
             ],
         ];
 
-        $asyncJob = $this->apiClient->post('/admin/async_jobs', json_encode($body));
+        $asyncJob = $this->apiClient->post('/async_jobs', json_encode($body));
 
         $this->result->addMessage('info', (string)__('Job {0} to import file "{1}" scheduled.', Hash::get($asyncJob, 'data.id'), $filename));
 

--- a/src/Utility/SchemaTrait.php
+++ b/src/Utility/SchemaTrait.php
@@ -18,11 +18,14 @@ use Authentication\Identity;
 use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Cache\Cache;
+use Cake\Log\LogTrait;
 use Cake\Utility\Hash;
 use Psr\Log\LogLevel;
 
 trait SchemaTrait
 {
+    use LogTrait;
+
     /**
      * Getter for home endpoint metadata from user identity.
      *

--- a/src/Utility/SchemaTrait.php
+++ b/src/Utility/SchemaTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace App\Utility;
 
+use Authentication\Identity;
 use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Cache\Cache;
@@ -23,15 +24,14 @@ use Psr\Log\LogLevel;
 trait SchemaTrait
 {
     /**
-     * Getter for home endpoint metadata.
+     * Getter for home endpoint metadata from user identity.
      *
+     * @param \Authentication\Identity $user User identity.
      * @return array
      */
-    public function getMeta(): array
+    public function getMeta(Identity $user): array
     {
         try {
-            /** @var \Authentication\Identity|null $user */
-            $user = $this->Authentication->getIdentity();
             $home = Cache::remember(
                 sprintf('home_%d', $user->get('id')),
                 function () {

--- a/src/Utility/SchemaTrait.php
+++ b/src/Utility/SchemaTrait.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Utility;
+
+use Cake\Cache\Cache;
+use Psr\Log\LogLevel;
+use Cake\Utility\Hash;
+use BEdita\SDK\BEditaClientException;
+use BEdita\WebTools\ApiClientProvider;
+
+trait SchemaTrait
+{
+    /**
+     * Getter for home endpoint metadata.
+     *
+     * @return array
+     */
+    public function getMeta(): array
+    {
+        try {
+            /** @var \Authentication\Identity|null $user */
+            $user = $this->Authentication->getIdentity();
+            $home = Cache::remember(
+                sprintf('home_%d', $user->get('id')),
+                function () {
+                    $client = ApiClientProvider::getApiClient();
+
+                    return $client->get('/home');
+                }
+            );
+        } catch (BEditaClientException $e) {
+            // Something bad happened. Returning an empty array instead.
+            // The exception is being caught _outside_ of `Cache::remember()` to avoid caching the fallback.
+            $this->log($e->getMessage(), LogLevel::ERROR);
+
+            return [];
+        }
+
+        return (array)Hash::get($home, 'meta');
+    }
+}

--- a/src/Utility/SchemaTrait.php
+++ b/src/Utility/SchemaTrait.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
  */
 namespace App\Utility;
 
-use Cake\Cache\Cache;
-use Psr\Log\LogLevel;
-use Cake\Utility\Hash;
 use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;
+use Cake\Cache\Cache;
+use Cake\Utility\Hash;
+use Psr\Log\LogLevel;
 
 trait SchemaTrait
 {

--- a/templates/Pages/Dashboard/index.twig
+++ b/templates/Pages/Dashboard/index.twig
@@ -48,7 +48,7 @@
                     <Icon icon="carbon:user-profile"></Icon>
                 </a>
 
-                {% if config('Filters.import') %}
+                {% if config('Filters.import') and ('POST' in jobsAllow or 'GET' in jobsAllow) %}
                     <a href="{{ Url.build({'_name': 'import:index'}) }}" title="{{ __('Import') }}" class="dashboard-item has-background-black">
                         <span>{{ __('Import') }}</span>
                         <Icon icon="carbon:download"></Icon>

--- a/templates/Pages/Import/index.twig
+++ b/templates/Pages/Import/index.twig
@@ -1,13 +1,23 @@
 {% do _view.assign('title', __('Data Import')) %}
 
-{{ Form.create(null, { 'id': 'form-import', 'type': 'file', 'url': {'_name': 'import:file'} })|raw }}
-    <import-index :filters="{{ filters|json_encode() }}">
-    </import-index>
-    {{ Form.hidden('MAX_FILE_SIZE', { 'value': System.getMaxFileSize() })|raw }}
-{{ Form.end()|raw }}
+{% if 'POST' in jobsAllow %}
+    {% if filters %}
+    {{ Form.create(null, { 'id': 'form-import', 'type': 'file', 'url': {'_name': 'import:file'} })|raw }}
+        <import-index :filters="{{ filters|json_encode() }}">
+        </import-index>
+        {{ Form.hidden('MAX_FILE_SIZE', { 'value': System.getMaxFileSize() })|raw }}
+    {{ Form.end()|raw }}
+    {% else %}
+        <div>
+            {{ __('No import filters set') }}
+        </div>
+    {% endif %}
 
-<import-result :result="{{ result|json_encode() }}">
-</import-result>
+    <import-result :result="{{ result|json_encode() }}">
+    </import-result>
+{% endif %}
 
-<import-jobs :jobs="{{ jobs|json_encode() }}" :services="{{ services|json_encode() }}">
-</import-jobs>
+{% if 'GET' in jobsAllow %}
+    <import-jobs :jobs="{{ jobs|json_encode() }}" :services="{{ services|json_encode() }}">
+    </import-jobs>
+{% endif %}

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -199,7 +199,6 @@ class ModulesComponentTest extends TestCase
      * @param array $config Project config to set.
      * @return void
      * @dataProvider getProjectProvider()
-     * @covers ::getMeta()
      * @covers ::getProject()
      */
     public function testGetProject($expected, $meta, $config = []): void
@@ -496,7 +495,6 @@ class ModulesComponentTest extends TestCase
      * @return void
      * @dataProvider getModulesProvider()
      * @covers ::modulesFromMeta()
-     * @covers ::getMeta()
      * @covers ::getModules()
      */
     public function testGetModules($expected, $meta, array $modules = []): void

--- a/tests/TestCase/Controller/DashboardControllerTest.php
+++ b/tests/TestCase/Controller/DashboardControllerTest.php
@@ -152,6 +152,7 @@ class DashboardControllerTest extends TestCase
         // recent items
         static::assertArrayHasKey('recentItems', $this->Dashboard->viewBuilder()->getVars());
         static::assertEmpty($this->Dashboard->viewBuilder()->getVar('recentItems'));
+        static::assertArrayHasKey('jobsAllow', $this->Dashboard->viewBuilder()->getVars());
     }
 
     /**

--- a/tests/TestCase/Controller/DashboardControllerTest.php
+++ b/tests/TestCase/Controller/DashboardControllerTest.php
@@ -14,10 +14,13 @@
 namespace App\Test\TestCase\Controller;
 
 use App\Controller\DashboardController;
+use Authentication\AuthenticationService;
 use Authentication\AuthenticationServiceInterface;
+use Authentication\Identifier\IdentifierInterface;
 use Authentication\Identity;
 use Authentication\IdentityInterface;
 use BEdita\WebTools\ApiClientProvider;
+use BEdita\WebTools\Identifier\ApiIdentifier;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -52,6 +55,42 @@ class DashboardControllerTest extends TestCase
             $request = new ServerRequest($config);
         }
         $this->Dashboard = new DashboardController($request);
+    }
+
+    /**
+     * Setup controller and manually login user
+     *
+     * @return array|null
+     */
+    protected function setupControllerAndLogin(array $requestConfig): ?array
+    {
+        $config = $requestConfig + [
+            'post' => [
+                'username' => env('BEDITA_ADMIN_USR'),
+                'password' => env('BEDITA_ADMIN_PWD'),
+            ],
+        ];
+        $this->setupController($config);
+
+        // Mock Authentication component
+        ApiClientProvider::getApiClient()->setupTokens([]); // reset client
+        $service = new AuthenticationService();
+        $service->loadIdentifier(ApiIdentifier::class);
+        $service->loadAuthenticator('Authentication.Form', [
+            'fields' => [
+                IdentifierInterface::CREDENTIAL_USERNAME => 'username',
+                IdentifierInterface::CREDENTIAL_PASSWORD => 'password',
+            ],
+        ]);
+        $this->Dashboard->setRequest($this->Dashboard->getRequest()->withAttribute('authentication', $service));
+        $result = $this->Dashboard->Authentication->getAuthenticationService()->authenticate($this->Dashboard->getRequest());
+        $identity = new Identity($result->getData());
+        $request = $this->Dashboard->getRequest()->withAttribute('identity', $identity);
+        $this->Dashboard->setRequest($request);
+        $user = $this->Dashboard->Authentication->getIdentity() ?: new Identity([]);
+        $this->Dashboard->Authentication->setIdentity($user);
+
+        return $user->getOriginalData();
     }
 
     /**
@@ -144,14 +183,14 @@ class DashboardControllerTest extends TestCase
             static::expectException(get_class($expected));
         }
 
-        $this->setupController($requestConfig);
+        $this->setupControllerAndLogin($requestConfig);
+
         $this->Dashboard->index();
         $response = $this->Dashboard->getResponse();
 
         static::assertEquals(200, $response->getStatusCode());
         // recent items
         static::assertArrayHasKey('recentItems', $this->Dashboard->viewBuilder()->getVars());
-        static::assertEmpty($this->Dashboard->viewBuilder()->getVar('recentItems'));
         static::assertArrayHasKey('jobsAllow', $this->Dashboard->viewBuilder()->getVars());
     }
 

--- a/tests/TestCase/Controller/ImportControllerTest.php
+++ b/tests/TestCase/Controller/ImportControllerTest.php
@@ -204,7 +204,7 @@ class ImportControllerTest extends TestCase
             ->setConstructorArgs(['https://media.example.com'])
             ->getMock();
         $apiClient->method('get')
-            ->with('/admin/async_jobs')
+            ->with('/async_jobs')
             ->willThrowException(new BEditaClientException('My test exception'));
         $this->Import->apiClient = $apiClient;
         $method->invokeArgs($this->Import, []);
@@ -214,13 +214,13 @@ class ImportControllerTest extends TestCase
         $flash = $this->Import->getRequest()->getSession()->read('Flash.flash');
         static::assertEquals('My test exception', Hash::get($flash, '0.message'));
 
-        // mock api get /admin/async_jobs
+        // mock api get /async_jobs
         $expected = [['id' => 1], ['id' => 2], ['id' => 3]];
         $apiClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs(['https://media.example.com'])
             ->getMock();
         $apiClient->method('get')
-            ->with('/admin/async_jobs')
+            ->with('/async_jobs')
             ->willReturn(['data' => $expected]);
         $this->Import->apiClient = $apiClient;
         $method->invokeArgs($this->Import, []);

--- a/tests/TestCase/Controller/ImportControllerTest.php
+++ b/tests/TestCase/Controller/ImportControllerTest.php
@@ -324,6 +324,7 @@ class ImportControllerTest extends TestCase
         static::assertEmpty($this->Import->viewBuilder()->getVar('services'));
         static::assertEmpty($this->Import->viewBuilder()->getVar('filters'));
         static::assertEmpty($this->Import->viewBuilder()->getVar('result'));
+        static::assertArrayHasKey('jobsAllow', $this->Import->viewBuilder()->getVars());
         $this->Import->dispatchEvent('Controller.beforeRender');
         static::assertEquals(['_name' => 'import:index'], $this->Import->viewBuilder()->getVar('moduleLink'));
     }

--- a/tests/TestCase/Core/Filter/ImportFilterTest.php
+++ b/tests/TestCase/Core/Filter/ImportFilterTest.php
@@ -99,9 +99,9 @@ class ImportFilterTest extends TestCase
                 ],
             ]);
 
-        // mock post /admin/async_jobs
+        // mock post /async_jobs
         $apiClient->method('post')
-            ->with('/admin/async_jobs')
+            ->with('/async_jobs')
             ->willReturn([
                 'data' => [
                     'id' => $this->asyncJobId,

--- a/tests/TestCase/Utility/SchemaTraitTest.php
+++ b/tests/TestCase/Utility/SchemaTraitTest.php
@@ -93,7 +93,9 @@ class SchemaTraitTest extends TestCase
                 ],
             ]);
         ApiClientProvider::setApiClient($apiClient);
-        $actual = $this->getMeta();
+        /** @var \Authentication\Identity $user */
+        $user = $this->Authentication->getIdentity();
+        $actual = $this->getMeta($user);
         $expected = [
             'cats' => [],
             'dogs' => [],
@@ -124,7 +126,9 @@ class SchemaTraitTest extends TestCase
             ->with('/home')
             ->willThrowException($expectedException);
         ApiClientProvider::setApiClient($apiClient);
-        $actual = $this->getMeta();
+        /** @var \Authentication\Identity $user */
+        $user = $this->Authentication->getIdentity();
+        $actual = $this->getMeta($user);
         $expected = [];
         static::assertEquals($expected, $actual);
         static::assertEquals($expectedLogger, $this->logger);

--- a/tests/TestCase/Utility/SchemaTraitTest.php
+++ b/tests/TestCase/Utility/SchemaTraitTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Test\TestCase\Utility;
+
+use App\Utility\SchemaTrait;
+use Authentication\AuthenticationServiceInterface;
+use Authentication\Controller\Component\AuthenticationComponent;
+use Authentication\Identity;
+use Authentication\IdentityInterface;
+use BEdita\SDK\BEditaClient;
+use BEdita\SDK\BEditaClientException;
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Cache\Cache;
+use Cake\Controller\Controller;
+use Cake\TestSuite\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * {@see \App\Utility\SchemaTrait} Test Case
+ *
+ * @coversDefaultClass \App\Utility\SchemaTrait
+ */
+class SchemaTraitTest extends TestCase
+{
+    use SchemaTrait;
+
+    protected $Authentication;
+
+    protected $logger = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        Cache::enable();
+        Cache::clearAll();
+        $controller = new Controller();
+        $controller->setRequest($controller->getRequest()->withAttribute('authentication', $this->getAuthenticationServiceMock()));
+        $registry = $controller->components();
+        $registry->load('Authentication.Authentication');
+        /** @var \Authentication\Controller\Component\AuthenticationComponent $authenticationComponent */
+        $authenticationComponent = $registry->load(AuthenticationComponent::class);
+        $this->Authentication = $authenticationComponent;
+        $user = ['id' => 123, 'attributes' => ['name' => 'Gustavo', 'surname' => 'Support']];
+        $this->Authentication->setIdentity(new Identity($user));
+
+        parent::setUp();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        Cache::disable();
+        ApiClientProvider::setApiClient(null);
+        parent::tearDown();
+    }
+
+    /**
+     * Test `getMeta`.
+     *
+     * @return void
+     * @covers ::getMeta()
+     */
+    public function testGetMeta(): void
+    {
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->method('get')
+            ->with('/home')
+            ->willReturn([
+                'meta' => [
+                    'cats' => [],
+                    'dogs' => [],
+                ],
+            ]);
+        ApiClientProvider::setApiClient($apiClient);
+        $actual = $this->getMeta();
+        $expected = [
+            'cats' => [],
+            'dogs' => [],
+        ];
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `getMeta` with exception.
+     *
+     * @return void
+     * @covers ::getMeta()
+     */
+    public function testGetMetaException(): void
+    {
+        $this->logger = [];
+        $expectedException = new BEditaClientException('test');
+        $expectedLogger = [
+            [
+                'message' => $expectedException->getMessage(),
+                'level' => 'error',
+            ],
+        ];
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->method('get')
+            ->with('/home')
+            ->willThrowException($expectedException);
+        ApiClientProvider::setApiClient($apiClient);
+        $actual = $this->getMeta();
+        $expected = [];
+        static::assertEquals($expected, $actual);
+        static::assertEquals($expectedLogger, $this->logger);
+    }
+
+    /**
+     * Get mocked AuthenticationService.
+     *
+     * @return AuthenticationServiceInterface
+     */
+    protected function getAuthenticationServiceMock(): AuthenticationServiceInterface
+    {
+        $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)
+            ->getMock();
+        $authenticationService->method('clearIdentity')
+            ->willReturnCallback(function (ServerRequestInterface $request, ResponseInterface $response): array {
+                return [
+                    'request' => $request->withoutAttribute('identity'),
+                    'response' => $response,
+                ];
+            });
+        $authenticationService->method('persistIdentity')
+            ->willReturnCallback(function (ServerRequestInterface $request, ResponseInterface $response, IdentityInterface $identity): array {
+                return [
+                    'request' => $request->withAttribute('identity', $identity),
+                    'response' => $response,
+                ];
+            });
+
+        return $authenticationService;
+    }
+
+    private function log(string $message, string $level): void
+    {
+        $this->logger[] = compact('message', 'level');
+    }
+}

--- a/tests/TestCase/Utility/SchemaTraitTest.php
+++ b/tests/TestCase/Utility/SchemaTraitTest.php
@@ -41,8 +41,6 @@ class SchemaTraitTest extends TestCase
 
     protected $Authentication;
 
-    protected $logger = [];
-
     /**
      * @inheritDoc
      */
@@ -111,14 +109,7 @@ class SchemaTraitTest extends TestCase
      */
     public function testGetMetaException(): void
     {
-        $this->logger = [];
         $expectedException = new BEditaClientException('test');
-        $expectedLogger = [
-            [
-                'message' => $expectedException->getMessage(),
-                'level' => 'error',
-            ],
-        ];
         $apiClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs(['https://api.example.org'])
             ->getMock();
@@ -131,7 +122,6 @@ class SchemaTraitTest extends TestCase
         $actual = $this->getMeta($user);
         $expected = [];
         static::assertEquals($expected, $actual);
-        static::assertEquals($expectedLogger, $this->logger);
     }
 
     /**
@@ -159,10 +149,5 @@ class SchemaTraitTest extends TestCase
             });
 
         return $authenticationService;
-    }
-
-    private function log(string $message, string $level): void
-    {
-        $this->logger[] = compact('message', 'level');
     }
 }


### PR DESCRIPTION
This PR provides a change to use the new `/async_jobs` endpoint in data import page.

Import page link is shown to user only if `async_jobs` is allowed for `GET` or `POST` for the user (the system check `GET /home` response for that), and if there's a `Filters.import` configuration.

In import page:

 - form upload and submit section is shown if user is allowed for `POST /async_jobs` 
 - job list section is shown if user is allowed for `GET /async_jobs`

In the actual page, `/admin/async_jobs` endpoint is used: admin only can use it.
With this change, non-admin user will be able to import data as well, if API provides an endpoint_permission for manager and user role to do that.

API dependency: https://github.com/bedita/bedita/pull/2012