### PR TITLE
Refactor `<tree-view>` component and save menu, canonical, parents

### DIFF
--- a/resources/js/app/components/tree-view/tree-view.vue
+++ b/resources/js/app/components/tree-view/tree-view.vue
@@ -10,6 +10,7 @@
                     :value="value"
                     :checked="isParent"
                     :class="isLocked ? 'disabled' : ''"
+                    :data-folder-id="node.id"
                     @click="isLocked ? $event.preventDefault() : ''"
                     @change="toggleFolderRelation" />
                 {{ node.attributes.title }}
@@ -27,23 +28,34 @@
             <a :href="url" v-else>{{ msgEdit }}</a>
             <div class="tree-params">
                 <div v-if="relationName && isParent" class="tree-param">
-                    <input :id="'tree-menu-' + node.id"
-                        type="checkbox"
-                        :checked="isMenu"
-                        @change="toggleFolderRelationMenu" />
-                    <label :for="'tree-menu-' + node.id">
-                        {{ msgMenu }}
-                    </label>
+                    <template v-if="hasPermissionRoles && isLocked">
+                        <label>{{ msgMenu }}</label>
+                    </template>
+                    <template v-else>
+                        <input :id="'tree-menu-' + node.id"
+                            type="checkbox"
+                            :data-folder-id="node.id"
+                            :checked="isMenu"
+                            @change="toggleFolderRelationMenu" />
+                        <label :for="'tree-menu-' + node.id">
+                            {{ msgMenu }}
+                        </label>
+                    </template>
                 </div>
                 <div v-if="relationName && isParent && multipleChoice" class="tree-param">
-                    <input :id="'tree-canonical-' + node.id"
-                        name="_changedCanonical"
-                        type="radio"
-                        :checked="isCanonical"
-                        @change="toggleFolderRelationCanonical" />
-                    <label :for="'tree-canonical-' + node.id">
-                        {{ msgCanonical }}
-                    </label>
+                    <template v-if="hasPermissionRoles && isLocked">
+                        <label>{{ msgCanonical }}</label>
+                    </template>
+                    <template v-else>
+                        <input :id="'tree-canonical-' + node.id"
+                            type="radio"
+                            :data-folder-id="node.id"
+                            :checked="isCanonical"
+                            @change="toggleFolderRelationCanonical" />
+                        <label :for="'tree-canonical-' + node.id">
+                            {{ msgCanonical }}
+                        </label>
+                    </template>
                 </div>
             </div>
         </div>
@@ -462,7 +474,7 @@ export default {
          * @return {void}
          */
         toggleFolderRelation(event) {
-            document.getElementById('changedParents').value = 1;
+            this.updateChangedParents(event);
             if (this.multipleChoice) {
                 let index = this.parents.findIndex(({ id }) => id == this.node.id);
                 if (event.target.checked) {
@@ -490,7 +502,7 @@ export default {
          */
         toggleFolderRelationMenu(event) {
             if (this.isParent) {
-                document.getElementById('changedParents').value = 1;
+                this.updateChangedParents(event);
             }
 
             let relation = this.node?.meta?.relation || {};
@@ -505,11 +517,22 @@ export default {
          */
         toggleFolderRelationCanonical(event) {
             if (this.isParent) {
-                document.getElementById('changedParents').value = 1;
+                this.updateChangedParents(event);
             }
 
             let relation = this.node?.meta?.relation || {};
             relation.canonical = event.target.checked;
+        },
+
+        updateChangedParents(event) {
+            const folderId = event.target.attributes['data-folder-id'].value;
+            const val = document.getElementById('changedParents').value.trim() || '';
+            let arr = val.split(',') || [];
+            arr = arr.filter((item) => item !== '');
+            if (!arr.includes(folderId)) {
+                arr.push(folderId);
+            }
+            document.getElementById('changedParents').value = arr.join(',');
         },
     },
 }

--- a/resources/js/app/components/tree-view/tree-view.vue
+++ b/resources/js/app/components/tree-view/tree-view.vue
@@ -48,7 +48,7 @@
                     </template>
                     <template v-else>
                         <input :id="'tree-canonical-' + node.id"
-                            type="radio"
+                            type="checkbox"
                             :data-folder-id="node.id"
                             :checked="isCanonical"
                             @change="toggleFolderRelationCanonical" />

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -336,7 +336,7 @@ class AppController extends Controller
     }
 
     /**
-     * Handle `parents` or `parent` relationship looking at `_changedParents` input flag
+     * Handle `parents` or `parent` relationship looking at `_changedParents` input
      *
      * @param string $type Object type
      * @param array $data Form data
@@ -344,17 +344,17 @@ class AppController extends Controller
      */
     protected function setupParentsRelation(string $type, array &$data): void
     {
-        $changedParents = (bool)Hash::get($data, '_changedParents');
-        $originalParents = (string)Hash::get($data, '_originalParents');
-        $originalParents = empty($originalParents) ? [] : explode(',', $originalParents);
-        unset($data['_changedParents'], $data['_originalParents']);
+        $changedParents = (string)Hash::get($data, '_changedParents');
         $relation = $type === 'folders' ? 'parent' : 'parents';
         if (empty($changedParents)) {
-            unset($data['relations'][$relation]);
+            unset($data['relations'][$relation], $data['_changedParents'], $data['_originalParents']);
 
             return;
         }
-        if (empty($data['relations'][$relation]['replaceRelated']) && empty($originalParents)) {
+        $changedParents = array_unique(explode(',', $changedParents));
+        $originalParents = array_filter(explode(',', (string)Hash::get($data, '_originalParents')));
+        unset($data['_changedParents'], $data['_originalParents']);
+        if (empty($data['relations'][$relation]['replaceRelated'])) {
             return;
         }
         $replaceRelated = array_reduce(
@@ -367,12 +367,11 @@ class AppController extends Controller
             },
             []
         );
-        $add = array_diff(array_keys($replaceRelated), $originalParents);
         $data['relations'][$relation]['addRelated'] = array_map(
             function ($id) use ($replaceRelated) {
                 return $replaceRelated[$id];
             },
-            $add
+            $changedParents
         );
         // no need to remove when relation is "parent"
         // ParentsComponent::addRelated already performs a replaceRelated

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -354,7 +354,7 @@ class AppController extends Controller
         $changedParents = array_unique(explode(',', $changedParents));
         $originalParents = array_filter(explode(',', (string)Hash::get($data, '_originalParents')));
         unset($data['_changedParents'], $data['_originalParents']);
-        if (empty($data['relations'][$relation]['replaceRelated'])) {
+        if (empty($data['relations'][$relation]['replaceRelated']) && empty($changedParents)) {
             return;
         }
         $replaceRelated = array_reduce(

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -367,12 +367,20 @@ class AppController extends Controller
             },
             []
         );
-        $data['relations'][$relation]['addRelated'] = array_map(
+        $addRelated = array_map(
             function ($id) use ($replaceRelated) {
-                return $replaceRelated[$id];
+                return Hash::get($replaceRelated, $id);
             },
             $changedParents
         );
+        $addRelated = array_filter(
+            $addRelated,
+            function ($elem) {
+                return !empty($elem);
+            }
+        );
+        $data['relations'][$relation]['addRelated'] = $addRelated;
+
         // no need to remove when relation is "parent"
         // ParentsComponent::addRelated already performs a replaceRelated
         if ($relation !== 'parent') {

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -354,10 +354,6 @@ class AppController extends Controller
         $changedParents = array_unique(explode(',', $changedParents));
         $originalParents = array_filter(explode(',', (string)Hash::get($data, '_originalParents')));
         unset($data['_changedParents'], $data['_originalParents']);
-        // @phpstan-ignore-next-line
-        if (empty($data['relations'][$relation]['replaceRelated']) && empty($changedParents)) {
-            return;
-        }
         $replaceRelated = array_reduce(
             (array)Hash::get($data, sprintf('relations.%s.replaceRelated', $relation)),
             function ($acc, $obj) {

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -354,6 +354,7 @@ class AppController extends Controller
         $changedParents = array_unique(explode(',', $changedParents));
         $originalParents = array_filter(explode(',', (string)Hash::get($data, '_originalParents')));
         unset($data['_changedParents'], $data['_originalParents']);
+        // @phpstan-ignore-next-line
         if (empty($data['relations'][$relation]['replaceRelated']) && empty($changedParents)) {
             return;
         }

--- a/templates/Element/Form/trees.twig
+++ b/templates/Element/Form/trees.twig
@@ -29,9 +29,8 @@
                 :has-permissions="{{ hasPermissions|json_encode }}">
             </tree-view>
             {% do Form.unlockField('relations.' ~ relationName ~ '.replaceRelated') %}
-            {{ Form.hidden('_changedParents', {'value': '0', 'id': 'changedParents'})|raw }}
+            {{ Form.hidden('_changedParents', {'value': '', 'id': 'changedParents'})|raw }}
             {% do Form.unlockField('_changedParents') %}
-            {% do Form.unlockField('_changedCanonical') %}
             {% do Form.unlockField('_originalParents') %}
         </div>
     </section>

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -521,7 +521,7 @@ class AppControllerTest extends TestCase
                 [ // data provided
                     'id' => '1', // fake document id
                     'relations' => [],
-                    '_changedParents' => true,
+                    '_changedParents' => [1],
                 ],
             ],
             'no parents action' => [
@@ -567,7 +567,7 @@ class AppControllerTest extends TestCase
                             ],
                         ],
                     ],
-                    '_changedParents' => true,
+                    '_changedParents' => [1],
                 ],
             ],
             'categories' => [
@@ -661,7 +661,7 @@ class AppControllerTest extends TestCase
                             ],
                         ],
                     ],
-                    '_changedParents' => true,
+                    '_changedParents' => [44],
                     '_originalParents' => '999,888',
                 ],
             ],

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -521,7 +521,7 @@ class AppControllerTest extends TestCase
                 [ // data provided
                     'id' => '1', // fake document id
                     'relations' => [],
-                    '_changedParents' => [1],
+                    '_changedParents' => '1',
                 ],
             ],
             'no parents action' => [
@@ -567,7 +567,7 @@ class AppControllerTest extends TestCase
                             ],
                         ],
                     ],
-                    '_changedParents' => [1],
+                    '_changedParents' => '1',
                 ],
             ],
             'categories' => [
@@ -661,7 +661,7 @@ class AppControllerTest extends TestCase
                             ],
                         ],
                     ],
-                    '_changedParents' => [44],
+                    '_changedParents' => '44',
                     '_originalParents' => '999,888',
                 ],
             ],

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -517,6 +517,7 @@ class AppControllerTest extends TestCase
                 'documents', // object_type
                 [
                     'id' => '1',
+                    '_api' => [],
                 ],
                 [ // data provided
                     'id' => '1', // fake document id


### PR DESCRIPTION
This provides a refactor on `<tree-view>` component, to fix `menu` and `canonical` meta save. 

When `folders` have association `permissions` and user has no permissions on "parent" folder, `menu` and `canonical` are readonly.