### PR TITLE
Svg in media list, do not use thumbnails

### DIFF
--- a/templates/Element/Form/media.twig
+++ b/templates/Element/Form/media.twig
@@ -52,7 +52,7 @@
                         {% else %}
                             <figure class="thumb">
                                 <a href={{ stream.meta.url }} title="{{ __('Open image') }}" target="_blank">
-                                    <img :src=previewImage("{{ thumb }}") alt="" id="imageThumb" />
+                                    <img :src=previewImage("{{ thumb }}") alt="" id="imageThumb" style="min-width:500px;" />
                                 </a>
                             </figure>
                         {% endif %}

--- a/templates/Element/Modules/thumb.twig
+++ b/templates/Element/Modules/thumb.twig
@@ -4,12 +4,16 @@
 {# Use external provider thumbnail if available #}
 {% if object.attributes.provider_thumbnail %}
 
-        <img src={{ object.attributes.provider_thumbnail }} width={{ width }} />
+    <img src={{ object.attributes.provider_thumbnail }} width={{ width }} />
 
 {# Otherwise create/display thumb if type is an image #}
 {% elseif object.type ==  'images' %}
 
-    {% set thumb = Thumb.getUrl(object, { 'options': { 'w': width } }) %}
+    {% if object.relationships.streams.data[0].attributes.mime_type == 'image/svg+xml' %}
+        {% set thumb = object.relationships.streams.data[0].meta.url %}
+    {% else %}
+        {% set thumb = Thumb.getUrl(object, { 'options': { 'w': width } }) %}
+    {% endif %}
 
     {% if thumb == constant('BEdita\\WebTools\\View\\Helper\\ThumbHelper::NOT_AVAILABLE') %}
         <div class="missing-image has-text-size-largest" title="{{ __('Thumb not available') }}">


### PR DESCRIPTION
This provides a fix to avoid ask for thumbnail in media list when file is svg.