### PR TITLE
Fix save related data including meta

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -661,6 +661,7 @@ class ModulesComponent extends Component
                 $relatedObjects[] = [
                     'id' => $obj['id'],
                     'type' => $obj['type'],
+                    'meta' => (array)Hash::get($obj, 'meta'),
                 ];
                 continue;
             }
@@ -671,6 +672,7 @@ class ModulesComponent extends Component
             $relatedObjects[] = [
                 'id' => Hash::get($response, 'data.id'),
                 'type' => Hash::get($response, 'data.type'),
+                'meta' => (array)Hash::get($response, 'data.meta'),
             ];
         }
 


### PR DESCRIPTION
This fixes an issue introduced by https://github.com/bedita/manager/pull/1015.

The `getRelated` MUST include `meta`, otherwise position won't be saved properly, in reordering related data saves