### PR TITLE
Save related object when no id

### DIFF
--- a/resources/js/app/components/locations-view/location-view.vue
+++ b/resources/js/app/components/locations-view/location-view.vue
@@ -1,3 +1,97 @@
+<template>
+    <div class="location mb-2 is-flex">
+        <div class="order mr-1 p-1 has-background-white is-flex align-center has-text-black">
+            {{ index + 1 }}
+        </div>
+        <div class="location-form is-flex-column">
+            <div class="is-flex">
+                <div class="is-flex-column is-expanded">
+                    <label>
+                        {{ msgTitle }}
+                        <autocomplete
+                            autocomplete="none"
+                            ref="title"
+                            class="autocomplete-title"
+                            :default-value="title"
+                            :search="searchTitle"
+                            base-class="autocomplete-title"
+                            :get-result-value="getResultTitle"
+                            @submit="onAutocompleteSubmit"
+                            @input="onInputTitle"
+                            @change="onChange"
+                            :debounce-time="500"
+                            :disabled="!!id"
+                        >
+                        </autocomplete>
+                    </label>
+                </div>
+                <div class="is-flex-column is-expanded">
+                    <label>
+                        {{ msgAddress }}
+                        <autocomplete
+                            autocomplete="none"
+                            ref="address"
+                            class="autocomplete autocomplete-address"
+                            :default-value="address"
+                            :search="searchAddress"
+                            base-class="autocomplete-address"
+                            :get-result-value="getResultAddress"
+                            @submit="onAutocompleteSubmit"
+                            @input="onInputAddress"
+                            @change="onChange"
+                            :debounce-time="500"
+                            :disabled="!!id"
+                        >
+                        </autocomplete>
+                    </label>
+                </div>
+            </div>
+            <div class="is-flex mt-1">
+                <div class="is-flex-column is-expanded">
+                    <label>
+                        {{ msgCoordinates }}
+                        <div class="is-flex">
+                            <input class="coordinates" type="text" v-model="coordinates" @change="onChange" :disabled="!!id" />
+                            <button class="get-coordinates" @click.prevent="geocode" :disabled="!apiKey || !address">
+                                <Icon icon="carbon:wikis"></Icon>
+                                <span class="ml-05">{{ msgGet }}</span>
+                            </button>
+                        </div>
+                    </label>
+                </div>
+                <div class="is-flex-column">
+                    <label>
+                        {{ msgZoom }}
+                        <input @change="onChange" v-model.number="zoom" type="number" min="2" max="20" :disabled="!!id" />
+                    </label>
+                </div>
+                <div class="is-flex-column">
+                    <label>
+                        {{ msgPitch }}°
+                        <input @change="onChange" v-model.number="pitch" type="number" min="0" max="60" :disabled="!!id" />
+                    </label>
+                </div>
+                <div class="is-flex-column">
+                    <label>
+                        {{ msgBearing }}°
+                        <input @change="onChange" v-model.number="bearing" type="number" min="-180" max="180" :disabled="!!id" />
+                    </label>
+                </div>
+            </div>
+            <div class="location-buttons">
+                <a v-if="id" class="button button-text-white" :href="$helpers.buildViewUrl(id)" target="_blank">
+                    <Icon icon="carbon:launch"></Icon>
+                    <span class="ml-05">{{ msgEdit }}</span>
+                </a>
+                <button @click.prevent="onRemove" class="button button-text-white remove">
+                <Icon icon="carbon:unlink"></Icon>
+                    <span class="ml-05">{{ msgRemove }}</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</template>
+<script>
 import { t } from 'ttag';
 
 const options = {
@@ -34,104 +128,7 @@ function stripHtml(str) {
     return str.replace(/<\/?[^>]+(>|$)/g, '');
 }
 
-/**
- * <location-view> component used for ModulesPage -> View
- *
- * Handle Locations and reverse geocoding from addresses
- */
 export default {
-    template: `<div class="location mb-2 is-flex">
-        <div class="order mr-1 p-1 has-background-white is-flex align-center has-text-black">
-            <: index + 1 :>
-        </div>
-        <div class="location-form is-flex-column">
-            <div class="is-flex">
-                <div class="is-flex-column is-expanded">
-                    <label>
-                        ${t`Title`}
-                        <autocomplete
-                            autocomplete="none"
-                            ref="title"
-                            class="autocomplete-title"
-                            :default-value="title"
-                            :search="searchTitle"
-                            base-class="autocomplete-title"
-                            :get-result-value="getResultTitle"
-                            @submit="onAutocompleteSubmit"
-                            @input="onInputTitle"
-                            @change="onChange"
-                            :debounce-time="500"
-                            :disabled="!!id"
-                        >
-                        </autocomplete>
-                    </label>
-                </div>
-                <div class="is-flex-column is-expanded">
-                    <label>
-                        ${t`Address`}
-                        <autocomplete
-                            autocomplete="none"
-                            ref="address"
-                            class="autocomplete autocomplete-address"
-                            :default-value="address"
-                            :search="searchAddress"
-                            base-class="autocomplete-address"
-                            :get-result-value="getResultAddress"
-                            @submit="onAutocompleteSubmit"
-                            @input="onInputAddress"
-                            @change="onChange"
-                            :debounce-time="500"
-                            :disabled="!!id"
-                        >
-                        </autocomplete>
-                    </label>
-                </div>
-            </div>
-            <div class="is-flex mt-1">
-                <div class="is-flex-column is-expanded">
-                    <label>
-                        ${t`Long Lat Coordinates`}
-                        <div class="is-flex">
-                            <input class="coordinates" type="text" v-model="coordinates" @change="onChange" :disabled="!!id" />
-                            <button class="get-coordinates" @click.prevent="geocode" :disabled="!apiKey || !address">
-                                <Icon icon="carbon:wikis"></Icon>
-                                <span class="ml-05">${t`GET`}</span>
-                            </button>
-                        </div>
-                    </label>
-                </div>
-                <div class="is-flex-column">
-                    <label>
-                        Zoom
-                        <input @change="onChange" v-model.number="zoom" type="number" min="2" max="20" :disabled="!!id" />
-                    </label>
-                </div>
-                <div class="is-flex-column">
-                    <label>
-                        Pitch°
-                        <input @change="onChange" v-model.number="pitch" type="number" min="0" max="60" :disabled="!!id" />
-                    </label>
-                </div>
-                <div class="is-flex-column">
-                    <label>
-                        Bearing°
-                        <input @change="onChange" v-model.number="bearing" type="number" min="-180" max="180" :disabled="!!id" />
-                    </label>
-                </div>
-            </div>
-            <div class="location-buttons">
-                <a v-if="id" class="button button-text-white" :href="$helpers.buildViewUrl(id)" target="_blank">
-                    <Icon icon="carbon:launch"></Icon>
-                    <span class="ml-05">${t`edit`}</span>
-                </a>
-                <button @click.prevent="onRemove" class="button button-text-white remove">
-                <Icon icon="carbon:unlink"></Icon>
-                    <span class="ml-05">${t`remove`}</span>
-                </button>
-            </div>
-        </div>
-    </div>`,
-
     props: {
         index: Number,
         apiKey: String,
@@ -160,6 +157,15 @@ export default {
                 this.locationData.meta.relation &&
                 this.locationData.meta.relation.params &&
                 this.locationData.meta.relation.params.bearing) || 0,
+            msgAddress: t`Address`,
+            msgBearing: t`Bearing`,
+            msgCoordinates: t`Long Lat Coordinates`,
+            msgEdit: t`edit`,
+            msgGet: t`GET`,
+            msgPitch: t`Pitch`,
+            msgRemove: t`remove`,
+            msgTitle: t`Title`,
+            msgZoom: t`Zoom`,
         }
     },
 
@@ -355,3 +361,4 @@ export default {
         },
     }
 }
+</script>

--- a/resources/js/app/components/locations-view/locations-view.vue
+++ b/resources/js/app/components/locations-view/locations-view.vue
@@ -1,3 +1,23 @@
+<template>
+    <div class="locations">
+        <input type="hidden" :name="'relations[' + relationName + '][replaceRelated]'" :value="locationsData" />
+        <div v-if="!locations" class="is-loading-spinner"></div>
+        <div v-else v-for="(location, index) in locations">
+            <location-view
+                :key="locationSymbol(location)"
+                :index="index"
+                :location-data="location"
+                :api-key="apiKey"
+                :api-url="apiUrl"
+                :relation-name="relationName"
+                :relation-label="relationLabel" />
+        </div>
+        <div v-if="locations" class="is-flex mt-1">
+            <button @click.prevent @click="onAddNew">{{ msgAddNew }}</button>
+        </div>
+    </div>
+</template>
+<script>
 import { t } from 'ttag';
 
 const options = {
@@ -7,29 +27,10 @@ const options = {
     }
 };
 
-/**
- * Templates that uses this component (directly or indirectly):
- *  ...
- *
- * <locations-view> component used for ModulesPage -> View
- *
- * Handle Locations and reverse geocoding from addresses
- */
 export default {
     components: {
         LocationView: () => import(/* webpackChunkName: "location-view" */'app/components/locations-view/location-view'),
     },
-
-    template: `<div class="locations">
-        <input type="hidden" :name="'relations[' + relationName + '][replaceRelated]'" :value="locationsData" />
-        <div v-if="!locations" class="is-loading-spinner"></div>
-        <div v-else v-for="(location, index) in locations">
-            <location-view :key="locationSymbol(location)" :index="index" :location-data="location" :api-key="apiKey" :api-url="apiUrl" :relation-name="relationName" :relation-label="relationLabel" />
-        </div>
-        <div v-if="locations" class="is-flex mt-1">
-            <button @click.prevent @click="onAddNew">${t`add new`}</button>
-        </div>
-    </div>`,
 
     props: {
         apiKey: String,
@@ -41,6 +42,7 @@ export default {
     data() {
         return {
             locations: null,
+            msgAddNew: t`add new`,
         }
     },
 
@@ -123,3 +125,4 @@ export default {
         }
     }
 }
+</script>

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -631,7 +631,7 @@ class ModulesComponent extends Component
             throw new BadRequestException(__('Bad related data method'));
         }
         $relation = (string)Hash::get($data, 'relation');
-        $related = (array)Hash::get($data, 'relatedIds');
+        $related = $this->getRelated($data);
         if ($relation === 'parent' && $type === 'folders') {
             return $this->Parents->{$method}($id, $related);
         }
@@ -640,5 +640,40 @@ class ModulesComponent extends Component
         }
 
         return ApiClientProvider::getApiClient()->{$method}($id, $type, $relation, $related);
+    }
+
+    /**
+     * Get related objects.
+     * If related object has no ID, it will be created.
+     *
+     * @param array $data Related object data
+     * @return array
+     */
+    public function getRelated(array $data): array
+    {
+        $related = (array)Hash::get($data, 'relatedIds');
+        if (empty($related)) {
+            return [];
+        }
+        $relatedObjects = [];
+        foreach ($related as $obj) {
+            if (!empty($obj['id'])) {
+                $relatedObjects[] = [
+                    'id' => $obj['id'],
+                    'type' => $obj['type'],
+                ];
+                continue;
+            }
+            $response = ApiClientProvider::getApiClient()->save(
+                (string)Hash::get($obj, 'type'),
+                (array)Hash::get($obj, 'attributes')
+            );
+            $relatedObjects[] = [
+                'id' => Hash::get($response, 'data.id'),
+                'type' => Hash::get($response, 'data.type'),
+            ];
+        }
+
+        return $relatedObjects;
     }
 }

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1745,6 +1745,7 @@ class ModulesComponentTest extends TestCase
         $actual = $this->Modules->getRelated($data);
         static::assertIsArray($actual);
         static::assertCount(3, $actual);
+        $objs = [];
         foreach ($actual as $obj) {
             $objs[] = $apiClient->getObject($obj['id']);
         }


### PR DESCRIPTION
This provides a way to save related object when it's a new one (related data form has no id for the object).

This fixes a problem on saving a new location, in "fast creation location" (in object view, paragraph "Positions").

Bonus: refactor `locations-view` and `location-view` components to pass them to `.vue` format.