### PR TITLE
POC DeeplTranslator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     ],
     "require": {
         "php": ">=7.4",
+        "babymarkt/deepl-php-lib": "^1.0",
         "bedita/i18n": "^4.4.1",
         "bedita/web-tools": "^3.10.1",
         "cakephp/authentication": "^2.9",

--- a/src/Core/I18n/DeepLTranslator.php
+++ b/src/Core/I18n/DeepLTranslator.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Core\I18n;
+
+use App\Core\I18n\TranslatorInterface;
+use BabyMarkt\DeepL\DeepL;
+use Cake\Utility\Hash;
+
+class DeepLTranslator implements TranslatorInterface
+{
+    /**
+     * The engine options.
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * Setup translator engine.
+     *
+     * @param array $options The options
+     * @return void
+     */
+    public function setup(array $options = []): void
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * Translate an array of texts $texts from language source $from to language target $to
+     *
+     * @param array $texts The texts to translate
+     * @param string $from The source language
+     * @param string $to The target language
+     * @return string The translation in json format, i.e.
+     * {
+     *     "translation": [
+     *         "<translation of first text>",
+     *         "<translation of second text>",
+     *         [...]
+     *         "<translation of last text>"
+     *     ]
+     * }
+     */
+    public function translate($texts, string $from, string $to): string
+    {
+        $deepl = new DeepL((string)Hash::get($this->options, 'auth_key'), 2);
+        $translation = $deepl->translate($texts, $from, $to);
+        if (empty($translation)) {
+            return json_encode(['translation' => []]);
+        }
+        if (is_array($translation)) {
+            $translation = Hash::extract($translation, '{n}.text');
+        }
+
+        return json_encode(compact('translation'));
+    }
+}

--- a/src/Core/I18n/DeepLTranslator.php
+++ b/src/Core/I18n/DeepLTranslator.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace App\Core\I18n;
 
-use App\Core\I18n\TranslatorInterface;
 use BabyMarkt\DeepL\DeepL;
 use Cake\Utility\Hash;
 


### PR DESCRIPTION
This introduces `DeeplTranslator` class, that uses `babymarkt/deepl-php-lib`.

Setup example. In `config/app_local.php`:
```php
'Translator' => [
    'class' => '\App\Core\I18n\DeepLTranslator',
    'options' => [
        'auth_key' => '******************************',
    ],
],
```

When `Translator` is set, Manager UI provides "auto-translate" buttons in translations views.

Note: this is a POC. This logic will be moved to a separate plugin, with other translators implementations (i.e. AWSTranslator).