### PR TITLE
Filter label customizable

### DIFF
--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -331,8 +331,8 @@ class SchemaHelper extends Helper
      */
     public function filterOptions($filter, array $properties): array
     {
-        $filterName = is_array($filter) ? (string)Hash::get($filter, 'name') : $filter;
-        $filterLabel = is_array($filter) ? (string)Hash::get($filter, 'label') : $filter;
+        $filterName = is_array($filter) ? (string)Hash::get($filter, 'name', __('untitled')) : $filter;
+        $filterLabel = is_array($filter) ? (string)Hash::get($filter, 'label', $filterName) : $filter;
         $filterProperties = (array)Hash::get($properties, $filterName, []);
         $options = self::controlOptions($filterName, null, $filterProperties);
 

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -321,4 +321,21 @@ class SchemaHelper extends Helper
 
         return \App\Utility\Schema::rightTypes($relationsSchema);
     }
+
+    /**
+     * Return filter options for schema and filter.
+     *
+     * @param mixed $filter Filter name or filter array.
+     * @param array $properties Properties schema.
+     * @return array
+     */
+    public function filterOptions($filter, array $properties): array
+    {
+        $filterName = is_array($filter) ? (string)Hash::get($filter, 'name') : $filter;
+        $filterLabel = is_array($filter) ? (string)Hash::get($filter, 'label') : $filter;
+        $filterProperties = (array)Hash::get($properties, $filterName, []);
+        $options = self::controlOptions($filterName, null, $filterProperties);
+
+        return array_merge($options, ['name' => $filterName, 'label' => $filterLabel]);
+    }
 }

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -323,19 +323,45 @@ class SchemaHelper extends Helper
     }
 
     /**
-     * Return filter options for schema and filter.
+     * Get filter list from filters and schema properties
      *
-     * @param mixed $filter Filter name or filter array.
-     * @param array $properties Properties schema.
+     * @param array $filters Filters list
+     * @param array|null $schemaProperties Schema properties
      * @return array
      */
-    public function filterOptions($filter, array $properties): array
+    public function filterList(array $filters, ?array $schemaProperties): array
     {
-        $filterName = is_array($filter) ? (string)Hash::get($filter, 'name', __('untitled')) : $filter;
-        $filterLabel = is_array($filter) ? (string)Hash::get($filter, 'label', $filterName) : $filter;
-        $filterProperties = (array)Hash::get($properties, $filterName, []);
-        $options = self::controlOptions($filterName, null, $filterProperties);
+        $list = [];
+        foreach ($filters as $f) {
+            $fname = is_array($f) ? (string)Hash::get($f, 'name', __('untitled')) : $f;
+            $flabel = is_array($f) ? (string)Hash::get($f, 'label', $fname) : Inflector::humanize($f);
+            $noProperties = empty($schemaProperties) || !array_key_exists($fname, $schemaProperties);
+            $schema = $noProperties ? null : (array)Hash::get($schemaProperties, $fname);
+            $item = self::controlOptions($fname, null, $schema);
+            $item['name'] = $fname;
+            $item['label'] = $flabel;
+            $list[] = $item;
+        }
 
-        return array_merge($options, ['name' => $filterName, 'label' => $filterLabel]);
+        return $list;
+    }
+
+    /**
+     * Get filter list by type
+     *
+     * @param array $filtersByType Filters list by type
+     * @param array|null $schemasByType Schema properties by type
+     * @return array
+     */
+    public function filterListByType(array $filtersByType, ?array $schemasByType): array
+    {
+        $list = [];
+        foreach ($filtersByType as $type => $filters) {
+            $noSchema = empty($schemasByType) || !array_key_exists($type, $schemasByType);
+            $schemaProperties = $noSchema ? null : Hash::get($schemasByType, $type);
+            $list[$type] = self::filterList($filters, $schemaProperties);
+        }
+
+        return $list;
     }
 }

--- a/templates/Element/FilterBox/filter_box.scss
+++ b/templates/Element/FilterBox/filter_box.scss
@@ -81,8 +81,7 @@
             }
         }
 
-        &.parent .filter-label,
-        &.categories .filter-label {
+        &.parent .filter-label {
             display: none;
         }
 

--- a/templates/Element/FilterBox/filter_box_common.twig
+++ b/templates/Element/FilterBox/filter_box_common.twig
@@ -97,7 +97,7 @@
         {# other dynamic filters #}
         <div v-for="filter in dynamicFilters" class="filter-container" :class="[filter.name, filter.type, filter.date ? 'date' : '']">
             <input type="hidden" form="_filters" :name="filter.name" :value="filter.value">
-            <label class="filter-label"><: t(filter.name) | humanize :></label>
+            <label class="filter-label"><: t(filter.label || filter.name) | humanize :></label>
 
             <span v-if="filter.name === 'categories'">
                 <label>{{ __('Categories') }}</label>

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -26,7 +26,8 @@
         <div class="related-list-container">
             {# FilterBoxView #}
             <div class="mb-1" v-show="showFilter">
-                {% set list = Schema.filterListByType(filtersByType, schemasByType) %}
+                {% set fbt = filtersByType ? filtersByType : [] %}
+                {% set list = Schema.filterListByType(fbt, schemasByType) %}
                 <filter-box-view
                     :config-paginate-sizes="configPaginateSizes"
                     :pagination.sync="pagination"

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -168,6 +168,7 @@
                         <span class="ml-05">{{ __('Export') }}</span>
                     </a>
                     <a
+                        v-if="Object.keys(activeFilter).length > 0"
                         class="button button-outlined"
                         target="_blank"
                         :href="exportFilteredUrl('{{ Url.build(filteredOptions|merge({'format': format})) }}')"

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -30,15 +30,8 @@
                 {% for type, filters in filtersByType %}
                     {% set options = [] %}
                     {% for f in filters %}
-                        {% set filterName = f %}
-                        {% set filterLabel = f %}
-                        {% if f is iterable %}
-                            {% set filterName = f.name %}
-                            {% set filterLabel = f.label %}
-                        {% endif %}
-                        {% set o = Schema.controlOptions(filterName, null, schemasByType[type].properties[filterName]) %}
-                        {% set options = options|merge([o|merge({ 'name': filterName, 'label': filterLabel })]) %}
-                    {% endfor %}
+                        {% set options = options|merge(Schema.filterOptions(f, schemasByType[type].properties)) %}
+                     {% endfor %}
                     {% set list = list|merge({ (type): options }) %}
                 {% endfor %}
                 <filter-box-view

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -26,14 +26,7 @@
         <div class="related-list-container">
             {# FilterBoxView #}
             <div class="mb-1" v-show="showFilter">
-                {% set list = {} %}
-                {% for type, filters in filtersByType %}
-                    {% set options = [] %}
-                    {% for f in filters %}
-                        {% set options = options|merge(Schema.filterOptions(f, schemasByType[type].properties)) %}
-                     {% endfor %}
-                    {% set list = list|merge({ (type): options }) %}
-                {% endfor %}
+                {% set list = Schema.filterListByType(filtersByType, schemasByType) %}
                 <filter-box-view
                     :config-paginate-sizes="configPaginateSizes"
                     :pagination.sync="pagination"

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -30,8 +30,14 @@
                 {% for type, filters in filtersByType %}
                     {% set options = [] %}
                     {% for f in filters %}
-                        {% set o = Schema.controlOptions(f, null, schemasByType[type].properties[f]) %}
-                        {% set options = options|merge([o|merge({ 'name': f })]) %}
+                        {% set filterName = f %}
+                        {% set filterLabel = f %}
+                        {% if f is iterable %}
+                            {% set filterName = f.name %}
+                            {% set filterLabel = f.label %}
+                        {% endif %}
+                        {% set o = Schema.controlOptions(filterName, null, schemasByType[type].properties[filterName]) %}
+                        {% set options = options|merge([o|merge({ 'name': filterName, 'label': filterLabel })]) %}
                     {% endfor %}
                     {% set list = list|merge({ (type): options }) %}
                 {% endfor %}

--- a/templates/Element/Modules/index_header.twig
+++ b/templates/Element/Modules/index_header.twig
@@ -1,11 +1,6 @@
 <div class="module-header">
     {% set filterActive = (_view.request.getQuery('filter') or _view.request.getQuery('q')) %}
-    {% set list = [] %}
-    {% for f in filter %}
-        {% set options = Schema.filterOptions(f, schema.properties|default([])) %}
-        {% set list = list|merge({ (loop.index0): options }) %}
-    {% endfor %}
-
+    {% set list = Schema.filterList(filter, schema.properties) %}
     <filter-box-view
         :pagination="{{ meta.pagination|json_encode|escape('html_attr') }}"
         :init-filter="urlFilterQuery"

--- a/templates/Element/Modules/index_header.twig
+++ b/templates/Element/Modules/index_header.twig
@@ -2,8 +2,14 @@
     {% set filterActive = (_view.request.getQuery('filter') or _view.request.getQuery('q')) %}
     {% set list = [] %}
     {% for f in filter %}
-        {% set options = Schema.controlOptions(f, null, schema.properties[f]) %}
-        {% set options = options|merge({ 'name': f }) %}
+        {% set filterName = f %}
+        {% set filterLabel = f %}
+        {% if f is iterable %}
+            {% set filterName = f.name %}
+            {% set filterLabel = f.label %}
+        {% endif %}
+        {% set options = Schema.controlOptions(filterName, null, schema.properties[filterName]) %}
+        {% set options = options|merge({ 'name': filterName, 'label': filterLabel }) %}
         {% set list = list|merge({ (loop.index0): options }) %}
     {% endfor %}
 

--- a/templates/Element/Modules/index_header.twig
+++ b/templates/Element/Modules/index_header.twig
@@ -1,10 +1,8 @@
 <div class="module-header">
     {% set filterActive = (_view.request.getQuery('filter') or _view.request.getQuery('q')) %}
     {% set list = [] %}
-    {% set options = [] %}
-    {% set properties = schema.properties|default([]) %}
     {% for f in filter %}
-        {% set options = options|merge(Schema.filterOptions(f, properties)) %}
+        {% set options = Schema.filterOptions(f, schema.properties|default([])) %}
         {% set list = list|merge({ (loop.index0): options }) %}
     {% endfor %}
 

--- a/templates/Element/Modules/index_header.twig
+++ b/templates/Element/Modules/index_header.twig
@@ -1,15 +1,10 @@
 <div class="module-header">
     {% set filterActive = (_view.request.getQuery('filter') or _view.request.getQuery('q')) %}
     {% set list = [] %}
+    {% set options = [] %}
+    {% set properties = schema.properties|default([]) %}
     {% for f in filter %}
-        {% set filterName = f %}
-        {% set filterLabel = f %}
-        {% if f is iterable %}
-            {% set filterName = f.name %}
-            {% set filterLabel = f.label %}
-        {% endif %}
-        {% set options = Schema.controlOptions(filterName, null, schema.properties[filterName]) %}
-        {% set options = options|merge({ 'name': filterName, 'label': filterLabel }) %}
+        {% set options = options|merge(Schema.filterOptions(f, properties)) %}
         {% set list = list|merge({ (loop.index0): options }) %}
     {% endfor %}
 

--- a/templates/Element/Panel/relations_add.twig
+++ b/templates/Element/Panel/relations_add.twig
@@ -92,14 +92,7 @@
             {% for type, filters in filtersByType %}
                 {% set options = [] %}
                 {% for f in filters %}
-                    {% set filterName = f %}
-                    {% set filterLabel = f %}
-                    {% if f is iterable %}
-                        {% set filterName = f.name %}
-                        {% set filterLabel = f.label %}
-                    {% endif %}
-                    {% set o = Schema.controlOptions(filterName, null, schemasByType[type].properties[filterName]) %}
-                    {% set options = options|merge([o|merge({ 'name': filterName, 'label': filterLabel })]) %}
+                    {% set options = options|merge(Schema.filterOptions(f, schemasByType[type].properties)) %}
                 {% endfor %}
                 {% set list = list|merge({ (type): options }) %}
             {% endfor %}

--- a/templates/Element/Panel/relations_add.twig
+++ b/templates/Element/Panel/relations_add.twig
@@ -88,7 +88,8 @@
         </header>
 
         <div class="px-1 my-1">
-            {% set list = Schema.filterListByType(filtersByType, schemasByType) %}
+            {% set fbt = filtersByType ? filtersByType : [] %}
+            {% set list = Schema.filterListByType(fbt, schemasByType) %}
             <filter-box-view
                 config-paginate-sizes={{ config('Pagination.sizeAvailable')|json_encode|escape('html_attr') }}
                 :pagination.sync="pagination"

--- a/templates/Element/Panel/relations_add.twig
+++ b/templates/Element/Panel/relations_add.twig
@@ -88,15 +88,7 @@
         </header>
 
         <div class="px-1 my-1">
-            {% set list = {} %}
-            {% for type, filters in filtersByType %}
-                {% set options = [] %}
-                {% for f in filters %}
-                    {% set options = options|merge(Schema.filterOptions(f, schemasByType[type].properties)) %}
-                {% endfor %}
-                {% set list = list|merge({ (type): options }) %}
-            {% endfor %}
-
+            {% set list = Schema.filterListByType(filtersByType, schemasByType) %}
             <filter-box-view
                 config-paginate-sizes={{ config('Pagination.sizeAvailable')|json_encode|escape('html_attr') }}
                 :pagination.sync="pagination"

--- a/templates/Element/Panel/relations_add.twig
+++ b/templates/Element/Panel/relations_add.twig
@@ -92,8 +92,14 @@
             {% for type, filters in filtersByType %}
                 {% set options = [] %}
                 {% for f in filters %}
-                    {% set o = Schema.controlOptions(f, null, schemasByType[type].properties[f]) %}
-                    {% set options = options|merge([o|merge({ 'name': f })]) %}
+                    {% set filterName = f %}
+                    {% set filterLabel = f %}
+                    {% if f is iterable %}
+                        {% set filterName = f.name %}
+                        {% set filterLabel = f.label %}
+                    {% endif %}
+                    {% set o = Schema.controlOptions(filterName, null, schemasByType[type].properties[filterName]) %}
+                    {% set options = options|merge([o|merge({ 'name': filterName, 'label': filterLabel })]) %}
                 {% endfor %}
                 {% set list = list|merge({ (type): options }) %}
             {% endfor %}

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -847,60 +847,181 @@ class SchemaHelperTest extends TestCase
     }
 
     /**
-     * Data provider for `filterOptions` test case.
+     * Data provider for `filterList` test case.
      *
      * @return array
      */
-    public function filterOptionsProvider(): array
+    public function filterListProvider(): array
     {
         return [
             'parent string' => [
-                'parent',
-                [],
+                ['parent'],
+                null,
                 [
-                    'class' => 'json',
-                    'disabled' => false,
-                    'label' => 'parent',
-                    'name' => 'parent',
-                    'readonly' => false,
-                    'type' => 'textarea',
-                    'value' => 'null',
-                    'v-jsoneditor' => 'true',
+                    [
+                        'disabled' => false,
+                        'label' => 'Parent',
+                        'name' => 'parent',
+                        'readonly' => false,
+                        'type' => 'text',
+                        'value' => null,
+                    ],
                 ],
             ],
             'filter title custom' => [
-                ['name' => 'title', 'label' => 'Title'],
+                [['name' => 'title', 'label' => 'My Title']],
                 ['title' => []],
                 [
-                    'class' => 'title',
-                    'disabled' => false,
-                    'label' => 'Title',
-                    'name' => 'title',
-                    'readonly' => false,
-                    'templates' => ['inputContainer' => '<div class="input title {{type}}{{required}}">{{content}}</div>'],
-                    'type' => 'text',
-                    'value' => null,
+                    [
+                        'class' => 'title',
+                        'disabled' => false,
+                        'label' => 'My Title',
+                        'name' => 'title',
+                        'readonly' => false,
+                        'templates' => ['inputContainer' => '<div class="input title {{type}}{{required}}">{{content}}</div>'],
+                        'type' => 'text',
+                        'value' => null,
+                    ],
                 ],
             ],
         ];
     }
 
     /**
-     * Test `filterOptions`.
+     * Test `filterList`.
      *
+     * @param array $filters The filters
+     * @param array|null $properties The properties
+     * @param array $expected The expected result
      * @return void
-     * @dataProvider filterOptionsProvider()
-     * @covers ::filterOptions()
+     * @dataProvider filterListProvider()
+     * @covers ::filterList()
+     * @covers ::controlOptions()
      */
-    public function testFilterOptions($filter, array $properties, array $expected): void
+    public function testFilterList(array $filters, ?array $properties, array $expected): void
     {
         $view = $this->Schema->getView();
         $view->set('schema', [
             'properties' => $properties,
         ]);
-        $actual = $this->Schema->filterOptions($filter, $properties);
-        ksort($actual);
-        ksort($expected);
+        $actual = $this->Schema->filterList($filters, $properties);
+        ksort($actual[0]);
+        ksort($expected[0]);
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Data provider for `filterListByType` test case.
+     *
+     * @return array
+     */
+    public function filterListByTypeProvider(): array
+    {
+        return [
+            'schema null' => [
+                [
+                    'documents' => [
+                        'parent',
+                        'status',
+                        ['name' => 'title', 'label' => 'My Title'],
+                    ],
+                ],
+                null,
+                [
+                    'documents' => [
+                        [
+                            'value' => null,
+                            'label' => 'Parent',
+                            'readonly' => false,
+                            'disabled' => false,
+                            'type' => 'text',
+                            'name' => 'parent',
+                        ],
+                        [
+                            'options' => [
+                                ['value' => 'on', 'text' => 'On'],
+                                ['value' => 'draft', 'text' => 'Draft'],
+                                ['value' => 'off', 'text' => 'Off'],
+                            ],
+                            'templateVars' => ['containerClass' => 'status'],
+                            'type' => 'radio',
+                            'value' => null,
+                            'label' => 'Status',
+                            'readonly' => false,
+                            'disabled' => false,
+                            'name' => 'status',
+                        ],
+                        [
+                            'class' => 'title',
+                            'templates' => ['inputContainer' => '<div class="input title {{type}}{{required}}">{{content}}</div>'],
+                            'type' => 'text',
+                            'value' => null,
+                            'label' => 'My Title',
+                            'readonly' => false,
+                            'disabled' => false,
+                            'name' => 'title',
+                        ],
+                    ],
+                ],
+            ],
+            'schema not null' => [
+                [
+                    'documents' => [
+                        'categories',
+                        ['name' => 'title', 'label' => 'My Title'],
+                    ],
+                ],
+                [
+                    'documents' => [
+                        'categories' => [
+                            'type' => 'categories',
+                        ],
+                    ],
+                ],
+                [
+                    'documents' => [
+                        [
+                            'value' => [],
+                            'label' => 'Categories',
+                            'readonly' => false,
+                            'disabled' => false,
+                            'type' => 'select',
+                            'options' => [],
+                            'multiple' => 'checkbox',
+                            'name' => 'categories',
+                        ],
+                        [
+                            'class' => 'title',
+                            'templates' => [
+                                'inputContainer' => '<div class="input title {{type}}{{required}}">{{content}}</div>',
+                            ],
+                            'type' => 'text',
+                            'value' => null,
+                            'label' => 'My Title',
+                            'readonly' => false,
+                            'disabled' => false,
+                            'name' => 'title',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `filterListByType`.
+     *
+     * @return void
+     * @dataProvider filterListByTypeProvider()
+     * @covers ::filterListByType()
+     * @covers ::filterList()
+     * @covers ::controlOptions()
+     */
+    public function testfilterListByType(array $filtersByType, ?array $schemasByType, array $expected): void
+    {
+        $view = $this->Schema->getView();
+        $view->set('schema', $schemasByType);
+        $actual = $this->Schema->filterListByType($filtersByType, $schemasByType);
         static::assertSame($expected, $actual);
     }
 }

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -845,4 +845,62 @@ class SchemaHelperTest extends TestCase
         $actual = $this->Schema->rightTypes();
         static::assertSame($expected, $actual);
     }
+
+    /**
+     * Data provider for `filterOptions` test case.
+     *
+     * @return array
+     */
+    public function filterOptionsProvider(): array
+    {
+        return [
+            'parent string' => [
+                'parent',
+                [],
+                [
+                    'class' => 'json',
+                    'disabled' => false,
+                    'label' => 'parent',
+                    'name' => 'parent',
+                    'readonly' => false,
+                    'type' => 'textarea',
+                    'value' => 'null',
+                    'v-jsoneditor' => 'true',
+                ],
+            ],
+            'filter title custom' => [
+                ['name' => 'title', 'label' => 'Title'],
+                ['title' => []],
+                [
+                    'class' => 'title',
+                    'disabled' => false,
+                    'label' => 'Title',
+                    'name' => 'title',
+                    'readonly' => false,
+                    'templates' => ['inputContainer' => '<div class="input title {{type}}{{required}}">{{content}}</div>'],
+                    'type' => 'text',
+                    'value' => null,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `filterOptions`.
+     *
+     * @return void
+     * @dataProvider filterOptionsProvider()
+     * @covers ::filterOptions()
+     */
+    public function testFilterOptions($filter, array $properties, array $expected): void
+    {
+        $view = $this->Schema->getView();
+        $view->set('schema', [
+            'properties' => $properties,
+        ]);
+        $actual = $this->Schema->filterOptions($filter, $properties);
+        ksort($actual);
+        ksort($expected);
+        static::assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
This provides a way to customize filter labels using an object in `Properties.<type>.filter` configuration.
Example
```json
{
    "Properties": {
        "documents": {
            "filter": [
                "status",
                {"name": "title", "label": "My Title"}
            ],
        }
    }
}
```