### PR TITLE
Fix tree parents metadata

### DIFF
--- a/resources/js/app/components/tree-view/tree-view.vue
+++ b/resources/js/app/components/tree-view/tree-view.vue
@@ -388,9 +388,15 @@ export default {
             let included = json.parents || [];
             this.totalCounter = included.length;
             this.loadingCounter = 0;
+
+            // store parents with meta
             for (let item of included) {
                 this.store[item.id] = item;
                 this.parents.push(item);
+            }
+
+            // load parent for each included
+            for (let item of included) {
                 item = await this.loadFolderParentRecursive(item);
                 this.loadingCounter++;
                 this.loadingMainMessage = this.msgLoadingBranchesForPosition + `: ${this.loadingCounter} / ${this.totalCounter}`;
@@ -431,6 +437,7 @@ export default {
          * @return {Promise}
          */
         async loadChildren(folder) {
+            console.log(folder.attributes.title, Object.keys(this.store));
             let page = 1;
             let children = [];
             let done = false;

--- a/resources/js/app/components/tree-view/tree-view.vue
+++ b/resources/js/app/components/tree-view/tree-view.vue
@@ -389,13 +389,13 @@ export default {
             this.totalCounter = included.length;
             this.loadingCounter = 0;
 
-            // store parents with meta
-            for (let item of included) {
+            // first, store parent references with meta
+            included.forEach((item) => {
                 this.store[item.id] = item;
                 this.parents.push(item);
-            }
+            });
 
-            // load parent for each included
+            // then load parent for each included
             for (let item of included) {
                 item = await this.loadFolderParentRecursive(item);
                 this.loadingCounter++;
@@ -437,7 +437,6 @@ export default {
          * @return {Promise}
          */
         async loadChildren(folder) {
-            console.log(folder.attributes.title, Object.keys(this.store));
             let page = 1;
             let children = [];
             let done = false;

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -212,7 +212,7 @@ class TreeController extends AppController
                     $response = ApiClientProvider::getApiClient()->get(sprintf('/%s/%s?include=parents', $type, $id));
                     $included = (array)Hash::get($response, 'included');
                     foreach ($included as &$item) {
-                        $item = $this->minimalData((array)$item);
+                        $item = $this->minimalDataWithMeta((array)$item);
                     }
 
                     return $included;

--- a/src/Event/TreeCacheEventHandler.php
+++ b/src/Event/TreeCacheEventHandler.php
@@ -77,17 +77,18 @@ class TreeCacheEventHandler implements EventListenerInterface
      */
     protected function updateCache(array $data): void
     {
-        $type = (string)Hash::get($data, 'type');
-        if ($type !== 'folders') {
+        $relation = (string)Hash::get($data, 'data.relation');
+        if (in_array($relation, ['children', 'parent', 'parents'])) {
+            Cache::clearGroup('tree', self::CACHE_CONFIG);
+
             return;
         }
-        $children = (string)Hash::get($data, 'data.relation') === 'children';
-        $parent = (string)Hash::get($data, 'data.relation') === 'parent';
-        $position = (string)Hash::get($data, 'data.children_order') === 'position';
-        $intersection = array_intersect(array_keys((array)Hash::get($data, 'data')), ['title', 'status']);
-        if (empty($intersection) && !$children && !$parent && !$position) {
-            return;
+        if ((string)Hash::get($data, 'type') === 'folders') {
+            $position = (string)Hash::get($data, 'data.children_order') === 'position';
+            $intersection = array_intersect(array_keys((array)Hash::get($data, 'data')), ['title', 'status']);
+            if (!empty($intersection) || $position) {
+                Cache::clearGroup('tree', self::CACHE_CONFIG);
+            }
         }
-        Cache::clearGroup('tree', self::CACHE_CONFIG);
     }
 }

--- a/tests/TestCase/Event/TreeCacheEventHandlerTest.php
+++ b/tests/TestCase/Event/TreeCacheEventHandlerTest.php
@@ -92,7 +92,7 @@ class TreeCacheEventHandlerTest extends TestCase
                 [],
                 false,
             ],
-            'afterSave type is not folders' => [
+            'afterSave type is not folders, and no relation' => [
                 'afterSave',
                 ['type' => 'documents'],
                 false,
@@ -110,6 +110,11 @@ class TreeCacheEventHandlerTest extends TestCase
             'afterSave parent' => [
                 'afterSave',
                 ['type' => 'folders', 'id' => 999, 'data' => ['relation' => 'parent']],
+                true,
+            ],
+            'afterSave parents' => [
+                'afterSave',
+                ['type' => 'documents', 'id' => 999, 'data' => ['relation' => 'parents']],
                 true,
             ],
             'afterSave title' => [
@@ -145,6 +150,11 @@ class TreeCacheEventHandlerTest extends TestCase
             'afterSaveRelated parent' => [
                 'afterSaveRelated',
                 ['type' => 'folders', 'id' => 999, 'data' => ['relation' => 'parent']],
+                true,
+            ],
+            'afterSaveRelated parents' => [
+                'afterSaveRelated',
+                ['type' => 'documents', 'id' => 999, 'data' => ['relation' => 'parents']],
                 true,
             ],
             'afterSaveRelated children_order' => [


### PR DESCRIPTION
Parents chain was loaded before all direct parents (which include metadata) were added to the store. This PR should fix it and restore the `menu`/`canonical` state.