### PR TITLE
Nullable boolean properties shown as `select` in forms

### DIFF
--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -26,7 +26,17 @@ class Control
     /**
      * Control types
      */
-    public const CONTROL_TYPES = ['json', 'richtext', 'plaintext', 'date-time', 'date', 'checkbox', 'enum', 'categories'];
+    public const CONTROL_TYPES = [
+        'json',
+        'richtext',
+        'plaintext',
+        'date-time',
+        'date',
+        'checkbox',
+        'checkboxNullable',
+        'enum',
+        'categories',
+    ];
 
     /**
      * Get control by options
@@ -240,6 +250,25 @@ class Control
             'type' => 'checkbox',
             'checked' => filter_var($value, FILTER_VALIDATE_BOOLEAN),
             'value' => '1',
+        ];
+    }
+
+    /**
+     * Control for checkbox nullable
+     *
+     * @param array $options The options
+     * @return array
+     */
+    public static function checkboxNullable(array $options): array
+    {
+        return [
+            'type' => 'select',
+            'options' => [
+                'null' => '',
+                '1' => __('Yes'),
+                '0' => __('No'),
+            ],
+            'value' => Hash::get($options, 'value'),
         ];
     }
 

--- a/tests/TestCase/Form/ControlTest.php
+++ b/tests/TestCase/Form/ControlTest.php
@@ -167,6 +167,25 @@ class ControlTest extends TestCase
                     'checked' => false,
                 ],
             ],
+            'checkbox nullable' => [
+                [
+                    'type' => 'boolean',
+                    'oneOf' => [
+                        [
+                            'type' => 'null',
+                        ],
+                        [
+                            'type' => 'boolean',
+                        ],
+                    ],
+                ],
+                'checkbox',
+                'false',
+                [
+                    'type' => 'checkboxNullable',
+                    'checked' => false,
+                ],
+            ],
             'enum' => [
                 [
                     'type' => 'string',
@@ -297,6 +316,7 @@ class ControlTest extends TestCase
      * @covers ::datetime()
      * @covers ::date()
      * @covers ::checkbox()
+     * @covers ::checkboxNullable()
      * @covers ::enum()
      * @covers ::categories()
      * @covers ::oneOptions()

--- a/tests/TestCase/Form/ControlTest.php
+++ b/tests/TestCase/Form/ControlTest.php
@@ -58,7 +58,6 @@ class ControlTest extends TestCase
                 [
                     'type' => 'textarea',
                     'v-richeditor' => '""',
-                    'readonly' => 0,
                     'value' => $value,
                 ],
             ],
@@ -109,6 +108,7 @@ class ControlTest extends TestCase
                 [
                     'type' => 'checkbox',
                     'checked' => true,
+                    'value' => '1',
                 ],
             ],
             'checkbox' => [
@@ -151,6 +151,7 @@ class ControlTest extends TestCase
                         ],
                     ],
                     'multiple' => 'checkbox',
+                    'value' => null,
                 ],
             ],
             'checkbox no options' => [
@@ -165,6 +166,7 @@ class ControlTest extends TestCase
                 [
                     'type' => 'checkbox',
                     'checked' => false,
+                    'value' => '1',
                 ],
             ],
             'checkbox nullable' => [
@@ -179,11 +181,16 @@ class ControlTest extends TestCase
                         ],
                     ],
                 ],
-                'checkbox',
+                'checkboxNullable',
                 'false',
                 [
-                    'type' => 'checkboxNullable',
-                    'checked' => false,
+                    'type' => 'select',
+                    'options' => [
+                        'null' => '',
+                        '1' => 'Yes',
+                        '0' => 'No',
+                    ],
+                    'value' => 'false',
                 ],
             ],
             'enum' => [
@@ -333,8 +340,9 @@ class ControlTest extends TestCase
             'propertyType' => $type,
         ];
         $actual = Control::control($options);
-
-        static::assertSame(sort($expected), sort($actual));
+        ksort($expected);
+        ksort($actual);
+        static::assertSame($expected, $actual);
     }
 
     /**

--- a/tests/TestCase/Form/ControlTypeTest.php
+++ b/tests/TestCase/Form/ControlTypeTest.php
@@ -83,10 +83,24 @@ class ControlTypeTest extends TestCase
                     'type' => 'boolean',
                 ],
             ],
-            'one of' => [
-                'checkbox',
+            'checkbox nullable' => [
+                'checkboxNullable',
                 [
-                    'type' => 'string',
+                    'type' => 'array',
+                    'oneOf' => [
+                        [
+                            'type' => 'null',
+                        ],
+                        [
+                            'type' => 'boolean',
+                        ],
+                    ],
+                ],
+            ],
+            'one of' => [
+                'checkboxNullable',
+                [
+                    'type' => 'boolean',
                     'oneOf' => [
                         [
                             'type' => 'null',

--- a/tests/TestCase/Form/ControlTypeTest.php
+++ b/tests/TestCase/Form/ControlTypeTest.php
@@ -86,7 +86,7 @@ class ControlTypeTest extends TestCase
             'checkbox nullable' => [
                 'checkboxNullable',
                 [
-                    'type' => 'array',
+                    'type' => 'boolean',
                     'oneOf' => [
                         [
                             'type' => 'null',


### PR DESCRIPTION
This resolves #1007. Nullable boolean properties are shown as `select` with 3 possible choices:

 - empty label (`null`)
 - Yes (`true`)
 - No (`false`)