### PR TITLE
Fix remove failed save session data on successfull save

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -290,7 +290,8 @@ class ModulesController extends AppController
                 (array)$this->Schema->getSchema($this->objectType),
                 (array)Hash::get($requestData, 'permissions')
             );
-            $this->Modules->saveRelated((string)Hash::get($response, 'data.id'), $this->objectType, $relatedData);
+            $id = (string)Hash::get($response, 'data.id');
+            $this->Modules->saveRelated($id, $this->objectType, $relatedData);
             $options = [
                 'id' => Hash::get($response, 'data.id'),
                 'type' => $this->objectType,
@@ -298,6 +299,7 @@ class ModulesController extends AppController
             ];
             $event = new Event('Controller.afterSave', $this, $options);
             $this->getEventManager()->dispatch($event);
+            $this->getRequest()->getSession()->delete(sprintf('failedSave.%s.%s', $this->objectType, $id));
         } catch (BEditaClientException $error) {
             $this->log($error->getMessage(), LogLevel::ERROR);
             $this->Flash->error($error->getMessage(), ['params' => $error]);


### PR DESCRIPTION
This resolves a buggy behaviour in object save.

Example to reproduce the bug: save an object with some data in form that will produce an error on save. BEM will show you an error (form data is stored in session and shown again on page). Fix form data and save again, there will be a successfull save, but you will see the form with previous data (session from failed save is used).

This fixes it by deleting failed save session data, when data save is successfull.