### PR TITLE
Fix svg images do not need thumbnails

### DIFF
--- a/templates/Element/Form/media.twig
+++ b/templates/Element/Form/media.twig
@@ -27,8 +27,11 @@
                 <div class="stream">
                     {# thumb #}
                     {% if object.type == 'images' %}
-                        {# TODO process below #}
-                        {% set thumb = Thumb.getUrl(object) %}
+                        {% if stream.attributes.mime_type == 'image/svg+xml' %}
+                            {% set thumb = stream.meta.url %}
+                        {% else %}
+                            {% set thumb = Thumb.getUrl(object) %}
+                        {% endif %}
                         {% if thumb == constant('BEdita\\WebTools\\View\\Helper\\ThumbHelper::NOT_ACCEPTABLE') %}
                             <p>{{ __('Cannot produce a thumbnail for this file') }}</p>
                         {% elseif thumb == constant('BEdita\\WebTools\\View\\Helper\\ThumbHelper::NOT_AVAILABLE') %}


### PR DESCRIPTION
This provides a fix on images object view: when the referenced image file is an svg, do not load a thumbnail, use original file instead.