### PR TITLE
Bump cakephp-codesniffer from v4.5.1 to v4.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,15 +37,15 @@
     },
     "require-dev": {
         "cakephp/bake": "^2.6",
-        "cakephp/cakephp-codesniffer": "~4.5.1",
+        "cakephp/cakephp-codesniffer": "~4.7.0",
         "cakephp/console": "^4.4",
         "cakephp/debug_kit": "^4.7.1",
+        "cakephp/repl": "^0.1",
         "dereuromark/cakephp-ide-helper": "~1.17.0",
-        "phpstan/phpstan": "^1.8.2",
         "phpstan/extension-installer": "^1.2",
+        "phpstan/phpstan": "^1.8.2",
         "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpunit/phpunit": "^9.5",
-        "cakephp/repl": "^0.1"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Controller/Component/HistoryComponent.php
+++ b/src/Controller/Component/HistoryComponent.php
@@ -91,7 +91,7 @@ class HistoryComponent extends Component
         $historyId = (string)$options['historyId'];
         /** @var bool $keepUname */
         $keepUname = (bool)$options['keepUname'];
-        /** @var \BEdita\SDK\BEditaClient; $ApiClient */
+        /** @var \BEdita\SDK\BEditaClient $ApiClient */
         $ApiClient = $options['ApiClient'];
 
         // get history by $objectType, $id and $historyId


### PR DESCRIPTION
This updates a dev dependency to solve a recent CI problem when running phpcs.

The problem was caused by another dependency: `squizlabs/php_codesniffer` 3.8.0 was recently released https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.8.0. This release version changed Slevomat coding standard dependency, dropping some rules (i.e. `newlinesCountAfterDeclare`) used by `cakephp-codesniffer` 4.5.1, causing an error when launching phpcs on the project:
```
> vendor/bin/phpcs
ERROR: Ruleset invalid. Property "newlinesCountAfterDeclare" does not exist on sniff SlevomatCodingStandard.TypeHints.DeclareStrictTypes
```

This patches the issue bumping `cakephp-codesniffer` to version 4.7.0