### PR TITLE
Fix boolean nullable search filter

### DIFF
--- a/resources/js/app/components/filter-box.js
+++ b/resources/js/app/components/filter-box.js
@@ -209,10 +209,21 @@ export default {
         availableFilters() {
             this.normalizeQueryFilter();
             this.dynamicFilters = this.availableFilters.filter(f => {
-                if (f.name == 'status') {
+                if (f.name === 'status') {
                     this.statusFilter = f;
 
                     return false;
+                }
+                if (f.type === 'select' && f.options) {
+                    const items = [];
+                    Object.keys(f.options).forEach((k) => {
+                        items.push({
+                            name: f.name,
+                            text: k === ':::null:::' ? t`NULL` : f.options[k],
+                            value: k,
+                        });
+                    });
+                    f.options = items;
                 }
 
                 return true;

--- a/resources/js/app/components/filter-box.js
+++ b/resources/js/app/components/filter-box.js
@@ -214,7 +214,7 @@ export default {
 
                     return false;
                 }
-                if (f.type === 'select' && f.options) {
+                if (f.type === 'select' && f.options && typeof f.options[0].text === 'undefined') {
                     const items = [];
                     Object.keys(f.options).forEach((k) => {
                         items.push({


### PR DESCRIPTION
A "boolean nullable" field is represented as a `<select>` in index search filter.

Wrong (actual) behaviour: `<select></select>` with no `<option>`.

Fixed (this patch) behaviour:

```html
<select>
    <option>All</option>
    <option>Yes</option>
    <option>No</option>
    <option>NULL</option>
</select>
```