### PR TITLE
Input number attribute step

### DIFF
--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -48,7 +48,7 @@ class Control
     {
         $type = $options['propertyType'];
         $format = self::format((array)$options['schema']);
-        $controlOptions = array_intersect_key($options, array_flip(['label', 'disabled', 'readonly', 'value']));
+        $controlOptions = array_intersect_key($options, array_flip(['label', 'disabled', 'readonly', 'step', 'value']));
         if ($type === 'text' && in_array($format, ['email', 'uri'])) {
             $result = call_user_func_array(Form::getMethod(self::class, $type, $format), [$options]);
 

--- a/src/Form/ControlType.php
+++ b/src/Form/ControlType.php
@@ -132,14 +132,14 @@ class ControlType
     }
 
     /**
-     * Return the type for integer: 'number'
+     * Return the type for integer: 'integer'
      *
      * @param array $schema Object schema array.
      * @return string
      */
     public static function fromInteger(array $schema): string
     {
-        return 'number';
+        return 'integer';
     }
 
     /**

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -73,15 +73,19 @@ class SchemaHelper extends Helper
             ]);
         }
         if (empty($ctrlOptions['type'])) {
-            $ctrlOptions['type'] = ControlType::fromSchema($schema);
+            $ctrlOptionsType = ControlType::fromSchema($schema);
+            $ctrlOptions['type'] = $ctrlOptionsType;
+            if (in_array($ctrlOptionsType, ['integer', 'number'])) {
+                $ctrlOptions['step'] = $ctrlOptionsType === 'number' ? 'any' : '1';
+                $ctrlOptions['type'] = 'number';
+            }
         }
         // verify if there's a custom control handler for $type and $name
         $custom = $this->customControl($name, $value, $ctrlOptions);
         if (!empty($custom)) {
             return $custom;
         }
-
-        return Control::control([
+        $opts = [
             'objectType' => $objectType,
             'property' => $name,
             'value' => $value,
@@ -90,7 +94,12 @@ class SchemaHelper extends Helper
             'label' => Hash::get($ctrlOptions, 'label'),
             'readonly' => Hash::get($ctrlOptions, 'readonly', false),
             'disabled' => Hash::get($ctrlOptions, 'readonly', false),
-        ]);
+        ];
+        if (!empty($ctrlOptions['step'])) {
+            $opts['step'] = $ctrlOptions['step'];
+        }
+
+        return Control::control($opts);
     }
 
     /**

--- a/tests/TestCase/Form/ControlTypeTest.php
+++ b/tests/TestCase/Form/ControlTypeTest.php
@@ -66,7 +66,7 @@ class ControlTypeTest extends TestCase
                 ],
             ],
             'integer' => [
-                'number',
+                'integer',
                 [
                     'type' => 'integer',
                 ],

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -401,7 +401,7 @@ class SchemaHelperTest extends TestCase
      * @covers ::controlOptions()
      * @covers ::customControl()
      */
-    public function testControlOptions(array $expected, array $schema, string $name, mixed $value): void
+    public function testControlOptions(array $expected, array $schema, string $name, $value): void
     {
         $actual = $this->Schema->controlOptions($name, $value, $schema);
 

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -218,6 +218,34 @@ class SchemaHelperTest extends TestCase
                 'body',
                 'test',
             ],
+            'integer' => [
+                // expected result
+                [
+                    'step' => 1,
+                    'type' => 'integer',
+                    'value' => 123,
+                ],
+                // schema type
+                [
+                    'type' => 'integer',
+                ],
+                'integer',
+                123,
+            ],
+            'number' => [
+                // expected result
+                [
+                    'step' => 'any',
+                    'type' => 'number',
+                    'value' => 123.45,
+                ],
+                // schema type
+                [
+                    'type' => 'number',
+                ],
+                'number',
+                123.45,
+            ],
             'publish_start' => [
                 // expected result
                 [
@@ -367,13 +395,13 @@ class SchemaHelperTest extends TestCase
      * @param array $expected Expected result.
      * @param array $schema The JSON schema
      * @param string $name The field name.
-     * @param string|null $value The field value.
+     * @param mixed $value The field value.
      * @return void
      * @dataProvider controlOptionsSchemaProvider()
      * @covers ::controlOptions()
      * @covers ::customControl()
      */
-    public function testControlOptions(array $expected, array $schema, string $name, ?string $value): void
+    public function testControlOptions(array $expected, array $schema, string $name, mixed $value): void
     {
         $actual = $this->Schema->controlOptions($name, $value, $schema);
 


### PR DESCRIPTION
`<input type="number">` doesn't allow to save when value is a float (browser validation blocks).

This provides a fix:

 - when object field is an integer: `<input type="number" step="1">`
 - when object field is a float: `<input type="number" step="any">`