### PR TITLE
RolesModules and Admin index load data

### DIFF
--- a/resources/js/app/components/relation-view/relationships-view/relationships-view.js
+++ b/resources/js/app/components/relation-view/relationships-view/relationships-view.js
@@ -127,15 +127,10 @@ export default {
     },
 
     methods: {
-        /**
-         * load objects using PaginatedContentMixin.getPaginatedObjects()
-         *
-         * @return {Promise} resp
-         */
-        async loadObjects() {
+        async loadObjects(autoload = true, query = {}) {
             this.loading = true;
 
-            let response = this.getPaginatedObjects();
+            let response = this.getPaginatedObjects(autoload, query);
 
             response
                 .then((objs) => {

--- a/resources/js/app/components/relation-view/roles-list-view.vue
+++ b/resources/js/app/components/relation-view/roles-list-view.vue
@@ -52,7 +52,7 @@ export default {
     },
 
     async mounted() {
-        await this.loadObjects();
+        await this.loadObjects(true, {page_size:100});
         this.$nextTick(() => {
             let groups = this.groups;
             if (Object.keys(groups).length === 0) {
@@ -119,3 +119,9 @@ export default {
     },
 }
 </script>
+<style>
+.roles-list-view {
+    height: 50vh;
+    overflow-y: scroll;
+}
+</style>

--- a/resources/js/app/components/relation-view/roles-list-view.vue
+++ b/resources/js/app/components/relation-view/roles-list-view.vue
@@ -52,7 +52,7 @@ export default {
     },
 
     async mounted() {
-        await this.loadObjects(true, {page_size:100});
+        await this.loadObjects(true, { page_size:100 });
         this.$nextTick(() => {
             let groups = this.groups;
             if (Object.keys(groups).length === 0) {
@@ -120,8 +120,8 @@ export default {
 }
 </script>
 <style>
-.roles-list-view {
-    height: 50vh;
-    overflow-y: scroll;
-}
+    .roles-list-view {
+        height: 50vh;
+        overflow-y: scroll;
+    }
 </style>

--- a/src/Controller/Admin/AdministrationBaseController.php
+++ b/src/Controller/Admin/AdministrationBaseController.php
@@ -219,7 +219,7 @@ abstract class AdministrationBaseController extends AppController
         $pagination = ['page' => 0];
         while ($pagination['page'] === 0 || $pagination['page'] < $pagination['page_count']) {
             $query['page'] = $pagination['page'] + 1;
-            $response = $this->apiClient->get($endpoint, $query);
+            $response = (array)$this->apiClient->get($endpoint, $query);
             $pagination = (array)Hash::get($response, 'meta.pagination');
             foreach ((array)Hash::get($response, 'data') as $data) {
                 $resultResponse['data'][] = $data;

--- a/src/Controller/Admin/RolesModulesController.php
+++ b/src/Controller/Admin/RolesModulesController.php
@@ -126,9 +126,9 @@ class RolesModulesController extends AdministrationBaseController
                 }
             }
         }
-        $response = $this->apiClient->get('/config', ['filter' => ['name' => 'AccessControl']]);
+        $response = (array)$this->apiClient->get('/config', ['filter' => ['name' => 'AccessControl']]);
         $content = json_decode((string)Hash::get($response, 'data.0.attributes.content'), true);
-        $payload = array_merge($content, $payload);
+        $payload = is_array($content) ? array_merge($content, $payload) : $payload;
         $this->saveApiConfig(Inflector::camelize('access_control'), $payload);
 
         return $this->redirect(['_name' => 'admin:list:roles_modules']);

--- a/src/Controller/Admin/RolesModulesController.php
+++ b/src/Controller/Admin/RolesModulesController.php
@@ -126,6 +126,9 @@ class RolesModulesController extends AdministrationBaseController
                 }
             }
         }
+        $response = $this->apiClient->get('/config', ['filter' => ['name' => 'AccessControl']]);
+        $content = json_decode((string)Hash::get($response, 'data.0.attributes.content'), true);
+        $payload = array_merge($content, $payload);
         $this->saveApiConfig(Inflector::camelize('access_control'), $payload);
 
         return $this->redirect(['_name' => 'admin:list:roles_modules']);

--- a/templates/Pages/Admin/RolesModules/index.twig
+++ b/templates/Pages/Admin/RolesModules/index.twig
@@ -7,11 +7,6 @@
 <admin-index inline-template>
 
     <div class="module-index">
-        {{ Form.create(null, {
-            'id': 'form-roles-modules',
-            'url': {'_name': 'admin:save:roles_modules'},
-            'class': 'table-row',
-        })|raw }}
 
         <div class="list-objects">
 
@@ -20,6 +15,11 @@
             {% endif %}
 
             {% for resource in resources %}
+                {{ Form.create(null, {
+                    'id': 'form-roles-' ~ resource.attributes.name,
+                    'url': {'_name': 'admin:save:roles_modules'},
+                    'class': 'table-row',
+                })|raw }}
                 {% set roleName = resource.attributes.name %}
 
                 <property-view inline-template :tab-open="tabsOpen" tab-name="roles-modules-{{ resource.attributes.name }}">
@@ -56,23 +56,20 @@
                                     {{ Form.control(key, radio)|raw }}
                                     </div>
                                 {% endfor %}
+                                <button class="button button-primary button-primary-hover-module-admin is-width-auto mt-2" title="{{ __('Save') }}">
+                                    <app-icon icon="carbon:save"></app-icon>
+                                    <span class="ml-05">{{ __('Save') }}</span>
+                                </button>
                             </div>
                         </div>
                     </section>
 
                 </property-view>
 
+                {{ Form.end()|raw }}
+
             {% endfor %}
         </div>
-
-        <div class="buttons-cell narrow mt-1">
-            <button class="button button-primary button-primary-hover-module-admin is-width-auto" title="{{ __('Save') }}">
-                <app-icon icon="carbon:save"></app-icon>
-                <span class="ml-05">{{ __('Save') }}</span>
-            </button>
-        </div>
-
-        {{ Form.end()|raw }}
     </div>
 
 </admin-index>

--- a/tests/TestCase/Controller/Admin/AdministrationBaseControllerTest.php
+++ b/tests/TestCase/Controller/Admin/AdministrationBaseControllerTest.php
@@ -346,4 +346,33 @@ class AdministrationBaseControllerTest extends TestCase
         $actual = $method->invokeArgs($this->AdministrationBaseController, []);
         static::assertEquals('/admin/applications', $actual);
     }
+
+    /**
+     * Test `loadData` method
+     *
+     * @return void
+     * @covers ::loadData()
+     */
+    public function testLoadData(): void
+    {
+        $this->initRolesController(
+            [
+                'environment' => [
+                    'REQUEST_METHOD' => 'GET',
+                ],
+                'params' => [
+                    'resource_type' => 'roles',
+                ],
+                'query' => [
+                    'page' => 1,
+                    'page_size' => 1,
+                ],
+            ]
+        );
+        $reflectionClass = new \ReflectionClass($this->RlsController);
+        $method = $reflectionClass->getMethod('loadData');
+        $method->setAccessible(true);
+        $actual = $method->invokeArgs($this->RlsController, []);
+        static::assertNotEmpty($actual);
+    }
 }


### PR DESCRIPTION
This provides an enhancement in Admin sections:

 - Admin all modules indexes: all data is retrieved (iterating over pagination result)
 - Admin Roles Modules: button save (and form) inside each block of permissions, to avoid an error of "too many variables in form"
 - User view - roles: load roles with limit 100 (it was 20), show a scrollbar when there are several roles