### PR TITLE
Custom template in view, without properties + build includes plugins install

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     },
     "homepage": "https://github.com/bedita/manager#README",
     "scripts": {
-        "build": "webpack --mode production && webpack --config ./webpack.config.plugin.js --mode production",
+        "install:plugins": "for D in ./plugins/*; do echo \"Installing stuff on ${D}\" && yarn --cwd \"./plugins/${D}\"; done",
+        "build": "yarn install:plugins; webpack --mode production && webpack --config ./webpack.config.plugin.js --mode production",
         "bundle-report": "webpack --mode production --report",
         "develop": "webpack --mode development --hot",
         "dev": "webpack --mode development --hot",
         "dev-plugins": "webpack --config ./webpack.config.plugin.js --mode development",
-        "build-plugins": "webpack --config ./webpack.config.plugin.js --mode production"
+        "build-plugins": "yarn install:plugins; webpack --config ./webpack.config.plugin.js --mode production"
     },
     "dependencies": {
         "@chialab/typos": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     },
     "homepage": "https://github.com/bedita/manager#README",
     "scripts": {
-        "install:plugins": "for D in ./plugins/*; do echo \"Installing stuff on ${D}\" && yarn --cwd \"./plugins/${D}\"; done",
+        "install:plugins": "for D in ./plugins/*; do echo \"Installing stuff on ${D}\" && yarn install --cwd \"${D}\"; done",
         "build": "yarn install:plugins; webpack --mode production && webpack --config ./webpack.config.plugin.js --mode production",
         "bundle-report": "webpack --mode production --report",
         "develop": "webpack --mode development --hot",

--- a/resources/js/app/components/relation-view/relation-view.js
+++ b/resources/js/app/components/relation-view/relation-view.js
@@ -206,7 +206,7 @@ export default {
                 return positions;
             }, {});
             this.priorities = newObjects.reduce((priorities, object) => {
-                priorities[object.id] = object.meta.relation.priority;
+                priorities[object.id] = object?.meta?.relation?.priority || '';
                 return priorities;
             }, {});
         },

--- a/templates/Element/Form/other_properties.twig
+++ b/templates/Element/Form/other_properties.twig
@@ -20,6 +20,28 @@
         </section>
 
     </property-view>
+    {% else %}
+
+    <property-view inline-template :tab-open="tabsOpen" tab-name="{{ group }}">
+
+        <section class="fieldset">
+            <header @click.prevent="toggleVisibility()"
+                class="tab unselectable"
+                :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                <h2>{{ Layout.tr(group) }}</h2>
+            </header>
+
+            <div v-show="isOpen" class="tab-container">
+
+                {% set customElement = Element.custom(group, 'group') %}
+                {% if customElement %}
+                    {{ element(customElement) }}
+                {% endif %}
+
+            </div>
+        </section>
+
+    </property-view>
 
     {% endif %}
 {% endfor %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,9 +2094,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001400:
-  version "1.0.30001439"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz#ab7371faeb4adff4b74dad1718a6fd122e45d9cb"
-  integrity sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==
+  version "1.0.30001502"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz"
+  integrity sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==
 
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -4999,7 +4999,7 @@ socket.io-client@^4.4.1:
     engine.io-client "~6.2.3"
     socket.io-parser "~4.2.1"
 
-socket.io-parser@4.2.3, socket.io-parser@~4.2.1:
+socket.io-parser@~4.2.1:
   version "4.2.3"
   resolved "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.3.tgz#926bcc6658e2ae0883dc9dee69acbdc76e4e3667"
   integrity sha512-JMafRntWVO2DCJimKsRTh/wnqVvO4hrfwOqtO7f+uzwsQMuxO6VwImtYxaQ+ieoyshWOTJyV0fA21lccEXRPpQ==


### PR DESCRIPTION
This provides:

 - a way to embed custom templates that don't have any form properties
 - a change in javascript `build`: a `install:plugins` step is performed, before javascript building

Minor fixes:

 - update `caniuse-lite`
 - fix in `relation-view` to avoid console error on missing `meta.relation.priority` (`Cannot read properties of undefined (reading 'priority')`