### PR TITLE
Fix index: get objects filtered by type

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -100,7 +100,7 @@ class ModulesController extends AppController
         }
 
         try {
-            $response = $this->apiClient->getObjects($this->objectType, $this->Query->index());
+            $response = $this->apiClient->get('/objects?filter[type][]=' . $this->objectType, $this->Query->index());
         } catch (BEditaClientException $e) {
             $this->log($e->getMessage(), LogLevel::ERROR);
             $this->Flash->error($e->getMessage(), ['params' => $e]);


### PR DESCRIPTION
This provides a fix in modules index.

`GET /objects?filter[type][]=<type>` is used instead of `GET /<type>`, to provide the proper behaviour in data search.