### PR TITLE
Use `null` as default attribute value on new objects

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -247,7 +247,7 @@ class ModulesController extends AppController
                     }
                 )
             ),
-            ''
+            null
         );
         $object = [
             'type' => $this->objectType,


### PR DESCRIPTION
This PR replaces the empty string `''` with `null` as default value on new object attributes 
This way JSON fields are initialized with actual default `null` instead of empty string