### PR TITLE
Fix save children on reorder

### DIFF
--- a/src/Controller/Component/ChildrenComponent.php
+++ b/src/Controller/Component/ChildrenComponent.php
@@ -38,7 +38,7 @@ class ChildrenComponent extends Component
     public function addRelated(string $parentId, array $children): array
     {
         $results = [];
-        $actualRelated = $this->getClient()->get(sprintf('/objects?filter[parent]=%s', $parentId));
+        $actualRelated = (array)$this->getClient()->get(sprintf('/objects?filter[parent]=%s', $parentId));
         $actualRelated = (array)Hash::extract($actualRelated, 'data.{n}.id');
         $index = 0;
         foreach ($children as $child) {

--- a/src/Controller/Component/ChildrenComponent.php
+++ b/src/Controller/Component/ChildrenComponent.php
@@ -38,7 +38,14 @@ class ChildrenComponent extends Component
     public function addRelated(string $parentId, array $children): array
     {
         $results = [];
+        $actualRelated = $this->getClient()->get(sprintf('/objects?filter[parent]=%s', $parentId));
+        $actualRelated = (array)Hash::extract($actualRelated, 'data.{n}.id');
+        $index = 0;
         foreach ($children as $child) {
+            // skip save when child is already related and in the same position
+            if (!empty($actualRelated) && $actualRelated[$index++] === $child['id']) {
+                continue;
+            }
             $results[] = $this->addRelatedChild($parentId, $child);
         }
 

--- a/src/Controller/Component/ChildrenComponent.php
+++ b/src/Controller/Component/ChildrenComponent.php
@@ -42,31 +42,15 @@ class ChildrenComponent extends Component
         $actualRelated = (array)Hash::extract($actualRelated, 'data.{n}.id');
         $index = 0;
         foreach ($children as $child) {
+            $found = array_search($child['id'], $actualRelated) > -1;
             // skip save when child is already related and in the same position
-            if (!empty($actualRelated) && $actualRelated[$index++] === $child['id']) {
+            if ($found && $actualRelated[$index++] === $child['id']) {
                 continue;
             }
-            $results[] = $this->addRelatedChild($parentId, $child);
+            $results[] = $this->getClient()->addRelated($parentId, 'folders', 'children', [$child]);
         }
 
         return $results;
-    }
-
-    /**
-     * Add single child by parent ID and child data.
-     *
-     * @param string $parentId The parent ID.
-     * @param array $child The child data (id, type, meta).
-     * @return array|null
-     */
-    public function addRelatedChild(string $parentId, array $child): ?array
-    {
-        $type = (string)Hash::get($child, 'type');
-        if ($type !== 'folders') {
-            return $this->getClient()->addRelated($parentId, 'folders', 'children', [$child]);
-        }
-
-        return $this->getClient()->addRelated($parentId, 'folders', 'parent', $child);
     }
 
     /**

--- a/src/Controller/Component/ChildrenComponent.php
+++ b/src/Controller/Component/ChildrenComponent.php
@@ -76,7 +76,7 @@ class ChildrenComponent extends Component
         $type = (string)Hash::get($child, 'type');
         if ($type === 'folders') {
             // invert relation call => use 'parent' relation on children folder
-            return $this->getClient()->replaceRelated((string)Hash::get($child, 'id'), 'folders', 'parent', [null]);
+            return $this->getClient()->replaceRelated((string)Hash::get($child, 'id'), 'folders', 'parent', []);
         }
 
         return $this->getClient()->removeRelated($parentId, 'folders', 'children', [$child]);

--- a/src/Controller/Component/ChildrenComponent.php
+++ b/src/Controller/Component/ChildrenComponent.php
@@ -38,15 +38,7 @@ class ChildrenComponent extends Component
     public function addRelated(string $parentId, array $children): array
     {
         $results = [];
-        $actualRelated = (array)$this->getClient()->get(sprintf('/objects?filter[parent]=%s', $parentId));
-        $actualRelated = (array)Hash::extract($actualRelated, 'data.{n}.id');
-        $index = 0;
         foreach ($children as $child) {
-            $found = array_search($child['id'], $actualRelated) > -1;
-            // skip save when child is already related and in the same position
-            if ($found && $actualRelated[$index++] === $child['id']) {
-                continue;
-            }
             $results[] = $this->getClient()->addRelated($parentId, 'folders', 'children', [$child]);
         }
 

--- a/tests/TestCase/Controller/Component/ChildrenComponentTest.php
+++ b/tests/TestCase/Controller/Component/ChildrenComponentTest.php
@@ -35,7 +35,6 @@ class ChildrenComponentTest extends TestCase
      *
      * @return void
      * @covers ::addRelated()
-     * @covers ::addRelatedChild()
      */
     public function testAddRelated(): void
     {
@@ -64,7 +63,6 @@ class ChildrenComponentTest extends TestCase
      *
      * @return void
      * @covers ::addRelated()
-     * @covers ::addRelatedChild()
      */
     public function testAddRelatedReorder(): void
     {

--- a/tests/TestCase/Controller/Component/ChildrenComponentTest.php
+++ b/tests/TestCase/Controller/Component/ChildrenComponentTest.php
@@ -82,14 +82,14 @@ class ChildrenComponentTest extends TestCase
                 ['id' => '9993', 'type' => 'folders', 'meta' => ['title' => 'Folder']],
             ],
         ]);
-        $apiClient->expects($this->exactly(2))
+        $apiClient->expects($this->exactly(3))
             ->method('addRelated')
             ->willReturn(['add response']);
         ApiClientProvider::setApiClient($apiClient);
         $registry = new ComponentRegistry();
         $this->component = new ChildrenComponent($registry);
         $result = $this->component->addRelated('9990', $children);
-        $this->assertEquals([['add response'], ['add response']], $result);
+        $this->assertEquals([['add response'], ['add response'], ['add response']], $result);
         ApiClientProvider::setApiClient($safeClient);
     }
 

--- a/tests/TestCase/Controller/Component/ChildrenComponentTest.php
+++ b/tests/TestCase/Controller/Component/ChildrenComponentTest.php
@@ -60,6 +60,42 @@ class ChildrenComponentTest extends TestCase
     }
 
     /**
+     * Test addRelated method with valid data and reorder.
+     *
+     * @return void
+     * @covers ::addRelated()
+     * @covers ::addRelatedChild()
+     */
+    public function testAddRelatedReorder(): void
+    {
+        $safeClient = ApiClientProvider::getApiClient();
+        $children = [
+            ['id' => '9991', 'type' => 'documents', 'meta' => ['title' => 'Document']],
+            ['id' => '9992', 'type' => 'images', 'meta' => ['title' => 'Image']],
+            ['id' => '9993', 'type' => 'folders', 'meta' => ['title' => 'Folder']],
+        ];
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->method('get')->willReturn([
+            'data' => [
+                ['id' => '9992', 'type' => 'images', 'meta' => ['title' => 'Image']],
+                ['id' => '9991', 'type' => 'documents', 'meta' => ['title' => 'Document']],
+                ['id' => '9993', 'type' => 'folders', 'meta' => ['title' => 'Folder']],
+            ],
+        ]);
+        $apiClient->expects($this->exactly(2))
+            ->method('addRelated')
+            ->willReturn(['add response']);
+        ApiClientProvider::setApiClient($apiClient);
+        $registry = new ComponentRegistry();
+        $this->component = new ChildrenComponent($registry);
+        $result = $this->component->addRelated('9990', $children);
+        $this->assertEquals([['add response'], ['add response']], $result);
+        ApiClientProvider::setApiClient($safeClient);
+    }
+
+    /**
      * Test removeRelated method with valid data.
      *
      * @return void


### PR DESCRIPTION
This provides a fix to avoid a `405 Method not allowed` error when changing position of children and save it.