### PR TITLE
Fix `end_date` seconds when date range interval has params `all_day`

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -246,6 +246,7 @@ class AppController extends Controller
                 },
                 $data['date_ranges']
             );
+            $data['date_ranges'] = array_values($data['date_ranges']);
         }
 
         // prepare categories

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -235,6 +235,17 @@ class AppController extends Controller
                     return !empty($item['start_date']) || !empty($item['end_date']);
                 }
             );
+            $data['date_ranges'] = array_map(
+                function ($item) {
+                    if (empty($item['params']['all_day']) || empty($item['end_date'])) {
+                        return $item;
+                    }
+                    $item['end_date'] = str_replace(':59:00.000', ':59:59.000', $item['end_date']);
+
+                    return $item;
+                },
+                $data['date_ranges']
+            );
         }
 
         // prepare categories

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -227,27 +227,7 @@ class AppController extends Controller
 
         $this->decodeJsonAttributes($data);
 
-        // remove date_ranges items having empty both start & end dates
-        if (!empty($data['date_ranges'])) {
-            $data['date_ranges'] = array_filter(
-                (array)$data['date_ranges'],
-                function ($item) {
-                    return !empty($item['start_date']) || !empty($item['end_date']);
-                }
-            );
-            $data['date_ranges'] = array_map(
-                function ($item) {
-                    if (empty($item['params']['all_day']) || empty($item['end_date'])) {
-                        return $item;
-                    }
-                    $item['end_date'] = str_replace(':59:00.000', ':59:59.000', $item['end_date']);
-
-                    return $item;
-                },
-                $data['date_ranges']
-            );
-            $data['date_ranges'] = array_values($data['date_ranges']);
-        }
+        $this->prepareDateRanges($data);
 
         // prepare categories
         if (!empty($data['categories'])) {
@@ -291,6 +271,39 @@ class AppController extends Controller
             $data = Hash::insert($data, $key, $decoded);
         }
         unset($data['_jsonKeys']);
+    }
+
+    /**
+     * Prepare date ranges.
+     * Remove empty date ranges.
+     * Fix end date time to 23:59:59.000 if all_day is true.
+     *
+     * @param array $data The data to prepare
+     * @return void
+     */
+    protected function prepareDateRanges(array &$data): void
+    {
+        if (empty($data['date_ranges'])) {
+            return;
+        }
+        $data['date_ranges'] = array_filter(
+            (array)$data['date_ranges'],
+            function ($item) {
+                return !empty($item['start_date']) || !empty($item['end_date']);
+            }
+        );
+        $data['date_ranges'] = array_map(
+            function ($item) {
+                if (empty($item['params']['all_day']) || empty($item['end_date'])) {
+                    return $item;
+                }
+                $item['end_date'] = str_replace(':59:00.000', ':59:59.000', $item['end_date']);
+
+                return $item;
+            },
+            $data['date_ranges']
+        );
+        $data['date_ranges'] = array_values($data['date_ranges']);
     }
 
     /**

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -701,6 +701,7 @@ class AppControllerTest extends TestCase
      * @covers ::prepareRequest()
      * @covers ::specialAttributes()
      * @covers ::decodeJsonAttributes()
+     * @covers ::prepareDateRanges()
      * @covers ::prepareRelations()
      * @covers ::setupParentsRelation()
      * @covers ::changedAttributes()

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -458,13 +458,36 @@ class AppControllerTest extends TestCase
                 'events', // object_type
                 [ // expected
                     'id' => '7',
-                    'date_ranges' => [],
+                    'date_ranges' => [
+                        [
+                            'start_date' => '2020-01-01T00:00:00.000Z',
+                            'end_date' => '2020-01-01T23:59:59.000Z',
+                            'params' => [
+                                'all_day' => true,
+                            ],
+                        ],
+                        [
+                            'start_date' => '2020-01-01T00:00:00.000Z',
+                            'end_date' => '',
+                        ],
+                    ],
                 ],
                 [ // data provided
                     'id' => '7',
                     'date_ranges' => [
                         [
                             'start_date' => '',
+                            'end_date' => '',
+                        ],
+                        [
+                            'start_date' => '2020-01-01T00:00:00.000Z',
+                            'end_date' => '2020-01-01T23:59:00.000Z',
+                            'params' => [
+                                'all_day' => true,
+                            ],
+                        ],
+                        [
+                            'start_date' => '2020-01-01T00:00:00.000Z',
                             'end_date' => '',
                         ],
                     ],


### PR DESCRIPTION
This provides a fix in date ranges save: when `all_day` is set, `end_date` seconds is set to 59