### PR TITLE
Fix duplicated fields in translation form

### DIFF
--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -251,7 +251,7 @@ class SchemaHelper extends Helper
             ));
         }
 
-        return array_values(array_merge($priorityFields, $otherFields));
+        return array_unique(array_values(array_merge($priorityFields, $otherFields)));
     }
 
     /**


### PR DESCRIPTION
This fixes an unexpected behaviour in translation form: duplicated fields.