### PR TITLE
Use objects endpoint to search by type

### DIFF
--- a/resources/js/app/components/relation-view/roles-list-view.vue
+++ b/resources/js/app/components/relation-view/roles-list-view.vue
@@ -3,10 +3,10 @@
         <div>
             <div v-for="groupName in Object.keys(objectsByGroups)">
                 <h4 class="is-small has-font-weight-bold has-text-transform-upper">{{ groupName }}</h4>
-                <div v-for="role in objectsByGroups[groupName]">
+                <label v-for="role in objectsByGroups[groupName]" class="cursor-pointer">
                     <input type="checkbox" :value="role" :disabled="userRolePriority > role.meta.priority" v-model="checkedRelations"/>
-                    <span class="mx-05">{{ getRoleLabel(role.attributes.name, role.attributes.description) }}</span>
-                </div>
+                    <span>{{ getRoleLabel(role.attributes.name, role.attributes.description) }}</span>
+                </label>
             </div>
         </div>
 

--- a/resources/styles/_utility_classes.scss
+++ b/resources/styles/_utility_classes.scss
@@ -6,6 +6,8 @@
 
 .pointer-events-none { pointer-events: none; }
 
+.cursor-pointer { cursor: pointer; }
+
 .is-text-hidden { @include hide-text(); }
 
 .is-clipped { overflow: hidden!important; }

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -495,9 +495,6 @@ class ModulesController extends AppController
 
         $relationsSchema = $this->Schema->getRelationsSchema();
         $types = $this->Modules->relatedTypes($relationsSchema, $relation);
-        if (count($types) === 1) {
-            return sprintf('/%s', $types[0]);
-        }
 
         return '/objects?filter[type][]=' . implode('&filter[type][]=', $types);
     }

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -937,7 +937,7 @@ class ModulesControllerTest extends BaseControllerTest
             ->willReturn(['documents']);
 
         $url = $this->controller->availableRelationshipsUrl('test_relation');
-        static::assertEquals('/documents', $url);
+        static::assertEquals('/objects?filter[type][]=documents', $url);
 
         $this->controller->Modules = $this->createMock(ModulesComponent::class);
         $this->controller->Modules->method('relatedTypes')


### PR DESCRIPTION
This provides a fix in object(s) side panel search by calling a `GET /objects?filter[type][]=...` instead of `GET /<type>`.

Bonus: minor ui fix for roles list view in user view.