### PR TITLE
Translatable fields from schema

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -188,7 +188,6 @@ return [
      *  - 'filter' filters to display
      *  - 'bulk' bulk actions list
      *  - 'fastCreate' fields for fast creation forms, by type
-     *  - 'translatable' fields to add to translatable fields, not included by default (e.g. JSON fields)
      *
      * A special custom element 'Form/empty' can be used to hide a property group or relation via `_element`
      */
@@ -250,10 +249,6 @@ return [
         //     'fastCreate' => [
         //         'required' => ['status', 'title'],
         //         'all' => ['status', 'title', 'description'],
-        //     ],
-        //     'translatable' => [
-        //         'some_field',
-        //         'another_field',
         //     ],
         // ],
     // ],

--- a/resources/js/app/components/object-property/object-properties.vue
+++ b/resources/js/app/components/object-property/object-properties.vue
@@ -8,6 +8,7 @@
             :type="type"
             :is-hidden="hidden.includes(prop.attributes?.name)"
             :is-new="prop.id == 0"
+            :is-translatable="translatableProperties.includes(prop.attributes?.name)"
             :nobuttonsfor="immutable">
         </object-property>
 
@@ -25,6 +26,8 @@ export default {
         initProperties: [],
         type: '',
         hidden: [],
+        translatable: [],
+        translationRules: [],
     },
 
     components: {
@@ -34,12 +37,23 @@ export default {
     data() {
         return {
             properties: [],
+            translatableProperties: [],
             immutable: ['created', 'id', 'lang', 'locked', 'modified', 'status', 'uname'],
         };
     },
 
     mounted() {
         this.properties = this.initProperties;
+        this.translatableProperties = this.translatable;
+        if (this.translationRules) {
+            this.translatableProperties = this.translatable.filter((prop) => {
+                return !(prop in this.translationRules);
+            });
+            const forceTranslatable = Object.keys(this.translationRules).filter((prop) => {
+                return this.translationRules[prop] === true;
+            });
+            this.translatableProperties = [...this.translatableProperties, ...forceTranslatable];
+        }
         if (this.type !== 'custom') {
             return;
         }

--- a/resources/js/app/components/object-property/object-properties.vue
+++ b/resources/js/app/components/object-property/object-properties.vue
@@ -8,7 +8,7 @@
             :type="type"
             :is-hidden="hidden.includes(prop.attributes?.name)"
             :is-new="prop.id == 0"
-            :is-translatable="translatableProperties.includes(prop.attributes?.name)"
+            :is-translatable="translatable.includes(prop.attributes?.name)"
             :nobuttonsfor="immutable">
         </object-property>
 
@@ -37,23 +37,12 @@ export default {
     data() {
         return {
             properties: [],
-            translatableProperties: [],
             immutable: ['created', 'id', 'lang', 'locked', 'modified', 'status', 'uname'],
         };
     },
 
     mounted() {
         this.properties = this.initProperties;
-        this.translatableProperties = this.translatable;
-        if (this.translationRules) {
-            this.translatableProperties = this.translatable.filter((prop) => {
-                return !(prop in this.translationRules);
-            });
-            const forceTranslatable = Object.keys(this.translationRules).filter((prop) => {
-                return this.translationRules[prop] === true;
-            });
-            this.translatableProperties = [...this.translatableProperties, ...forceTranslatable];
-        }
         if (this.type !== 'custom') {
             return;
         }

--- a/resources/js/app/components/object-property/object-property.vue
+++ b/resources/js/app/components/object-property/object-property.vue
@@ -8,35 +8,42 @@
                         <Icon icon="carbon:information"></Icon>
                     </i>
                 </span>
-                <div class="grid">
-                    <span class="column-header">{{ msgLabel }}</span>
-                    <span>{{ prop.attributes.label || '-' }}</span>
-
-                    <span class="column-header">{{ msgType }}</span>
-                    <span class="property-val">{{ prop.attributes.property_type_name }}</span>
-
-                    <span class="column-header">{{ msgReadonly }}</span>
-                    <span class="property-val">{{ readonly }}</span>
-
-                    <span class="column-header">{{ msgHidden }}</span>
-                    <span>
-                        <select v-model="hidden" @change="updateHidden()">
-                            <option value="true">{{ msgYes }}</option>
-                            <option value="false">{{ msgNo }}</option>
-                        </select>
-                    </span>
-
-                    <span class="column-header">{{ msgTranslatable }}</span>
-                    <span>
-                        <select v-model="translatable" @change="updateTranslationRules()">
-                            <option value="true">{{ msgYes }}</option>
-                            <option value="false">{{ msgNo }}</option>
-                        </select>
-                    </span>
-
-                    <span v-if="type === 'inherited'" class="column-header">{{ msgInheritedFrom }}</span>
-                    <span v-if="type === 'inherited'">{{ prop.attributes.object_type_name }}</span>
-                </div>
+                <table>
+                    <tr>
+                        <td class="column-header">{{ msgLabel }}</td>
+                        <td>{{ prop.attributes.label }}</td>
+                    </tr>
+                    <tr>
+                        <td class="column-header">{{ msgType }}</td>
+                        <td class="property-val">{{ prop.attributes.property_type_name }}</td>
+                    </tr>
+                    <tr>
+                        <td class="column-header">{{ msgReadonly }}</td>
+                        <td class="property-val">{{ readonly }}</td>
+                    </tr>
+                    <tr>
+                        <td class="column-header">{{ msgHidden }}</td>
+                        <td>
+                            <select v-model="hidden" @change="updateHidden()">
+                                <option :value="true">{{ msgYes }}</option>
+                                <option :value="false">{{ msgNo }}</option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="column-header">{{ msgTranslatable }}</td>
+                        <td>
+                            <select v-model="translatable" @change="updateTranslationRules()">
+                                <option value="true">{{ msgYes }}</option>
+                                <option value="false">{{ msgNo }}</option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr v-if="type === 'inherited'">
+                        <td v-if="type === 'inherited'" class="column-header">{{ msgInheritedFrom }}</td>
+                        <td v-if="type === 'inherited'">{{ prop.attributes.object_type_name }}</td>
+                    </tr>
+                </table>
             </div>
             <div v-if="!nobuttonsfor.includes(prop.attributes.name)" class="column is-narrow">
                 <div class="buttons-container">
@@ -91,16 +98,16 @@ export default {
     computed: {
         boxClass() {
             if (this.hidden === true) {
-                return 'box pb-05 has-background-gray-600 has-text-white';
+                return 'container box pb-05 has-background-gray-600 has-text-white';
             }
             if (this.type === 'custom') {
-                return 'box pb-05 has-background-info has-text-white';
+                return 'container box pb-05 has-background-info has-text-white';
             }
             if (this.type === 'inherited') {
-                return 'box pb-05 has-background-gray-800 has-text-white';
+                return 'container box pb-05 has-background-gray-800 has-text-white';
             }
 
-            return 'box pb-05 has-background-black has-text-white';
+            return 'container box pb-05 has-background-black has-text-white';
         },
         tagClass() {
             if (this.type === 'custom') {
@@ -118,7 +125,7 @@ export default {
         updateHidden() {
             let hiddenProperties = JSON.parse(document.getElementById('hidden').value || '[]') || [];
             const index = hiddenProperties.indexOf(this.prop.attributes.name);
-            if (index >= 0 && this.hidden === 'false') {
+            if (index >= 0 && this.hidden === false) {
                 // remove property from hidden properties
                 hiddenProperties.splice(index, 1);
                 const newVal = JSON.stringify(hiddenProperties);
@@ -126,7 +133,7 @@ export default {
 
                 return;
             }
-            if (index < 0 && this.hidden === 'true') {
+            if (index < 0 && this.hidden === true) {
                 // add property to hidden properties
                 hiddenProperties.push(this.prop.attributes.name);
                 hiddenProperties.sort();
@@ -181,8 +188,7 @@ export default {
 }
 </script>
 <style>
-div.box {
-    min-width: 350px;
+div.container {
     padding: 0.5rem;
     margin: 0.5rem 0;
     border-radius: 25px;
@@ -193,12 +199,6 @@ div.column > p {
     margin: 0.5rem 0;
     border-bottom: dashed 1px gray;
 }
-div.column > div.grid {
-    display: grid;
-    grid-template-columns: 100px 1fr;
-    border-top: 1px dotted black;
-    border-right: 1px dotted black;
-}
 div.column > div > span {
     padding: 4px 8px;
     border-left: 1px dotted black;
@@ -206,14 +206,18 @@ div.column > div > span {
     white-space: normal;
     vertical-align: middle;
 }
-div.column > div > span.column-header {
-    color: yellow;
-    text-align: left;
-}
 div.column > div > span > a:hover {
     text-decoration: underline;
 }
-div.column > div > span.property-val {
+div.column > div.rows > div {
+    border-bottom: solid 1px gray;
+    padding: 0.5rem 0;
+}
+td.column-header {
+    color: yellow;
+    text-align: left;
+}
+td.property-val {
     font-family: monospace;
 }
 </style>

--- a/resources/js/app/components/object-property/object-property.vue
+++ b/resources/js/app/components/object-property/object-property.vue
@@ -13,15 +13,10 @@
                     <span>{{ prop.attributes.label || '-' }}</span>
 
                     <span class="column-header">{{ msgType }}</span>
-                    <span class="property-type-name">{{ prop.attributes.property_type_name }}</span>
+                    <span class="property-val">{{ prop.attributes.property_type_name }}</span>
 
                     <span class="column-header">{{ msgReadonly }}</span>
-                    <span>
-                        <select v-model="readonly">
-                            <option value="true">{{ msgYes }}</option>
-                            <option value="false">{{ msgNo }}</option>
-                        </select>
-                    </span>
+                    <span class="property-val">{{ readonly }}</span>
 
                     <span class="column-header">{{ msgHidden }}</span>
                     <span>
@@ -218,7 +213,7 @@ div.column > div > span.column-header {
 div.column > div > span > a:hover {
     text-decoration: underline;
 }
-div.column > div > span.property-type-name {
+div.column > div > span.property-val {
     font-family: monospace;
 }
 </style>

--- a/resources/js/app/components/object-property/object-property.vue
+++ b/resources/js/app/components/object-property/object-property.vue
@@ -1,29 +1,47 @@
 <template>
-    <div :class="boxClass()" v-show="display">
+    <div :class="boxClass" v-show="display">
         <div class="columns">
             <div class="column">
-                <span :class="tagClass()">{{ prop.attributes.name }}</span>
-                <span v-if="prop.attributes.description">
-                    {{ prop.attributes.description }}
+                <span :class="tagClass">
+                    {{ prop.attributes.name }}
+                    <i v-if="prop.attributes.description" v-title="prop.attributes.description" class="ml-05">
+                        <Icon icon="carbon:information"></Icon>
+                    </i>
                 </span>
-                <p>{{ msgLabel }}: {{ prop.attributes.label || '-' }}</p>
-                <p>{{ msgType }}: <b>{{ prop.attributes.property_type_name }}</b></p>
-                <p>{{ msgHidden }}:
-                    <select v-model="hidden" @change="updateHidden()">
-                        <option value="true">{{ msgYes }}</option>
-                        <option value="false">{{ msgNo }}</option>
-                    </select>
-                </p>
-                <p>{{ msgTranslatable }}:
-                    <select v-model="translatable" @change="updateTranslationRules()">
-                        <option value="true">{{ msgYes }}</option>
-                        <option value="false">{{ msgNo }}</option>
-                    </select>
-                </p>
-                <p v-if="type === 'inherited'">
-                    {{ msgInheritedFrom }}:
-                    {{ prop.attributes.object_type_name }}
-                </p>
+                <div class="grid">
+                    <span class="column-header">{{ msgLabel }}</span>
+                    <span>{{ prop.attributes.label || '-' }}</span>
+
+                    <span class="column-header">{{ msgType }}</span>
+                    <span>{{ prop.attributes.property_type_name }}</span>
+
+                    <span class="column-header">{{ msgReadonly }}</span>
+                    <span>
+                        <select v-model="readonly">
+                            <option value="true">{{ msgYes }}</option>
+                            <option value="false">{{ msgNo }}</option>
+                        </select>
+                    </span>
+
+                    <span class="column-header">{{ msgHidden }}</span>
+                    <span>
+                        <select v-model="hidden" @change="updateHidden()">
+                            <option value="true">{{ msgYes }}</option>
+                            <option value="false">{{ msgNo }}</option>
+                        </select>
+                    </span>
+
+                    <span class="column-header">{{ msgTranslatable }}</span>
+                    <span>
+                        <select v-model="translatable" @change="updateTranslationRules()">
+                            <option value="true">{{ msgYes }}</option>
+                            <option value="false">{{ msgNo }}</option>
+                        </select>
+                    </span>
+
+                    <span v-if="type === 'inherited'" class="column-header">{{ msgInheritedFrom }}</span>
+                    <span v-if="type === 'inherited'">{{ prop.attributes.object_type_name }}</span>
+                </div>
             </div>
             <div v-if="!nobuttonsfor.includes(prop.attributes.name)" class="column is-narrow">
                 <div class="buttons-container">
@@ -53,12 +71,14 @@ export default {
             hidden: false,
             translatable: false,
             display: true,
+            readonly: false,
             msgDelete: t`Delete`,
             msgHidden: t`Hidden`,
             msgHide: t`Hide`,
             msgInheritedFrom: t`Inherited from`,
             msgLabel: t`Label`,
             msgNo: t`No`,
+            msgReadonly: t`Readonly`,
             msgShow: t`Show`,
             msgTranslatable: t`Translatable`,
             msgType: t`Type`,
@@ -69,13 +89,13 @@ export default {
     mounted() {
         this.$nextTick(() => {
             this.hidden = this.isHidden || false;
+            this.readonly = this.prop.attributes.read_only || false;
             this.translatable = this.isTranslatable || false;
         });
     },
-
-    methods: {
+    computed: {
         boxClass() {
-            if (this.hidden === 'true') {
+            if (this.hidden === true) {
                 return 'box pb-05 has-background-gray-600 has-text-white';
             }
             if (this.type === 'custom') {
@@ -97,6 +117,9 @@ export default {
 
             return 'tag';
         },
+    },
+
+    methods: {
         updateHidden() {
             let hiddenProperties = JSON.parse(document.getElementById('hidden').value || '[]') || [];
             const index = hiddenProperties.indexOf(this.prop.attributes.name);
@@ -164,6 +187,7 @@ export default {
 </script>
 <style>
 div.box {
+    min-width: 350px;
     padding: 0.5rem;
     margin: 0.5rem 0;
     border-radius: 25px;
@@ -174,4 +198,28 @@ div.column > p {
     margin: 0.5rem 0;
     border-bottom: dashed 1px gray;
 }
+div.column > div.grid {
+    display: grid;
+    grid-template-columns: 100px 240px;
+    border-top: 1px dotted black;
+    border-right: 1px dotted black;
+}
+div.column > div > span {
+    padding: 4px 8px;
+    border-left: 1px dotted black;
+    border-bottom: 1px dotted black;
+    white-space: normal;
+}
+div.column > div > span.column-header {
+    text-align: left;
+}
+div.column > div > span > a:hover {
+    text-decoration: underline;
+}
+div.column > div > span.column-header {
+    color: yellow;
+    text-align: left;
+}
 </style>
+ 109 changes: 109 additions & 0 deletions109
+resources/js/app/components/pagination-navigation/pagination-navigation.vue

--- a/resources/js/app/components/object-property/object-property.vue
+++ b/resources/js/app/components/object-property/object-property.vue
@@ -13,7 +13,7 @@
                     <span>{{ prop.attributes.label || '-' }}</span>
 
                     <span class="column-header">{{ msgType }}</span>
-                    <span>{{ prop.attributes.property_type_name }}</span>
+                    <span class="property-type-name">{{ prop.attributes.property_type_name }}</span>
 
                     <span class="column-header">{{ msgReadonly }}</span>
                     <span>
@@ -200,7 +200,7 @@ div.column > p {
 }
 div.column > div.grid {
     display: grid;
-    grid-template-columns: 100px 240px;
+    grid-template-columns: 100px 1fr;
     border-top: 1px dotted black;
     border-right: 1px dotted black;
 }
@@ -209,17 +209,16 @@ div.column > div > span {
     border-left: 1px dotted black;
     border-bottom: 1px dotted black;
     white-space: normal;
-}
-div.column > div > span.column-header {
-    text-align: left;
-}
-div.column > div > span > a:hover {
-    text-decoration: underline;
+    vertical-align: middle;
 }
 div.column > div > span.column-header {
     color: yellow;
     text-align: left;
 }
+div.column > div > span > a:hover {
+    text-decoration: underline;
+}
+div.column > div > span.property-type-name {
+    font-family: monospace;
+}
 </style>
- 109 changes: 109 additions & 0 deletions109
-resources/js/app/components/pagination-navigation/pagination-navigation.vue

--- a/src/Controller/Model/ObjectTypesController.php
+++ b/src/Controller/Model/ObjectTypesController.php
@@ -71,10 +71,7 @@ class ObjectTypesController extends ModelBaseController
         $name = Hash::get($resource, 'attributes.name', 'undefined');
         $filter = ['object_type' => $name];
         try {
-            $response = $this->apiClient->get(
-                '/model/properties',
-                compact('filter') + ['page_size' => 100]
-            );
+            $data = $this->propertiesData($filter);
         } catch (BEditaClientException $e) {
             $this->log($e->getMessage(), LogLevel::ERROR);
             $this->Flash->error($e->getMessage(), ['params' => $e]);
@@ -82,7 +79,7 @@ class ObjectTypesController extends ModelBaseController
             return $this->redirect(['_name' => 'model:list:' . $this->resourceType]);
         }
 
-        $objectTypeProperties = $this->prepareProperties((array)$response['data'], $name);
+        $objectTypeProperties = $this->prepareProperties($data, $name);
         $this->set(compact('objectTypeProperties'));
         $schema = $this->Schema->getSchema();
         $this->set('schema', $this->updateSchema($schema, $resource));
@@ -92,12 +89,37 @@ class ObjectTypesController extends ModelBaseController
         // setup `currentAttributes`
         $this->Modules->setupAttributes($resource);
 
-        // get translatable fields
+        // get object schema
         $this->Schema->setConfig(['internalSchema' => false]);
-        $resourceSchema = $this->Schema->getSchema($name);
-        $this->set('translatable', (array)Hash::get($resourceSchema, 'translatable'));
+        $this->set('objectTypeSchema', $this->Schema->getSchema($name));
+        $this->Schema->setConfig(['internalSchema' => true]);
 
         return null;
+    }
+
+    /**
+     * Read all properties via API, performing multiple calls if necessary.
+     *
+     * @param array $filter Properties filter
+     * @return array
+     */
+    protected function propertiesData(array $filter): array
+    {
+        $data = [];
+        $done = false;
+        $page = 1;
+        while (!$done) {
+            $response = $this->apiClient->get(
+                '/model/properties',
+                compact('filter', 'page') + ['page_size' => 100]
+            );
+            $data = array_merge($data, (array)Hash::get($response, 'data'));
+            $pageCount = (int)Hash::get($response, 'meta.pagination.page_count');
+            $done = $pageCount === $page;
+            $page++;
+        }
+
+        return $data;
     }
 
     /**

--- a/src/Controller/Model/ObjectTypesController.php
+++ b/src/Controller/Model/ObjectTypesController.php
@@ -92,6 +92,11 @@ class ObjectTypesController extends ModelBaseController
         // setup `currentAttributes`
         $this->Modules->setupAttributes($resource);
 
+        // get translatable fields
+        $this->Schema->setConfig(['internalSchema' => false]);
+        $resourceSchema = $this->Schema->getSchema($name);
+        $this->set('translatable', (array)Hash::get($resourceSchema, 'translatable'));
+
         return null;
     }
 

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -215,15 +215,14 @@ class SchemaHelper extends Helper
     }
 
     /**
-     * Provides list of translatable fields per schema
+     * Provides list of translatable fields
      *
-     * @param array $schema The schema
+     * @param array $properties The properties
      * @param string $objectType The object type
      * @return array
      */
-    public function translatableFields(array $schema, ?string $objectType = null): array
+    public function translatableFields(array $properties, ?string $objectType = null): array
     {
-        $properties = (array)Hash::get($schema, 'translatable');
         $translatable = (array)Configure::read(sprintf('Properties.%s.translatable', (string)$objectType));
         $fields = !empty($translatable) ? array_intersect($properties, $translatable) : $properties;
         usort($fields, function ($a, $b) {

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -225,27 +225,20 @@ class SchemaHelper extends Helper
     {
         $translatable = (array)Configure::read(sprintf('Properties.%s.translatable', (string)$objectType));
         $fields = !empty($translatable) ? array_intersect($properties, $translatable) : $properties;
-        usort($fields, function ($a, $b) {
-            if ($a === 'title') {
-                return -1;
-            }
-            if ($b === 'title') {
-                return 1;
-            }
-            if ($a === 'description') {
-                return -1;
-            }
-            if ($b === 'description') {
-                return 1;
-            }
-            if ($a === 'body') {
-                return -1;
-            }
-            if ($b === 'body') {
-                return 1;
-            }
+        $priorityFields = ['title', 'description', 'body'];
+        usort($fields, function ($a, $b) use ($priorityFields) {
+            $aIndex = array_search($a, $priorityFields);
+            $bIndex = array_search($b, $priorityFields);
 
-            return strcmp($a, $b);
+            if ($aIndex !== false && $bIndex !== false) {
+                return $aIndex - $bIndex;
+            } elseif ($aIndex !== false) {
+                return -1;
+            } elseif ($bIndex !== false) {
+                return 1;
+            } else {
+                return strcmp($a, $b);
+            }
         });
 
         return $fields;

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -225,23 +225,39 @@ class SchemaHelper extends Helper
     {
         $translatable = (array)Configure::read(sprintf('Properties.%s.translatable', (string)$objectType));
         $fields = !empty($translatable) ? array_intersect($properties, $translatable) : $properties;
+        $fields = array_unique($fields);
         $priorityFields = ['title', 'description', 'body'];
         usort($fields, function ($a, $b) use ($priorityFields) {
-            $aIndex = array_search($a, $priorityFields);
-            $bIndex = array_search($b, $priorityFields);
-
-            if ($aIndex !== false && $bIndex !== false) {
-                return $aIndex - $bIndex;
-            } elseif ($aIndex !== false) {
-                return -1;
-            } elseif ($bIndex !== false) {
-                return 1;
-            } else {
-                return strcmp($a, $b);
-            }
+            return $this->compareFields($a, $b, $priorityFields);
         });
 
         return $fields;
+    }
+
+    /**
+     * Compare fields and return int, considering priority fields.
+     *
+     * @param string $a The first field
+     * @param string $b The second field
+     * @param array $priorityFields The priority fields
+     * @return int
+     */
+    public function compareFields(string $a, string $b, array $priorityFields): int
+    {
+        $aIndex = array_search($a, $priorityFields);
+        $bIndex = array_search($b, $priorityFields);
+
+        if ($aIndex !== false && $bIndex !== false) {
+            return $aIndex - $bIndex;
+        }
+        if ($aIndex !== false) {
+            return -1;
+        }
+        if ($bIndex !== false) {
+            return 1;
+        }
+
+        return strcmp($a, $b);
     }
 
     /**

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -227,7 +227,7 @@ class SchemaHelper extends Helper
         $translatable = (array)Configure::read(sprintf('Properties.%s.translatable', (string)$objectType));
         $fields = !empty($translatable) ? array_merge($properties, $translatable) : $properties;
         $fields = array_unique($fields);
-        $priorityFields = array_merge(['title', 'description', 'body'], $translatable);
+        $priorityFields = array_unique(array_merge(['title', 'description', 'body'], $translatable));
         usort($fields, function ($a, $b) use ($priorityFields) {
             return $this->compareFields($a, $b, $priorityFields);
         });

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -215,7 +215,8 @@ class SchemaHelper extends Helper
     }
 
     /**
-     * Provides list of translatable fields
+     * Provides list of translatable fields.
+     * If set Properties.<objectType>.translatable, it will be added to translatable fields.
      *
      * @param array $properties The properties
      * @param string $objectType The object type
@@ -224,9 +225,9 @@ class SchemaHelper extends Helper
     public function translatableFields(array $properties, ?string $objectType = null): array
     {
         $translatable = (array)Configure::read(sprintf('Properties.%s.translatable', (string)$objectType));
-        $fields = !empty($translatable) ? array_intersect($properties, $translatable) : $properties;
+        $fields = !empty($translatable) ? array_merge($properties, $translatable) : $properties;
         $fields = array_unique($fields);
-        $priorityFields = ['title', 'description', 'body'];
+        $priorityFields = array_merge(['title', 'description', 'body'], $translatable);
         usort($fields, function ($a, $b) use ($priorityFields) {
             return $this->compareFields($a, $b, $priorityFields);
         });

--- a/templates/Element/Form/related_translations.twig
+++ b/templates/Element/Form/related_translations.twig
@@ -1,3 +1,9 @@
+{% set translatable = true %}
+{% if schema.translatable is iterable %}
+    {% set translatable = schema.translatable is not empty %}
+{% else %}
+    {% set translatable = object.relationships.translations is not empty %}
+{% endif %}
 {% if schema.properties.lang %}
     <property-view inline-template :tab-open="tabsOpen" tab-name="translations" ref={{ resourceName }}>
         <section class="fieldset order-{{ cssOrder }}" :class="isOpen? '' : 'closed'">
@@ -20,7 +26,7 @@
                     {% set lang = object.id ? object.attributes.lang : config('Project.config.I18n.default') %}
                     {{ Property.control('lang', lang, { 'label': __('The main language is') })|raw }}
 
-                    {% if object.relationships.translations %}
+                    {% if translatable %}
                         {{ Html.link(__('Add translation'), {
                             '_name': 'translations:add',
                             'object_type': object.type,

--- a/templates/Element/translation.twig
+++ b/templates/Element/translation.twig
@@ -1,6 +1,6 @@
 {% do _view.assign('title', __('Translations')) %}
 {% do _view.assign('bodyViewClass', 'translation-module') %}
-{% set translatable = Schema.translatableFields(schema.properties|default([]), objectType) %}
+{% set translatable = Schema.translatableFields(schema|default([]), objectType) %}
 
 <modules-view inline-template ref="moduleView">
     <div class="modules-view">

--- a/templates/Element/translation.twig
+++ b/templates/Element/translation.twig
@@ -1,6 +1,6 @@
 {% do _view.assign('title', __('Translations')) %}
 {% do _view.assign('bodyViewClass', 'translation-module') %}
-{% set translatable = Schema.translatableFields(schema.translatable|default([]), objectType) %}
+{% set translatable = Schema.translatableFields(schema|default([])) %}
 
 <modules-view inline-template ref="moduleView">
     <div class="modules-view">

--- a/templates/Element/translation.twig
+++ b/templates/Element/translation.twig
@@ -1,6 +1,6 @@
 {% do _view.assign('title', __('Translations')) %}
 {% do _view.assign('bodyViewClass', 'translation-module') %}
-{% set translatable = Schema.translatableFields(schema|default([]), objectType) %}
+{% set translatable = Schema.translatableFields(schema.translatable|default([]), objectType) %}
 
 <modules-view inline-template ref="moduleView">
     <div class="modules-view">

--- a/templates/Pages/Model/ObjectTypes/view.twig
+++ b/templates/Pages/Model/ObjectTypes/view.twig
@@ -1,5 +1,6 @@
 {% do _view.assign('title', 'Model ' ~ resourceType|humanize) %}
 {% do _view.assign('bodyViewClass', 'view-module view-model') %}
+{% set translatable = Schema.translatableFields(objectTypeSchema|default([])) %}
 
 <modules-view inline-template ref="moduleView">
 <div class="modules-view">
@@ -131,7 +132,7 @@
                     :init-properties="{{ objectTypeProperties.core|default([])|json_encode }}"
                     type="core"
                     :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
-                    :translatable="{{ translatable|default({})|json_encode }}"
+                    :translatable="{{ translatable|json_encode }}"
                     :translation-rules="{{ resource.attributes.translation_rules|json_encode }}"
                 >
                 </object-properties>
@@ -151,7 +152,7 @@
                     :init-properties="{{ objectTypeProperties.inherited|default([])|json_encode }}"
                     type="inherited"
                     :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
-                    :translatable="{{ translatable|default({})|json_encode }}"
+                    :translatable="{{ translatable|json_encode }}"
                     :translation-rules="{{ resource.attributes.translation_rules|json_encode }}"
                 >
                 </object-properties>
@@ -171,7 +172,7 @@
                     :init-properties="{{ objectTypeProperties.custom|default([])|json_encode }}"
                     type="custom"
                     :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
-                    :translatable="{{ translatable|default({})|json_encode }}"
+                    :translatable="{{ translatable|json_encode }}"
                     :translation-rules="{{ resource.attributes.translation_rules|json_encode }}"
                 >
                 </object-properties>

--- a/templates/Pages/Model/ObjectTypes/view.twig
+++ b/templates/Pages/Model/ObjectTypes/view.twig
@@ -26,12 +26,11 @@
                 value: resource.attributes.hidden|default([])|json_encode,
             })|raw }}
             {% do Form.unlockField('hidden') %}
-            {# TODO: handle translation rules in properties directly, like `hidden` #}
-            {# {{ Form.hidden('translation_rules', {
-                id: 'translation_rules',
-                value: resource.attributes.translation_rules|default({})|json_encode,
+            {{ Form.hidden('translation_rules', {
+                id: 'translationRules',
+                value: resource.attributes.translation_rules|json_encode,
             })|raw }}
-            {% do Form.unlockField('translation_rules') %} #}
+            {% do Form.unlockField('translation_rules') %}
 
             {# Handle newly created custom props via `addedProperties` hidden input for now #}
             {{ Form.hidden('addedProperties', {
@@ -80,7 +79,7 @@
                 </property-view>
 
         {# Set `_jsonKeys` hidden input from config #}
-        {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': config('_jsonKeys', [])|merge(['hidden'])|join(',')})|raw }}
+        {{ Form.control('_jsonKeys', {'type': 'hidden', 'value': config('_jsonKeys', [])|merge(['hidden','translation_rules'])|join(',')})|raw }}
 
         {{ Form.end()|raw }}
 
@@ -132,6 +131,8 @@
                     :init-properties="{{ objectTypeProperties.core|default([])|json_encode }}"
                     type="core"
                     :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
+                    :translatable="{{ translatable|default({})|json_encode }}"
+                    :translation-rules="{{ resource.attributes.translation_rules|json_encode }}"
                 >
                 </object-properties>
             </div>
@@ -150,6 +151,8 @@
                     :init-properties="{{ objectTypeProperties.inherited|default([])|json_encode }}"
                     type="inherited"
                     :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
+                    :translatable="{{ translatable|default({})|json_encode }}"
+                    :translation-rules="{{ resource.attributes.translation_rules|json_encode }}"
                 >
                 </object-properties>
             </div>
@@ -168,6 +171,8 @@
                     :init-properties="{{ objectTypeProperties.custom|default([])|json_encode }}"
                     type="custom"
                     :hidden="{{ resource.attributes.hidden|default([])|json_encode }}"
+                    :translatable="{{ translatable|default({})|json_encode }}"
+                    :translation-rules="{{ resource.attributes.translation_rules|json_encode }}"
                 >
                 </object-properties>
                 <object-property-add

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -147,14 +147,15 @@ class ObjectTypesControllerTest extends TestCase
      * Test `view` method
      *
      * @covers ::view()
-     * @covers ::prepareProperties
+     * @covers ::prepareProperties()
+     * @covers ::propertiesData()
      * @return void
      */
     public function testView(): void
     {
         $this->setupController();
         $this->ModelController->view(2);
-        $vars = ['resource', 'schema', 'properties', 'propertyTypesOptions', 'associationsOptions'];
+        $vars = ['resource', 'schema', 'properties', 'propertyTypesOptions', 'associationsOptions', 'objectTypeSchema'];
         foreach ($vars as $var) {
             static::assertNotEmpty($this->ModelController->viewBuilder()->getVar($var));
         }

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -434,20 +434,75 @@ class SchemaHelperTest extends TestCase
     public function translatableFieldsProvider(): array
     {
         return [
-            'empty properties' => [
-                [], // properties
-                [], // conf
-                [], // expected
+            'empty translatable' => [
+                ['translatable' => []],
+                [],
+            ],
+            'translatable list' => [
+                ['translatable' => ['subtitle', 'other_field', 'title']],
+                ['title', 'subtitle', 'other_field'],
             ],
             'simple' => [
-                ['description', 'title', 'body'],
-                [],
-                ['title', 'description', 'body'],
+                [
+                    'properties' => [
+                        'field' => [
+                            'oneOf' => [
+                                [
+                                    'type' => 'string',
+                                    'contentMediaType' => 'text/plain',
+                                ],
+                                [
+                                    'type' => 'null',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                ['field'],
             ],
-            'more fields and reorder' => [
-                ['id', 'title', 'description', 'body', 'created', 'modified', 'dummy', 'status', 'extra'],
-                ['dummy3', 'dummy2', 'dummy1', 'description', 'body'],
-                ['title', 'description', 'body', 'dummy3', 'dummy2', 'dummy1', 'created', 'dummy', 'extra', 'id', 'modified', 'status'],
+            'not translatable' => [
+                [
+                    'properties' => [
+                        'field1' => [
+                            'type' => 'integer',
+                        ],
+                        'field2' => [
+                            'type' => 'string',
+                            'contentMediaType' => 'text/css',
+                        ],
+                    ],
+                ],
+                [],
+            ],
+            'properties' => [
+                [
+                    'properties' => [
+                        'dummy' => [
+                            'oneOf' => [
+                                [
+                                    'type' => 'null',
+                                ],
+                                [
+                                    'type' => 'string',
+                                    'contentMediaType' => 'text/plain',
+                                ],
+                            ],
+                        ],
+                        'description' => [
+                            'type' => 'string',
+                            'contentMediaType' => 'text/html',
+                        ],
+                        'title' => [
+                            'type' => 'string',
+                            'contentMediaType' => 'text/html',
+                        ],
+                    ],
+                ],
+                [
+                    'title',
+                    'description',
+                    'dummy',
+                ],
             ],
         ];
     }
@@ -455,65 +510,16 @@ class SchemaHelperTest extends TestCase
     /**
      * Test `translatableFields` method
      *
-     * @param array $properties The properties
-     * @param array $conf The configuration
+     * @param array $schema The object schema
      * @param array $expected Expected result
      * @return void
      * @dataProvider translatableFieldsProvider()
      * @covers ::translatableFields()
+     * @covers ::translatableType()
      */
-    public function testTranslatableFields(array $properties, array $conf, array $expected): void
+    public function testTranslatableFields(array $schema, array $expected): void
     {
-        Configure::write('Properties.documents.translatable', $conf);
-        $actual = $this->Schema->translatableFields($properties, 'documents');
-        static::assertSame($expected, $actual);
-    }
-
-    /**
-     * Data provider for `testCompareFields` test case.
-     *
-     * @return array
-     */
-    public function compareFieldsProvider(): array
-    {
-        return [
-            'priority fields have both, return strcmp($a, $b)' => [
-                'a',
-                'b',
-                ['a', 'b'],
-                -1,
-            ],
-            'priority fields has first field, return -1' => [
-                'a',
-                'b',
-                ['a'],
-                -1,
-            ],
-            'priority fields has second field, return 1' => [
-                'a',
-                'b',
-                ['b'],
-                1,
-            ],
-            'empty priority fields, return strcmp($a, $b)' => [
-                'a',
-                'b',
-                [],
-                -1,
-            ],
-        ];
-    }
-
-    /**
-     * Test `compareFields` method
-     *
-     * @return void
-     * @dataProvider compareFieldsProvider()
-     * @covers ::compareFields()
-     */
-    public function testCompareFields(string $a, string $b, array $priorityFields, int $expected): void
-    {
-        $actual = $this->Schema->compareFields($a, $b, $priorityFields);
+        $actual = $this->Schema->translatableFields($schema);
         static::assertSame($expected, $actual);
     }
 

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -435,64 +435,19 @@ class SchemaHelperTest extends TestCase
     {
         return [
             'empty properties' => [
-                [],
-                [],
+                [], // properties
+                [], // conf
+                [], // expected
             ],
             'simple' => [
-                [
-                    'field' => [
-                        'oneOf' => [
-                            [
-                                'type' => 'string',
-                                'contentMediaType' => 'text/plain',
-                            ],
-                            [
-                                'type' => 'null',
-                            ],
-                        ],
-                    ],
-                ],
-                ['field'],
+                ['description', 'title', 'body'],
+                [],
+                ['title', 'description', 'body'],
             ],
             'not translatable' => [
-                [
-                    'field1' => [
-                        'type' => 'string',
-                    ],
-                    'field2' => [
-                        'type' => 'string',
-                        'contentMediaType' => 'text/css',
-                    ],
-                ],
-                [],
-            ],
-            'properties' => [
-                [
-                    'dummy' => [
-                        'oneOf' => [
-                            [
-                                'type' => 'null',
-                            ],
-                            [
-                                'type' => 'string',
-                                'contentMediaType' => 'text/plain',
-                            ],
-                        ],
-                    ],
-                    'description' => [
-                        'type' => 'string',
-                        'contentMediaType' => 'text/html',
-                    ],
-                    'title' => [
-                        'type' => 'string',
-                        'contentMediaType' => 'text/html',
-                    ],
-                ],
-                [
-                    'title',
-                    'description',
-                    'dummy',
-                ],
+                ['description', 'title', 'body'],
+                ['description', 'body'],
+                ['description', 'body'],
             ],
         ];
     }
@@ -501,35 +456,17 @@ class SchemaHelperTest extends TestCase
      * Test `translatableFields` method
      *
      * @param array $properties The properties
+     * @param array $conf The configuration
      * @param array $expected Expected result
      * @return void
      * @dataProvider translatableFieldsProvider()
      * @covers ::translatableFields()
      */
-    public function testTranslatableFields(array $properties, array $expected): void
+    public function testTranslatableFields(array $properties, array $conf, array $expected): void
     {
-        $actual = $this->Schema->translatableFields($properties);
-        static::assertSame($expected, $actual);
-    }
-
-    /**
-     * Test `translatableFields` method with `Properties` configuration
-     *
-     * @covers ::translatableFields()
-     */
-    public function testTranslatableFieldsConfiguration(): void
-    {
-        $properties = [
-            'field1' => [
-                'type' => 'object',
-            ],
-        ];
-        $actual = $this->Schema->translatableFields($properties);
-        static::assertEmpty($actual);
-
-        Configure::write('Properties.documents.translatable', ['field1']);
+        Configure::write('Properties.documents.translatable', $conf);
         $actual = $this->Schema->translatableFields($properties, 'documents');
-        static::assertEquals(['field1'], $actual);
+        static::assertSame($expected, $actual);
     }
 
     /**

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -505,7 +505,6 @@ class SchemaHelperTest extends TestCase
      * @return void
      * @dataProvider translatableFieldsProvider()
      * @covers ::translatableFields()
-     * @covers ::translatableType()
      */
     public function testTranslatableFields(array $properties, array $expected): void
     {

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -449,6 +449,11 @@ class SchemaHelperTest extends TestCase
                 ['description', 'body'],
                 ['description', 'body'],
             ],
+            'more fields and reorder' => [
+                ['id', 'title', 'description', 'body', 'created', 'modified', 'dummy', 'status', 'extra'],
+                ['dummy3', 'dummy2', 'dummy1', 'description', 'body'],
+                ['description', 'body'],
+            ],
         ];
     }
 
@@ -466,6 +471,54 @@ class SchemaHelperTest extends TestCase
     {
         Configure::write('Properties.documents.translatable', $conf);
         $actual = $this->Schema->translatableFields($properties, 'documents');
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testCompareFields` test case.
+     *
+     * @return array
+     */
+    public function compareFieldsProvider(): array
+    {
+        return [
+            'priority fields have both, return strcmp($a, $b)' => [
+                'a',
+                'b',
+                ['a', 'b'],
+                -1,
+            ],
+            'priority fields has first field, return -1' => [
+                'a',
+                'b',
+                ['a'],
+                -1,
+            ],
+            'priority fields has second field, return 1' => [
+                'a',
+                'b',
+                ['b'],
+                1,
+            ],
+            'empty priority fields, return strcmp($a, $b)' => [
+                'a',
+                'b',
+                [],
+                -1,
+            ],
+        ];
+    }
+
+    /**
+     * Test `compareFields` method
+     *
+     * @return void
+     * @dataProvider compareFieldsProvider()
+     * @covers ::compareFields()
+     */
+    public function testCompareFields(string $a, string $b, array $priorityFields, int $expected): void
+    {
+        $actual = $this->Schema->compareFields($a, $b, $priorityFields);
         static::assertSame($expected, $actual);
     }
 

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -444,15 +444,10 @@ class SchemaHelperTest extends TestCase
                 [],
                 ['title', 'description', 'body'],
             ],
-            'not translatable' => [
-                ['description', 'title', 'body'],
-                ['description', 'body'],
-                ['description', 'body'],
-            ],
             'more fields and reorder' => [
                 ['id', 'title', 'description', 'body', 'created', 'modified', 'dummy', 'status', 'extra'],
                 ['dummy3', 'dummy2', 'dummy1', 'description', 'body'],
-                ['description', 'body'],
+                ['title', 'description', 'body', 'dummy3', 'dummy2', 'dummy1', 'created', 'dummy', 'extra', 'id', 'modified', 'status'],
             ],
         ];
     }


### PR DESCRIPTION
This resolves https://github.com/bedita/manager/issues/682

Translatable field for an object are provided by schema.
`Properties.<objectType>.translatable` is not used anymore: you can force translation of a property by object type modelling.

Modelling object type provides a way to set/unset translatable on properties.

Bonus: better UI in modelling view