### PR TITLE
Use `null` and not `"null"` when saving  boolean nullable properties

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -12,6 +12,7 @@
  */
 namespace App\Controller;
 
+use App\Form\Form;
 use Authentication\Identity;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Controller\Controller;
@@ -403,6 +404,9 @@ class AppController extends Controller
                 $attributes = [];
             }
             foreach ($attributes as $key => $value) {
+                if ($data[$key] === Form::NULL_VALUE) {
+                    $data[$key] = null;
+                }
                 // remove unchanged attributes from $data
                 if (array_key_exists($key, $data) && !$this->hasFieldChanged($value, $data[$key])) {
                     unset($data[$key]);

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -264,7 +264,7 @@ class Control
         return [
             'type' => 'select',
             'options' => [
-                'null' => '',
+                Form::NULL_VALUE => '',
                 '1' => __('Yes'),
                 '0' => __('No'),
             ],

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -21,6 +21,11 @@ use Cake\Utility\Inflector;
 class Form
 {
     /**
+     * Form null value
+     */
+    public const NULL_VALUE = ':::null:::';
+
+    /**
      * Return method [$className, $methodName], if it's callable.
      * Otherwise, throw \InvalidArgumentException
      *

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -14,6 +14,7 @@
 namespace App\Test\TestCase\Controller;
 
 use App\Controller\AppController;
+use App\Form\Form;
 use App\Identifier\ApiIdentifier;
 use Authentication\AuthenticationService;
 use Authentication\AuthenticationServiceInterface;
@@ -366,6 +367,34 @@ class AppControllerTest extends TestCase
                     'title' => 'bibo',
                     'description' => 'dido',
                     '_actualAttributes' => '{"title":"bibo","description":""}',
+                ],
+            ],
+            'boolean with null value' => [
+                'documents', // object_type
+                [ // expected
+                    'id' => '1', // fake document id
+                    //'unchanged-a' => true,
+                    //'unchanged-b' => false,
+                    //'unchanged-c' => null,
+                    'changed-d' => false,
+                    'changed-e' => true,
+                    'changed-f' => true,
+                    'changed-g' => false,
+                    'changed-h' => null,
+                    'changed-i' => null,
+                ],
+                [ // data provided
+                    'id' => '1', // fake document id
+                    'unchanged-a' => true,
+                    'unchanged-b' => false,
+                    'unchanged-c' => Form::NULL_VALUE,
+                    'changed-d' => false,
+                    'changed-e' => true,
+                    'changed-f' => true,
+                    'changed-g' => false,
+                    'changed-h' => Form::NULL_VALUE,
+                    'changed-i' => Form::NULL_VALUE,
+                    '_actualAttributes' => '{"unchanged-a":true,"unchanged-b":false,"unchanged-c":null,"changed-d":true,"changed-e":false,"changed-f":null,"changed-g":null,"changed-h":false,"changed-i":true}',
                 ],
             ],
             'wrong json string actual attrs' => [ // test '_actualAttributes'

--- a/tests/TestCase/Form/ControlTest.php
+++ b/tests/TestCase/Form/ControlTest.php
@@ -14,6 +14,7 @@
 namespace App\Test\TestCase\Form;
 
 use App\Form\Control;
+use App\Form\Form;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
@@ -186,7 +187,7 @@ class ControlTest extends TestCase
                 [
                     'type' => 'select',
                     'options' => [
-                        'null' => '',
+                        Form::NULL_VALUE => '',
                         '1' => 'Yes',
                         '0' => 'No',
                     ],


### PR DESCRIPTION
This fixes an unexpected behavior on saving "null" values from boolean nullable properties.

To avoid problems, explicit `Form::NULL_VALUE` constant is used; before saving, form data is parsed and `Form::NULL_VALUE` is replaced with `null`. This way, the `AppController` can verify correctly which data is changed, compared to database data, and save it properly.

Furthermore this avoids to save `"property_name": "null"` by saving `"property_name":null` instead.