### PR TITLE
Roles automatic groups in user view

### DIFF
--- a/resources/js/app/components/relation-view/roles-list-view.vue
+++ b/resources/js/app/components/relation-view/roles-list-view.vue
@@ -5,7 +5,7 @@
                 <h4 class="is-small has-font-weight-bold has-text-transform-upper">{{ groupName }}</h4>
                 <div v-for="role in objectsByGroups[groupName]">
                     <input type="checkbox" :value="role" :disabled="userRolePriority > role.meta.priority" v-model="checkedRelations"/>
-                    <span class="mx-05">{{ getRoleLabel(role.attributes.name) }}</span>
+                    <span class="mx-05">{{ getRoleLabel(role.attributes.name, role.attributes.description) }}</span>
                 </div>
             </div>
         </div>
@@ -103,15 +103,18 @@ export default {
                 return 'BEdita Manager';
             }
 
-            return roleName.substr(0, index);
+            return this.$helpers.humanize(roleName.substr(0, index));
         },
-        getRoleLabel(roleName) {
+        getRoleLabel(roleName, roleDescription) {
             const index = roleName.indexOf('__');
             if (index < 0) {
                 return roleName;
             }
+            if (roleDescription) {
+                return roleDescription;
+            }
 
-            return roleName.substr(index + 2);
+            return this.$helpers.humanize(roleName.substr(index + 2));
         },
     },
 }

--- a/resources/js/app/components/relation-view/roles-list-view.vue
+++ b/resources/js/app/components/relation-view/roles-list-view.vue
@@ -1,18 +1,11 @@
 <template>
     <div class="roles-list-view">
-        <div v-if="Object.keys(this.groups).length === 0">
-            <div v-for="role in objects">
-                <input type="checkbox" :value="role" :disabled="userRolePriority > role.meta.priority" v-model="checkedRelations"/>
-                <span class="mx-05">{{ role.attributes.name }}</span>
-            </div>
-        </div>
-
-        <div v-else>
+        <div>
             <div v-for="groupName in Object.keys(objectsByGroups)">
                 <h4 class="is-small has-font-weight-bold has-text-transform-upper">{{ groupName }}</h4>
                 <div v-for="role in objectsByGroups[groupName]">
                     <input type="checkbox" :value="role" :disabled="userRolePriority > role.meta.priority" v-model="checkedRelations"/>
-                    <span class="mx-05">{{ role.attributes.name }}</span>
+                    <span class="mx-05">{{ getRoleLabel(role.attributes.name) }}</span>
                 </div>
             </div>
         </div>
@@ -61,9 +54,18 @@ export default {
     async mounted() {
         await this.loadObjects();
         this.$nextTick(() => {
-            for (let groupName of Object.keys(this.groups)) {
+            let groups = this.groups;
+            if (Object.keys(groups).length === 0) {
+                for (let role of this.objects) {
+                    if (!groups[this.getGroup(role.attributes.name)]) {
+                        groups[this.getGroup(role.attributes.name)] = new Array();
+                    }
+                    groups[this.getGroup(role.attributes.name)].push(role.attributes.name);
+                }
+            }
+            for (let groupName of Object.keys(groups)) {
                 this.objectsByGroups[groupName] = new Array();
-                for (let roleName of this.groups[groupName]) {
+                for (let roleName of groups[groupName]) {
                     const role = this.objects.filter((v) => v.attributes.name === roleName)[0];
                     this.objectsByGroups[groupName].push(role);
                 }
@@ -91,6 +93,25 @@ export default {
                 // emit event to pass data to parent
                 this.$emit('remove-relations', relationsToRemove);
             }
+        },
+    },
+
+    methods: {
+        getGroup(roleName) {
+            const index = roleName.indexOf('__');
+            if (index < 0) {
+                return 'BEdita Manager';
+            }
+
+            return roleName.substr(0, index);
+        },
+        getRoleLabel(roleName) {
+            const index = roleName.indexOf('__');
+            if (index < 0) {
+                return roleName;
+            }
+
+            return roleName.substr(index + 2);
         },
     },
 }

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -1,5 +1,6 @@
 import { t } from 'ttag';
 import { warning } from 'app/components/dialog/dialog';
+import { humanizeString } from 'app/helpers/text-helper.js';
 
 export default {
     install (Vue) {
@@ -253,6 +254,10 @@ export default {
                 const now = new Date();
 
                 return new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
+            },
+
+            humanize(str) {
+                return humanizeString(str);
             },
         }
     }


### PR DESCRIPTION
This provides an UI update in user view:

 - when `RolesGroups` configuration is set, the configuration is used to organize roles by groups (as it was before this PR)
 - when `RolesGroups` configuration is not set, UI shows automatic groups following a specific logic (look at the following example)

I.e., we have these roles (`name` / `description`):

 - admin / Administrator
 - manager / Manager
 - editor / Editor
 - viewer / Viewer
 - project_a__editor / Project A editor
 - project_a__viewer / Project A viewer
 - project_b__editor / Project B editor
 - project_b__viewer / Project B viewer

Note: `__` inside role name allows BEM to consider it to group roles.

Roles shown in user view will be grouped as follows:

```
BEDITA MANAGER

 - Admin
 - Manager
 - Editor
 - Viewer

PROJECT A

 - Project A editor
 - Project B viewer

PROJECT B

 - Project B editor
 - Project B viewer
```
On missing role description, there will be a "humanized" `role.name` as label. 