### PR TITLE
Fix warning on save

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -28,9 +28,11 @@ jobs:
     with:
       php_versions: '["7.4", "8.1", "8.2"]'
       bedita_version: '4'
+      coverage_min_percentage: 98
 
   unit-5:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1
     with:
       php_versions: '["7.4", "8.1", "8.2"]'
       bedita_version: '5'
+      coverage_min_percentage: 98

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -404,11 +404,14 @@ class AppController extends Controller
                 $attributes = [];
             }
             foreach ($attributes as $key => $value) {
+                if (!array_key_exists($key, $data)) {
+                    continue;
+                }
                 if ($data[$key] === Form::NULL_VALUE) {
                     $data[$key] = null;
                 }
                 // remove unchanged attributes from $data
-                if (array_key_exists($key, $data) && !$this->hasFieldChanged($value, $data[$key])) {
+                if (!$this->hasFieldChanged($value, $data[$key])) {
                     unset($data[$key]);
                 }
             }

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -397,26 +397,29 @@ class AppController extends Controller
      */
     protected function changedAttributes(array &$data): void
     {
-        if (!empty($data['_actualAttributes'])) {
-            $attributes = json_decode($data['_actualAttributes'], true);
-            if ($attributes === null) {
-                $this->log(sprintf('Wrong _actualAttributes, not a json string: %s', $data['_actualAttributes']), 'error');
-                $attributes = [];
-            }
-            foreach ($attributes as $key => $value) {
-                if (!array_key_exists($key, $data)) {
-                    continue;
-                }
-                if ($data[$key] === Form::NULL_VALUE) {
-                    $data[$key] = null;
-                }
-                // remove unchanged attributes from $data
-                if (!$this->hasFieldChanged($value, $data[$key])) {
-                    unset($data[$key]);
-                }
-            }
-            unset($data['_actualAttributes']);
+        if (empty($data['_actualAttributes'])) {
+            return;
         }
+        $attributes = json_decode($data['_actualAttributes'], true);
+        if ($attributes === null) {
+            $this->log(sprintf('Wrong _actualAttributes, not a json string: %s', $data['_actualAttributes']), 'error');
+            unset($data['_actualAttributes']);
+
+            return;
+        }
+        foreach ($attributes as $key => $value) {
+            if (!array_key_exists($key, $data)) {
+                continue;
+            }
+            if ($data[$key] === Form::NULL_VALUE) {
+                $data[$key] = null;
+            }
+            // remove unchanged attributes from $data
+            if (!$this->hasFieldChanged($value, $data[$key])) {
+                unset($data[$key]);
+            }
+        }
+        unset($data['_actualAttributes']);
     }
 
     /**

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -702,6 +702,11 @@ class AppControllerTest extends TestCase
         static::assertEquals($expected, $actual);
     }
 
+    /**
+     * Data provider for `testPrepareRequest` test case.
+     *
+     * @return array
+     */
     public function changedAttributesProvider(): array
     {
         return [

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -703,7 +703,7 @@ class AppControllerTest extends TestCase
     }
 
     /**
-     * Data provider for `testPrepareRequest` test case.
+     * Data provider for `testChangedAttributes` test case.
      *
      * @return array
      */

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -702,6 +702,65 @@ class AppControllerTest extends TestCase
         static::assertEquals($expected, $actual);
     }
 
+    public function changedAttributesProvider(): array
+    {
+        return [
+            'missing _actualAttributes' => [
+                ['what' => 'ever'],
+                ['what' => 'ever'],
+            ],
+            'invalid json _actualAttributes' => [
+                [
+                    '_actualAttributes' => '{"""]',
+                    'a' => 'whatever',
+                    'b' => Form::NULL_VALUE,
+                ],
+                [
+                    'a' => 'whatever',
+                    'b' => Form::NULL_VALUE,
+                ],
+            ],
+            'valid json _actualAttributes' => [
+                [
+                    '_actualAttributes' => '{"a":null,"b":"whatever","c":null}',
+                    'a' => Form::NULL_VALUE,
+                    'b' => 'whatever',
+                ],
+                [
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `changedAttributes` method.
+     *
+     * @param array $data The data
+     * @param array $expected The expected data
+     * @return void
+     * @covers ::changedAttributes()
+     * @dataProvider changedAttributesProvider()
+     */
+    public function testChangedAttributes(array $data, array $expected): void
+    {
+        $controller = new class extends AppController {
+            /**
+             * Wrapper for changedAttributes() method.
+             *
+             * @param array $data The data
+             * @return array
+             */
+            public function myChangedAttributes(array $data): array
+            {
+                $this->changedAttributes($data);
+
+                return $data;
+            }
+        };
+        $actual = $controller->myChangedAttributes($data);
+        static::assertEquals($expected, $actual);
+    }
+
     /**
      * Data provider for `hasFieldChanged` test case.
      *


### PR DESCRIPTION
This fixes a warning on save data, in `AppController::changedAttributes` by refactoring the function.

Bonus:

 - a new test for `AppController::changedAttributes`
 - add `coverage_min_percentage` 98 in `php-unit` workflow