### PR TITLE
Tags "no create" view

### DIFF
--- a/resources/js/app/components/date-ranges-view/date-ranges-view.vue
+++ b/resources/js/app/components/date-ranges-view/date-ranges-view.vue
@@ -1,74 +1,116 @@
 <template>
     <div>
         <div class="date-ranges-list">
-            <div class="date-ranges-item mb-1" v-for="(dateRange, index) in dateRanges">
+            <div class="date-ranges-item mb-1"
+                 v-for="(dateRange, index) in dateRanges"
+                 :key="index"
+            >
                 <div>
                     <span>{{ msgFrom }}</span>
                     <div :class="dateRangeClass(dateRange)">
                         <input type="text"
-                            :name="getName(index, 'start_date')"
-                            v-model="dateRange.start_date"
-                            @change="onDateChanged(dateRange, $event)"
-                            v-datepicker="true" date="true" :time="!dateRange.params.all_day" daterange="true"
-                        />
+                               :name="getName(index, 'start_date')"
+                               date="true"
+                               :time="!dateRange.params.all_day"
+                               daterange="true"
+                               v-model="dateRange.start_date"
+                               v-datepicker="true"
+                               @change="onDateChanged(dateRange, $event)"
+                        >
                     </div>
                 </div>
                 <div :class="dateRangeClass(dateRange)">
                     <span>{{ msgTo }}</span>
                     <div>
-                        <input v-if="dateRange.start_date"
-                            type="text"
-                            :name="getName(index, 'end_date')"
-                            v-model="dateRange.end_date"
-                            @change="onDateChanged(dateRange, $event)"
-                            v-datepicker="true" date="true" :time="!dateRange.params.all_day" daterange="true"
-                        />
-                        <input v-else type="text" disabled="disabled" />
+                        <input type="text"
+                               :name="getName(index, 'end_date')"
+                               date="true"
+                               v-model="dateRange.end_date"
+                               :time="!dateRange.params.all_day"
+                               v-datepicker="true"
+                               daterange="true"
+                               @change="onDateChanged(dateRange, $event)"
+                               v-if="dateRange.start_date"
+                        >
+                        <input type="text"
+                               disabled="disabled"
+                               v-else
+                        >
                     </div>
                 </div>
                 <div>
                     <label class="m-0 nowrap has-text-size-smaller">
                         <input type="checkbox"
-                            :disabled="!dateRange.start_date"
-                            :name="getNameAllDay(index)"
-                            v-model="dateRange.params.all_day"
-                            @change="onAllDayChanged(dateRange, $event)" />
+                               :disabled="!dateRange.start_date"
+                               :name="getNameAllDay(index)"
+                               v-model="dateRange.params.all_day"
+                               @change="onAllDayChanged(dateRange, $event)"
+                        >
                         {{ msgAllDay }}
                     </label>
                 </div>
                 <div>
                     <label class="m-0 nowrap has-text-size-smaller">
                         <input type="checkbox"
-                            :disabled="!isDaysInterval(dateRange)"
-                            :name="getNameEveryDay(index)"
-                            v-model="dateRange.params.every_day"
-                            @change="onEveryDayChanged(dateRange, $event)"
-                            checked="dateRange.params.every_day" />
+                               :disabled="!isDaysInterval(dateRange)"
+                               :name="getNameEveryDay(index)"
+                               checked="dateRange.params.every_day"
+                               v-model="dateRange.params.every_day"
+                               @change="onEveryDayChanged(dateRange, $event)"
+                        >
                         {{ msgEveryDay }}
                     </label>
                 </div>
                 <div>
-                    <button @click.prevent="remove(index, $event)" :disabled="dateRanges.length < 2" class="button button-primary">
-                        <app-icon icon="carbon:trash-can"></app-icon>
+                    <button :disabled="dateRanges.length < 2"
+                            class="button button-primary"
+                            @click.prevent="remove(index, $event)"
+                    >
+                        <app-icon icon="carbon:trash-can" />
                         <span class="ml-05">{{ msgRemove }}</span>
                     </button>
                 </div>
-                <div v-if="dateRange.params.every_day === false" class="m-0 nowrap has-text-size-smaller weekdays">
-                    <label><input type="checkbox" v-model="dateRange.params.weekdays.sunday" />{{ msgSunday }}</label>
-                    <label><input type="checkbox" v-model="dateRange.params.weekdays.monday" />{{ msgMonday }}</label>
-                    <label><input type="checkbox" v-model="dateRange.params.weekdays.tuesday" />{{ msgTuesday }}</label>
-                    <label><input type="checkbox" v-model="dateRange.params.weekdays.wednesday" />{{ msgWednesday }}</label>
-                    <label><input type="checkbox" v-model="dateRange.params.weekdays.thursday" />{{ msgThursday }}</label>
-                    <label><input type="checkbox" v-model="dateRange.params.weekdays.friday" />{{ msgFriday }}</label>
-                    <label><input type="checkbox" v-model="dateRange.params.weekdays.saturday" />{{ msgSaturday }}</label>
-                    <input type="hidden" :name="getName(index, 'params')" :value="JSON.stringify(dateRange.params)" />
+                <div class="m-0 nowrap has-text-size-smaller weekdays"
+                     v-if="dateRange.params.every_day === false"
+                >
+                    <label><input type="checkbox"
+                                  v-model="dateRange.params.weekdays.sunday"
+                    >{{ msgSunday }}</label>
+                    <label><input type="checkbox"
+                                  v-model="dateRange.params.weekdays.monday"
+                    >{{ msgMonday }}</label>
+                    <label><input type="checkbox"
+                                  v-model="dateRange.params.weekdays.tuesday"
+                    >{{ msgTuesday }}</label>
+                    <label><input type="checkbox"
+                                  v-model="dateRange.params.weekdays.wednesday"
+                    >{{ msgWednesday }}</label>
+                    <label><input type="checkbox"
+                                  v-model="dateRange.params.weekdays.thursday"
+                    >{{ msgThursday }}</label>
+                    <label><input type="checkbox"
+                                  v-model="dateRange.params.weekdays.friday"
+                    >{{ msgFriday }}</label>
+                    <label><input type="checkbox"
+                                  v-model="dateRange.params.weekdays.saturday"
+                    >{{ msgSaturday }}</label>
+                    <input type="hidden"
+                           :name="getName(index, 'params')"
+                           :value="JSON.stringify(dateRange.params)"
+                    >
                 </div>
-                <div v-if="msdiff(dateRange) < 0" class="icon-error">{{ msgInvalidDateRange }}</div>
+                <div class="icon-error"
+                     v-if="msdiff(dateRange) < 0"
+                >
+                    {{ msgInvalidDateRange }}
+                </div>
             </div>
         </div>
 
-        <button @click.prevent="add" class="button button-primary">
-            <app-icon icon="carbon:add"></app-icon>
+        <button class="button button-primary"
+                @click.prevent="add"
+        >
+            <app-icon icon="carbon:add" />
             <span class="ml-05">{{ msgAdd }}</span>
         </button>
     </div>
@@ -103,6 +145,12 @@ export default {
         }
     },
 
+    computed: {
+        emptyStartDate() {
+            return this.dateRanges.length === 1 && !this.dateRanges[0].start_date;
+        },
+    },
+
     created() {
         const ranges = JSON.parse(this.ranges);
         if (ranges) {
@@ -121,12 +169,6 @@ export default {
         if (!this.dateRanges.length) {
             this.add();
         }
-    },
-
-    computed: {
-        emptyStartDate() {
-            return this.dateRanges.length === 1 && !this.dateRanges[0].start_date;
-        },
     },
 
     methods: {

--- a/resources/js/app/components/date-ranges-view/date-ranges-view.vue
+++ b/resources/js/app/components/date-ranges-view/date-ranges-view.vue
@@ -49,7 +49,7 @@
                 </div>
                 <div>
                     <button @click.prevent="remove(index, $event)" :disabled="dateRanges.length < 2" class="button button-primary">
-                        <Icon icon="carbon:trash-can"></Icon>
+                        <app-icon icon="carbon:trash-can"></app-icon>
                         <span class="ml-05">{{ msgRemove }}</span>
                     </button>
                 </div>
@@ -68,7 +68,7 @@
         </div>
 
         <button @click.prevent="add" class="button button-primary">
-            <Icon icon="carbon:add"></Icon>
+            <app-icon icon="carbon:add"></app-icon>
             <span class="ml-05">{{ msgAdd }}</span>
         </button>
     </div>

--- a/resources/js/app/components/date-ranges-view/date-ranges-view.vue
+++ b/resources/js/app/components/date-ranges-view/date-ranges-view.vue
@@ -25,10 +25,10 @@
                         <input type="text"
                                :name="getName(index, 'end_date')"
                                date="true"
-                               v-model="dateRange.end_date"
                                :time="!dateRange.params.all_day"
-                               v-datepicker="true"
                                daterange="true"
+                               v-model="dateRange.end_date"
+                               v-datepicker="true"
                                @change="onDateChanged(dateRange, $event)"
                                v-if="dateRange.start_date"
                         >
@@ -122,7 +122,10 @@ import { t } from 'ttag';
 export default {
 
     props: {
-        ranges: String,
+        ranges: {
+            type: String,
+            default: undefined,
+        },
     },
 
     data() {

--- a/resources/js/app/components/tag-picker/tag-picker.vue
+++ b/resources/js/app/components/tag-picker/tag-picker.vue
@@ -48,20 +48,23 @@ export default {
     props: {
         id: {
             type: String,
-            default: '',
+            default: undefined,
         },
-        disabled: Boolean,
+        disabled: {
+            type: Boolean,
+            default: false,
+        },
         label: {
             type: String,
             default: '',
         },
         form: {
             type: String,
-            default: '',
+            default: undefined,
         },
         initialTags: {
             type: Array,
-            default: () => ([]),
+            default: () => [],
         },
         searchonly: {
             type: Boolean,

--- a/resources/js/app/components/tag-picker/tag-picker.vue
+++ b/resources/js/app/components/tag-picker/tag-picker.vue
@@ -16,7 +16,7 @@
             @deselect="onRemove"
             @input="onChange"
         />
-        <div class="new-tag" v-show="!searchonly">
+        <div class="new-tag" v-show="!searchonly" v-if="canSave">
             <label for="new-tag">{{ msgAddNewTag }}</label>
             <div class="input-container">
                 <input type="text" :form="form" :value="text" id="new-tag" @input="update($event.target.value)" />
@@ -49,6 +49,10 @@ export default {
         id: {
             type: String,
             default: undefined,
+        },
+        canSave: {
+            type: Boolean,
+            default: false,
         },
         disabled: {
             type: Boolean,

--- a/templates/Element/FilterBox/filter_box_common.twig
+++ b/templates/Element/FilterBox/filter_box_common.twig
@@ -91,8 +91,8 @@
 
             <span v-else-if="filter.name === 'tags'">
                 <tag-picker
-                    id="tag-filter"
-                    form="_filters"
+                    :id="tag-filter"
+                    :form="_filters"
                     :initial-tags="initTags"
                     :searchonly="true"
                     @change="onTagChange"></tag-picker>

--- a/templates/Element/Form/tags.twig
+++ b/templates/Element/Form/tags.twig
@@ -8,18 +8,11 @@
             </header>
             <div v-show="isOpen" class="tab-container">
                 <div class="tags-container">
-                {% if Perms.canSave('tags') %}
                     <tag-picker
                         :id="`tagPick`"
-                        :initial-tags="{{ object.attributes.tags|default([])|json_encode }}">
+                        :initial-tags="{{ object.attributes.tags|default([])|json_encode }}"
+                        :can-save="{{ Perms.canSave('tags')|json_encode }}">
                     </tag-picker>
-                {% else %}
-                    <div class="tags">
-                    {% for tag in object.attributes.tags %}
-                        <span class="tag has-background-module-tags">{{ tag.label|default(tag.name) }}</span>
-                    {% endfor %}
-                    </div>
-                {% endif %}
                 </div>
             </div>
         </section>

--- a/templates/Element/Form/tags.twig
+++ b/templates/Element/Form/tags.twig
@@ -8,7 +8,18 @@
             </header>
             <div v-show="isOpen" class="tab-container">
                 <div class="tags-container">
-                    <tag-picker id="tagPick" :initial-tags="{{ object.attributes.tags|default([])|json_encode }}"></tag-picker>
+                {% if Perms.canSave('tags') %}
+                    <tag-picker
+                        :id="`tagPick`"
+                        :initial-tags="{{ object.attributes.tags|default([])|json_encode }}">
+                    </tag-picker>
+                {% else %}
+                    <div class="tags">
+                    {% for tag in object.attributes.tags %}
+                        <span class="tag has-background-module-tags">{{ tag.label|default(tag.name) }}</span>
+                    {% endfor %}
+                    </div>
+                {% endif %}
                 </div>
             </div>
         </section>


### PR DESCRIPTION
This provides a change in object view "tags" section. If user has not permits to modelling tags, then UI show tags without "add new tag" input and button.

Bonus: fix `date-ranges-view` linting + wrong `<Icon>` reference