### PR TITLE
Fix `tag-picker`: name basic validation and autocomplete picks enabled only

### DIFF
--- a/resources/js/app/components/tag-picker/tag-picker.js
+++ b/resources/js/app/components/tag-picker/tag-picker.js
@@ -99,7 +99,7 @@ export default {
                 }
             }
             this.selectedTags.push({
-                'id': this.text,
+                'id': this.text.toLowerCase(),
                 'label': this.text,
                 'originalLabel': this.text
             });
@@ -112,7 +112,7 @@ export default {
                 return callback(null, []);
             }
 
-            const res = await fetch(`${BEDITA.base}/api/model/tags?filter[query]=${searchQuery}&page_size=30`, API_OPTIONS);
+            const res = await fetch(`${BEDITA.base}/api/model/tags?filter[query]=${searchQuery}&filter[enabled]=1page_size=30`, API_OPTIONS);
             const json = await res.json();
             const tags = [...(json.data || [])];
 

--- a/resources/js/app/components/tag-picker/tag-picker.js
+++ b/resources/js/app/components/tag-picker/tag-picker.js
@@ -112,7 +112,7 @@ export default {
                 return callback(null, []);
             }
 
-            const res = await fetch(`${BEDITA.base}/api/model/tags?filter[query]=${searchQuery}&filter[enabled]=1page_size=30`, API_OPTIONS);
+            const res = await fetch(`${BEDITA.base}/api/model/tags?filter[query]=${searchQuery}&filter[enabled]=1&page_size=30`, API_OPTIONS);
             const json = await res.json();
             const tags = [...(json.data || [])];
 

--- a/resources/js/app/components/tag-picker/tag-picker.vue
+++ b/resources/js/app/components/tag-picker/tag-picker.vue
@@ -101,14 +101,31 @@ export default {
                 }
             }
             this.selectedTags.push({
-                'id': this.text.toLowerCase(),
+                'id': this.validatedName(this.text),
                 'label': this.text,
                 'originalLabel': this.text
             });
             this.text = '';
             this.parseBeforeSave();
         },
+        validatedName(name) {
+            // no spaces
+            name = name.trim();
+            name = name.replaceAll(' ', '-');
 
+            // starts with a lowercase letter or number
+            if (name.charAt(0).match(/[a-z]/i)) {
+                name = name.charAt(0).toLowerCase() + name.slice(1);
+            }
+            console.log(name);
+
+            // length between 2 and 50 characters
+            if (name.length > 50) {
+                return name.substring(0, 50);
+            }
+
+            return name;
+        },
         async fetchTags({ action, searchQuery, callback }) {
             if (action !== ASYNC_SEARCH || searchQuery?.length < QUERY_MIN_LENGTH) {
                 return callback(null, []);

--- a/resources/js/app/components/tag-picker/tag-picker.vue
+++ b/resources/js/app/components/tag-picker/tag-picker.vue
@@ -114,7 +114,7 @@ export default {
             name = name.replaceAll(' ', '-');
 
             // starts with a lowercase letter or number
-            if (name.charAt(0).match(/[a-z]/i)) {
+            if (name.charAt(0).match(/[A-Z]/)) {
                 name = name.charAt(0).toLowerCase() + name.slice(1);
             }
 

--- a/resources/js/app/components/tag-picker/tag-picker.vue
+++ b/resources/js/app/components/tag-picker/tag-picker.vue
@@ -2,7 +2,7 @@
     <div class="tag-picker">
         <label v-if="label">{{ label }}</label>
         <Treeselect
-            placeholder="${t`Search existing tags`}"
+            :placeholder="msgSearchExistingTags"
             :options="tagsOptions"
             :async="true"
             :clearable="false"
@@ -62,6 +62,7 @@ export default {
             text: '',
             msgAdd: t`Add`,
             msgAddNewTag: t`Add new tag`,
+            msgSearchExistingTags: t`Search existing tags`,
         };
     },
 

--- a/resources/js/app/components/tag-picker/tag-picker.vue
+++ b/resources/js/app/components/tag-picker/tag-picker.vue
@@ -117,7 +117,6 @@ export default {
             if (name.charAt(0).match(/[a-z]/i)) {
                 name = name.charAt(0).toLowerCase() + name.slice(1);
             }
-            console.log(name);
 
             // length between 2 and 50 characters
             if (name.length > 50) {

--- a/resources/js/app/components/tag-picker/tag-picker.vue
+++ b/resources/js/app/components/tag-picker/tag-picker.vue
@@ -1,3 +1,33 @@
+<template>
+    <div class="tag-picker">
+        <label v-if="label">{{ label }}</label>
+        <Treeselect
+            placeholder="${t`Search existing tags`}"
+            :options="tagsOptions"
+            :async="true"
+            :clearable="false"
+            :load-options="fetchTags"
+            :disabled="disabled"
+            :disable-branch-nodes="true"
+            :multiple="true"
+            value-format="object"
+            v-model="selectedTags"
+            @select="onAdd"
+            @deselect="onRemove"
+            @input="onChange"
+        />
+        <div class="new-tag" v-show="!searchonly">
+            <label for="new-tag">{{ msgAddNewTag }}</label>
+            <div class="input-container">
+                <input type="text" :form="form" :value="text" id="new-tag" @input="update($event.target.value)" />
+                <button @click.prevent="addNewTag">{{ msgAdd }}</button>
+            </div>
+        </div>
+        <input type="hidden" :form="form" :id="id" name="tags" :value="modifiedTags" />
+        <input type="hidden" :form="form" name="_types[tags]" value="json" />
+    </div>
+</template>
+<script>
 import { Treeselect, ASYNC_SEARCH } from '@riophae/vue-treeselect'
 import { t } from 'ttag';
 import '@riophae/vue-treeselect/dist/vue-treeselect.css'
@@ -15,36 +45,6 @@ export default {
         Treeselect,
     },
 
-    template: `
-        <div class="tag-picker">
-            <label v-if="label"><: label :></label>
-            <Treeselect
-                placeholder="${t`Search existing tags`}"
-                :options="tagsOptions"
-                :async="true"
-                :clearable="false"
-                :load-options="fetchTags"
-                :disabled="disabled"
-                :disable-branch-nodes="true"
-                :multiple="true"
-                value-format="object"
-                v-model="selectedTags"
-                @select="onAdd"
-                @deselect="onRemove"
-                @input="onChange"
-            />
-            <div class="new-tag" v-show="!searchonly">
-                <label for="new-tag">${t`Add new tag`}</label>
-                <div class="input-container">
-                    <input type="text" :form="form" :value="text" id="new-tag" @input="update($event.target.value)" />
-                    <button @click.prevent="addNewTag">${t`Add`}</button>
-                </div>
-            </div>
-            <input type="hidden" :form="form" :id="id" name="tags" :value="modifiedTags" />
-            <input type="hidden" :form="form" name="_types[tags]" value="json" />
-        </div>
-    `,
-
     props: {
         id: String,
         disabled: Boolean,
@@ -60,6 +60,8 @@ export default {
             modifiedTags: null,
             tagsOptions: [],
             text: '',
+            msgAdd: t`Add`,
+            msgAddNewTag: t`Add new tag`,
         };
     },
 
@@ -123,3 +125,4 @@ export default {
         },
     },
 }
+</script>


### PR DESCRIPTION
This provides a fix in tag usage in object views:

 - new tag name basic validation (to avoid an API error on save, after the validation introduced by https://github.com/bedita/bedita/pull/1976 and https://github.com/bedita/bedita/pull/1977)
 - autocomplete shows enabled only results

New tag name is generated from label, applying some modifications:

 - trim
 - replace spaces with '-'
 - if first char is an upper case letter, replace it with lower case one
 - truncate to 50 chars, if longer than that