### PR TITLE
Customize calendar label and options

### DIFF
--- a/templates/Element/Form/calendar.twig
+++ b/templates/Element/Form/calendar.twig
@@ -1,16 +1,21 @@
 {# Calendar: use date_ranges if `DateRanges` association is set #}
 
 {% if in_array('DateRanges', schema.associations) %}
+{% set key = 'Properties.%s.options.date_ranges.label'|format(object.type) %}
+{% set label = config(key)|default('Calendar') %}
+{% set key2 = 'Properties.%s.options.date_ranges.options'|format(object.type) %}
+{% set options = config(key2)|default({"weekdays":{}}) %}
 <property-view inline-template :tab-open="tabsOpen" tab-name="calendar">
     <section class="fieldset">
         <header @click.prevent="toggleVisibility()"
             class="tab unselectable"
             :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
-            <h2>{{ __('Calendar') }}</h2>
+            <h2>{{ __(label) }}</h2>
         </header>
 
         <div v-show="isOpen" class="tab-container">
-            <date-ranges-view ranges={{ object.attributes.date_ranges|json_encode }}>
+            <date-ranges-view ranges={{ object.attributes.date_ranges|json_encode }}
+                :options={{ options|json_encode }}>
             </date-ranges-view>
             {% do Form.unlockField('date_ranges') %}
         </div>


### PR DESCRIPTION
This provides a way to customize calendar label and options, using `Properties` configuration.
I.e.:
```
"Properties": {
  "events": {
    "options": {
      "date_ranges": {
        "label": "Il nostro calendario",
        "options": {
          "all_day": true,
          "every_day": true
        }
      }
    }
}
```
![image](https://github.com/bedita/manager/assets/2227145/19edb772-3a8e-4341-9959-3e8ee79ea8a3)

In the example above, "all_day" and "every_day" are not shown, as their default value is set in the configuration.