### PR TITLE
Optimize tree loading

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -101,6 +101,21 @@ $routes->scope('/', function (RouteBuilder $routes) {
         ['controller' => 'Tree', 'action' => 'get'],
         ['_name' => 'tree:get']
     );
+    $routes->connect(
+        '/tree/node/{id}',
+        ['controller' => 'Tree', 'action' => 'node'],
+        ['_name' => 'tree:node', 'pass' => ['id']]
+    );
+    $routes->connect(
+        '/tree/parent/{id}',
+        ['controller' => 'Tree', 'action' => 'parent'],
+        ['_name' => 'tree:parent', 'pass' => ['id']]
+    );
+    $routes->connect(
+        '/tree/parents/{type}/{id}',
+        ['controller' => 'Tree', 'action' => 'parents'],
+        ['_name' => 'tree:parents', 'pass' => ['type', 'id']]
+    );
 
     // Admin.
     $routes->prefix('admin', ['_namePrefix' => 'admin:'], function (RouteBuilder $routes) {

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-02-26 14:54:49 \n"
+"POT-Creation-Date: 2024-03-19 07:51:20 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1221,7 +1221,28 @@ msgstr ""
 msgid "Canonical"
 msgstr ""
 
+msgid "Loading branches for position"
+msgstr ""
+
+msgid "Loading children for folder"
+msgstr ""
+
+msgid "Loading folder"
+msgstr ""
+
+msgid "Loading parent for folder"
+msgstr ""
+
+msgid "Loading positions for object"
+msgstr ""
+
+msgid "Loading root folders"
+msgstr ""
+
 msgid "Menu"
+msgstr ""
+
+msgid "page"
 msgstr ""
 
 msgid "View"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-02-26 14:54:49 \n"
+"POT-Creation-Date: 2024-03-19 07:51:20 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1224,7 +1224,28 @@ msgstr ""
 msgid "Canonical"
 msgstr ""
 
+msgid "Loading branches for position"
+msgstr ""
+
+msgid "Loading children for folder"
+msgstr ""
+
+msgid "Loading folder"
+msgstr ""
+
+msgid "Loading parent for folder"
+msgstr ""
+
+msgid "Loading positions for object"
+msgstr ""
+
+msgid "Loading root folders"
+msgstr ""
+
 msgid "Menu"
+msgstr ""
+
+msgid "page"
 msgstr ""
 
 msgid "View"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-02-26 14:54:49 \n"
+"POT-Creation-Date: 2024-03-19 07:51:20 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1236,8 +1236,29 @@ msgstr "Utente"
 msgid "Canonical"
 msgstr "Canonica"
 
+msgid "Loading branches for position"
+msgstr "Caricamento rami per posizione"
+
+msgid "Loading children for folder"
+msgstr "Caricamento contenuti per cartella"
+
+msgid "Loading folder"
+msgstr "Caricamento cartella"
+
+msgid "Loading parent for folder"
+msgstr "Caricamento genitore per cartella"
+
+msgid "Loading positions for object"
+msgstr "Caricamento posizioni per oggetto"
+
+msgid "Loading root folders"
+msgstr "Caricamento cartelle principali"
+
 msgid "Menu"
 msgstr "Menù"
+
+msgid "page"
+msgstr "pagina"
 
 msgid "View"
 msgstr "Vedi"

--- a/resources/js/app/components/folder-picker/folder-picker.js
+++ b/resources/js/app/components/folder-picker/folder-picker.js
@@ -75,7 +75,8 @@ export default {
             const pageSize = 100;
             const filter = !parent ? 'filter[roots]' : `filter[parent]=${parent.id}`;
             const firstResponse = await fetch(`${API_URL}tree?${filter}&page=1&page_size=${pageSize}`, API_OPTIONS);
-            const json = await firstResponse.json();
+            let json = await firstResponse.json();
+            json = json.tree || {};
             const folders = [...(json.data || [])];
             const pageCount = json.meta.pagination.page_count;
 

--- a/tests/TestCase/Controller/TreeControllerTest.php
+++ b/tests/TestCase/Controller/TreeControllerTest.php
@@ -16,9 +16,8 @@ namespace App\Test\TestCase\Controller;
 
 use App\Controller\TreeController;
 use BEdita\SDK\BEditaClientException;
-use BEdita\WebTools\ApiClientProvider;
 use Cake\Http\ServerRequest;
-use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * {@see \App\Controller\TreeController} Test Case
@@ -26,7 +25,7 @@ use Cake\TestSuite\TestCase;
  * @coversDefaultClass \App\Controller\TreeController
  * @uses \App\Controller\TreeController
  */
-class TreeControllerTest extends TestCase
+class TreeControllerTest extends BaseControllerTest
 {
     /**
      * @inheritDoc
@@ -38,33 +37,12 @@ class TreeControllerTest extends TestCase
     }
 
     /**
-     * Test api client
-     *
-     * @var \BEdita\SDK\BEditaClient
-     */
-    public $client;
-
-    /**
-     * Setup api client and auth
-     *
-     * @return void
-     */
-    private function setupApi(): void
-    {
-        $this->client = ApiClientProvider::getApiClient();
-        $adminUser = getenv('BEDITA_ADMIN_USR');
-        $adminPassword = getenv('BEDITA_ADMIN_PWD');
-        $response = $this->client->authenticate($adminUser, $adminPassword);
-        $this->client->setupTokens($response['meta']);
-    }
-
-    /**
      * Test `get` method
      *
      * @return void
      * @covers ::get()
-     * @covers ::data()
-     * @covers ::fetchData()
+     * @covers ::treeData()
+     * @covers ::fetchTreeData()
      */
     public function testGet(): void
     {
@@ -88,11 +66,11 @@ class TreeControllerTest extends TestCase
     }
 
     /**
-     * Test `data` method on exception
+     * Test `treeData` method on exception
      *
      * @return void
      * @covers ::get()
-     * @covers ::data()
+     * @covers ::treeData()
      */
     public function testDataException(): void
     {
@@ -113,6 +91,227 @@ class TreeControllerTest extends TestCase
         };
         $tree->get();
         $actual = $tree->viewBuilder()->getVar('tree');
+        static::assertEmpty($actual);
+    }
+
+    /**
+     * Test `node` method
+     *
+     * @return void
+     * @covers ::node()
+     * @covers ::fetchNodeData()
+     * @covers ::minimalData()
+     */
+    public function testNode(): void
+    {
+        $this->setupApi();
+        $folder = $this->createTestFolder();
+        $id = (string)Hash::get($folder, 'id');
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+            'get' => [],
+            'params' => compact('id'),
+        ];
+        $request = new ServerRequest($config);
+        $tree = new TreeController($request);
+        $tree->node($id);
+        $actual = $tree->viewBuilder()->getVar('node');
+        static::assertNotEmpty($actual);
+        static::assertEquals($id, $actual['id']);
+        static::assertEquals('folders', $actual['type']);
+        static::assertEquals('controller test folder', $actual['attributes']['title']);
+        $expectedAttributes = ['status', 'title'];
+        $actualAttributes = array_keys($actual['attributes']);
+        sort($actualAttributes);
+        static::assertEquals($expectedAttributes, $actualAttributes);
+    }
+
+    /**
+     * Test `node` method
+     *
+     * @return void
+     * @covers ::node()
+     * @covers ::fetchNodeData()
+     */
+    public function testNodeException(): void
+    {
+        $this->setupApi();
+        $id = '99999999';
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+            'get' => [],
+            'params' => compact('id'),
+        ];
+        $request = new ServerRequest($config);
+        $tree = new TreeController($request);
+        $tree->node($id);
+        $actual = $tree->viewBuilder()->getVar('node');
+        static::assertEmpty($actual);
+    }
+
+    /**
+     * Test `parent` method
+     *
+     * @return void
+     * @covers ::parent()
+     * @covers ::fetchParentData()
+     * @covers ::minimalDataWithMeta()
+     */
+    public function testParent(): void
+    {
+        $this->setupApi();
+        $parent = $this->createTestFolder();
+        $response = $this->client->save('folders', [
+            'title' => 'controller test folder child',
+            'parent_id' => (string)Hash::get($parent, 'id'),
+        ]);
+        $child = $response['data'];
+        $id = (string)Hash::get($child, 'id');
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+            'get' => [],
+            'params' => compact('id'),
+        ];
+        $request = new ServerRequest($config);
+        $tree = new TreeController($request);
+        $tree->parent($id);
+        $actual = $tree->viewBuilder()->getVar('parent');
+        static::assertNotEmpty($actual);
+        static::assertEquals('folders', $actual['type']);
+        static::assertEquals($parent['id'], $actual['id']);
+    }
+
+    /**
+     * Test `parent` method
+     *
+     * @return void
+     * @covers ::parent()
+     * @covers ::fetchParentData()
+     * @covers ::minimalDataWithMeta()
+     */
+    public function testParentNull(): void
+    {
+        $this->setupApi();
+        $child = $this->createTestFolder();
+        $id = (string)Hash::get($child, 'id');
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+            'get' => [],
+            'params' => compact('id'),
+        ];
+        $request = new ServerRequest($config);
+        $tree = new TreeController($request);
+        $tree->parent($id);
+        $actual = $tree->viewBuilder()->getVar('parent');
+        static::assertNull($actual);
+    }
+
+    /**
+     * Test `parent` method
+     *
+     * @return void
+     * @covers ::parent()
+     * @covers ::fetchParentData()
+     */
+    public function testParentException(): void
+    {
+        $this->setupApi();
+        $id = '99999999';
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+            'get' => [],
+            'params' => compact('id'),
+        ];
+        $request = new ServerRequest($config);
+        $tree = new TreeController($request);
+        $tree->parent($id);
+        $actual = $tree->viewBuilder()->getVar('parent');
+        static::assertEmpty($actual);
+    }
+
+    /**
+     * Test `parents` method
+     *
+     * @return void
+     * @covers ::parents()
+     * @covers ::fetchParentsData()
+     * @covers ::minimalData()
+     */
+    public function testParents(): void
+    {
+        $this->setupApi();
+        $parent = $this->createTestFolder();
+        $docs = [
+            'child document 1',
+            'child document 2',
+            'child document 3',
+        ];
+        $ids = [];
+        $type = 'documents';
+        foreach ($docs as $title) {
+            $response = $this->client->save($type, [
+                'title' => $title,
+            ]);
+            $this->client->addRelated($parent['id'], 'folders', 'children', [
+                [
+                    'id' => (string)Hash::get($response, 'data.id'),
+                    'type' => $type,
+                ],
+            ]);
+            $ids[] = (string)Hash::get($response, 'data.id');
+        }
+        foreach ($ids as $id) {
+            $config = [
+                'environment' => [
+                    'REQUEST_METHOD' => 'GET',
+                ],
+                'get' => [],
+                'params' => compact('type', 'id'),
+            ];
+            $request = new ServerRequest($config);
+            $tree = new TreeController($request);
+            $tree->parents($type, $id);
+            $actual = $tree->viewBuilder()->getVar('parents');
+            $actual = $actual[0];
+            static::assertNotEmpty($actual);
+            static::assertEquals('folders', $actual['type']);
+            static::assertEquals($parent['id'], $actual['id']);
+        }
+    }
+
+    /**
+     * Test `parents` method on exception
+     *
+     * @return void
+     * @covers ::parents()
+     * @covers ::fetchParentsData()
+     */
+    public function testParentsException(): void
+    {
+        $this->setupApi();
+        $type = 'documents';
+        $id = '99999999999';
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+            'get' => [],
+            'params' => compact('type', 'id'),
+        ];
+        $request = new ServerRequest($config);
+        $tree = new TreeController($request);
+        $tree->parents($type, $id);
+        $actual = $tree->viewBuilder()->getVar('parents');
         static::assertEmpty($actual);
     }
 }

--- a/tests/TestCase/Controller/TreeControllerTest.php
+++ b/tests/TestCase/Controller/TreeControllerTest.php
@@ -348,6 +348,5 @@ class TreeControllerTest extends BaseControllerTest
         };
         $actual = $tree->minData([]);
         static::assertEmpty($actual);
-
     }
 }

--- a/tests/TestCase/Controller/TreeControllerTest.php
+++ b/tests/TestCase/Controller/TreeControllerTest.php
@@ -80,11 +80,11 @@ class TreeControllerTest extends BaseControllerTest
                 'REQUEST_METHOD' => 'GET',
             ],
             'get' => [],
-            'query' => ['filter' => ['parent' => 999], 'pageSize' => 10],
+            'query' => [],
         ];
         $request = new ServerRequest($config);
         $tree = new class ($request) extends TreeController {
-            public function fetchData(array $query): array
+            public function fetchTreeData(array $query): array
             {
                 throw new BEditaClientException('test exception');
             }


### PR DESCRIPTION
This provides an optimization on tree load data in 2 ways: performance (using cache and reducing total calls number) and UI.

This introduces 3 endpoints (that internally use cache):

 - GET /tree/node/{id} (cache key is `tree-node-<id>`)
 - GET /tree/parent/{id} (cache key is `tree-parent-<id>`)
 - GET /tree/parents/{type}/{id} (cache key is `tree-parents-<id>-<type>`)

In UI, we have a message that tells what exactly it's loading in that moment: the user knows what's going on.
