### PR TITLE
Improve oembed feature

### DIFF
--- a/config/oembed.php
+++ b/config/oembed.php
@@ -1,25 +1,50 @@
 <?php
+
+use Cake\Routing\Router;
+
 return [
     /**
      * Simplified oEmbed configuration.
      * This method is not meant to give a precise provider match but it simply gives
      * the most probable oembed provider for an URL.
      *
-     *  - providers: list of hostnames with associated providers oEmbed endpoints
+     *  - providers: list providers with oEmbed endpoints and hostnames to match.
+     *    With optional 'options' you can specify options for the oembed request as headers, ...
      */
     'OEmbed' => [
         'providers' => [
-
-            'soundcloud.com' => 'https://soundcloud.com/oembed',
-
-            '*.spotify.com' => 'https://embed.spotify.com/oembed/',
-
-            'vimeo.com' => 'https://vimeo.com/api/oembed.json',
-            '*.vimeo.com' => 'https://vimeo.com/api/oembed.json',
-
-            'youtube.com' => 'https://www.youtube.com/oembed',
-            'www.youtube.com' => 'https://www.youtube.com/oembed',
-            'youtu.be' => 'https://www.youtube.com/oembed',
+            'soundcloud' => [
+                'name' => 'SoundCloud',
+                'match' => ['soundcloud.com'],
+                'url' => 'https://soundcloud.com/oembed',
+            ],
+            'spotify' => [
+                'name' => 'Spotify',
+                'match' => ['*.spotify.com'],
+                'url' => 'https://embed.spotify.com/oembed',
+            ],
+            'vimeo' => [
+                'name' => 'Vimeo',
+                'match' => [
+                    'vimeo.com',
+                    '*.vimeo.com',
+                ],
+                'url' => 'https://vimeo.com/api/oembed.json',
+                'options' => [
+                    'headers' => [
+                        'Referer' => env('VIMEO_REFERER_HEADER', Router::url('/', true)),
+                    ],
+                ],
+            ],
+            'youtube' => [
+                'name' => 'YouTube',
+                'match' => [
+                    'youtube.com',
+                    'www.youtube.com',
+                    'youtu.be',
+                ],
+                'url' => 'https://www.youtube.com/oembed',
+            ],
         ],
     ],
 ];

--- a/templates/Element/Form/media.twig
+++ b/templates/Element/Form/media.twig
@@ -9,8 +9,12 @@
         <div v-show="isOpen" class="tab-container">
             {# Display embedded video if available #}
             {% if object.attributes.provider_extra.html %}
+                {% set height = object.attributes.provider_extra.height|default(1) %}
+                {% set width = object.attributes.provider_extra.width|default(1) %}
                 <div class="embedded-container"
-                    style="padding-bottom: {{ 100 * object.attributes.provider_extra.height / object.attributes.provider_extra.width }}%;">
+                    {% if height matches '/^\\d+$/' and width matches '/^\\d+$/' %}
+                        style="padding-bottom: {{ 100 * height / width|default(1) }}%;"
+                    {% endif %}>
                     {{ object.attributes.provider_extra.html|raw }}
                 </div>
             {% else %}

--- a/tests/TestCase/Utility/OEmbedTest.php
+++ b/tests/TestCase/Utility/OEmbedTest.php
@@ -83,7 +83,7 @@ class OEmbedTest extends TestCase
         $oembed = new class () extends OEmbed
         {
             public $json = [];
-            protected function fetchJson(string $oembedUrl): array
+            protected function fetchJson(string $oembedUrl, array $options = []): array
             {
                 return $this->json;
             }


### PR DESCRIPTION
This PR improves the oembed support in order to get all Vimeo metadata [embedding videos with domain-level privacy](https://developer.vimeo.com/api/oembed/videos#embedding-a-video-with-oembed-step-1).

In that case the oembed request has to send a `Referer` header.
The configuration of oembed providers is modified to support an `options` key passed to HTTP client:

```php
'OEmbed' => [
    'providers' => [
        'vimeo' => [
            'name' => 'Vimeo',
            'match' => [
                'vimeo.com',
                '*.vimeo.com',
            ],
            'url' => 'https://vimeo.com/api/oembed.json',
            'options' => [
                'headers' => [
                    'Referer' => env('VIMEO_REFERER_HEADER', Router::url('/', true)),
                ],
            ],
        ],
    ...
    ],
];
```