### PR TITLE
Folder picker load all children for a branch

### DIFF
--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-03-19 07:51:20 \n"
+"POT-Creation-Date: 2024-03-21 08:19:20 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1460,6 +1460,9 @@ msgstr ""
 msgid ""
 "Restored data will replace current data (you can still check the data before "
 "saving). Are you sure?"
+msgstr ""
+
+msgid "untitled"
 msgstr ""
 
 msgid "Every day"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-03-19 07:51:20 \n"
+"POT-Creation-Date: 2024-03-21 08:19:20 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1463,6 +1463,9 @@ msgstr ""
 msgid ""
 "Restored data will replace current data (you can still check the data before "
 "saving). Are you sure?"
+msgstr ""
+
+msgid "untitled"
 msgstr ""
 
 msgid "Every day"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-03-19 07:51:20 \n"
+"POT-Creation-Date: 2024-03-21 08:19:20 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1478,6 +1478,9 @@ msgid ""
 msgstr ""
 "I dati recuperati sostiruiranno quelli attuali (potrai comunque controllarli "
 "prima di salvare). Vuoi procedere?"
+
+msgid "untitled"
+msgstr "senza titolo"
 
 msgid "Every day"
 msgstr "Tutti i giorni"

--- a/resources/js/app/components/folder-picker/folder-picker.js
+++ b/resources/js/app/components/folder-picker/folder-picker.js
@@ -1,5 +1,6 @@
 import { Treeselect, LOAD_ROOT_OPTIONS, LOAD_CHILDREN_OPTIONS } from '@riophae/vue-treeselect';
 import '@riophae/vue-treeselect/dist/vue-treeselect.css';
+import { t } from 'ttag';
 
 const API_URL = new URL(BEDITA.base).pathname;
 const API_OPTIONS = {
@@ -8,6 +9,7 @@ const API_OPTIONS = {
         'accept': 'application/json',
     }
 };
+const PAGE_SIZE = 100;
 
 /**
  * Folder picker component.
@@ -72,25 +74,18 @@ export default {
 
     methods: {
         async fetchFolders(parent) {
-            const pageSize = 100;
             const filter = !parent ? 'filter[roots]' : `filter[parent]=${parent.id}`;
-            const firstResponse = await fetch(`${API_URL}tree?${filter}&page=1&page_size=${pageSize}`, API_OPTIONS);
-            let json = await firstResponse.json();
-            json = json.tree || {};
-            const folders = [...(json.data || [])];
-            const pageCount = json.meta.pagination.page_count;
-
-            const deferred = [];
+            const firstResponse = await fetch(`${API_URL}tree?${filter}&page=1&page_size=${PAGE_SIZE}`, API_OPTIONS);
+            const json = await firstResponse.json();
+            const folders = [...(json?.tree?.data || [])];
+            const pageCount = json?.tree?.meta?.pagination?.page_count || 1;
             for (let page = 2; page <= pageCount; page++) {
-                deferred.push(fetch(`${API_URL}tree?${filter}&page=${page}&page_size=${pageSize}`, API_OPTIONS));
-            }
-            const responses = await Promise.all(deferred);
-            responses.forEach(async (response) => {
+                const response = await fetch(`${API_URL}tree?${filter}&page=${page}&page_size=${PAGE_SIZE}`, API_OPTIONS);
                 const json = await response.json();
-                folders.push(...(json.data || []));
-            });
+                folders.push(...(json?.tree?.data || []));
+            }
 
-            return folders.map((folder) => ({ id: folder.id, label: folder.attributes.title, children: null }));
+            return folders.map((folder) => ({ id: folder.id, label: folder.attributes.title || '(' + t`untitled` + ' ' + folder.id + ')', children: null }));
         },
 
         async loadOptions({ action, parentNode, callback }) {

--- a/resources/js/app/components/uri-input.js
+++ b/resources/js/app/components/uri-input.js
@@ -22,6 +22,8 @@ export default {
         const anchor = document.createElement('a');
         anchor.innerHTML = t`Open Uri`;
         anchor.classList.add('icon-link-ext');
+        anchor.classList.add('mt-075');
+        anchor.classList.add('is-block');
         anchor.style = 'cursor: pointer;';
         anchor.addEventListener('click', (ev) => {
             ev.preventDefault()

--- a/resources/styles/_utility_classes.scss
+++ b/resources/styles/_utility_classes.scss
@@ -10,6 +10,8 @@
 
 .is-text-hidden { @include hide-text(); }
 
+.is-block { display: block;}
+
 .is-clipped { overflow: hidden!important; }
 
 .is-expanded { width: 100%; }
@@ -109,6 +111,7 @@
 .mt-0     { margin-top: 0 !important; }
 .mt-025    { margin-top: $gutter * .25; }
 .mt-05    { margin-top: $gutter * .5; }
+.mt-075    { margin-top: $gutter * .75; }
 .mt-1     { margin-top: $gutter; }
 .mt-15    { margin-top: $gutter * 1.5; }
 .mt-2     { margin-top: $gutter * 2; }


### PR DESCRIPTION
This fixes a limit in folder picker: when loading branch children, force to load them all.

Bonus: minor UI fix for uri-input