### PR TITLE
Add `Microsoft Entra ID / Azure AD` login support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "league/oauth2-google": "^4.0",
         "mobiledetect/mobiledetectlib": "^2.8",
         "phpoffice/phpspreadsheet": "^1.22",
+        "thenetworg/oauth2-azure": "^2.2",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },
     "require-dev": {

--- a/config/app.php
+++ b/config/app.php
@@ -448,5 +448,25 @@ return [
                 'provider_username' => 'login',
             ],
         ],
+        'microsoft' => [
+            // OAuth2 class name
+            'class' => '\TheNetworg\OAuth2\Client\Provider\Azure',
+            // Provider class setup parameters - should be set in `app_local.php` to activate this provider
+            // 'setup' => [
+            //     'clientId' => '####',
+            //     'clientSecret' => '####',
+            //      'tenant' => '####',
+            //      'redirectUrl' => '####',
+            // ],
+            // Provider authorization options
+            'options' => [
+                'scope' => ['https://graph.microsoft.com/.default', 'openid'],
+            ],
+            // Map BEdita user fields with auth provider data path, using dot notation like 'user.id'
+            'map' => [
+                'provider_username' => 'oid',
+            ],
+        ],
+
     ],
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -460,7 +460,7 @@ return [
             // ],
             // Provider authorization options
             'options' => [
-                'scope' => ['https://graph.microsoft.com/.default', 'openid'],
+                'scope' => ['profile', 'https://graph.microsoft.com/.default', 'openid'],
             ],
             // Map BEdita user fields with auth provider data path, using dot notation like 'user.id'
             'map' => [


### PR DESCRIPTION
This PR adds initial support to login users via `Microsoft Entra ID/Azure AD` 

* `thenetworg/oauth2-azure` oauth client library based on `league/oauth2-client` has been added
* a new initial `microsoft` key on `'OAuth2Providers'` configuration has been added to `config/app.php` 
