### PR TITLE
Fix richtext undesired content by disabling TinyMCE unload triggers

### DIFF
--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -112,6 +112,7 @@ export default {
                     autoresize_bottom_margin: 50,
                     relative_urls: false,
                     paste_block_drop: true,
+                    add_unload_trigger: false, // fix populating textarea elements with garbage when the user initiates a navigation with unsaved changes, but cancels it when the alert is shown
                     readonly: element.getAttribute('readonly') === 'readonly' ? 1 : 0,
                 });
 


### PR DESCRIPTION
### Problem
When the user is editing an object and initiates a navigation (ex. going back to the module index, or changing module from the navigation menu), the Manager asks for confirmation with an alert. The triggers of TinyMCE are run even when the user stops the navigation, thus populating all textareas with `<p><br data-mce-bogus="1"></p>`.

### Solution
Disable TinyMCE's unload triggers ([docs](https://www.tiny.cloud/docs-3x/reference/Configuration3x/Configuration3x@add_unload_trigger/)), which is ok because the Manager doesn't need storing the editor's contents to "save" them locally.