### PR TITLE
Remove unnecessary 404 on missing `showForbidden` session var

### DIFF
--- a/resources/js/app/components/permission-toggle/permission-toggle.vue
+++ b/resources/js/app/components/permission-toggle/permission-toggle.vue
@@ -50,12 +50,8 @@ export default {
         async getShowForbidden() {
             try {
                 const response = await fetch(`${new URL(BEDITA.base).pathname}session/showForbidden`);
-                // Default to true
-                if (!response.ok) {
-                    return true;
-                }
 
-                return (await response.json())?.value;
+                return (await response.json())?.value || true;
             } catch (e) {
                 console.error('Error retrieving session variable', e);
 

--- a/src/Controller/SessionController.php
+++ b/src/Controller/SessionController.php
@@ -12,8 +12,6 @@
  */
 namespace App\Controller;
 
-use Cake\Http\Exception\NotFoundException;
-
 class SessionController extends AppController
 {
     /**
@@ -39,10 +37,6 @@ class SessionController extends AppController
     {
         $this->request->allowMethod(['GET']);
         $value = $this->request->getSession()->read($name);
-        if ($value === null) {
-            throw new NotFoundException('Session variable not defined');
-        }
-
         $this->set(compact('value'));
         $this->viewBuilder()->setOption('serialize', ['value']);
     }
@@ -74,13 +68,9 @@ class SessionController extends AppController
     public function delete(string $name): void
     {
         $this->request->allowMethod(['DELETE']);
-        $exists = $this->request->getSession()->check($name);
-        if (!$exists) {
-            throw new NotFoundException('Session variable not defined');
+        if ($this->request->getSession()->check($name)) {
+            $this->request->getSession()->delete($name);
         }
-
-        $this->request->getSession()->delete($name);
-
         $this->setResponse($this->response->withStatus(204));
     }
 }

--- a/tests/TestCase/Controller/SessionControllerTest.php
+++ b/tests/TestCase/Controller/SessionControllerTest.php
@@ -13,7 +13,6 @@
 namespace App\Test\TestCase\Controller;
 
 use App\Controller\SessionController;
-use Cake\Http\Exception\NotFoundException;
 use Cake\Http\ServerRequest;
 use Cake\Http\Session;
 
@@ -58,8 +57,11 @@ class SessionControllerTest extends \Cake\TestSuite\TestCase
                 'session' => $session,
             ])
         );
-        static::expectException(NotFoundException::class);
         $controller->view('tast');
+        static::assertEquals(200, $controller->getResponse()->getStatusCode());
+        static::assertEquals([
+            'value' => null,
+        ], $controller->viewBuilder()->getVars());
     }
 
     /**
@@ -146,7 +148,8 @@ class SessionControllerTest extends \Cake\TestSuite\TestCase
                 'session' => $session,
             ])
         );
-        static::expectException(NotFoundException::class);
         $controller->delete('tast');
+        static::assertNull($session->read('tast'));
+        static::assertEquals(204, $controller->getResponse()->getStatusCode());
     }
 }


### PR DESCRIPTION
This provides a refactor to remove unnecessary exception (and error logs) on missing session variable (when permission toggle component try to fetch `showForbidden`).