### PR TITLE
Manual release with Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,17 @@ name: Release
 on:
   pull_request_target:
     types: [closed]
-
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: 'Release type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+        - patch
+        - minor
+        - major
 jobs:
 
   release_job:
@@ -11,6 +21,7 @@ jobs:
     with:
       main_branch: 'master'
       dist_branches: '["master", "3.x"]'
+      bump_version: ${{ inputs.releaseType }}
       version_ini_path: config/version.ini
       version_ini_prefix: "[Manager]\nversion="
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     with:
       main_branch: 'master'
       dist_branches: '["master", "3.x"]'
-      bump_version: ${{ inputs.releaseType }}
+      version_bump: ${{ inputs.releaseType }}
       version_ini_path: config/version.ini
       version_ini_prefix: "[Manager]\nversion="
 


### PR DESCRIPTION
This provides the possibility to create a release using the reusable workflow Release (this is possible after https://github.com/bedita/github-workflows/pull/16, thanks to @fquffio ).

Usual PR labels still work as expected (on merging PR with `release:*` labels, Release workflow create the release, the tag, etc.).