### PR TITLE
Fix save `end_date` like 23:59:00 as 23:59:59

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -276,7 +276,7 @@ class AppController extends Controller
     /**
      * Prepare date ranges.
      * Remove empty date ranges.
-     * Fix end date time to 23:59:59.000 if all_day is true.
+     * Fix end date time to 23:59:59.000 if end_date contains '23:59:00.000'.
      *
      * @param array $data The data to prepare
      * @return void
@@ -294,10 +294,10 @@ class AppController extends Controller
         );
         $data['date_ranges'] = array_map(
             function ($item) {
-                if (empty($item['params']['all_day']) || empty($item['end_date'])) {
+                if (empty($item['end_date'])) {
                     return $item;
                 }
-                $item['end_date'] = str_replace(':59:00.000', ':59:59.000', $item['end_date']);
+                $item['end_date'] = str_replace('23:59:00.000', '23:59:59.000', $item['end_date']);
 
                 return $item;
             },

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -462,9 +462,6 @@ class AppControllerTest extends TestCase
                         [
                             'start_date' => '2020-01-01T00:00:00.000Z',
                             'end_date' => '2020-01-01T23:59:59.000Z',
-                            'params' => [
-                                'all_day' => true,
-                            ],
                         ],
                         [
                             'start_date' => '2020-01-01T00:00:00.000Z',
@@ -482,9 +479,6 @@ class AppControllerTest extends TestCase
                         [
                             'start_date' => '2020-01-01T00:00:00.000Z',
                             'end_date' => '2020-01-01T23:59:00.000Z',
-                            'params' => [
-                                'all_day' => true,
-                            ],
                         ],
                         [
                             'start_date' => '2020-01-01T00:00:00.000Z',


### PR DESCRIPTION
This provides a fix to save `end_date` like 23:59:00 as 23:59:59 (no matter what `params.all_day` value is).