### PR TITLE
`AlertMessageByArea` configuration

### DIFF
--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2023-11-30 09:02:53 \n"
+"POT-Creation-Date: 2023-12-04 17:06:38 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -41,6 +41,9 @@ msgid "Advanced Data"
 msgstr ""
 
 msgid "Alert Message"
+msgstr ""
+
+msgid "Alert Message By Prefix"
 msgstr ""
 
 msgid "Alert!"

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Alert Message"
 msgstr ""
 
-msgid "Alert Message By Prefix"
+msgid "Alert Message By Area"
 msgstr ""
 
 msgid "Alert!"
@@ -1395,7 +1395,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.  
+#.
 msgid "No History data found"
 msgstr ""
 

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -46,7 +46,7 @@ msgstr ""
 msgid "Alert Message"
 msgstr ""
 
-msgid "Alert Message By Prefix"
+msgid "Alert Message By Area"
 msgstr ""
 
 msgid "Alert!"
@@ -1398,7 +1398,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.  
+#.
 msgid "No History data found"
 msgstr ""
 

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-11-30 09:02:53 \n"
+"POT-Creation-Date: 2023-12-04 17:06:38 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -44,6 +44,9 @@ msgid "Advanced Data"
 msgstr ""
 
 msgid "Alert Message"
+msgstr ""
+
+msgid "Alert Message By Prefix"
 msgstr ""
 
 msgid "Alert!"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-11-30 09:02:53 \n"
+"POT-Creation-Date: 2023-12-04 17:06:38 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -47,6 +47,9 @@ msgstr "Dati Avanzati"
 
 msgid "Alert Message"
 msgstr "Messaggio di Attenzione"
+
+msgid "Alert Message By Prefix"
+msgstr "Messaggio di Attenzione per Prefisso"
 
 msgid "Alert!"
 msgstr "Attenzione!"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -48,8 +48,8 @@ msgstr "Dati Avanzati"
 msgid "Alert Message"
 msgstr "Messaggio di Attenzione"
 
-msgid "Alert Message By Prefix"
-msgstr "Messaggio di Attenzione per Prefisso"
+msgid "Alert Message By Area"
+msgstr "Messaggio di Attenzione per Area"
 
 msgid "Alert!"
 msgstr "Attenzione!"

--- a/src/Utility/ApiConfigTrait.php
+++ b/src/Utility/ApiConfigTrait.php
@@ -43,6 +43,7 @@ trait ApiConfigTrait
     protected static $configKeys = [
         'AccessControl',
         'AlertMessage',
+        'AlertMessageByPrefix',
         'Export',
         'Modules',
         'Pagination',

--- a/src/Utility/ApiConfigTrait.php
+++ b/src/Utility/ApiConfigTrait.php
@@ -43,7 +43,7 @@ trait ApiConfigTrait
     protected static $configKeys = [
         'AccessControl',
         'AlertMessage',
-        'AlertMessageByPrefix',
+        'AlertMessageByArea',
         'Export',
         'Modules',
         'Pagination',

--- a/src/View/Helper/SystemHelper.php
+++ b/src/View/Helper/SystemHelper.php
@@ -111,4 +111,47 @@ class SystemHelper extends Helper
 
         return compact('accepted', 'forbidden');
     }
+
+    /**
+     * Get alert background color
+     *
+     * @return string
+     */
+    public function alertBgColor(): string
+    {
+        if (Configure::read('Recovery')) {
+            return '#FE2F03';
+        }
+        $request = $this->getView()->getRequest();
+        $prefix = $request->getParam('prefix');
+        if (Configure::read(sprintf('AlertMessageByPrefix.%s.color', $prefix))) {
+            return Configure::read(sprintf('AlertMessageByPrefix.%s.color', $prefix));
+        }
+
+        return Configure::read('AlertMessage.color') ?? '';
+    }
+
+    /**
+     * Get alert message
+     *
+     * @return string
+     */
+    public function alertMsg(): string
+    {
+        if (Configure::read('Recovery')) {
+            return __('Recovery Mode - Access restricted to admin users');
+        }
+        $request = $this->getView()->getRequest();
+        $prefix = $request->getParam('prefix');
+        if (Configure::read(sprintf('AlertMessageByPrefix.%s.text', $prefix))) {
+            return Configure::read(sprintf('AlertMessageByPrefix.%s.text', $prefix));
+        }
+        $message = Configure::read('AlertMessage.text') ?? '';
+        $user = $this->getView()->get('user');
+        if ($user && in_array('admin', $user->get('roles')) && !$this->checkBeditaApiVersion()) {
+            $message .= ' ' . __('API version required: {0}', Configure::read('BEditaAPI.versions'));
+        }
+
+        return $message;
+    }
 }

--- a/src/View/Helper/SystemHelper.php
+++ b/src/View/Helper/SystemHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace App\View\Helper;
@@ -124,8 +125,8 @@ class SystemHelper extends Helper
         }
         $request = $this->getView()->getRequest();
         $prefix = $request->getParam('prefix');
-        if (Configure::read(sprintf('AlertMessageByPrefix.%s.color', $prefix))) {
-            return Configure::read(sprintf('AlertMessageByPrefix.%s.color', $prefix));
+        if (Configure::read(sprintf('AlertMessageByArea.%s.color', $prefix))) {
+            return Configure::read(sprintf('AlertMessageByArea.%s.color', $prefix));
         }
 
         return Configure::read('AlertMessage.color') ?? '';
@@ -143,8 +144,8 @@ class SystemHelper extends Helper
         }
         $request = $this->getView()->getRequest();
         $prefix = $request->getParam('prefix');
-        if (Configure::read(sprintf('AlertMessageByPrefix.%s.text', $prefix))) {
-            return Configure::read(sprintf('AlertMessageByPrefix.%s.text', $prefix));
+        if (Configure::read(sprintf('AlertMessageByArea.%s.text', $prefix))) {
+            return Configure::read(sprintf('AlertMessageByArea.%s.text', $prefix));
         }
         $message = Configure::read('AlertMessage.text') ?? '';
         $user = $this->getView()->get('user');

--- a/templates/Element/custom_colors.twig
+++ b/templates/Element/custom_colors.twig
@@ -15,12 +15,7 @@
     {%- endfor -%}
 
     {# override alert message color if in config #}
-    {% set alertBgColor = '' %}
-    {% if config('Recovery') %}
-        {% set alertBgColor = '#FE2F03' %}
-    {% elseif config('AlertMessage.color') %}
-        {% set alertBgColor = config('AlertMessage.color') %}
-    {% endif %}
+    {% set alertBgColor = System.alertBgColor() %}
     {%- if alertBgColor -%}
         body[alert-message]:after { background-color: {{ alertBgColor }}; }
     {%- endif -%}

--- a/templates/Layout/default.twig
+++ b/templates/Layout/default.twig
@@ -41,16 +41,7 @@ BEdita Manager
     {% set bodyClass = bodyClass ~ ' view-module module-' ~ currentModule.name %}
 {% endif %}
 
-{% set alertMsg = '' %}
-{% if config('Recovery') %}
-    {% set alertMsg = __('Recovery Mode - Access restricted to admin users') %}
-{% elseif config('AlertMessage.text') %}
-    {% set alertMsg = config('AlertMessage.text') %}
-{% endif %}
-
-{% if user and in_array('admin', user.roles) and System.checkBeditaApiVersion() != 1 %}
-    {% set alertMsg = alertMsg ~ ' ' ~ __('API version required: {0}', config('BEditaAPI.versions')|join(' | '))|json_encode %}
-{% endif %}
+{% set alertMsg = System.alertMsg() %}
 
 <body class="{{ bodyClass }}"
     {% if alertMsg %}alert-message="{{ alertMsg }}"{% endif %}>

--- a/templates/Pages/Admin/Appearance/index.twig
+++ b/templates/Pages/Admin/Appearance/index.twig
@@ -6,6 +6,7 @@
 {#
 // i18n
 __('Alert Message')
+__('Alert Message By Prefix')
 __('Export')
 __('Modules')
 __('Pagination')

--- a/templates/Pages/Admin/Appearance/index.twig
+++ b/templates/Pages/Admin/Appearance/index.twig
@@ -6,7 +6,7 @@
 {#
 // i18n
 __('Alert Message')
-__('Alert Message By Prefix')
+__('Alert Message By Area')
 __('Export')
 __('Modules')
 __('Pagination')

--- a/tests/TestCase/View/Helper/SystemHelperTest.php
+++ b/tests/TestCase/View/Helper/SystemHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 /**
  * BEdita, API-first content management framework
@@ -134,7 +135,7 @@ class SystemHelperTest extends TestCase
         static::assertSame('', $this->System->alertBgColor());
         Configure::write('AlertMessage.color', '#FFF000');
         static::assertSame('#FFF000', $this->System->alertBgColor());
-        Configure::write('AlertMessageByPrefix..color', '#000FFF');
+        Configure::write('AlertMessageByArea..color', '#000FFF');
         static::assertSame('#000FFF', $this->System->alertBgColor());
     }
 
@@ -155,12 +156,13 @@ class SystemHelperTest extends TestCase
         // test AlertMessage.text
         Configure::write('AlertMessage.text', 'Alert Message');
         static::assertSame('Alert Message', $this->System->alertMsg());
-        // test AlertMessageByPrefix..text
-        Configure::write('AlertMessageByPrefix..text', 'Alert Message by prefix');
+        // test AlertMessageByArea..text
+        Configure::write('AlertMessageByArea..text', 'Alert Message by prefix');
         static::assertSame('Alert Message by prefix', $this->System->alertMsg());
         // test with api version
-        Configure::delete('AlertMessageByPrefix..text');
-        $user = new class {
+        Configure::delete('AlertMessageByArea..text');
+        $user = new class
+        {
             public function get($key)
             {
                 return $key === 'roles' ? ['admin'] : null;


### PR DESCRIPTION
This introduces a configuration to set a specific header banner for a Manager area (accepted values are `Admin` and `Model`).

You can set the configuration in Administration / Appearance page:

![image](https://github.com/bedita/manager/assets/2227145/71ef78d1-2fe4-484b-9bd2-d292b863c8a9)

Then you should see header changing according to the area you are navigating.

In this example, Admin:

![Schermata del 2023-12-04 17-22-54](https://github.com/bedita/manager/assets/2227145/0b35654a-d9cc-41bc-a973-aeee6359f1a3)

Modelling:

![Schermata del 2023-12-04 17-23-11](https://github.com/bedita/manager/assets/2227145/b26349e2-3a8b-49ba-85d7-19f168b68ce9)


