### PR TITLE
Fix ClipboardItem in relations-add

### DIFF
--- a/resources/js/app/components/relation-view/relations-add.js
+++ b/resources/js/app/components/relation-view/relations-add.js
@@ -36,6 +36,7 @@ export default {
     components: {
         FilterBoxView: () => import(/* webpackChunkName: "filter-box-view" */'app/components/filter-box'),
         Thumbnail:() => import(/* webpackChunkName: "thumbnail" */'app/components/thumbnail/thumbnail'),
+        ClipboardItem: () => import(/* webpackChunkName: "clipboard-item" */'app/components/clipboard-item/clipboard-item'),
     },
 
     props: {


### PR DESCRIPTION
This fixes a dependency in the component "relations-add", that references `ClipboardItem`, recently introduced by https://github.com/bedita/manager/pull/1108.