### PR TITLE
Fix locked by parents on empty perms

### DIFF
--- a/src/View/Helper/PermsHelper.php
+++ b/src/View/Helper/PermsHelper.php
@@ -237,7 +237,8 @@ class PermsHelper extends Helper
         }
         $roles = $this->userRoles();
         foreach ($included as $data) {
-            if (count(array_intersect($roles, (array)Hash::get($data, 'meta.perms.roles'))) > 0) {
+            $metaPermsRoles = (array)Hash::get($data, 'meta.perms.roles');
+            if (empty($metaPermsRoles) || count(array_intersect($roles, $metaPermsRoles)) > 0) {
                 return false;
             }
         }

--- a/src/View/Helper/PermsHelper.php
+++ b/src/View/Helper/PermsHelper.php
@@ -218,8 +218,8 @@ class PermsHelper extends Helper
     /**
      * Return true if object is locked by parents.
      * When user is admin, return false.
-     * When user is not admin, return false if at least one parent is not locked for user.
-     * Return true if all parents are locked for user.
+     * When user is not admin, return true if at least one parent is locked for user.
+     * Return false otherwise
      *
      * @param string $id The object id
      * @return bool
@@ -238,11 +238,14 @@ class PermsHelper extends Helper
         $roles = $this->userRoles();
         foreach ($included as $data) {
             $metaPermsRoles = (array)Hash::get($data, 'meta.perms.roles');
-            if (empty($metaPermsRoles) || count(array_intersect($roles, $metaPermsRoles)) > 0) {
-                return false;
+            if (empty($metaPermsRoles)) {
+                continue;
+            }
+            if (count(array_intersect($roles, $metaPermsRoles)) === 0) {
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 }

--- a/tests/TestCase/View/Helper/PermsHelperTest.php
+++ b/tests/TestCase/View/Helper/PermsHelperTest.php
@@ -445,6 +445,45 @@ class PermsHelperTest extends TestCase
         $actual = $this->Perms->isLockedByParents('123');
         static::assertTrue($actual);
 
+        // user is not admin, has parents, one with no perms => false
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://example.com'])
+            ->getMock();
+        $apiClient->method('get')
+            ->withAnyParameters()
+            ->willReturn([
+                'included' => [
+                    [
+                        'id' => '123451',
+                        'type' => 'folders',
+                        'meta' => [
+                            'perms' => [],
+                        ],
+                    ],
+                    [
+                        'id' => '123452',
+                        'type' => 'folders',
+                        'meta' => [
+                            'perms' => [
+                                'roles' => ['d', 'e', 'f'],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => '123452',
+                        'type' => 'folders',
+                        'meta' => [
+                            'perms' => [
+                                'roles' => ['g', 'h', 'i'],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+        ApiClientProvider::setApiClient($apiClient);
+        $actual = $this->Perms->isLockedByParents('123');
+        static::assertFalse($actual);
+
         ApiClientProvider::setApiClient($safeApiClient);
     }
 }

--- a/tests/TestCase/View/Helper/PermsHelperTest.php
+++ b/tests/TestCase/View/Helper/PermsHelperTest.php
@@ -363,7 +363,7 @@ class PermsHelperTest extends TestCase
         $actual = $this->Perms->isLockedByParents('123');
         static::assertFalse($actual);
 
-        // user is not admin, has one parent with perms => false
+        // user is not admin, has one parent with perms roles different than user's roles => true
         $apiClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs(['https://example.com'])
             ->getMock();
@@ -402,7 +402,7 @@ class PermsHelperTest extends TestCase
             ]);
         ApiClientProvider::setApiClient($apiClient);
         $actual = $this->Perms->isLockedByParents('123');
-        static::assertFalse($actual);
+        static::assertTrue($actual);
 
         // user is not admin, has parents, none with perms => true
         $apiClient = $this->getMockBuilder(BEditaClient::class)
@@ -445,7 +445,7 @@ class PermsHelperTest extends TestCase
         $actual = $this->Perms->isLockedByParents('123');
         static::assertTrue($actual);
 
-        // user is not admin, has parents, one with no perms => false
+        // user is not admin, has parents, one with no perms => true
         $apiClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs(['https://example.com'])
             ->getMock();
@@ -482,7 +482,7 @@ class PermsHelperTest extends TestCase
             ]);
         ApiClientProvider::setApiClient($apiClient);
         $actual = $this->Perms->isLockedByParents('123');
-        static::assertFalse($actual);
+        static::assertTrue($actual);
 
         ApiClientProvider::setApiClient($safeApiClient);
     }


### PR DESCRIPTION
Fix `Perms::isLockedByParents` logic, to be the same of `bedita/bedita` API logic.

Object is locked by parents when at least one parent has roles perms different than authenticated user roles.