### PR TITLE
Update typos package

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1124,9 +1124,9 @@
     to-fast-properties "^2.0.0"
 
 "@chialab/typos@^0.1.1":
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/@chialab/typos/-/typos-0.1.2.tgz#80d6c9635e3e635d7f8a5d6fa1e1e4f0c8859953"
-  integrity sha512-6qTLbDOEaCqIsPOU3AMGhlqdQ7qmzkQ1Y6/rQXkDN8f26lDX0HJrL/GN6+J+f26fObuF9f6Tv3B0jW0ybJyQ8w==
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/@chialab/typos/-/typos-0.1.3.tgz#4062a07a9f0d50537ea0b6f29d1939a477441f70"
+  integrity sha512-xpqxx/wtuZ7YCEXZJEdhXVa6tZqtaUPIYU3HpO0jA+4snjqRHaMdzdRzEDNMIzY3QTev0I8jsCZST1E7k2TgHQ==
 
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"


### PR DESCRIPTION
Update the `@chialab/typos` to correctly handle apostrophes.