### PR TITLE
CalendarHelper::list null date ranges

### DIFF
--- a/src/View/Helper/CalendarHelper.php
+++ b/src/View/Helper/CalendarHelper.php
@@ -32,11 +32,14 @@ class CalendarHelper extends Helper
     /**
      * Get calendar date ranges list html
      *
-     * @param array $dateRanges The date ranges intervals
+     * @param array|null $dateRanges The date ranges intervals
      * @return string
      */
-    public function list(array $dateRanges): string
+    public function list(?array $dateRanges): string
     {
+        if (empty($dateRanges)) {
+            return '';
+        }
         $list = '';
         foreach ($dateRanges as $dateRange) {
             $list .= $this->dateRange($dateRange);

--- a/tests/TestCase/View/Helper/CalendarHelperTest.php
+++ b/tests/TestCase/View/Helper/CalendarHelperTest.php
@@ -64,6 +64,10 @@ class CalendarHelperTest extends TestCase
                 [],
                 '',
             ],
+            'null date ranges' => [
+                null,
+                '',
+            ],
             'multiple date ranges' => [
                 [
                     ['start_date' => '2020-10-14 12:45:00'], // start date only

--- a/tests/TestCase/View/Helper/CalendarHelperTest.php
+++ b/tests/TestCase/View/Helper/CalendarHelperTest.php
@@ -82,13 +82,13 @@ class CalendarHelperTest extends TestCase
     /**
      * Test `list()` method.
      *
-     * @param array $dateRanges The array.
+     * @param array|null $dateRanges The array.
      * @param string $expected The expected string.
      * @return void
      * @dataProvider listProvider()
      * @covers ::list()
      */
-    public function testList(array $dateRanges, string $expected): void
+    public function testList(?array $dateRanges, string $expected): void
     {
         $actual = $this->Calendar->list($dateRanges);
         static::assertSame($expected, $actual);


### PR DESCRIPTION
This fixes a buggy behaviour on `CalendarHelper::list`: the methods will accept null input `$dateRanges` argument.