### PR TITLE
User's Dashboard Recent Activity

### DIFF
--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2023-12-04 17:06:38 \n"
+"POT-Creation-Date: 2023-12-14 14:45:43 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -889,9 +889,6 @@ msgstr ""
 msgid "You have requested a password change, please provide a new password"
 msgstr ""
 
-msgid "Your recent items"
-msgstr ""
-
 msgid "Zipcode"
 msgstr ""
 
@@ -1034,9 +1031,6 @@ msgid "undo"
 msgstr ""
 
 msgid "undo remove"
-msgstr ""
-
-msgid "untitled"
 msgstr ""
 
 msgid "username"
@@ -1253,6 +1247,7 @@ msgstr ""
 msgid "Created on ${ created }."
 msgstr ""
 
+#, javascript-format
 msgid "Modified on ${ modified }."
 msgstr ""
 
@@ -1260,10 +1255,32 @@ msgstr ""
 msgid "Publish start on ${ published }."
 msgstr ""
 
+#, javascript-format
 msgid "Missing required data \"${ required }\". Retry"
 msgstr ""
 
 msgid "Error while creating new object."
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Activity"
+msgstr ""
+
+msgid "Changed"
+msgstr ""
+
+msgid "items"
+msgstr ""
+
+msgid "Your recent activity"
+msgstr ""
+
+msgid "Title or #id uname"
+msgstr ""
+
+msgid "(deleted)"
 msgstr ""
 
 msgid "You can modify the permissions"
@@ -1282,9 +1299,6 @@ msgid "Hide forbidden folders"
 msgstr ""
 
 msgid "Inherited"
-msgstr ""
-
-msgid "Action"
 msgstr ""
 
 msgid "by user"
@@ -1395,7 +1409,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 
@@ -1403,6 +1417,7 @@ msgstr ""
 msgid "by ${ name } via ${ application }"
 msgstr ""
 
+#, javascript-format
 msgid "by ${ name }"
 msgstr ""
 

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2023-12-14 14:45:43 \n"
+"POT-Creation-Date: 2023-12-15 11:11:26 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1265,13 +1265,16 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
+msgid "activities"
+msgstr ""
+
 msgid "Activity"
 msgstr ""
 
 msgid "Changed"
 msgstr ""
 
-msgid "items"
+msgid "No activity found"
 msgstr ""
 
 msgid "Your recent activity"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-12-04 17:06:38 \n"
+"POT-Creation-Date: 2023-12-14 14:45:43 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -892,9 +892,6 @@ msgstr ""
 msgid "You have requested a password change, please provide a new password"
 msgstr ""
 
-msgid "Your recent items"
-msgstr ""
-
 msgid "Zipcode"
 msgstr ""
 
@@ -1037,9 +1034,6 @@ msgid "undo"
 msgstr ""
 
 msgid "undo remove"
-msgstr ""
-
-msgid "untitled"
 msgstr ""
 
 msgid "username"
@@ -1256,6 +1250,7 @@ msgstr ""
 msgid "Created on ${ created }."
 msgstr ""
 
+#, javascript-format
 msgid "Modified on ${ modified }."
 msgstr ""
 
@@ -1263,10 +1258,32 @@ msgstr ""
 msgid "Publish start on ${ published }."
 msgstr ""
 
+#, javascript-format
 msgid "Missing required data \"${ required }\". Retry"
 msgstr ""
 
 msgid "Error while creating new object."
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Activity"
+msgstr ""
+
+msgid "Changed"
+msgstr ""
+
+msgid "items"
+msgstr ""
+
+msgid "Your recent activity"
+msgstr ""
+
+msgid "Title or #id uname"
+msgstr ""
+
+msgid "(deleted)"
 msgstr ""
 
 msgid "You can modify the permissions"
@@ -1285,9 +1302,6 @@ msgid "Hide forbidden folders"
 msgstr ""
 
 msgid "Inherited"
-msgstr ""
-
-msgid "Action"
 msgstr ""
 
 msgid "by user"
@@ -1398,7 +1412,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 
@@ -1406,6 +1420,7 @@ msgstr ""
 msgid "by ${ name } via ${ application }"
 msgstr ""
 
+#, javascript-format
 msgid "by ${ name }"
 msgstr ""
 

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-12-14 14:45:43 \n"
+"POT-Creation-Date: 2023-12-15 11:11:26 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1268,13 +1268,16 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
+msgid "activities"
+msgstr ""
+
 msgid "Activity"
 msgstr ""
 
 msgid "Changed"
 msgstr ""
 
-msgid "items"
+msgid "No activity found"
 msgstr ""
 
 msgid "Your recent activity"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-12-04 17:06:38 \n"
+"POT-Creation-Date: 2023-12-14 14:45:43 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -897,9 +897,6 @@ msgstr "Non sei autorizzato ad accedere a quest'area."
 msgid "You have requested a password change, please provide a new password"
 msgstr "Hai richiesto una modifica della password, fornisci una nuova password"
 
-msgid "Your recent items"
-msgstr "I tuoi elementi più recenti"
-
 msgid "Zipcode"
 msgstr "Cap"
 
@@ -1043,9 +1040,6 @@ msgstr "annulla"
 
 msgid "undo remove"
 msgstr "annulla rimozione"
-
-msgid "untitled"
-msgstr "senza titolo"
 
 msgid "username"
 msgstr "nome utente"
@@ -1268,6 +1262,7 @@ msgstr "copiato negli appunti"
 msgid "Created on ${ created }."
 msgstr "Creato il ${ created }."
 
+#, javascript-format
 msgid "Modified on ${ modified }."
 msgstr "Modificato il ${ modified }."
 
@@ -1275,11 +1270,33 @@ msgstr "Modificato il ${ modified }."
 msgid "Publish start on ${ published }."
 msgstr "Pubblicato il ${ published }."
 
+#, javascript-format
 msgid "Missing required data \"${ required }\". Retry"
 msgstr "Dato obbligatorio mancante \"${ required }\". Riprovare"
 
 msgid "Error while creating new object."
 msgstr "Si è verificato un errore durante la creazione del nuovo oggetto."
+
+msgid "Action"
+msgstr "Azione"
+
+msgid "Activity"
+msgstr "Attività"
+
+msgid "Changed"
+msgstr "Cambiamento"
+
+msgid "items"
+msgstr "oggetti"
+
+msgid "Your recent activity"
+msgstr "La tua attività recente"
+
+msgid "Title or #id uname"
+msgstr "Titolo o #id nome univoco"
+
+msgid "(deleted)"
+msgstr "(eliminato)"
 
 msgid "You can modify the permissions"
 msgstr "Puoi modificare i permessi"
@@ -1298,9 +1315,6 @@ msgstr "Nascondi non disponibili"
 
 msgid "Inherited"
 msgstr "Ereditato"
-
-msgid "Action"
-msgstr "Azione"
 
 msgid "by user"
 msgstr "da utente"
@@ -1418,6 +1432,7 @@ msgstr "Nessun dato di Cronologia"
 msgid "by ${ name } via ${ application }"
 msgstr "modificato da ${ name } con applicazione ${ application }"
 
+#, javascript-format
 msgid "by ${ name }"
 msgstr "modificato da ${ name }"
 
@@ -1469,3 +1484,9 @@ msgstr "Errore durante il salvataggio della categoria"
 
 msgid "Error on deleting category"
 msgstr "Errore durante l'eliminazione della categoria"
+
+#~ msgid "Your recent items"
+#~ msgstr "I tuoi elementi più recenti"
+
+#~ msgid "untitled"
+#~ msgstr "senza titolo"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2023-12-14 14:45:43 \n"
+"POT-Creation-Date: 2023-12-15 11:11:26 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1280,14 +1280,17 @@ msgstr "Si è verificato un errore durante la creazione del nuovo oggetto."
 msgid "Action"
 msgstr "Azione"
 
+msgid "activities"
+msgstr "attività"
+
 msgid "Activity"
 msgstr "Attività"
 
 msgid "Changed"
 msgstr "Cambiamento"
 
-msgid "items"
-msgstr "oggetti"
+msgid "No activity found"
+msgstr "Nessuna attività"
 
 msgid "Your recent activity"
 msgstr "La tua attività recente"
@@ -1484,9 +1487,3 @@ msgstr "Errore durante il salvataggio della categoria"
 
 msgid "Error on deleting category"
 msgstr "Errore durante l'eliminazione della categoria"
-
-#~ msgid "Your recent items"
-#~ msgstr "I tuoi elementi più recenti"
-
-#~ msgid "untitled"
-#~ msgstr "senza titolo"

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -75,6 +75,7 @@ const _vueInstance = new Vue({
         Permissions:() => import(/* webpackChunkName: "permissions" */'app/components/permissions/permissions'),
         PaginationNavigation:() => import(/* webpackChunkName: "pagination-navigation" */'app/components/pagination-navigation/pagination-navigation'),
         ObjectsHistory:() => import(/* webpackChunkName: "objects-history" */'app/components/objects-history/objects-history'),
+        RecentActivity:() => import(/* webpackChunkName: "recent-activity" */'app/components/recent-activity/recent-activity'),
         ShowHide:() => import(/* webpackChunkName: "show-hide" */'app/components/show-hide/show-hide'),
         SystemInfo:() => import(/* webpackChunkName: "system-info" */'app/components/system-info/system-info'),
         UserAccesses:() => import(/* webpackChunkName: "user-accesses" */'app/components/user-accesses/user-accesses'),

--- a/resources/js/app/components/recent-activity/recent-activity.vue
+++ b/resources/js/app/components/recent-activity/recent-activity.vue
@@ -6,9 +6,9 @@
 
         <div v-if="pagination">
             <nav class="pagination has-text-size-smallest">
-                <div class="count-items">
+                <div class="count-activities">
                     <span class="has-font-weight-bold">{{ pagination.count }}</span>
-                    <span>{{ msgItems }}</span>
+                    <span>{{ msgActivities }}</span>
                 </div>
                 <div class="page-size">
                     <span>{{ msgSize }}</span>
@@ -46,7 +46,7 @@
             </nav>
         </div>
         <div class="is-loading-spinner mt-05" v-if="loading" />
-        <div class="list-objects" v-if="items.length > 0 && !loading">
+        <div class="list-objects" v-if="activities.length > 0 && !loading">
             <div class="table-row">
                 <div class="narrow">{{ msgTitle }}</div>
                 <div class="narrow">{{ msgType }}</div>
@@ -54,7 +54,7 @@
                 <div class="narrow">{{ msgChanged }}</div>
                 <div class="narrow">{{ msgDate }}</div>
             </div>
-            <template v-for="item in items">
+            <template v-for="item in activities">
                 <a :key="item.id" v-if="item.object_type" :href="url(item)" class="table-row" :class="`object-status-${item.object_status}`">
                     <div class="narrow">{{ title(item) }}</div>
                     <div class="type-cell"><span :class="`tag has-background-module-${item.object_type}`">{{ t(item.object_type || '?') }}</span></div>
@@ -71,8 +71,8 @@
                 </div>
             </template>
         </div>
-        <div v-if="!items.length">
-            {{ msgNoItemsFound }}
+        <div v-if="!activities.length">
+            {{ msgNoActivityFound }}
         </div>
     </section>
 </template>
@@ -103,17 +103,17 @@ export default {
 
     data() {
         return {
+            activities: [],
             currentPage: 1,
-            items: [],
             loading: false,
             pageSize: null,
             pagination: {},
             msgAction: t`Action`,
+            msgActivities: t`activities`,
             msgActivity: t`Activity`,
             msgChanged: t`Changed`,
             msgDate: t`Date`,
-            msgItems: t`items`,
-            msgNoItemsFound: t`No items found`,
+            msgNoActivityFound: t`No activity found`,
             msgRecentActivity: t`Your recent activity`,
             msgSize: t`Size`,
             msgTitle: t`Title or #id uname`,
@@ -145,12 +145,12 @@ export default {
             const json = await response.json();
             this.pagination = json.meta.pagination;
             this.currentPage = json.meta.pagination.page;
-            this.items = [...(json.data || [])];
-            const ids = this.items.filter(item => item.meta.resource_id).map(item => item.meta.resource_id).filter((v, i, a) => a.indexOf(v) === i).map(i=>Number(i));
+            this.activities = [...(json.data || [])];
+            const ids = this.activities.filter(item => item.meta.resource_id).map(item => item.meta.resource_id).filter((v, i, a) => a.indexOf(v) === i).map(i=>Number(i));
             console.log(ids);
             const objectResponse = await fetch(`${API_URL}api/objects?filter[id]=${ids.join(',')}&page_size=${pageSize}`, API_OPTIONS);
             const objectJson = await objectResponse.json();
-            for (const item of this.items) {
+            for (const item of this.activities) {
                 const object = objectJson.data.find(obj => obj.id === item.meta.resource_id);
                 if (!object) {
                     continue;

--- a/resources/js/app/components/recent-activity/recent-activity.vue
+++ b/resources/js/app/components/recent-activity/recent-activity.vue
@@ -1,0 +1,185 @@
+<template>
+    <section class="dashboard-section">
+        <header>
+            <h2>{{ msgRecentActivity }}</h2>
+        </header>
+
+        <div v-if="pagination">
+            <nav class="pagination has-text-size-smallest">
+                <div class="count-items">
+                    <span class="has-font-weight-bold">{{ pagination.count }}</span>
+                    <span>{{ msgItems }}</span>
+                </div>
+                <div class="page-size">
+                    <span>{{ msgSize }}</span>
+                    <select
+                        class="page-size-selector has-background-gray-700 has-border-gray-700 has-font-weight-light has-text-gray-200 has-text-size-smallest"
+                        v-model="pageSize"
+                        @change="changePage"
+                    >
+                        <option
+                            v-for="pSize in pageSizes"
+                            :key="pSize"
+                        >
+                            {{ pSize }}
+                        </option>
+                    </select>
+                </div>
+                <div class="pagination-buttons">
+                    <div>
+                        <!-- first page -->
+                        <button :class="pageButtonClass" @click.prevent="changePage(1)" v-if="pagination.page > 1">{{ 1 }}</button>
+                        <!-- delimiter -->
+                        <span class="pages-delimiter" v-if="pagination.page > 3" />
+                        <!-- prev page -->
+                        <button :class="pageButtonClass" @click.prevent="changePage(pagination.page - 1)" v-if="pagination.page > 2">{{ pagination.page - 1 }}</button>
+                        <!-- current page -->
+                        <input size="2" class="ml-05" :class="pagination.page === 1 ? 'mr-05' : 'ml-05'" v-model="currentPage" />
+                        <!-- next page -->
+                        <button :class="pageButtonClass" @click.prevent="changePage(pagination.page + 1)" v-if="pagination.page < pagination.page_count - 1">{{ pagination.page + 1 }}</button>
+                        <!-- delimiter -->
+                        <span class="pages-delimiter" v-if="pagination.page < pagination.page_count - 2" />
+                        <!-- last page -->
+                        <button :class="pageButtonClass" @click.prevent="changePage(pagination.page_count)" v-if="pagination.page < pagination.page_count">{{ pagination.page_count }}</button>
+                    </div>
+                </div>
+            </nav>
+        </div>
+        <div class="is-loading-spinner mt-05" v-if="loading" />
+        <div class="list-objects" v-if="items.length > 0 && !loading">
+            <div class="table-row">
+                <div class="narrow">{{ msgTitle }}</div>
+                <div class="narrow">{{ msgType }}</div>
+                <div class="narrow">{{ msgAction }}</div>
+                <div class="narrow">{{ msgChanged }}</div>
+                <div class="narrow">{{ msgDate }}</div>
+            </div>
+            <template v-for="item in items">
+                <a :key="item.id" v-if="item.object_type" :href="url(item)" class="table-row" :class="`object-status-${item.object_status}`">
+                    <div class="narrow">{{ title(item) }}</div>
+                    <div class="type-cell"><span :class="`tag has-background-module-${item.object_type}`">{{ t(item.object_type || '?') }}</span></div>
+                    <div class="narrow">{{ item.meta.user_action }}</div>
+                    <div class="narrow" :title="changes(item, false)">{{ changes(item) }}</div>
+                    <div class="narrow">{{ formatDate(item.meta.created) }}</div>
+                </a>
+                <div class="table-row object-status-deleted" v-else>
+                    <div class="narrow">{{ title(item) }}</div>
+                    <div class="type-cell"><span :class="`tag`">?</span></div>
+                    <div class="narrow">{{ item.meta.user_action }}</div>
+                    <div class="narrow" :title="changes(item, false)">{{ changes(item) }}</div>
+                    <div class="narrow">{{ formatDate(item.meta.created) }}</div>
+                </div>
+            </template>
+        </div>
+        <div v-if="!items.length">
+            {{ msgNoItemsFound }}
+        </div>
+    </section>
+</template>
+<script>
+import { t } from 'ttag';
+
+const API_URL = new URL(BEDITA.base).pathname;
+const API_OPTIONS = {
+    credentials: 'same-origin',
+    headers: {
+        'accept': 'application/json',
+    }
+};
+
+export default {
+    name: 'RecentActivity',
+
+    props: {
+        pageSizes: {
+            type: Array,
+            default: () => [10, 20, 50, 100, 500],
+        },
+        userId: {
+            type: Number,
+            default: 0,
+        },
+    },
+
+    data() {
+        return {
+            currentPage: 1,
+            items: [],
+            loading: false,
+            pageSize: null,
+            pagination: {},
+            msgAction: t`Action`,
+            msgActivity: t`Activity`,
+            msgChanged: t`Changed`,
+            msgDate: t`Date`,
+            msgItems: t`items`,
+            msgNoItemsFound: t`No items found`,
+            msgRecentActivity: t`Your recent activity`,
+            msgSize: t`Size`,
+            msgTitle: t`Title or #id uname`,
+            msgType: t`Type`,
+        };
+    },
+
+    mounted() {
+        this.$nextTick(() => {
+            this.pageSize = this.pageSizes[0];
+            this.changePage();
+        });
+    },
+
+    methods: {
+        async changePage(page = 1) {
+            await this.fetchObjects(this.userId, page, this.pageSize);
+        },
+        changes(item, truncate = true) {
+            if (truncate) {
+                return this.$helpers.truncate(Object.keys(item.meta.changed).join(', '), 50);
+            }
+
+            return Object.keys(item.meta.changed).join(', ');
+        },
+        async fetchObjects(userId, page, pageSize) {
+            this.loading = true;
+            const response = await fetch(`${API_URL}api/history?filter[user_id]=${userId}&page=${page}&page_size=${pageSize}&sort=-created`, API_OPTIONS);
+            const json = await response.json();
+            this.pagination = json.meta.pagination;
+            this.currentPage = json.meta.pagination.page;
+            this.items = [...(json.data || [])];
+            const ids = this.items.filter(item => item.meta.resource_id).map(item => item.meta.resource_id).filter((v, i, a) => a.indexOf(v) === i).map(i=>Number(i));
+            console.log(ids);
+            const objectResponse = await fetch(`${API_URL}api/objects?filter[id]=${ids.join(',')}&page_size=${pageSize}`, API_OPTIONS);
+            const objectJson = await objectResponse.json();
+            for (const item of this.items) {
+                const object = objectJson.data.find(obj => obj.id === item.meta.resource_id);
+                if (!object) {
+                    continue;
+                }
+                item.object_title = object.attributes.title;
+                item.object_uname = object.attributes.uname;
+                item.object_status = object.attributes.status;
+                item.object_type = object.type;
+            }
+            this.loading = false;
+        },
+        formatDate(d) {
+            return d ?  new Date(d).toLocaleDateString() + ' ' + new Date(d).toLocaleTimeString() : '';
+        },
+        pageButtonClass() {
+            return 'has-text-size-smallest button is-width-auto button-outlined';
+        },
+        title(item) {
+            if (item.object_title) {
+                return this.$helpers.truncate(item.object_title, 100);
+            }
+            const id = `#${item.meta.resource_id}`;
+            const uname = item.object_uname ? this.$helpers.truncate(item.object_uname, 100) : t`(deleted)`;
+
+            return `${id} ${uname}`;
+        },
+        url(item) {
+            return `${item.object_type}/view/${item.meta.resource_id}`;
+        },
+    },
+}
+</script>

--- a/resources/js/app/pages/dashboard/index.js
+++ b/resources/js/app/pages/dashboard/index.js
@@ -1,11 +1,9 @@
-/**
- * Templates that uses this component (directly or indirectly)
- *  Template/Pages/Dashboard/index.twig
- *
- * <dashboard> component used for Dashboard -> Index
- *
- */
 export default {
+    name: 'DashboardIndex',
+
+    components: {
+        RecentActivity:() => import(/* webpackChunkName: "recent-activity" */'app/components/recent-activity/recent-activity'),
+    },
 
     props: {
         q: {
@@ -13,11 +11,13 @@ export default {
             default: '',
         },
     },
+
     data() {
         return {
             searchString: '',
         };
     },
+
     created() {
         if (document.referrer.endsWith('/login') && window.top !== window) {
             window.top.postMessage('login', BEDITA.base);
@@ -25,6 +25,7 @@ export default {
 
         this.searchString = this.q;
     },
+
     methods: {
         captureKeys(e) {
             let key = e.which || e.keyCode || 0;

--- a/resources/js/app/plugins/tinymce/placeholders.js
+++ b/resources/js/app/plugins/tinymce/placeholders.js
@@ -30,7 +30,7 @@ function loadPreview(editor, node, id) {
     node.empty();
 
     let text = tinymce.html.Node.create('#text');
-    text.value = `${t('loading')}…`;
+    text.value = 'loading…';
     node.append(text);
 
     fetchData(id)

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -41,7 +41,6 @@ class DashboardController extends AppController
     public function index(): void
     {
         $this->getRequest()->allowMethod(['get']);
-        $this->set('recentItems', $this->recentItems());
 
         /** @var \Authentication\Identity $user */
         $user = $this->Authentication->getIdentity();
@@ -61,24 +60,5 @@ class DashboardController extends AppController
         $this->getRequest()->allowMethod(['get']);
         $this->viewBuilder()->disableAutoLayout();
         $this->render('/Element/Dashboard/messages');
-    }
-
-    /**
-     * Load 20 most recent items modified by authenticated user.
-     *
-     * @return array
-     */
-    protected function recentItems(): array
-    {
-        $user = $this->Authentication->getIdentity();
-        if (empty($user)) {
-            return [];
-        }
-        $filter = ['modified_by' => $user['id']];
-        $limit = 20;
-        $sort = '-modified';
-        $response = $this->apiClient->getObjects('objects', compact('filter', 'limit', 'sort'));
-
-        return (array)Hash::extract((array)$response, 'data.{n}');
     }
 }

--- a/templates/Pages/Dashboard/_dashboard.scss
+++ b/templates/Pages/Dashboard/_dashboard.scss
@@ -173,8 +173,12 @@ body.view-dashboard {
 
             // table rows
             .table-row {
-                &.object-status-off, &.object-status-draft {
+                &.object-status-off, &.object-status-draft, &.object-status-deleted {
                     color: $gray-550;
+                }
+
+                &.object-status-deleted {
+                    text-decoration: line-through;
                 }
 
                 &:hover {

--- a/templates/Pages/Dashboard/index.twig
+++ b/templates/Pages/Dashboard/index.twig
@@ -75,26 +75,7 @@
 
         <div class="dashboard-area">
 
-            <section class="dashboard-section">
-                <header>
-                    <h2>{{ __('Your recent items') }}</h2>
-                </header>
-
-                <div class="list-objects">
-
-                    {% for object in recentItems %}
-                        <a href="{{ Url.build({'_name': 'modules:view', 'object_type': object.type, 'id': object.id}) }}" class="table-row object-status-{{ object.attributes.status }}">
-                            <div class="narrow">{{ object.attributes.title|truncate(100)|default(__('untitled')) }}</div>
-                            <div class="type-cell"><span class="tag has-background-module-{{ object.type }}">{{ __(object.type) }}</span></div>
-                            <div class="narrow">{{ object.attributes.status }}</div>
-                            {# <div class="narrow">{{ object.attributes.lang }}</div> #}
-                            <div class="narrow">{{ Time.format(object.meta.modified, 'd MMM YYYY') }} &nbsp; {{ Time.format(object.meta.modified, 'HH:mm') }}</div>
-                        </a>
-                    {% else %}
-                        {{ __('No items found') }}
-                    {% endfor %}
-                </div>
-            </section>
+            <recent-activity :page-sizes={{ config('Pagination.sizeAvailable')|json_encode|escape('html_attr') }} :user-id={{ user.id }}></recent-activity>
 
         </div>
 

--- a/tests/TestCase/Controller/DashboardControllerTest.php
+++ b/tests/TestCase/Controller/DashboardControllerTest.php
@@ -167,7 +167,6 @@ class DashboardControllerTest extends TestCase
      * @param MethodNotAllowedException|null $expected The expected exception or null
      * @param string $method The request method, can be 'GET', 'PATCH', 'POST', 'DELETE'
      * @covers ::index()
-     * @covers ::recentItems()
      * @dataProvider indexProvider()
      * @return void
      */
@@ -189,8 +188,6 @@ class DashboardControllerTest extends TestCase
         $response = $this->Dashboard->getResponse();
 
         static::assertEquals(200, $response->getStatusCode());
-        // recent items
-        static::assertArrayHasKey('recentItems', $this->Dashboard->viewBuilder()->getVars());
         static::assertArrayHasKey('jobsAllow', $this->Dashboard->viewBuilder()->getVars());
     }
 
@@ -230,37 +227,5 @@ class DashboardControllerTest extends TestCase
             ]);
             $this->Dashboard->messages();
         }
-    }
-
-    /**
-     * Test `recentItems` method
-     *
-     * @covers ::recentItems()
-     * @return void
-     */
-    public function testRecentItems(): void
-    {
-        $this->setupController([
-            'environment' => [
-                'REQUEST_METHOD' => 'GET',
-            ],
-        ]);
-
-        // Mock Authentication component
-        $this->Dashboard->setRequest($this->Dashboard->getRequest()->withAttribute('authentication', $this->getAuthenticationServiceMock()));
-
-        // setup api
-        $client = ApiClientProvider::getApiClient();
-        $adminUser = getenv('BEDITA_ADMIN_USR');
-        $adminPassword = getenv('BEDITA_ADMIN_PWD');
-        $response = $client->authenticate($adminUser, $adminPassword);
-        $client->setupTokens($response['meta']);
-        // set auth user admin
-        $this->Dashboard->Authentication->setIdentity(new Identity(['id' => 1]));
-        // call private method using AppControllerTest->invokeMethod
-        $test = new AppControllerTest();
-        $recentItems = $test->invokeMethod($this->Dashboard, 'recentItems', []);
-        // at least 1 element (the admin user itself)
-        static::assertGreaterThanOrEqual(1, count($recentItems));
     }
 }


### PR DESCRIPTION
This introduces a change on the user's dashboard "recent items" section.

Contents are slightly different, representing "user's activity" (fetching data from `history` endpoint): this means that there could be the same object in multiple rows (different changes on the same object).

Comparing to the previous version, this fetches also data modified sometime by the authenticated user, and with last modification by another user. 
The content for each row is:

 - Title or #id uname: the title, if available, `#id uname` otherwise
 - Object type: the object type
 - Action: the action performed (can be "update", "trash", etc.)
 - Changed: the list of fields that has been changed
 - Date: the date time for the change

Data is paginated. Deleted objects are "line-through" style strings.

The component `<recent-activity>` is reusable (for instance, we could use it to have an insight on user activity, in user object view).

![image](https://github.com/bedita/manager/assets/2227145/1ef79166-e856-4f29-91e0-413ce911771d)

Bonus: javascript fix in placeholders.js
