### PR TITLE
Perms and locked by parents checks when folders do not have Permissions association

### DIFF
--- a/src/View/Helper/PermsHelper.php
+++ b/src/View/Helper/PermsHelper.php
@@ -36,6 +36,13 @@ class PermsHelper extends Helper
     protected $allowed = [];
 
     /**
+     * Permissions on folders enabled flag
+     *
+     * @var bool
+     */
+    protected $permissionsOnFolders = false;
+
+    /**
      * {@inheritDoc}
      *
      * Init API and WebAPP base URL
@@ -54,6 +61,8 @@ class PermsHelper extends Helper
         }
         $currentModule = (array)$this->_View->get('currentModule');
         $this->current = (array)Hash::get($currentModule, 'hints.allow');
+        $schema = (array)$this->_View->get('foldersSchema');
+        $this->permissionsOnFolders = in_array('Permissions', (array)Hash::get($schema, 'associations'));
     }
 
     /**
@@ -180,7 +189,7 @@ class PermsHelper extends Helper
     public function userIsAllowed(?string $module): bool
     {
         $objectType = !empty($module) ? $module : $this->_View->get('objectType');
-        if ($objectType !== 'folders' || $this->userIsAdmin()) {
+        if ($this->permissionsOnFolders === false || $objectType !== 'folders' || $this->userIsAdmin()) {
             return true;
         }
 
@@ -217,7 +226,7 @@ class PermsHelper extends Helper
      */
     public function isLockedByParents(string $id): bool
     {
-        if ($this->userIsAdmin()) {
+        if ($this->permissionsOnFolders === false || $this->userIsAdmin()) {
             return false;
         }
         $apiClient = ApiClientProvider::getApiClient();

--- a/tests/TestCase/View/Helper/PermsHelperTest.php
+++ b/tests/TestCase/View/Helper/PermsHelperTest.php
@@ -283,6 +283,15 @@ class PermsHelperTest extends TestCase
      */
     public function testUserIsAllowed(): void
     {
+        // folders do not have association Permissions
+        $this->Perms->getView()->set('foldersSchema', ['associations' => []]);
+        $this->Perms->initialize([]);
+        $this->Perms->getView()->set('object', ['meta' => ['perms' => ['roles' => ['a', 'b', 'c', 'd']]]]);
+        $actual = $this->Perms->userIsAllowed(null);
+        static::assertTrue($actual);
+        $this->Perms->getView()->set('foldersSchema', ['associations' => ['Permissions']]);
+        $this->Perms->initialize([]);
+
         // not folders
         $this->Perms->getView()->set('objectType', 'documents');
         $actual = $this->Perms->userIsAllowed(null);
@@ -333,6 +342,9 @@ class PermsHelperTest extends TestCase
      */
     public function testIsLockedByParents(): void
     {
+        $this->Perms->getView()->set('foldersSchema', ['associations' => ['Permissions']]);
+        $this->Perms->initialize([]);
+
         // user is admin => false
         $this->Perms->getView()->set('user', new Identity(['roles' => ['admin']]));
         $actual = $this->Perms->isLockedByParents('123');


### PR DESCRIPTION
When folders don't have association permissions, some permissions checks on `meta.perms` are not necessary. This provides a fix to handle `userIsAllowed` and `isLockedByParents` when folders haven't permissions association.

Note: `foldersSchema` is set in `ModulesController::view`. This verifies whether `Permissions` is in `foldersSchema.associations` or not. When not present, no permissions.