### PR TITLE
Refactor: save folder parent and children

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -3,6 +3,7 @@ name: javascript
 on:
   pull_request:
     paths:
+      - '**/*.vue'
       - '**/*.js'
       - '**/*.scss'
       - '.github/workflows/javascript.yml'
@@ -10,6 +11,7 @@ on:
       - 'yarn.lock'
   push:
     paths:
+      - '**/*.vue'
       - '**/*.js'
       - '**/*.scss'
       - '.github/workflows/javascript.yml'

--- a/resources/js/app/components/tree-view/tree-view.vue
+++ b/resources/js/app/components/tree-view/tree-view.vue
@@ -1,8 +1,6 @@
 <template>
     <div class="tree-view-node" :class="{'is-root': isRoot}" v-show="showNode">
-        <div v-if="originalParents.length > 0">
-            <input type="hidden" name="_originalParents" :value="originalParents" />
-        </div>
+        <input v-if="originalParents.length > 0" type="hidden" name="_originalParents" :value="originalParents" />
         <div v-if="isLoading && !parent" class="is-loading-spinner"></div>
         <div v-if="parent" class="node-element py-05" :data-status="node.attributes.status">
             <label class="node-label" :class="{'icon-folder': !relationName, 'has-text-gray-550 disabled': object && node.id == object.id}" v-on="{ click: relationName ? () => {} : toggle }">

--- a/resources/js/app/components/tree-view/tree-view.vue
+++ b/resources/js/app/components/tree-view/tree-view.vue
@@ -1,5 +1,8 @@
 <template>
     <div class="tree-view-node" :class="{'is-root': isRoot}" v-show="showNode">
+        <div v-if="originalParents.length > 0">
+            <input type="hidden" name="_originalParents" :value="originalParents" />
+        </div>
         <div v-if="isLoading && !parent" class="is-loading-spinner"></div>
         <div v-if="parent" class="node-element py-05" :data-status="node.attributes.status">
             <label class="node-label" :class="{'icon-folder': !relationName, 'has-text-gray-550 disabled': object && node.id == object.id}" v-on="{ click: relationName ? () => {} : toggle }">
@@ -8,7 +11,8 @@
                     :name="'relations[' + relationName + '][replaceRelated][]'"
                     :value="value"
                     :checked="isParent"
-                    :disabled="isLocked"
+                    :class="isLocked ? 'disabled' : ''"
+                    @click="isLocked ? $event.preventDefault() : ''"
                     @change="toggleFolderRelation" />
                 {{ node.attributes.title }}
             </label>
@@ -149,6 +153,7 @@ export default {
             msgEdit: t`Edit`,
             msgMenu: t`Menu`,
             msgView: t`View`,
+            originalParents: [],
             showForbidden: true,
         };
     },
@@ -158,6 +163,9 @@ export default {
             this.isLoading = true;
             await this.loadRoots();
             this.isLoading = false;
+            for (let p of this.parents) {
+                this.originalParents.push(p.id);
+            }
         }
         this.isOpen = !!this.node.children;
         PermissionEvents.$on('toggle-forbidden', (value) => this.showForbidden = value);

--- a/resources/js/app/components/tree-view/tree-view.vue
+++ b/resources/js/app/components/tree-view/tree-view.vue
@@ -163,9 +163,7 @@ export default {
             this.isLoading = true;
             await this.loadRoots();
             this.isLoading = false;
-            for (let p of this.parents) {
-                this.originalParents.push(p.id);
-            }
+            this.originalParents = this.parents.map(p => p.id);
         }
         this.isOpen = !!this.node.children;
         PermissionEvents.$on('toggle-forbidden', (value) => this.showForbidden = value);

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -322,14 +322,8 @@ class AppController extends Controller
         if (is_string($items)) {
             return json_decode($items, true);
         }
-        $first = Hash::get($items, '0');
-        if (is_string($first)) {
-            return array_map(
-                function ($item) {
-                    return json_decode($item, true);
-                },
-                $items
-            );
+        if (is_string(Hash::get($items, 0))) {
+            return array_map(function ($json) { return json_decode($json, true); }, $items);
         }
 
         return $items;

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -323,7 +323,12 @@ class AppController extends Controller
             return json_decode($items, true);
         }
         if (is_string(Hash::get($items, 0))) {
-            return array_map(function ($json) { return json_decode($json, true); }, $items);
+            return array_map(
+                function ($json) {
+                    return json_decode($json, true);
+                },
+                $items
+            );
         }
 
         return $items;

--- a/src/Controller/Component/ChildrenComponent.php
+++ b/src/Controller/Component/ChildrenComponent.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 
 namespace App\Controller\Component;
 
-use BEdita\SDK\BEditaClient;
-use BEdita\WebTools\ApiClientProvider;
+use App\Utility\ApiClientTrait;
 use Cake\Controller\Component;
 use Cake\Utility\Hash;
 
@@ -27,26 +26,7 @@ use Cake\Utility\Hash;
  */
 class ChildrenComponent extends Component
 {
-    /**
-     * BEdita Api client
-     *
-     * @var \BEdita\SDK\BEditaClient
-     */
-    protected $apiClient = null;
-
-    /**
-     * Get API client.
-     *
-     * @return \BEdita\SDK\BEditaClient
-     */
-    public function getClient(): BEditaClient
-    {
-        if ($this->apiClient === null) {
-            $this->apiClient = ApiClientProvider::getApiClient();
-        }
-
-        return $this->apiClient;
-    }
+    use ApiClientTrait;
 
     /**
      * Add children to a folder.

--- a/src/Controller/Component/ChildrenComponent.php
+++ b/src/Controller/Component/ChildrenComponent.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Controller\Component;
+
+use BEdita\SDK\BEditaClient;
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Controller\Component;
+use Cake\Utility\Hash;
+
+/**
+ * Children component.
+ * This component is used to add/remove children to a folder.
+ * When a child is a subfolder, this use `PATCH /folders/:id/relationships/parent` to set parent to null.
+ * When a child is not a subfolder, it's removed as usual by `removeRelated`.
+ */
+class ChildrenComponent extends Component
+{
+    /**
+     * BEdita Api client
+     *
+     * @var \BEdita\SDK\BEditaClient
+     */
+    protected $apiClient = null;
+
+    /**
+     * Get API client.
+     *
+     * @return \BEdita\SDK\BEditaClient
+     */
+    public function getClient(): BEditaClient
+    {
+        if ($this->apiClient === null) {
+            $this->apiClient = ApiClientProvider::getApiClient();
+        }
+
+        return $this->apiClient;
+    }
+
+    /**
+     * Add children to a folder.
+     *
+     * @param string $parentId Folder ID.
+     * @param array $children Children objects as id/type pairs.
+     * @return array
+     */
+    public function addRelated(string $parentId, array $children): array
+    {
+        $results = [];
+        foreach ($children as $child) {
+            $results[] = $this->addRelatedChild($parentId, $child);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Add single child by parent ID and child data.
+     *
+     * @param string $parentId The parent ID.
+     * @param array $child The child data (id, type, meta).
+     * @return array|null
+     */
+    public function addRelatedChild(string $parentId, array $child): ?array
+    {
+        $type = (string)Hash::get($child, 'type');
+        if ($type !== 'folders') {
+            return $this->getClient()->addRelated($parentId, 'folders', 'children', [$child]);
+        }
+        $id = (string)Hash::get($child, 'id');
+        $meta = (array)Hash::get($child, 'meta');
+        $data = compact('id', 'type', 'meta');
+
+        // invert relation call => use 'parent' relation on children folder
+        return $this->getClient()->addRelated($parentId, 'folders', 'parent', $data);
+    }
+
+    /**
+     * Remove folder children.
+     * When a child is a subfolder, this use `PATCH /folders/:id/relationships/parent` to set parent to null
+     * When a child is not a subfolder, it's removed as usual by `removeRelated`
+     *
+     * @param string $parentId Folder ID
+     * @param array $children Children objects as id/type pairs.
+     * @return array
+     */
+    public function removeRelated(string $parentId, array $children): array
+    {
+        $results = [];
+        foreach ($children as $child) {
+            $results[] = $this->removeRelatedChild($parentId, $child);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Remove single child by parent ID and child data.
+     *
+     * @param string $parentId The parent ID.
+     * @param array $child The child data (id, type, meta).
+     * @return array|null
+     */
+    public function removeRelatedChild(string $parentId, array $child): ?array
+    {
+        $type = (string)Hash::get($child, 'type');
+        if ($type === 'folders') {
+            // invert relation call => use 'parent' relation on children folder
+            return $this->getClient()->replaceRelated((string)Hash::get($child, 'id'), 'folders', 'parent', [null]);
+        }
+
+        return $this->getClient()->removeRelated($parentId, 'folders', 'children', [$child]);
+    }
+}

--- a/src/Controller/Component/ChildrenComponent.php
+++ b/src/Controller/Component/ChildrenComponent.php
@@ -58,12 +58,8 @@ class ChildrenComponent extends Component
         if ($type !== 'folders') {
             return $this->getClient()->addRelated($parentId, 'folders', 'children', [$child]);
         }
-        $id = (string)Hash::get($child, 'id');
-        $meta = (array)Hash::get($child, 'meta');
-        $data = compact('id', 'type', 'meta');
 
-        // invert relation call => use 'parent' relation on children folder
-        return $this->getClient()->addRelated($parentId, 'folders', 'parent', $data);
+        return $this->getClient()->addRelated($parentId, 'folders', 'parent', $child);
     }
 
     /**

--- a/src/Controller/Component/ParentsComponent.php
+++ b/src/Controller/Component/ParentsComponent.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 
 namespace App\Controller\Component;
 
-use BEdita\SDK\BEditaClient;
-use BEdita\WebTools\ApiClientProvider;
+use App\Utility\ApiClientTrait;
 use Cake\Controller\Component;
 
 /**
@@ -24,26 +23,7 @@ use Cake\Controller\Component;
  */
 class ParentsComponent extends Component
 {
-    /**
-     * BEdita Api client
-     *
-     * @var \BEdita\SDK\BEditaClient
-     */
-    protected $apiClient = null;
-
-    /**
-     * Get API client.
-     *
-     * @return \BEdita\SDK\BEditaClient
-     */
-    public function getClient(): BEditaClient
-    {
-        if ($this->apiClient === null) {
-            $this->apiClient = ApiClientProvider::getApiClient();
-        }
-
-        return $this->apiClient;
-    }
+    use ApiClientTrait;
 
     /**
      * Add parent to a folder.

--- a/src/Controller/Component/ParentsComponent.php
+++ b/src/Controller/Component/ParentsComponent.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Controller\Component;
+
+use BEdita\SDK\BEditaClient;
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Controller\Component;
+
+/**
+ * Parents component.
+ * This component is used to add/remove parents to a folder.
+ */
+class ParentsComponent extends Component
+{
+    /**
+     * BEdita Api client
+     *
+     * @var \BEdita\SDK\BEditaClient
+     */
+    protected $apiClient = null;
+
+    /**
+     * Get API client.
+     *
+     * @return \BEdita\SDK\BEditaClient
+     */
+    public function getClient(): BEditaClient
+    {
+        if ($this->apiClient === null) {
+            $this->apiClient = ApiClientProvider::getApiClient();
+        }
+
+        return $this->apiClient;
+    }
+
+    /**
+     * Add parent to a folder.
+     *
+     * @param string $folderId Folder ID.
+     * @param array $parents Parent objects as id/type pairs.
+     * @return array
+     */
+    public function addRelated(string $folderId, array $parents): array
+    {
+        $results = [];
+        foreach ($parents as $parent) {
+            $results[] = $this->getClient()->replaceRelated($folderId, 'folders', 'parent', $parent);
+        }
+
+        return $results;
+    }
+}

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -24,9 +24,11 @@ use Psr\Log\LogLevel;
  * Modules controller: list, add, edit, remove objects
  *
  * @property \App\Controller\Component\CategoriesComponent $Categories
+ * @property \App\Controller\Component\ChildrenComponent $Children
  * @property \App\Controller\Component\CloneComponent $Clone
  * @property \App\Controller\Component\HistoryComponent $History
  * @property \App\Controller\Component\ObjectsEditorsComponent $ObjectsEditors
+ * @property \App\Controller\Component\ParentsComponent $Parents
  * @property \App\Controller\Component\ProjectConfigurationComponent $ProjectConfiguration
  * @property \App\Controller\Component\PropertiesComponent $Properties
  * @property \App\Controller\Component\QueryComponent $Query
@@ -52,9 +54,11 @@ class ModulesController extends AppController
         parent::initialize();
 
         $this->loadComponent('Categories');
+        $this->loadComponent('Children');
         $this->loadComponent('Clone');
         $this->loadComponent('History');
         $this->loadComponent('ObjectsEditors');
+        $this->loadComponent('Parents');
         $this->loadComponent('Properties');
         $this->loadComponent('ProjectConfiguration');
         $this->loadComponent('Query');

--- a/src/Utility/ApiClientTrait.php
+++ b/src/Utility/ApiClientTrait.php
@@ -25,7 +25,7 @@ trait ApiClientTrait
     /**
      * BEdita Api client
      *
-     * @var \BEdita\SDK\BEditaClient
+     * @var \BEdita\SDK\BEditaClient|null
      */
     protected $apiClient = null;
 

--- a/src/Utility/ApiClientTrait.php
+++ b/src/Utility/ApiClientTrait.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Utility;
+
+use BEdita\SDK\BEditaClient;
+use BEdita\WebTools\ApiClientProvider;
+
+/**
+ * Read and write configuration via API
+ */
+trait ApiClientTrait
+{
+    /**
+     * BEdita Api client
+     *
+     * @var \BEdita\SDK\BEditaClient
+     */
+    protected $apiClient = null;
+
+    /**
+     * Get API client.
+     *
+     * @return \BEdita\SDK\BEditaClient
+     */
+    public function getClient(): BEditaClient
+    {
+        if ($this->apiClient === null) {
+            $this->apiClient = ApiClientProvider::getApiClient();
+        }
+
+        return $this->apiClient;
+    }
+}

--- a/templates/Element/Form/trees.twig
+++ b/templates/Element/Form/trees.twig
@@ -32,6 +32,7 @@
             {{ Form.hidden('_changedParents', {'value': '0', 'id': 'changedParents'})|raw }}
             {% do Form.unlockField('_changedParents') %}
             {% do Form.unlockField('_changedCanonical') %}
+            {% do Form.unlockField('_originalParents') %}
         </div>
     </section>
 </property-view>

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -495,7 +495,6 @@ class AppControllerTest extends TestCase
                     '_changedParents' => true,
                 ],
             ],
-
             'no parents action' => [
                 'folders', // object_type
                 [
@@ -589,6 +588,52 @@ class AppControllerTest extends TestCase
                     '_jsonKeys' => 'json_prop,json_prop2',
                     'json_prop' => '{ }',
                     'json_prop2' => '{"gin":"vodka"}',
+                ],
+            ],
+            'remove related, not parent' => [
+                'documents', // object_type
+                [
+                    'id' => '1',
+                    '_api' => [
+                        [
+                            'method' => 'addRelated',
+                            'id' => '1',
+                            'relation' => 'parents',
+                            'relatedIds' => [
+                                [
+                                    'id' => '44',
+                                    'type' => 'images',
+                                ],
+                            ],
+                        ],
+                        [
+                            'method' => 'removeRelated',
+                            'id' => '1',
+                            'relation' => 'parents',
+                            'relatedIds' => [
+                                [
+                                    'id' => '999',
+                                    'type' => 'folders',
+                                ],
+                                [
+                                    'id' => '888',
+                                    'type' => 'folders',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [ // data provided
+                    'id' => '1', // fake document id
+                    'relations' => [
+                        'parents' => [
+                            'replaceRelated' => [
+                                '{ "id": "44", "type": "images"}',
+                            ],
+                        ],
+                    ],
+                    '_changedParents' => true,
+                    '_originalParents' => '999,888',
                 ],
             ],
         ];

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -488,14 +488,6 @@ class AppControllerTest extends TestCase
                 'documents', // object_type
                 [
                     'id' => '1',
-                    '_api' => [ // expected new property in data
-                        [
-                            'method' => 'replaceRelated',
-                            'id' => '1',
-                            'relation' => 'parents',
-                            'relatedIds' => [],
-                        ],
-                    ],
                 ],
                 [ // data provided
                     'id' => '1', // fake document id
@@ -526,7 +518,7 @@ class AppControllerTest extends TestCase
                     'id' => '2',
                     '_api' => [ // expected new property in data
                         [
-                            'method' => 'replaceRelated',
+                            'method' => 'addRelated',
                             'id' => '2',
                             'relation' => 'parents',
                             'relatedIds' => [
@@ -1098,5 +1090,69 @@ class AppControllerTest extends TestCase
         $actual = $method->invokeArgs($this->AppController, [ '' ]);
 
         static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testRelatedIds` test case.
+     */
+    public function relatedIdsProvider(): array
+    {
+        return [
+            'empty items' => [
+                [],
+                [],
+            ],
+            'string items' => [
+                '["1", "2", "3"]',
+                ['1', '2', '3'],
+            ],
+            'array of string items' => [
+                ['1', '2', '3'],
+                ['1', '2', '3'],
+            ],
+            'array of array items' => [
+                [
+                    ['id' => '1', 'name' => 'Item 1'],
+                    ['id' => '2', 'name' => 'Item 2'],
+                    ['id' => '3', 'name' => 'Item 3'],
+                ],
+                [
+                    ['id' => '1', 'name' => 'Item 1'],
+                    ['id' => '2', 'name' => 'Item 2'],
+                    ['id' => '3', 'name' => 'Item 3'],
+                ],
+            ],
+            'array of JSON string items' => [
+                [
+                    '{"id": "1", "name": "Item 1"}',
+                    '{"id": "2", "name": "Item 2"}',
+                    '{"id": "3", "name": "Item 3"}',
+                ],
+                [
+                    ['id' => '1', 'name' => 'Item 1'],
+                    ['id' => '2', 'name' => 'Item 2'],
+                    ['id' => '3', 'name' => 'Item 3'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test relatedIds method with empty items.
+     *
+     * @param mixed $items The items to test
+     * @param array $expected The expected result
+     * @return void
+     * @covers ::relatedIds()
+     * @dataProvider relatedIdsProvider()
+     */
+    public function testRelatedIds($items, array $expected): void
+    {
+        $this->setupController();
+        $reflectionClass = new \ReflectionClass($this->AppController);
+        $method = $reflectionClass->getMethod('relatedIds');
+        $method->setAccessible(true);
+        $actual = $method->invokeArgs($this->AppController, [$items]);
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/TestCase/Controller/BaseControllerTest.php
+++ b/tests/TestCase/Controller/BaseControllerTest.php
@@ -197,7 +197,7 @@ class BaseControllerTest extends TestCase
         $adminUser = getenv('BEDITA_ADMIN_USR');
         $adminPassword = getenv('BEDITA_ADMIN_PWD');
         $response = $this->client->authenticate($adminUser, $adminPassword);
-        $this->client->setupTokens($response['meta']);
+        $this->client->setupTokens((array)Hash::get($response, 'meta'));
     }
 
     public function testDummy(): void

--- a/tests/TestCase/Controller/Component/ChildrenComponentTest.php
+++ b/tests/TestCase/Controller/Component/ChildrenComponentTest.php
@@ -36,7 +36,6 @@ class ChildrenComponentTest extends TestCase
      * @return void
      * @covers ::addRelated()
      * @covers ::addRelatedChild()
-     * @covers ::getClient()
      */
     public function testAddRelated(): void
     {
@@ -66,7 +65,6 @@ class ChildrenComponentTest extends TestCase
      * @return void
      * @covers ::removeRelated()
      * @covers ::removeRelatedChild()
-     * @covers ::getClient()
      */
     public function testRemoveRelated(): void
     {

--- a/tests/TestCase/Controller/Component/ChildrenComponentTest.php
+++ b/tests/TestCase/Controller/Component/ChildrenComponentTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Controller\Component;
+
+use App\Controller\Component\ChildrenComponent;
+use BEdita\SDK\BEditaClient;
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Controller\ComponentRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \App\Controller\Component\ChildrenComponent} Test Case
+ *
+ * @coversDefaultClass \App\Controller\Component\ChildrenComponent
+ */
+class ChildrenComponentTest extends TestCase
+{
+    /**
+     * @var \App\Controller\Component\ChildrenComponent
+     */
+    protected $component;
+
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown(): void
+    {
+        unset($this->component);
+        parent::tearDown();
+    }
+
+    /**
+     * Test addRelated method with valid data.
+     *
+     * @return void
+     * @covers ::addRelated()
+     * @covers ::addRelatedChild()
+     * @covers ::getClient()
+     */
+    public function testAddRelated(): void
+    {
+        $safeClient = ApiClientProvider::getApiClient();
+        $children = [
+            ['id' => '9991', 'type' => 'documents', 'meta' => ['title' => 'Document']],
+            ['id' => '9992', 'type' => 'images', 'meta' => ['title' => 'Image']],
+            ['id' => '9993', 'type' => 'folders', 'meta' => ['title' => 'Folder']],
+        ];
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->expects($this->exactly(3))
+            ->method('addRelated')
+            ->willReturn(['add response']);
+        ApiClientProvider::setApiClient($apiClient);
+        $registry = new ComponentRegistry();
+        $this->component = new ChildrenComponent($registry);
+        $result = $this->component->addRelated('9990', $children);
+        $this->assertEquals([['add response'], ['add response'], ['add response']], $result);
+        ApiClientProvider::setApiClient($safeClient);
+    }
+
+    /**
+     * Test removeRelated method with valid data.
+     *
+     * @return void
+     * @covers ::removeRelated()
+     * @covers ::removeRelatedChild()
+     * @covers ::getClient()
+     */
+    public function testRemoveRelated(): void
+    {
+        $safeClient = ApiClientProvider::getApiClient();
+        $children = [
+            ['id' => '9991', 'type' => 'documents', 'meta' => ['title' => 'Document']],
+            ['id' => '9992', 'type' => 'images', 'meta' => ['title' => 'Image']],
+            ['id' => '9993', 'type' => 'folders', 'meta' => ['title' => 'Folder']],
+        ];
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->expects($this->exactly(2))
+            ->method('removeRelated')
+            ->willReturn(['remove response']);
+        $apiClient->expects($this->once())
+            ->method('replaceRelated')
+            ->willReturn(['replace response']);
+        ApiClientProvider::setApiClient($apiClient);
+        $registry = new ComponentRegistry();
+        $this->component = new ChildrenComponent($registry);
+        $result = $this->component->removeRelated('9990', $children);
+        $this->assertEquals([['remove response'], ['remove response'], ['replace response']], $result);
+        ApiClientProvider::setApiClient($safeClient);
+    }
+}

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1533,150 +1533,6 @@ class ModulesComponentTest extends TestCase
     }
 
     /**
-     * Data provider for testSaveObjects
-     *
-     * @return array
-     */
-    public function saveObjectsProvider(): array
-    {
-        return [
-            'empty data' => [
-                [], // objects
-                [], // expected
-            ],
-            'empty attributes' => [
-                [['attributes' => []]], // objects
-                [['attributes' => []]], // expected
-            ],
-            'full example' => [
-                [
-                    [
-                        'type' => 'documents',
-                        'attributes' => [
-                            'title' => 'dummy one',
-                            'status' => 'on',
-                            'something-empty' => '',
-                            'something-not-empty' => 'not empty',
-                        ],
-                    ],
-                    [
-                        'type' => 'documents',
-                        'attributes' => [
-                            'title' => 'dummy two',
-                            'status' => 'on',
-                            'something-empty' => '',
-                            'something-not-empty' => 'not empty',
-                        ],
-                    ],
-                ], // objects
-                [
-                    [
-                        'type' => 'documents',
-                        'attributes' => [
-                            'title' => 'dummy one',
-                            'status' => 'on',
-                            'something-empty' => '',
-                            'something-not-empty' => 'not empty',
-                        ],
-                    ],
-                    [
-                        'type' => 'documents',
-                        'attributes' => [
-                            'title' => 'dummy two',
-                            'status' => 'on',
-                            'something-empty' => '',
-                            'something-not-empty' => 'not empty',
-                        ],
-                    ],
-                ], // expected
-            ],
-        ];
-    }
-
-    /**
-     * Test `saveObjects`
-     *
-     * @param array $objects The test objects
-     * @param array $expected The expected data
-     * @return void
-     * @dataProvider saveObjectsProvider
-     * @covers ::saveObjects()
-     * @covers ::saveObject()
-     */
-    public function testSaveObjects(array $objects, array $expected): void
-    {
-        $this->setupApi();
-        $this->Modules->saveObjects($objects);
-        foreach ($expected as $index => &$exp) {
-            if (!empty($exp['attributes'])) {
-                $object = $objects[$index];
-                static::assertArrayHasKey('id', $object);
-                static::assertNotNull($object['id']);
-                $exp['id'] = $object['id'];
-            }
-        }
-        static::assertEquals($expected, $objects);
-    }
-
-    /**
-     * Data provider for testSaveObject
-     *
-     * @return array
-     */
-    public function saveObjectProvider(): array
-    {
-        return [
-            'empty data' => [
-                [], // object
-                [], // expected
-            ],
-            'empty attributes' => [
-                ['attributes' => []], // object
-                ['attributes' => []], // expected
-            ],
-            'full example' => [
-                [
-                    'type' => 'documents',
-                    'attributes' => [
-                        'status' => 'on',
-                        'something-empty' => '',
-                        'something-not-empty' => 'not empty',
-                    ],
-                ], // object
-                [
-                    'type' => 'documents',
-                    'attributes' => [
-                        'status' => 'on',
-                        'something-empty' => '',
-                        'something-not-empty' => 'not empty',
-                    ],
-                ], // expected
-            ],
-        ];
-    }
-
-    /**
-     * Test `saveObject`
-     *
-     * @param array $object The test object
-     * @param array $expected The expected data
-     * @return void
-     * @dataProvider saveObjectProvider
-     * @covers ::saveObject()
-     */
-    public function testSaveObject(array $object, array $expected): void
-    {
-        $this->setupApi();
-        $this->Modules->saveObject($object);
-        if (!empty($expected['attributes'])) {
-            static::assertArrayHasKey('id', $object);
-            static::assertNotNull($object['id']);
-            $expected['id'] = $object['id'];
-        }
-        static::assertEquals($expected, $object);
-    }
-
-    /**
      * Data provider for `testSaveRelated`.
      *
      * @return array
@@ -1767,7 +1623,7 @@ class ModulesComponentTest extends TestCase
                         ],
                     ],
                 ], // relatedData
-                'replaceRelated', // expected
+                'addRelated', // expected
             ],
             'folders children folders' => [
                 222, // id
@@ -1779,7 +1635,7 @@ class ModulesComponentTest extends TestCase
                         'relatedIds' => [['id' => 123, 'type' => 'folders']],
                     ],
                 ], // relatedData
-                'replaceRelated', // expected
+                'addRelated', // expected
             ],
             'folders children mixed' => [
                 333, // id
@@ -1806,8 +1662,7 @@ class ModulesComponentTest extends TestCase
      * @return void
      * @dataProvider saveRelatedProvider
      * @covers ::saveRelated()
-     * @covers ::folderChildrenRelated()
-     * @covers ::folderChildrenRemove()
+     * @covers ::saveRelatedObjects()
      */
     public function testSaveRelated(int $id, string $type, array $relatedData, $expected): void
     {
@@ -1824,17 +1679,22 @@ class ModulesComponentTest extends TestCase
         $apiClient->method('addRelated')
             ->will($this->returnCallback(function () use (&$actual) {
                 $actual = 'addRelated';
+
+                return ['response addRelated'];
             }));
         $apiClient->method('removeRelated')
             ->will($this->returnCallback(function () use (&$actual) {
                 $actual = 'removeRelated';
+
+                return ['response removeRelated'];
             }));
         $apiClient->method('replaceRelated')
             ->will($this->returnCallback(function () use (&$actual) {
                 $actual = 'replaceRelated';
+
+                return ['response replaceRelated'];
             }));
         ApiClientProvider::setApiClient($apiClient);
-
         $this->Modules->saveRelated((string)$id, $type, $relatedData);
         static::assertEquals($expected, $actual);
     }

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1649,6 +1649,18 @@ class ModulesComponentTest extends TestCase
                 ], // relatedData
                 'removeRelated', // expected
             ],
+            'folders parent' => [
+                333, // id
+                'documents', // type
+                [
+                    [
+                        'method' => 'addRelated',
+                        'relation' => 'parent',
+                        'relatedIds' => [['id' => 123, 'type' => 'folders'], ['id' => 456, 'type' => 'folders']],
+                    ],
+                ], // relatedData
+                'addRelated', // expected
+            ],
         ];
     }
 

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1651,7 +1651,7 @@ class ModulesComponentTest extends TestCase
             ],
             'folders parent' => [
                 333, // id
-                'documents', // type
+                'folders', // type
                 [
                     [
                         'method' => 'addRelated',
@@ -1659,7 +1659,7 @@ class ModulesComponentTest extends TestCase
                         'relatedIds' => [['id' => 123, 'type' => 'folders'], ['id' => 456, 'type' => 'folders']],
                     ],
                 ], // relatedData
-                'addRelated', // expected
+                'replaceRelated', // expected
             ],
         ];
     }

--- a/tests/TestCase/Controller/Component/ParentsComponentTest.php
+++ b/tests/TestCase/Controller/Component/ParentsComponentTest.php
@@ -35,7 +35,6 @@ class ParentsComponentTest extends TestCase
      *
      * @return void
      * @covers ::addRelated()
-     * @covers ::getClient()
      */
     public function testAddRelated(): void
     {

--- a/tests/TestCase/Controller/Component/ParentsComponentTest.php
+++ b/tests/TestCase/Controller/Component/ParentsComponentTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Controller\Component;
+
+use App\Controller\Component\ParentsComponent;
+use BEdita\SDK\BEditaClient;
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Controller\ComponentRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \App\Controller\Component\ParentsComponent} Test Case
+ *
+ * @coversDefaultClass \App\Controller\Component\ParentsComponent
+ */
+class ParentsComponentTest extends TestCase
+{
+    /**
+     * @var \App\Controller\Component\ParentsComponent
+     */
+    protected $component;
+
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown(): void
+    {
+        unset($this->component);
+        parent::tearDown();
+    }
+
+    /**
+     * Test addRelated method with valid data.
+     *
+     * @return void
+     * @covers ::addRelated()
+     * @covers ::getClient()
+     */
+    public function testAddRelated(): void
+    {
+        $safeClient = ApiClientProvider::getApiClient();
+        $children = [
+            ['id' => '9991', 'type' => 'documents', 'meta' => ['title' => 'Document']],
+            ['id' => '9992', 'type' => 'images', 'meta' => ['title' => 'Image']],
+            ['id' => '9993', 'type' => 'folders', 'meta' => ['title' => 'Folder']],
+        ];
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->expects($this->exactly(3))
+            ->method('replaceRelated')
+            ->willReturn(['replace response']);
+        ApiClientProvider::setApiClient($apiClient);
+        $registry = new ComponentRegistry();
+        $this->component = new ParentsComponent($registry);
+        $result = $this->component->addRelated('9990', $children);
+        $this->assertEquals([['replace response'], ['replace response'], ['replace response']], $result);
+        ApiClientProvider::setApiClient($safeClient);
+    }
+}

--- a/tests/TestCase/Utility/ApiClientTraitTest.php
+++ b/tests/TestCase/Utility/ApiClientTraitTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Test\TestCase\Utility;
+
+use App\Utility\ApiClientTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \App\Utility\ApiClientTrait} Test Case
+ *
+ * @coversDefaultClass \App\Utility\ApiClientTrait
+ */
+class ApiClientTraitTest extends TestCase
+{
+    use ApiClientTrait;
+
+    /**
+     * Test getClient method.
+     *
+     * @return void
+     * @covers ::getClient()
+     */
+    public function testGetClient(): void
+    {
+        $this->apiClient = null;
+        $actual = $this->getClient();
+        static::assertNotNull($actual);
+    }
+}


### PR DESCRIPTION
This provides a refactor in parent and children data save.
Details:

 - in `tree-view` component no more checkbox can be disabled, but some can be "readonly" (according to user permissions on specified folders)
 - on children save, only "changed" ids are involved
 - children save is organized in separate `addRelated` (`POST`) and `removeRelated` (`DELETE`), to avoid a `405 Method not allowed` when using `replaceRelated` (`PATCH`) on folders where the authenticated user has no permissions
 - parent save uses `replaceRelated` (`PATCH`)
 - remove `saveObjects` and `saveObject` calls used only to obtain id and type