### PR TITLE
Bump BEdita i18n to 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,16 +22,16 @@
     ],
     "require": {
         "php": ">=7.4",
-        "bedita/i18n": "^4.2.2",
+        "bedita/i18n": "^4.4.1",
         "bedita/web-tools": "^3.10.1",
         "cakephp/authentication": "^2.9",
         "cakephp/cakephp": "~4.4.0",
         "cakephp/plugin-installer": "^1.3",
         "josegonzalez/dotenv": "^3.2",
+        "league/flysystem": "^2.5",
         "league/oauth2-github": "^3.0",
         "league/oauth2-google": "^4.0",
         "mobiledetect/mobiledetectlib": "^2.8",
-        "league/flysystem": "^2.5",
         "phpoffice/phpspreadsheet": "^1.22",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },


### PR DESCRIPTION
This updates composer dependency `bedita/i18n` to `^4.4.1`.