### PR TITLE
Module icons

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -108,8 +108,8 @@ return [
      *  'sort' - sort order to be used in index; use a field name prepending optionl `-` sign
      *          to indicate a descendant order, f.i. '-title' will sort by title in reverse alphabetical order
      *          (default is '-id'),
-     *  'icon' - icon code, f.i. `icon-article`, have a look in
-     *      `webroot/css/be-icons-codes.css` for a complete list of codes
+     *  'icon' - icon, f.i. `carbon:document`, have a look at https://icon-sets.iconify.design/
+     *          for a complete list of icons
      *  'sidebar' - additional custom sidebar links added in modules index and single item view,
      *     defined as associative array with 'index' and 'view' keys
      */
@@ -119,7 +119,7 @@ return [
     //         'color' => '#230637',
     //         // 'secondaryColor' => '#d95700',
     //         'sort' => '-modified',
-    //         // 'icon' => 'icon-cube',
+    //         // 'icon' => 'carbon:document',
     //     ],
     //     'folders' => [
     //         'color' => '#072440',

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -219,7 +219,7 @@ class LayoutHelper extends Helper
             return sprintf(
                 '<a href="%s" class="%s"><span class="mr-05">%s</span>%s</a>',
                 $this->Url->build(['_name' => 'modules:list', 'object_type' => $name]),
-                sprintf('is-flex align-center justify-center space-between wrap has-background-module-%s', $name),
+                sprintf('module-item has-background-module-%s', $name),
                 $this->tr($label),
                 $this->moduleIcon($name, $currentModule)
             );

--- a/templates/Element/Menu/sidebar.scss
+++ b/templates/Element/Menu/sidebar.scss
@@ -150,6 +150,25 @@ ul.concurrent-editors {
             > *:not(:last-child) { margin-bottom: $gutter; }
         }
 
+        .app-module-box > a.module-item {
+            justify-content: center;
+        }
+
+        .app-module-box > a.module-item > span {
+            flex: 1;
+            display: inline-block;
+            transform: translateY(0);
+            transition: transform 0.3s;
+        }
+
+        .app-module-box > a.module-item > svg {
+            position: absolute;
+            display: block;
+            top: 40%;
+            height: 24px;
+            width: 24px;
+        }
+
         .listobjnav  {
             color:$gray-600;
             font-size:4em;

--- a/templates/Element/Menu/sidebar.scss
+++ b/templates/Element/Menu/sidebar.scss
@@ -85,6 +85,10 @@
     }
 }
 
+.app-module-box-concurrent-editors a.module-item > svg {
+    display:none;
+}
+
 ul.concurrent-editors {
     margin:0; padding:0;
     li {
@@ -167,6 +171,13 @@ ul.concurrent-editors {
             top: 40%;
             height: 24px;
             width: 24px;
+        }
+
+        .app-module-box:is(.locked) > a.module-item > svg,
+        .app-module-box:is(.expired) > a.module-item > svg,
+        .app-module-box:is(.future) > a.module-item > svg,
+        .app-module-box:is(.draft) > a.module-item > svg {
+            display: none;
         }
 
         .listobjnav  {

--- a/templates/Pages/Dashboard/index.twig
+++ b/templates/Pages/Dashboard/index.twig
@@ -6,17 +6,7 @@
         <section class="dashboard-section">
             <div class="dashboard-items">
             {% for name, module in modules %}
-                {% if not in_array(name, ['trash', 'users']) %}
-                    {% set module = name == 'objects' ? {'label': __('All objects')}|merge(module) : module %}
-                    {% set class = 'dashboard-item has-background-module-%s %s'|format(name, module.class|default('')) %}
-                    {% set url = module.route ? Url.build(module.route) : Url.build({ '_name': 'modules:list', 'object_type': name, 'plugin': null }) %}
-                    <a href="{{ url }}" class="{{ class }}">
-                        <span>{{ Layout.tr(module.label|default(name)) }}</span>
-                        {% if module.hints.multiple_types and not module.class %}<Icon icon="carbon:grid"></Icon>{% endif %}
-                        {% if name == 'publications' %}<Icon icon="carbon:wikis"></Icon>{% endif %}
-                        {% if name == 'folders' %}<Icon icon="carbon:tree-view"></Icon>{% endif %}
-                    </a>
-                {% endif %}
+                {{ Layout.dashboardModuleLink(name, module)|raw }}
             {% endfor %}
             </div>
         </section>

--- a/tests/TestCase/View/Helper/ElementHelperTest.php
+++ b/tests/TestCase/View/Helper/ElementHelperTest.php
@@ -76,7 +76,7 @@ class ElementHelperTest extends TestCase
     }
 
     /**
-     * Test `element` method
+     * Test `custom` method
      *
      * @param string $expected The expected element
      * @param string $item The item
@@ -84,7 +84,7 @@ class ElementHelperTest extends TestCase
      * @param array $conf Configuration to use
      * @return void
      * @dataProvider customProvider()
-     * @covers ::element()
+     * @covers ::custom()
      */
     public function testCustom(string $expected, string $item, string $type = 'relation', array $conf = []): void
     {

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -241,7 +241,7 @@ class LayoutHelperTest extends TestCase
                 ],
             ],
             'objects' => [
-                '<a href="/objects" id="module-icon" class="has-background-module-objects">Objects</a>',
+                '<a href="/objects" class="is-flex align-center justify-center space-between wrap has-background-module-objects"><span class="mr-05">Objects</span></a>',
                 'Module',
                 [
                     'currentModule' => ['name' => 'objects'],

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -241,7 +241,7 @@ class LayoutHelperTest extends TestCase
                 ],
             ],
             'objects' => [
-                '<a href="/objects" class="is-flex align-center justify-center space-between wrap has-background-module-objects"><span class="mr-05">Objects</span></a>',
+                '<a href="/objects" class="module-item has-background-module-objects"><span class="mr-05">Objects</span></a>',
                 'Module',
                 [
                     'currentModule' => ['name' => 'objects'],

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -537,4 +537,115 @@ class LayoutHelperTest extends TestCase
         $actual = $layout->trashLink('dummies');
         static::assertSame($expected, $actual);
     }
+
+    /**
+     * Data provider for `testDashboardModuleLink` test case.
+     *
+     * @return array
+     */
+    public function dashboardModuleLinkProvider(): array
+    {
+        return [
+            'trash' => [
+                'trash',
+                [],
+                '',
+            ],
+            'users' => [
+                'users',
+                [],
+                '',
+            ],
+            'documents' => [
+                'documents',
+                [],
+                '<a href="/documents" class="dashboard-item has-background-module-documents "><span>Documents</span><Icon icon="carbon:document"></Icon></a>',
+            ],
+        ];
+    }
+
+    /**
+     * Test `dashboardModuleLink`.
+     *
+     * @return void
+     * @dataProvider dashboardModuleLinkProvider()
+     * @covers ::dashboardModuleLink()
+     * @covers ::moduleIcon()
+     */
+    public function testDashboardModuleLink(string $name, array $module, string $expected): void
+    {
+        $modules = (array)Configure::read('Modules', []);
+        $modules['test_items'] = ['icon' => 'test:items'];
+        Configure::write('Modules', $modules);
+        $viewVars = [];
+        $request = new ServerRequest();
+        $view = new View($request, null, null, compact('viewVars'));
+        $layout = new LayoutHelper($view);
+        $actual = $layout->dashboardModuleLink($name, $module);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testModuleIcon` test case.
+     *
+     * @return array
+     */
+    public function moduleIconProvider(): array
+    {
+        return [
+            'hints multiple types' => [
+                'animals',
+                [
+                    'hints' => [
+                        'multiple_types' => true,
+                    ],
+                ],
+                '<Icon icon="carbon:grid"></Icon>',
+
+            ],
+            'documents' => [
+                'documents',
+                [],
+                '<Icon icon="carbon:document"></Icon>',
+            ],
+            'from conf' => [
+                'test_items',
+                [],
+                '<Icon icon="test:items"></Icon>',
+            ],
+            'from map (core modules)' => [
+                'locations',
+                [],
+                '<Icon icon="carbon:location"></Icon>',
+            ],
+            'other module (non core, non conf)' => [
+                'cats',
+                [],
+                '',
+            ],
+        ];
+    }
+
+    /**
+     * Test `moduleIcon`.
+     *
+     * @param string $name The module name
+     * @param array $module The module configuration
+     * @param string $expected The expected result
+     * @return void
+     * @dataProvider moduleIconProvider()
+     * @covers ::moduleIcon()
+     */
+    public function testModuleIcon(string $name, array $module, string $expected): void
+    {
+        $modules = (array)Configure::read('Modules', []);
+        $modules['test_items'] = ['icon' => 'test:items'];
+        Configure::write('Modules', $modules);
+        $viewVars = [];
+        $request = new ServerRequest();
+        $view = new View($request, null, null, compact('viewVars'));
+        $layout = new LayoutHelper($view);
+        $actual = $layout->moduleIcon($name, $module);
+        static::assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
This provides an update in module icons management.
All core modules have a default icon.
All modules (core + other) can have a custom icon, identified by a string like `material-symbols:festival` (https://icon-sets.iconify.design/material-symbols/festival/), set in `Modules.<moduleName>.icon` configuration.

Example:
```php
'festivals' => [
    'icon' => 'material-symbols:festival',
],
```

Dashboard example

![image](https://github.com/bedita/manager/assets/2227145/e7e8e940-bc0e-4e82-8089-97aa50dc03ee)

Document view sidebar box

![image](https://github.com/bedita/manager/assets/2227145/3558a618-5e48-4c35-b202-6213ef0528f6)

Available icons can be found at https://icon-sets.iconify.design/

Bonus: fix scss to avoid icons overlap in object view sidebar module box