### PR TITLE
Restore getObjects in Modules index

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -100,7 +100,7 @@ class ModulesController extends AppController
         }
 
         try {
-            $response = $this->apiClient->get('/objects?filter[type][]=' . $this->objectType, $this->Query->index());
+            $response = $this->apiClient->getObjects($this->objectType, $this->Query->index());
         } catch (BEditaClientException $e) {
             $this->log($e->getMessage(), LogLevel::ERROR);
             $this->Flash->error($e->getMessage(), ['params' => $e]);


### PR DESCRIPTION
This restore `getObjects` instead of `get` in ModulesController::index, to avoid unexpected behaviours in Users index.