### PR TITLE
Tree optimizations with cache and more compact data

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -189,6 +189,7 @@ return [
         '_tree_data_' => [
             'className' => FileEngine::class,
             'prefix' => 'tree_data_',
+            'groups' => ['tree'],
             'path' => CACHE,
             'serialize' => true,
             'duration' => '+1 years',

--- a/config/app.php
+++ b/config/app.php
@@ -169,7 +169,7 @@ return [
             'url' => env('CACHE_THUMBS_URL', null),
         ],
 
-        /*
+        /**
          * Configure the cache for routes. The cached routes collection is built the
          * first time the routes are processed through `config/routes.php`.
          * Duration will be set to '+2 seconds' in bootstrap.php when debug = true
@@ -181,6 +181,18 @@ return [
             'serialize' => true,
             'duration' => '+1 years',
             'url' => env('CACHE_CAKEROUTES_URL', null),
+        ],
+
+        /**
+         * Configure the cache for tree data.
+         */
+        '_tree_data_' => [
+            'className' => FileEngine::class,
+            'prefix' => 'tree_data_',
+            'path' => CACHE,
+            'serialize' => true,
+            'duration' => '+1 years',
+            'url' => env('CACHE_TREEDATA_URL', null),
         ],
     ],
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -96,6 +96,11 @@ $routes->scope('/', function (RouteBuilder $routes) {
         ['controller' => 'Dashboard', 'action' => 'messages'],
         ['_name' => 'dashboard:messages']
     );
+    $routes->connect(
+        '/tree',
+        ['controller' => 'Tree', 'action' => 'get'],
+        ['_name' => 'tree:get']
+    );
 
     // Admin.
     $routes->prefix('admin', ['_namePrefix' => 'admin:'], function (RouteBuilder $routes) {

--- a/resources/js/app/components/folder-picker/folder-picker.js
+++ b/resources/js/app/components/folder-picker/folder-picker.js
@@ -74,14 +74,14 @@ export default {
         async fetchFolders(parent) {
             const pageSize = 100;
             const filter = !parent ? 'filter[roots]' : `filter[parent]=${parent.id}`;
-            const firstResponse = await fetch(`${API_URL}api/folders?${filter}&page=1&page_size=${pageSize}`, API_OPTIONS);
+            const firstResponse = await fetch(`${API_URL}tree?${filter}&page=1&page_size=${pageSize}`, API_OPTIONS);
             const json = await firstResponse.json();
             const folders = [...(json.data || [])];
             const pageCount = json.meta.pagination.page_count;
 
             const deferred = [];
             for (let page = 2; page <= pageCount; page++) {
-                deferred.push(fetch(`${API_URL}api/folders?${filter}&page=${page}&page_size=${pageSize}`, API_OPTIONS));
+                deferred.push(fetch(`${API_URL}tree?${filter}&page=${page}&page_size=${pageSize}`, API_OPTIONS));
             }
             const responses = await Promise.all(deferred);
             responses.forEach(async (response) => {

--- a/resources/js/app/components/tree-view/tree-view.vue
+++ b/resources/js/app/components/tree-view/tree-view.vue
@@ -316,8 +316,9 @@ export default {
             let roots = [];
             let done = false;
             do {
-                let response = await fetch(`${API_URL}api/folders?filter[roots]&page=${page}&page_size=100`, API_OPTIONS);
+                let response = await fetch(`${API_URL}tree?filter[roots]&page=${page}&page_size=100`, API_OPTIONS);
                 let json = await response.json();
+                json = json?.tree || {};
                 if (json.data) {
                     roots.push(
                         ...json.data.map((object) =>
@@ -401,8 +402,9 @@ export default {
             let children = [];
             let done = false;
             do {
-                let childrenRes = await fetch(`${API_URL}api/folders?filter[parent]=${folder.id}&page=${page}`, API_OPTIONS);
+                let childrenRes = await fetch(`${API_URL}tree?filter[parent]=${folder.id}&page=${page}&page_size=100`, API_OPTIONS);
                 let childrenJson = await childrenRes.json();
+                childrenJson = childrenJson?.tree || {};
                 children.push(
                     ...childrenJson.data.map((object) =>
                         this.store[object.id] || (this.store[object.id] = object)
@@ -455,8 +457,9 @@ export default {
             let done = false;
             this.isLoading = true;
             do {
-                let response = await fetch(`${API_URL}api/folders?filter[parent]=${this.node.id}&page=${page}`, API_OPTIONS);
+                let response = await fetch(`${API_URL}tree?filter[parent]=${this.node.id}&page=${page}&page_size=100`, API_OPTIONS);
                 let json = await response.json();
+                json = json?.tree || {};
                 children.push(...json.data);
                 if (json.meta.pagination.page_count == page) {
                     done = true;

--- a/src/Application.php
+++ b/src/Application.php
@@ -12,6 +12,7 @@
  */
 namespace App;
 
+use App\Event\TreeCacheEventHandler;
 use App\Identifier\ApiIdentifier;
 use App\Middleware\ConfigurationMiddleware;
 use App\Middleware\ProjectMiddleware;
@@ -27,6 +28,7 @@ use BEdita\WebTools\Middleware\OAuth2Middleware;
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
+use Cake\Event\EventManager;
 use Cake\Http\BaseApplication;
 use Cake\Http\Middleware\BodyParserMiddleware;
 use Cake\Http\Middleware\CsrfProtectionMiddleware;
@@ -75,6 +77,8 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
         $this->addPlugin('BEdita/WebTools');
         $this->addPlugin('BEdita/I18n');
         $this->addPlugin('Authentication');
+
+        EventManager::instance()->on(new TreeCacheEventHandler());
     }
 
     /**

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -19,6 +19,7 @@ use BEdita\WebTools\ApiClientProvider;
 use Cake\Cache\Cache;
 use Cake\Controller\Component;
 use Cake\Core\Configure;
+use Cake\Event\Event;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Utility\Hash;
@@ -612,6 +613,8 @@ class ModulesComponent extends Component
     {
         foreach ($relatedData as $data) {
             $this->saveRelatedObjects($id, $type, $data);
+            $event = new Event('Controller.afterSaveRelated', $this, compact('id', 'type', 'data'));
+            $this->getController()->getEventManager()->dispatch($event);
         }
     }
 

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -81,12 +81,26 @@ class TreeController extends AppController
 
     /**
      * Fetch tree data from API.
+     * Retrieve minimal data for folders: id, status, title.
+     * Return data and meta (no links, no included).
      *
      * @param array $query Query params.
      * @return array
      */
     protected function fetchData(array $query): array
     {
-        return ApiClientProvider::getApiClient()->get('/folders', $query);
+        $fields = 'id,status,title';
+        $response = ApiClientProvider::getApiClient()->get('/folders', compact('fields') + $query);
+        $data = (array)Hash::get($response, 'data');
+        $meta = (array)Hash::get($response, 'meta');
+        foreach ($data as &$item) {
+            $item = [
+                'id' => $item['id'],
+                'type' => 'folders',
+                'attributes' => $item['attributes'],
+            ];
+        }
+
+        return compact('data', 'meta');
     }
 }

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Controller;
+
+use App\Event\TreeCacheEventHandler;
+use App\Utility\CacheTools;
+use BEdita\SDK\BEditaClientException;
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Cache\Cache;
+use Cake\Utility\Hash;
+use Psr\Log\LogLevel;
+
+/**
+ * Tree Controller: get tree data using cache
+ */
+class TreeController extends AppController
+{
+    /**
+     * Get tree data.
+     * Use this for /tree?filter[roots]&... and /tree?filter[parent]=x&...
+     *
+     * @return void
+     */
+    public function get(): void
+    {
+        $this->getRequest()->allowMethod(['get']);
+        $this->viewBuilder()->setClassName('Json');
+        $query = $this->getRequest()->getQueryParams();
+        $tree = $this->data($query);
+        $this->set('tree', $tree);
+        $this->setSerialize(['tree']);
+    }
+
+    /**
+     * Get tree data by query params.
+     * Use cache to store data.
+     *
+     * @param array $query Query params.
+     * @return array
+     */
+    public function data(array $query): array
+    {
+        $filter = Hash::get($query, 'filter', []);
+        $subkey = !empty($filter['parent']) ? sprintf('parent-%s', $filter['parent']) : 'roots';
+        $tmp = array_filter(
+            $query,
+            function ($key) {
+                return $key !== 'filter';
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+        $key = CacheTools::cacheKey(sprintf('tree-%s-%s', $subkey, md5(serialize($tmp))));
+        $data = [];
+        try {
+            $data = Cache::remember(
+                $key,
+                function () use ($query) {
+                    return $this->fetchData($query);
+                },
+                TreeCacheEventHandler::CACHE_CONFIG
+            );
+        } catch (BEditaClientException $e) {
+            // Something bad happened
+            $this->log($e->getMessage(), LogLevel::ERROR);
+
+            return [];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Fetch tree data from API.
+     *
+     * @param array $query Query params.
+     * @return array
+     */
+    protected function fetchData(array $query): array
+    {
+        return ApiClientProvider::getApiClient()->get('/folders', $query);
+    }
+}

--- a/src/Event/TreeCacheEventHandler.php
+++ b/src/Event/TreeCacheEventHandler.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Event;
+
+use Cake\Cache\Cache;
+use Cake\Event\Event;
+use Cake\Event\EventListenerInterface;
+use Cake\Utility\Hash;
+
+/**
+ * Event listener for cache management.
+ */
+class TreeCacheEventHandler implements EventListenerInterface
+{
+    /**
+     * Cache config name for tree data.
+     *
+     * @var string
+     */
+    public const CACHE_CONFIG = '_tree_data_';
+
+    /**
+     * @inheritDoc
+     */
+    public function implementedEvents(): array
+    {
+        return [
+            'Controller.afterDelete' => 'afterDelete',
+            'Controller.afterSave' => 'afterSave',
+            'Controller.afterSaveRelated' => 'afterSaveRelated',
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function afterDelete(Event $event)
+    {
+        $this->updateCache($event->getData());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function afterSave(Event $event)
+    {
+        $this->updateCache($event->getData());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function afterSaveRelated(Event $event): void
+    {
+        $this->updateCache($event->getData());
+    }
+
+    /**
+     * Update cache data if folders tree has changed somehow.
+     *
+     * @param array $data Event data.
+     * @return void
+     */
+    protected function updateCache(array $data): void
+    {
+        $type = (string)Hash::get($data, 'type');
+        if ($type !== 'folders') {
+            return;
+        }
+        $intersection = array_intersect(array_keys((array)Hash::get($data, 'data')), ['title', 'status']);
+        if (empty($intersection)) {
+            return;
+        }
+        Cache::clearGroup(self::CACHE_CONFIG);
+    }
+}

--- a/src/Event/TreeCacheEventHandler.php
+++ b/src/Event/TreeCacheEventHandler.php
@@ -79,8 +79,9 @@ class TreeCacheEventHandler implements EventListenerInterface
         if ($type !== 'folders') {
             return;
         }
+        $children = (string)Hash::get($data, 'data.relation') === 'children';
         $intersection = array_intersect(array_keys((array)Hash::get($data, 'data')), ['title', 'status']);
-        if (empty($intersection)) {
+        if (empty($intersection) && !$children) {
             return;
         }
         Cache::clearGroup(self::CACHE_CONFIG);

--- a/src/Event/TreeCacheEventHandler.php
+++ b/src/Event/TreeCacheEventHandler.php
@@ -82,8 +82,10 @@ class TreeCacheEventHandler implements EventListenerInterface
             return;
         }
         $children = (string)Hash::get($data, 'data.relation') === 'children';
+        $parent = (string)Hash::get($data, 'data.relation') === 'parent';
+        $position = (string)Hash::get($data, 'data.children_order') === 'position';
         $intersection = array_intersect(array_keys((array)Hash::get($data, 'data')), ['title', 'status']);
-        if (empty($intersection) && !$children) {
+        if (empty($intersection) && !$children && !$parent && !$position) {
             return;
         }
         Cache::clearGroup('tree', self::CACHE_CONFIG);

--- a/src/Event/TreeCacheEventHandler.php
+++ b/src/Event/TreeCacheEventHandler.php
@@ -48,7 +48,9 @@ class TreeCacheEventHandler implements EventListenerInterface
      */
     public function afterDelete(Event $event)
     {
-        $this->updateCache($event->getData());
+        if ((string)Hash::get((array)$event->getData(), 'type') === 'folders') {
+            Cache::clearGroup('tree', self::CACHE_CONFIG);
+        }
     }
 
     /**
@@ -56,7 +58,7 @@ class TreeCacheEventHandler implements EventListenerInterface
      */
     public function afterSave(Event $event)
     {
-        $this->updateCache($event->getData());
+        $this->updateCache((array)$event->getData());
     }
 
     /**
@@ -64,7 +66,7 @@ class TreeCacheEventHandler implements EventListenerInterface
      */
     public function afterSaveRelated(Event $event): void
     {
-        $this->updateCache($event->getData());
+        $this->updateCache((array)$event->getData());
     }
 
     /**
@@ -84,6 +86,6 @@ class TreeCacheEventHandler implements EventListenerInterface
         if (empty($intersection) && !$children) {
             return;
         }
-        Cache::clearGroup(self::CACHE_CONFIG);
+        Cache::clearGroup('tree', self::CACHE_CONFIG);
     }
 }

--- a/tests/TestCase/Controller/TreeControllerTest.php
+++ b/tests/TestCase/Controller/TreeControllerTest.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Test\TestCase\Controller;
+
+use App\Controller\TreeController;
+use BEdita\SDK\BEditaClientException;
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \App\Controller\TreeController} Test Case
+ *
+ * @coversDefaultClass \App\Controller\TreeController
+ * @uses \App\Controller\TreeController
+ */
+class TreeControllerTest extends TestCase
+{
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->loadRoutes();
+    }
+
+    /**
+     * Test api client
+     *
+     * @var \BEdita\SDK\BEditaClient
+     */
+    public $client;
+
+    /**
+     * Setup api client and auth
+     *
+     * @return void
+     */
+    private function setupApi(): void
+    {
+        $this->client = ApiClientProvider::getApiClient();
+        $adminUser = getenv('BEDITA_ADMIN_USR');
+        $adminPassword = getenv('BEDITA_ADMIN_PWD');
+        $response = $this->client->authenticate($adminUser, $adminPassword);
+        $this->client->setupTokens($response['meta']);
+    }
+
+    /**
+     * Test `get` method
+     *
+     * @return void
+     * @covers ::get()
+     * @covers ::data()
+     * @covers ::fetchData()
+     */
+    public function testGet(): void
+    {
+        $this->setupApi();
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+            'get' => [
+                'query' => ['filter' => ['roots' => true]],
+            ],
+        ];
+        $request = new ServerRequest($config);
+        $tree = new TreeController($request);
+        $tree->get();
+        $actual = $tree->viewBuilder()->getVar('tree');
+        static::assertNotEmpty($actual);
+        $vars = ['data', 'links', 'meta'];
+        foreach ($vars as $var) {
+            static::assertArrayHasKey($var, $actual);
+        }
+    }
+
+    /**
+     * Test `data` method on exception
+     *
+     * @return void
+     * @covers ::get()
+     * @covers ::data()
+     */
+    public function testDataException(): void
+    {
+        $this->setupApi();
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+            'get' => [
+                'query' => ['filter' => ['roots' => true]],
+            ],
+        ];
+        $request = new ServerRequest($config);
+        $tree = new class ($request) extends TreeController {
+            public function fetchData(array $query): array
+            {
+                throw new BEditaClientException('test exception');
+            }
+        };
+        $tree->get();
+        $actual = $tree->viewBuilder()->getVar('tree');
+        static::assertEmpty($actual);
+    }
+}

--- a/tests/TestCase/Controller/TreeControllerTest.php
+++ b/tests/TestCase/Controller/TreeControllerTest.php
@@ -81,7 +81,7 @@ class TreeControllerTest extends TestCase
         $tree->get();
         $actual = $tree->viewBuilder()->getVar('tree');
         static::assertNotEmpty($actual);
-        $vars = ['data', 'links', 'meta'];
+        $vars = ['data', 'meta'];
         foreach ($vars as $var) {
             static::assertArrayHasKey($var, $actual);
         }

--- a/tests/TestCase/Controller/TreeControllerTest.php
+++ b/tests/TestCase/Controller/TreeControllerTest.php
@@ -73,9 +73,8 @@ class TreeControllerTest extends TestCase
             'environment' => [
                 'REQUEST_METHOD' => 'GET',
             ],
-            'get' => [
-                'query' => ['filter' => ['roots' => true]],
-            ],
+            'get' => [],
+            'query' => ['filter' => ['roots' => true], 'pageSize' => 10],
         ];
         $request = new ServerRequest($config);
         $tree = new TreeController($request);
@@ -102,9 +101,8 @@ class TreeControllerTest extends TestCase
             'environment' => [
                 'REQUEST_METHOD' => 'GET',
             ],
-            'get' => [
-                'query' => ['filter' => ['roots' => true]],
-            ],
+            'get' => [],
+            'query' => ['filter' => ['parent' => 999], 'pageSize' => 10],
         ];
         $request = new ServerRequest($config);
         $tree = new class ($request) extends TreeController {

--- a/tests/TestCase/Event/TreeCacheEventHandlerTest.php
+++ b/tests/TestCase/Event/TreeCacheEventHandlerTest.php
@@ -1,0 +1,172 @@
+<?php
+declare(strict_types=1);
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Test\TestCase\Event;
+
+use App\Event\TreeCacheEventHandler;
+use Cake\Cache\Cache;
+use Cake\Event\Event;
+use Cake\Event\EventManager;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \App\Event\TreeCacheEventHandler} Test Case
+ *
+ * @coversDefaultClass \App\Event\TreeCacheEventHandler
+ * @uses \App\Event\TreeCacheEventHandler
+ */
+class TreeCacheEventHandlerTest extends TestCase
+{
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        Cache::enable();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        Cache::disable();
+        parent::tearDown();
+    }
+
+    /**
+     * Test `implementedEvents` method
+     *
+     * @covers ::implementedEvents()
+     * @return void
+     */
+    public function testImplementedEvents(): void
+    {
+        static::assertCount(0, EventManager::instance()->listeners('Controller.afterDelete'));
+        static::assertCount(0, EventManager::instance()->listeners('Controller.afterSave'));
+        static::assertCount(0, EventManager::instance()->listeners('Controller.afterSaveRelated'));
+        EventManager::instance()->on(new TreeCacheEventHandler());
+        static::assertCount(1, EventManager::instance()->listeners('Controller.afterDelete'));
+        static::assertCount(1, EventManager::instance()->listeners('Controller.afterSave'));
+        static::assertCount(1, EventManager::instance()->listeners('Controller.afterSaveRelated'));
+    }
+
+    /**
+     * Data provider for all test cases.
+     *
+     * @return array
+     */
+    public function dataProvider(): array
+    {
+        return [
+            'afterDelete no data' => [
+                'afterDelete',
+                [],
+                false,
+            ],
+            'afterDelete type is not folders' => [
+                'afterDelete',
+                ['type' => 'documents'],
+                false,
+            ],
+            'afterDelete is folders' => [
+                'afterDelete',
+                ['type' => 'folders', 'id' => 999],
+                true,
+            ],
+            'afterSave no data' => [
+                'afterSave',
+                [],
+                false,
+            ],
+            'afterSave type is not folders' => [
+                'afterSave',
+                ['type' => 'documents'],
+                false,
+            ],
+            'afterSave no children, no title, no status' => [
+                'afterSave',
+                ['type' => 'folders', 'id' => 999],
+                false,
+            ],
+            'afterSave children' => [
+                'afterSave',
+                ['type' => 'folders', 'id' => 999, 'data' => ['relation' => 'children']],
+                true,
+            ],
+            'afterSave title' => [
+                'afterSave',
+                ['type' => 'folders', 'id' => 999, 'data' => ['title' => 'test']],
+                true,
+            ],
+            'afterSave status' => [
+                'afterSave',
+                ['type' => 'folders', 'id' => 999, 'data' => ['status' => 'on']],
+                true,
+            ],
+            'afterSaveRelated no data' => [
+                'afterSaveRelated',
+                [],
+                false,
+            ],
+            'afterSaveRelated type is not folders' => [
+                'afterSaveRelated',
+                ['type' => 'documents'],
+                false,
+            ],
+            'afterSaveRelated no children, no title, no status' => [
+                'afterSaveRelated',
+                ['type' => 'folders', 'id' => 999],
+                false,
+            ],
+            'afterSaveRelated children' => [
+                'afterSaveRelated',
+                ['type' => 'folders', 'id' => 999, 'data' => ['relation' => 'children']],
+                true,
+            ],
+            'afterSaveRelated title' => [
+                'afterSaveRelated',
+                ['type' => 'folders', 'id' => 999, 'data' => ['title' => 'test']],
+                true,
+            ],
+            'afterSaveRelated status' => [
+                'afterSaveRelated',
+                ['type' => 'folders', 'id' => 999, 'data' => ['status' => 'on']],
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * Test `afterDelete`, `afterSave` and `afterSaveRelated` methods
+     *
+     * @param array $data Event data.
+     * @param bool $cacheClear Expected cache action.
+     * @return void
+     * @dataProvider dataProvider
+     * @covers ::afterDelete()
+     * @covers ::updateCache()
+     */
+    public function testAll(string $method, array $data, bool $cacheClear): void
+    {
+        Cache::write('tree-parent-1', ['test' => 'data'], TreeCacheEventHandler::CACHE_CONFIG);
+        $handler = new TreeCacheEventHandler();
+        $event = new Event(sprintf('Controller.%s', $method), $this, $data);
+        $handler->{$method}($event);
+        $actual = Cache::read('tree-parent-1', TreeCacheEventHandler::CACHE_CONFIG);
+        $expected = $cacheClear ? null : ['test' => 'data'];
+        static::assertEquals($expected, $actual);
+    }
+}

--- a/tests/TestCase/Event/TreeCacheEventHandlerTest.php
+++ b/tests/TestCase/Event/TreeCacheEventHandlerTest.php
@@ -158,6 +158,8 @@ class TreeCacheEventHandlerTest extends TestCase
      * @return void
      * @dataProvider dataProvider
      * @covers ::afterDelete()
+     * @covers ::afterSave()
+     * @covers ::afterSaveRelated()
      * @covers ::updateCache()
      */
     public function testAll(string $method, array $data, bool $cacheClear): void

--- a/tests/TestCase/Event/TreeCacheEventHandlerTest.php
+++ b/tests/TestCase/Event/TreeCacheEventHandlerTest.php
@@ -107,6 +107,11 @@ class TreeCacheEventHandlerTest extends TestCase
                 ['type' => 'folders', 'id' => 999, 'data' => ['relation' => 'children']],
                 true,
             ],
+            'afterSave parent' => [
+                'afterSave',
+                ['type' => 'folders', 'id' => 999, 'data' => ['relation' => 'parent']],
+                true,
+            ],
             'afterSave title' => [
                 'afterSave',
                 ['type' => 'folders', 'id' => 999, 'data' => ['title' => 'test']],
@@ -135,6 +140,16 @@ class TreeCacheEventHandlerTest extends TestCase
             'afterSaveRelated children' => [
                 'afterSaveRelated',
                 ['type' => 'folders', 'id' => 999, 'data' => ['relation' => 'children']],
+                true,
+            ],
+            'afterSaveRelated parent' => [
+                'afterSaveRelated',
+                ['type' => 'folders', 'id' => 999, 'data' => ['relation' => 'parent']],
+                true,
+            ],
+            'afterSaveRelated children_order' => [
+                'afterSaveRelated',
+                ['type' => 'folders', 'id' => 999, 'data' => ['children_order' => 'position']],
                 true,
             ],
             'afterSaveRelated title' => [

--- a/tests/TestCase/Event/TreeCacheEventHandlerTest.php
+++ b/tests/TestCase/Event/TreeCacheEventHandlerTest.php
@@ -19,6 +19,7 @@ use Cake\Cache\Cache;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Text;
 
 /**
  * {@see \App\Event\TreeCacheEventHandler} Test Case
@@ -161,6 +162,9 @@ class TreeCacheEventHandlerTest extends TestCase
      */
     public function testAll(string $method, array $data, bool $cacheClear): void
     {
+        $randomString = Text::uuid();
+        $randomNumber = rand(0, 100);
+        Cache::write($randomString, $randomNumber, 'default');
         Cache::write('tree-parent-1', ['test' => 'data'], TreeCacheEventHandler::CACHE_CONFIG);
         $handler = new TreeCacheEventHandler();
         $event = new Event(sprintf('Controller.%s', $method), $this, $data);
@@ -168,5 +172,6 @@ class TreeCacheEventHandlerTest extends TestCase
         $actual = Cache::read('tree-parent-1', TreeCacheEventHandler::CACHE_CONFIG);
         $expected = $cacheClear ? null : ['test' => 'data'];
         static::assertEquals($expected, $actual);
+        static::assertEquals(Cache::read($randomString), $randomNumber);
     }
 }


### PR DESCRIPTION
This introduces optimizations for folders tree data fetch.

### New endpoint tree

Basically BEM provides a new `/tree` endpoint, to use when `?filter[roots]` e `?filter[parent]` are involved.
When using `/tree` endpoint, minimal data (id, title, status) and meta is returned (no links, no included).
Page size for "get children" calls was default (20), now it is 100: this means that the number of total calls can be 1/5 compared with the previous behaviour.
The javascript component `tree-view` uses this new endpoint to tree data.
This optimizes cases of data load of huge tree branches.

### Tree cache

Every `GET /tree?filter[roots]` and `GET /tree?filter[parent]=<>&...` are stored in a cache.
Cache invalidation is provided by a `TreeCacheEventHandler` that perform a `Cache::clearGroup('tree', '_tree_data_')` (`tree` group cache is deleted... in future we could clear only some tree branches).

`TreeCacheEventHandler` is called when: an object is saved, an object is deleted, object relation data is changed: the handler does nothing if `folders` nor `parents`|`children` are involved, or "delicate" data is unchanged (`status`, `title` , `parent`, `children`, `children_order`).

Invalidation logic can be better. We introduce a basic logic for now.
