### PR TITLE
Enhance translations index

### DIFF
--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -504,12 +504,11 @@ const _vueInstance = new Vue({
                 if (!form) {
                     return;
                 }
-
                 const trashActions = [
                     '/trash/delete',
                     '/trash/empty',
+                    '/translation/delete',
                 ];
-
                 let msg = '';
                 let done = false;
                 for (const action of trashActions) {

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -331,7 +331,7 @@ class LayoutHelper extends Helper
      */
     public function trashLink(?string $type): string
     {
-        if (empty($type) || $type === 'trash') {
+        if (empty($type) || $type === 'trash' || $type === 'translations') {
             return '';
         }
 

--- a/templates/Pages/Translations/index.twig
+++ b/templates/Pages/Translations/index.twig
@@ -92,7 +92,43 @@
                 <div>
                     {{ element('Form/bulk_export') }}
                 </div>
+
+                <div class="bulk-header">{{ __('Actions on selected items') }}</div>
+
+                <div :class="[!selectedRows.length ? 'disabled' : '', 'is-flex', 'is-flex-column']">
+                    {{ element('Form/bulk_properties', {
+                        'schema': {
+                            'properties': {
+                                'status': {
+                                    'type': 'string',
+                                    'enum': [
+                                        'on',
+                                        'off',
+                                        'draft',
+                                    ],
+                                    '$id': '/properties/status',
+                                    'title': 'Status',
+                                    'description': 'object status: on, draft, off',
+                                    'default': 'draft',
+                                },
+                            },
+                        }
+                    }) }}
+                </div>
             </div>
+
+            <filter-box-view
+                inline-template
+                :pagination="{{ meta.pagination|json_encode|escape('html_attr') }}"
+                config-paginate-sizes="{{ config('Pagination.sizeAvailable')|json_encode|escape('html_attr') }}"
+                page-size="{{ meta.pagination.page_size }}"
+                @filter-update-page-size="onUpdatePageSize"
+                @filter-update-current-page="onUpdateCurrentPage"
+            >
+                <template v-if="pagination.count">
+                    {{ element('FilterBox/filter_box_page_toolbar') }}
+                </template>
+            </filter-box-view>
             {% endif %}
         </div>
 

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -511,12 +511,50 @@ class LayoutHelperTest extends TestCase
     }
 
     /**
+     * Data provider for `testTrashLink` test case.
+     *
+     * @return array
+     */
+    public function trashLinkProvider(): array
+    {
+        return [
+            'null' => [
+                null,
+                '',
+            ],
+            'empty' => [
+                '',
+                '',
+            ],
+            'trash' => [
+                'trash',
+                '',
+            ],
+            'translations' => [
+                'translations',
+                '',
+            ],
+            'not existing type' => [
+                'notExistingType',
+                '',
+            ],
+            'dummies' => [
+                'dummies',
+                '<a href="/trash?filter%5Btype%5D%5B0%5D=dummies" class="button icon icon-only-icon has-text-module-dummies" title="Dummies in Trashcan"><span class="is-sr-only">Trash</span><app-icon icon="carbon:trash-can"></app-icon></a>',
+            ],
+        ];
+    }
+
+    /**
      * Test `trashLink`.
      *
+     * @param string|null $input The input
+     * @param string $expected The expected result
      * @return void
+     * @dataProvider trashLinkProvider()
      * @covers ::trashLink()
      */
-    public function testTrashLink(): void
+    public function testTrashLink(?string $input, string $expected): void
     {
         $viewVars = [
             'modules' => [
@@ -530,14 +568,7 @@ class LayoutHelperTest extends TestCase
         $request = new ServerRequest();
         $view = new View($request, null, null, compact('viewVars'));
         $layout = new LayoutHelper($view);
-
-        foreach ([null, '', 'notExistingType', 'trash'] as $input) {
-            $actual = $layout->trashLink($input);
-            static::assertSame('', $actual);
-        }
-
-        $expected = '<a href="/trash?filter%5Btype%5D%5B0%5D=dummies" class="button icon icon-only-icon has-text-module-dummies" title="Dummies in Trashcan"><span class="is-sr-only">Trash</span><app-icon icon="carbon:trash-can"></app-icon></a>';
-        $actual = $layout->trashLink('dummies');
+        $actual = $layout->trashLink($input);
         static::assertSame($expected, $actual);
     }
 


### PR DESCRIPTION
This resolves https://github.com/bedita/manager/issues/1107 by:

 - removing trashcan link for translations (there's no trashcan for translations in BEdita, at least not yet)
 - showing bulk change status
 - showing pagination at the bottom of index list
 - in translation view, on remove button click, confirm message tells you that you are going to hard delete the translation (no trashcan)