### PR TITLE
Handle missing `Project.config.I18n` configuration

### DIFF
--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-04-16 10:48:09 \n"
+"POT-Creation-Date: 2024-05-06 10:50:24 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -506,6 +506,9 @@ msgid "No import filters set"
 msgstr ""
 
 msgid "No items found"
+msgstr ""
+
+msgid "No language configuration found"
 msgstr ""
 
 msgid "Number of created objects"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-04-16 10:31:11 \n"
+"POT-Creation-Date: 2024-05-06 10:50:24 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -509,6 +509,9 @@ msgid "No import filters set"
 msgstr ""
 
 msgid "No items found"
+msgstr ""
+
+msgid "No language configuration found"
 msgstr ""
 
 msgid "Number of created objects"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-04-16 10:48:09 \n"
+"POT-Creation-Date: 2024-05-06 10:50:24 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -512,6 +512,9 @@ msgstr "Nessun filtro di importazione impostato"
 
 msgid "No items found"
 msgstr "Nessun elemento trovato"
+
+msgid "No language configuration found"
+msgstr "Lingue non configurate a sistema"
 
 msgid "Number of created objects"
 msgstr "Numero di oggetti creati"

--- a/templates/Element/Form/related_translations.twig
+++ b/templates/Element/Form/related_translations.twig
@@ -25,9 +25,6 @@
                 {% if not config('Project.config.I18n') %}
                 <div class="alert alert-warning">
                     {{ __('No language configuration found') }}
-                    {% if Perms.userIsAdmin() %}
-                        <code>Project.config.I18n</code>
-                    {% endif %}
                 </div>
                 {% endif %}
 

--- a/templates/Element/Form/related_translations.twig
+++ b/templates/Element/Form/related_translations.twig
@@ -22,10 +22,20 @@
 
             <div v-show="isOpen" class="tab-container">
 
+                {% if not config('Project.config.I18n') %}
+                <div class="alert alert-warning">
+                    {{ __('No language configuration found') }}
+                    {% if Perms.userIsAdmin() %}
+                        <code>Project.config.I18n</code>
+                    {% endif %}
+                </div>
+                {% endif %}
+
+                {% if config('Project.config.I18n') %}
                 <div>
                     <language-selector
                         language="{{ object.id ? object.attributes.lang : config('Project.config.I18n.default') }}"
-                        :languages="{{ config('Project.config.I18n.languages')|default([])|json_encode|escape('html_attr') }}">
+                        :languages="{{ config('Project.config.I18n.languages')|default({"en":"English","it":"Italiano"})|json_encode|escape('html_attr') }}">
                     </language-selector>
 
                     {% if translatable and object.attributes.lang %}
@@ -39,6 +49,7 @@
                         })|raw }}
                     {% endif %}
                 </div>
+                {% endif %}
 
                 {% if object.relationships.translations %}
                 <relation-view inline-template


### PR DESCRIPTION
This provides a fix on missing `Project.config.I18n` configuration.

![image](https://github.com/bedita/manager/assets/2227145/f3c91a2c-7a49-41f7-9a06-29cbe56d08c6)
