### PR TITLE
Fix filter box (click "more filters" does nothing)

### DIFF
--- a/templates/Element/FilterBox/filter_box_common.twig
+++ b/templates/Element/FilterBox/filter_box_common.twig
@@ -91,8 +91,8 @@
 
             <span v-else-if="filter.name === 'tags'">
                 <tag-picker
-                    :id="tag-filter"
-                    :form="_filters"
+                    id="tag-filter"
+                    form="_filters"
                     :initial-tags="initTags"
                     :searchonly="true"
                     @change="onTagChange"></tag-picker>


### PR DESCRIPTION
There was a javascript error loading filter box component and it was not working on "more filters" click.
This fixes the issue, that was introduced by https://github.com/bedita/manager/pull/1055.