### PR TITLE
Fix save categories when none is checked

### DIFF
--- a/resources/js/app/components/object-categories/object-categories.vue
+++ b/resources/js/app/components/object-categories/object-categories.vue
@@ -40,7 +40,7 @@
                         <input
                             :id="`categories-${child.name}`"
                             type="checkbox"
-                            name="categories[]"
+                            name="selectedCategories[]"
                             :value="child.name"
                             :checked="child.name in selected"
                             v-model="selected"
@@ -70,7 +70,7 @@
                         <input
                             :id="`categories-${child.name}`"
                             type="checkbox"
-                            name="categories[]"
+                            name="selectedCategories[]"
                             :value="child.name"
                             :checked="child.name in selected"
                             v-model="selected"
@@ -80,6 +80,8 @@
                 </div>
             </div>
         </details>
+        <input type="hidden" name="categories" :value="JSON.stringify(selected)" />
+        <input type="hidden" name="_types[categories]" value="json" />
     </div>
 </template>
 <script>

--- a/resources/js/app/components/object-categories/object-categories.vue
+++ b/resources/js/app/components/object-categories/object-categories.vue
@@ -81,7 +81,6 @@
             </div>
         </details>
         <input type="hidden" name="categories" :value="JSON.stringify(selected)" />
-        <input type="hidden" name="_types[categories]" value="json" />
     </div>
 </template>
 <script>

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -231,6 +231,7 @@ class AppController extends Controller
 
         // prepare categories
         if (!empty($data['categories'])) {
+            $data['categories'] = json_decode($data['categories'], true);
             $data['categories'] = array_map(function ($category) {
                 return ['name' => $category];
             }, $data['categories']);

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -600,7 +600,7 @@ class AppControllerTest extends TestCase
                 ],
                 [
                     'id' => '2',
-                    'categories' => ['Blu', 'Red', 'Green'],
+                    'categories' => json_encode(['Blu', 'Red', 'Green']),
                 ],
             ],
             'types' => [


### PR DESCRIPTION
This fixes a buggy behaviour on save categories.
The bug: on an object view with at least one category checked (and saved), BEM doesn't let you save with no categories checked (save does not change data).