### PR TITLE
Save position remove all parents

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -357,7 +357,7 @@ class AppController extends Controller
             return;
         }
         $replaceRelated = array_reduce(
-            $data['relations'][$relation]['replaceRelated'],
+            (array)Hash::get($data, sprintf('relations.%s.replaceRelated', $relation)),
             function ($acc, $obj) {
                 $jsonObj = (array)json_decode($obj, true);
                 $acc[(string)Hash::get($jsonObj, 'id')] = $jsonObj;


### PR DESCRIPTION
This fixes a buggy behavior on saving an object, when position is an empty set (removing parents)