### PR TITLE
Enhance Categories UI in object view

### DIFF
--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-05-14 13:15:48 \n"
+"POT-Creation-Date: 2024-05-14 13:49:36 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-05-06 15:05:20 \n"
+"POT-Creation-Date: 2024-05-14 13:15:48 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1381,6 +1381,9 @@ msgstr ""
 msgid "Error on deleting property"
 msgstr ""
 
+msgid "Search on categories"
+msgstr ""
+
 msgid "Password"
 msgstr ""
 
@@ -1455,7 +1458,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-05-06 15:03:42 \n"
+"POT-Creation-Date: 2024-05-14 13:15:48 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1384,6 +1384,9 @@ msgstr ""
 msgid "Error on deleting property"
 msgstr ""
 
+msgid "Search on categories"
+msgstr ""
+
 msgid "Password"
 msgstr ""
 
@@ -1458,7 +1461,7 @@ msgstr ""
 
 #. *
 #.  * Component to fetch and display changes' history.
-#.
+#.  
 msgid "No History data found"
 msgstr ""
 

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-05-14 13:15:48 \n"
+"POT-Creation-Date: 2024-05-14 13:49:36 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-05-06 14:24:10 \n"
+"POT-Creation-Date: 2024-05-14 13:15:48 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -408,8 +408,8 @@ msgstr "Lingua e traduzioni"
 msgid "Left types"
 msgstr "Tipi di sinistra"
 
-msgid "Less filters"
-msgstr "Meno filtri"
+msgid "Less"
+msgstr ""
 
 msgid "List"
 msgstr "Lista"
@@ -470,9 +470,6 @@ msgstr "Moduli"
 
 msgid "More"
 msgstr "Altro"
-
-msgid "More filters"
-msgstr "Più filtri"
 
 msgid "Move to"
 msgstr "Sposta in"
@@ -686,8 +683,8 @@ msgstr "Rimuovi"
 msgid "Request password"
 msgstr "Reimposta password"
 
-msgid "Reset filters"
-msgstr "Reset filtri"
+msgid "Reset"
+msgstr ""
 
 msgid "Resource \"%s\" not available. Error: %s"
 msgstr "Risorsa \"%s\" non disponibile. Error: %s"
@@ -1203,8 +1200,15 @@ msgstr "Annulla"
 msgid "Mail to"
 msgstr "Invia mail a"
 
+msgid "Txt"
+msgstr ""
+
 msgid "Items"
 msgstr "Elementi"
+
+#, javascript-format
+msgid "Search by ${ selectedType }"
+msgstr ""
 
 msgid "NULL"
 msgstr ""
@@ -1392,6 +1396,9 @@ msgstr "Traducibile"
 msgid "Error on deleting property"
 msgstr "Errore nella cancellazione della proprietà"
 
+msgid "Search on categories"
+msgstr "Cerca tra le categorie"
+
 msgid "Password"
 msgstr "Password"
 
@@ -1529,3 +1536,12 @@ msgstr "Errore durante il salvataggio della categoria"
 
 msgid "Error on deleting category"
 msgstr "Errore durante l'eliminazione della categoria"
+
+#~ msgid "Less filters"
+#~ msgstr "Meno filtri"
+
+#~ msgid "More filters"
+#~ msgstr "Più filtri"
+
+#~ msgid "Reset filters"
+#~ msgstr "Reset filtri"

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -82,6 +82,7 @@ const _vueInstance = new Vue({
         UserAccesses:() => import(/* webpackChunkName: "user-accesses" */'app/components/user-accesses/user-accesses'),
         LanguageSelector:() => import(/* webpackChunkName: "language-selector" */'app/components/language-selector/language-selector'),
         ClipboardItem: () => import(/* webpackChunkName: "clipboard-item" */'app/components/clipboard-item/clipboard-item'),
+        ObjectCategories: () => import(/* webpackChunkName: "object-categories" */'app/components/object-categories/object-categories'),
         AppIcon,
     },
 

--- a/resources/js/app/components/object-categories/object-categories.vue
+++ b/resources/js/app/components/object-categories/object-categories.vue
@@ -16,9 +16,13 @@
                 <span class="ml-05">{{ msgEmpty }}</span>
             </button>
         </div>
+        <div v-if="searchInCategories.length" class="is-expanded tag mt-1">
+            <app-icon icon="carbon:filter"></app-icon>
+            <span class="ml-05">{{ msgDataIsFiltered }}</span>
+        </div>
         <details :open="forceOpen || countSelectedCommon() > 0 || foundInCommon()" v-if="common?.length > 0">
             <summary>
-                GLOBAL
+                {{ msgGlobal }}
                 <span
                     class="tag is-smallest is-black mx-05"
                     :class="countSelectedCommon() === 0 ? 'empty' : ''"
@@ -103,7 +107,9 @@ export default {
             root: [],
             searchInCategories: '',
             selected: [],
+            msgDataIsFiltered: t`Data is filtered`,
             msgEmpty: t`Empty`,
+            msgGlobal: t`Global`,
             msgSearch: t`Search on categories`,
         }
     },

--- a/resources/js/app/components/object-categories/object-categories.vue
+++ b/resources/js/app/components/object-categories/object-categories.vue
@@ -1,0 +1,185 @@
+<template>
+    <div class="object-categories">
+        <details :open="forceOpen || countSelectedCommon() > 0" v-if="common?.length > 0">
+            <summary>
+                GLOBAL
+                <span
+                    class="tag is-smallest is-black mx-05"
+                    :class="countSelectedCommon() === 0 ? 'empty' : ''"
+                >
+                    {{ countSelectedCommon() }} / {{ common.length }}
+                </span>
+            </summary>
+            <div class="categories-children">
+                <div
+                    class="checkbox"
+                    v-for="child in common"
+                    :key="child.name"
+                >
+                    <label>
+                        <input
+                            :id="`categories-${child.name}`"
+                            type="checkbox"
+                            name="categories[]"
+                            :value="child.name"
+                            :checked="child.name in selected"
+                            v-model="selected"
+                        >
+                        {{ child.label || child.name }}
+                    </label>
+                </div>
+            </div>
+        </details>
+        <details :open="forceOpen || countSelectedByParent(parent.id) > 0" v-for="parent in root" :key="parent.name">
+            <summary>
+                {{ parent.label || parent.name }}
+                <span
+                    class="tag is-smallest is-black mx-05"
+                    :class="countSelectedByParent(parent.id) === 0 ? 'empty' : ''"
+                >
+                    {{ countSelectedByParent(parent.id) }} / {{ children[parent.id].length }}
+                </span>
+            </summary>
+            <div class="categories-children">
+                <div
+                    class="checkbox"
+                    v-for="child in children[parent.id]"
+                    :key="child.name"
+                >
+                    <label>
+                        <input
+                            :id="`categories-${child.name}`"
+                            type="checkbox"
+                            name="categories[]"
+                            :value="child.name"
+                            :checked="child.name in selected"
+                            v-model="selected"
+                        >
+                        {{ child.label || child.name }}
+                    </label>
+                </div>
+            </div>
+        </details>
+    </div>
+</template>
+<script>
+export default {
+    name: 'ObjectCategories',
+    props: {
+        modelCategories: {
+            type: Array,
+            required: true
+        },
+        value: {
+            type: Array,
+            default: () => []
+        },
+    },
+    data() {
+        return {
+            children: {},
+            common: [],
+            forceOpen: false,
+            root: [],
+            selected: [],
+        }
+    },
+    mounted() {
+        this.$nextTick(() => {
+            this.selected = this.value;
+            this.root = this.modelCategories.filter(category => category.parent_id === null);
+            this.root.sort((a, b) => {
+                if (a.label && b.label) {
+                    return a.label.localeCompare(b.label);
+                }
+                return a.name.localeCompare(b.name);
+            });
+            this.children = this.modelCategories.reduce((acc, category) => {
+                if (!acc[category.parent_id]) {
+                    acc[category.parent_id] = [];
+                }
+                acc[category.parent_id].push(category);
+                return acc;
+            }, {});
+            this.root = this.root.filter(category => this.children[category.id]);
+            this.common = this.modelCategories.filter(category => category.parent_id === null && !this.children[category.id]);
+            for (const key in this.children) {
+                this.children[key].sort((a, b) => {
+                    if (a.label && b.label) {
+                        return a.label.localeCompare(b.label);
+                    }
+                    return a.name.localeCompare(b.name);
+                });
+            }
+            this.common.sort((a, b) => {
+                if (a.label && b.label) {
+                    return a.label.localeCompare(b.label);
+                }
+                return a.name.localeCompare(b.name);
+            });
+            this.selected = this.value.map(category => category.name);
+            let groupsNumber = Object.keys(this.children).length;
+            groupsNumber += this.common.length > 0 ? 1 : 0;
+            this.forceOpen = groupsNumber <= 3 || this.modelCategories.length <= 20;
+        });
+    },
+    methods: {
+        countSelectedCommon() {
+            return this.selected.filter(category => {
+                const arr = this.common || [];
+
+                return arr.find(child => child.name === category);
+            }).length;
+        },
+        countSelectedByParent(parentId) {
+            return this.selected.filter(category => {
+                const cc = this.children || {};
+                const arr = cc?.[parentId] || [];
+
+                return arr.find(child => child.name === category);
+            }).length;
+        },
+    },
+}
+</script>
+<style>
+.object-categories details>summary {
+  list-style-type: none;
+  outline: none;
+  cursor: pointer;
+  border-bottom: 1px solid #eee;
+  padding: 10px;
+  font-size: 1rem;
+  text-transform: uppercase;
+}
+
+.object-categories details>summary::-webkit-details-marker {
+  display: none;
+}
+
+.object-categories details>summary::before {
+  content: '+ ';
+  font-size: 1.2rem;
+}
+
+.object-categories details[open]>summary::before {
+  content: '- ';
+  font-size: 1.2rem;
+}
+
+.object-categories details[open]>summary {
+  margin-bottom: 0.5rem;
+}
+
+.object-categories .categories-children {
+  columns: 2 auto;
+}
+
+.object-categories .checkbox > label {
+  display: block;
+}
+
+.object-categories .checkbox > label {
+    cursor: pointer;
+}
+</style>

--- a/resources/js/app/components/object-categories/object-categories.vue
+++ b/resources/js/app/components/object-categories/object-categories.vue
@@ -201,12 +201,18 @@ export default {
 }
 </script>
 <style>
+.object-categories details {
+    padding: .5rem 0;
+}
+
+.object-categories details:not(:first-child) {
+    border-top: 1px dashed #555;
+}
+
 .object-categories details>summary {
   list-style-type: none;
   outline: none;
   cursor: pointer;
-  border-bottom: 1px solid #eee;
-  padding: 10px;
   font-size: 1rem;
   text-transform: uppercase;
 }
@@ -225,8 +231,8 @@ export default {
   font-size: 1.2rem;
 }
 
-.object-categories details[open]>summary {
-  margin-bottom: 0.5rem;
+.object-categories details:not([open]) > summary {
+    opacity: 0.7;
 }
 
 .object-categories .categories-children {

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -43,6 +43,7 @@ export default {
         PermissionToggle: () => import(/* webpackChunkName: "permission-toggle" */'app/components/permission-toggle/permission-toggle'),
         LanguageSelector:() => import(/* webpackChunkName: "language-selector" */'app/components/language-selector/language-selector'),
         ClipboardItem: () => import(/* webpackChunkName: "clipboard-item" */'app/components/clipboard-item/clipboard-item'),
+        ObjectCategories: () => import(/* webpackChunkName: "object-categories" */'app/components/object-categories/object-categories'),
     },
 
     props: {

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -21,7 +21,6 @@ use Cake\Utility\Hash;
  *
  * @property \App\View\Helper\AdminHelper $Admin
  * @property \App\View\Helper\CalendarHelper $Calendar
- * @property \App\View\Helper\CategoriesHelper $Categories
  * @property \App\View\Helper\EditorsHelper $Editors
  * @property \App\View\Helper\LayoutHelper $Layout
  * @property \App\View\Helper\ArrayHelper $Array
@@ -66,7 +65,6 @@ class AppView extends TwigView
         ]);
         $this->addHelper('Admin');
         $this->addHelper('Calendar');
-        $this->addHelper('Categories');
         $this->addHelper('Editors');
         $this->addHelper('Element');
         $this->addHelper('Layout');

--- a/src/View/Helper/CategoriesHelper.php
+++ b/src/View/Helper/CategoriesHelper.php
@@ -20,6 +20,7 @@ use Cake\View\Helper;
  *
  * @property \Cake\View\Helper\FormHelper $Form
  * @property \App\View\Helper\PropertyHelper $Property
+ * @deprecated version 4.21.1 This is not used anymore, it will be removed in next major version.
  */
 class CategoriesHelper extends Helper
 {

--- a/src/View/Helper/CategoriesHelper.php
+++ b/src/View/Helper/CategoriesHelper.php
@@ -20,7 +20,6 @@ use Cake\View\Helper;
  *
  * @property \Cake\View\Helper\FormHelper $Form
  * @property \App\View\Helper\PropertyHelper $Property
- * @deprecated version 4.21.1 This is not used anymore, it will be removed in next major version.
  */
 class CategoriesHelper extends Helper
 {

--- a/templates/Element/Form/categories.twig
+++ b/templates/Element/Form/categories.twig
@@ -10,7 +10,12 @@
 
             <div v-show="isOpen" class="tab-container">
                 <div class="categories-container">
-                    {{ Categories.control('categories', object.attributes.categories)|raw }}
+                    <object-categories
+                        :model-categories="{{ schema.categories|json_encode }}"
+                        :value="{{ object.attributes.categories|json_encode }}"
+                    >
+                    </object-categories>
+                    {% do Form.unlockField('categories') %}
                 </div>
             </div>
         </section>


### PR DESCRIPTION
This provides an enhancement in the single object view, in the section Categories: data is shown in groups (using accordions), each group is a parent category (global, for categories with no parents and no children).

A group is expanded if:

 - total number of groups is less than or equal to 3
 - total number of categories is less than or equal to 20
 - group contains a checked category for the object view
 - filter search is active and group have a category that matches the search
 
Example 1: multiple categories trees
============================

![image](https://github.com/bedita/manager/assets/2227145/2d519ec0-2563-420a-a3dd-9eb55a9b282a)

Example 2: global categories
======================

![image](https://github.com/bedita/manager/assets/2227145/7b986396-1643-43f9-b3d7-6eeff2c4ae41)