### PR TITLE
Add visual blocks to TinyMCE

### DIFF
--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -10,6 +10,7 @@ import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
 import 'tinymce/plugins/table';
 import 'tinymce/plugins/hr';
+import 'tinymce/plugins/visualblocks';
 import '../plugins/tinymce/placeholders.js';
 import { tinymcePlugin } from '@chialab/typos';
 
@@ -40,6 +41,7 @@ const DEFAULT_TOOLBAR = [
     'redo',
     '|',
     'fixQuotes',
+    'visualblocks',
     'code',
 ].join(' ');
 
@@ -108,6 +110,7 @@ export default {
                         'code',
                         'placeholders',
                         'typos',
+                        'visualblocks',
                     ].join(' '),
                     autoresize_bottom_margin: 50,
                     relative_urls: false,

--- a/resources/richeditor.lazy.scss
+++ b/resources/richeditor.lazy.scss
@@ -14,6 +14,9 @@ BEdita Manager
 // general
 @import './styles/base';
 
+// tinymce base content style
+@import '~tinymce/skins/ui/oxide/content';
+
 @import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,200;0,400;1,200;1,400&family=IBM+Plex+Sans:ital,wght@0,200;0,300;0,400;0,500;1,200;1,300;1,400;1,500&family=IBM+Plex+Serif:ital,wght@0,200;0,400;0,700;1,200;1,400;1,700&display=swap");
 
 body {


### PR DESCRIPTION
This PR introduces visual blocks in TinyMCE.

![visual-blocks](https://github.com/bedita/manager/assets/1306319/275a4e93-8e53-42ca-b7c6-5ef41df3a976)