### PR TITLE
Fix Admin Appearance style sheets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ bundle-report.*.html
 /webroot/bundle-report
 /webroot/*.hot-update.*
 /webroot/vendors/async/*.hot-update.*
+/webroot/css/admin-index*
 /webroot/css/app*
 /webroot/css/category*
 /webroot/css/date-input*
@@ -76,6 +77,7 @@ bundle-report.*.html
 /webroot/css/index-cell*
 /webroot/css/map-view*
 /webroot/css/menu*
+/webroot/css/object-categories*
 /webroot/css/object-nav*
 /webroot/css/object-property*
 /webroot/css/objects-history*

--- a/resources/js/app/pages/admin/appearance.vue
+++ b/resources/js/app/pages/admin/appearance.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="module-index">
+    <div class="appearance module-index">
         <details v-for="property,propertyKey in configs" :key="propertyKey">
             <summary>{{ title(propertyKey) }}</summary>
             <div class="main-container">
@@ -105,7 +105,7 @@ export default {
 };
 </script>
 <style>
-details>summary {
+div.appearance > details>summary {
   list-style-type: none;
   outline: none;
   cursor: pointer;
@@ -114,25 +114,25 @@ details>summary {
   font-size: 1rem;
 }
 
-details>summary::-webkit-details-marker {
+div.appearance > details>summary::-webkit-details-marker {
   display: none;
 }
 
-details>summary::before {
+div.appearance > details>summary::before {
   content: '+ ';
   font-size: 1.2rem;
 }
 
-details[open]>summary::before {
+div.appearance > details[open]>summary::before {
   content: '- ';
   font-size: 1.2rem;
 }
 
-details[open]>summary {
+div.appearance > details[open]>summary {
   margin-bottom: 0.5rem;
 }
 
-.main-container {
+div.appearance > details > .main-container {
   display: flex;
   justify-content: left;
   align-items: flex-start;


### PR DESCRIPTION
This fixes a stylesheets issue: the component Admin Appearance declares some css rules, without scoping them properly: the consequence is a wrong style elsewhere (Categories inside an object).