### PR TITLE
Object history: view all changes

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -395,9 +395,9 @@ $routes->scope('/', function (RouteBuilder $routes) {
         ['pass' => ['id', 'historyId'], '_name' => 'history:clone']
     );
     $routes->connect(
-        '/{object_type}/history/{id}',
+        '/{object_type}/history/{id}/{page}',
         ['controller' => 'History', 'action' => 'info'],
-        ['pass' => ['id'], '_name' => 'history:info']
+        ['pass' => ['id', 'page'], '_name' => 'history:info']
     );
     $routes->connect(
         '/{object_type}/delete',

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-05-16 09:46:10 \n"
+"POT-Creation-Date: 2024-05-28 09:39:32 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1457,19 +1457,13 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-msgid "version by"
+msgid "clone"
 msgstr ""
 
-msgid "date"
+msgid "No history data found"
 msgstr ""
 
-msgid "Trashed"
-msgstr ""
-
-#. *
-#.  * Component to fetch and display changes' history.
-#.
-msgid "No History data found"
+msgid "restore"
 msgstr ""
 
 #, javascript-format
@@ -1483,6 +1477,15 @@ msgstr ""
 msgid ""
 "Restored data will replace current data (you can still check the data before "
 "saving). Are you sure?"
+msgstr ""
+
+msgid "version by"
+msgstr ""
+
+msgid "date"
+msgstr ""
+
+msgid "Trashed"
 msgstr ""
 
 msgid "untitled"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-05-16 09:46:10 \n"
+"POT-Creation-Date: 2024-05-28 09:39:32 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1460,19 +1460,13 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-msgid "version by"
+msgid "clone"
 msgstr ""
 
-msgid "date"
+msgid "No history data found"
 msgstr ""
 
-msgid "Trashed"
-msgstr ""
-
-#. *
-#.  * Component to fetch and display changes' history.
-#.
-msgid "No History data found"
+msgid "restore"
 msgstr ""
 
 #, javascript-format
@@ -1486,6 +1480,15 @@ msgstr ""
 msgid ""
 "Restored data will replace current data (you can still check the data before "
 "saving). Are you sure?"
+msgstr ""
+
+msgid "version by"
+msgstr ""
+
+msgid "date"
+msgstr ""
+
+msgid "Trashed"
 msgstr ""
 
 msgid "untitled"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1473,7 +1473,7 @@ msgid "Result"
 msgstr "Risultato"
 
 msgid "clone"
-msgstr ""
+msgstr "clona"
 
 msgid "No history data found"
 msgstr "Nessun dato di Cronologia"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-05-16 09:46:10 \n"
+"POT-Creation-Date: 2024-05-28 09:39:32 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1472,20 +1472,14 @@ msgstr "Numero di errori"
 msgid "Result"
 msgstr "Risultato"
 
-msgid "version by"
-msgstr "versione di"
+msgid "clone"
+msgstr ""
 
-msgid "date"
-msgstr "data"
-
-msgid "Trashed"
-msgstr "Rimosso"
-
-#. *
-#.  * Component to fetch and display changes' history.
-#.
-msgid "No History data found"
+msgid "No history data found"
 msgstr "Nessun dato di Cronologia"
+
+msgid "restore"
+msgstr "ripristina"
 
 #, javascript-format
 msgid "by ${ name } via ${ application }"
@@ -1501,6 +1495,15 @@ msgid ""
 msgstr ""
 "I dati recuperati sostiruiranno quelli attuali (potrai comunque controllarli "
 "prima di salvare). Vuoi procedere?"
+
+msgid "version by"
+msgstr "versione di"
+
+msgid "date"
+msgstr "data"
+
+msgid "Trashed"
+msgstr "Rimosso"
 
 msgid "untitled"
 msgstr "senza titolo"
@@ -1546,12 +1549,3 @@ msgstr "Errore durante il salvataggio della categoria"
 
 msgid "Error on deleting category"
 msgstr "Errore durante l'eliminazione della categoria"
-
-#~ msgid "Less filters"
-#~ msgstr "Meno filtri"
-
-#~ msgid "More filters"
-#~ msgstr "Più filtri"
-
-#~ msgid "Reset filters"
-#~ msgstr "Reset filtri"

--- a/resources/js/app/components/history/history-changes.vue
+++ b/resources/js/app/components/history/history-changes.vue
@@ -88,9 +88,7 @@ export default {
         let count = 0;
         while (!done) {
             const historyRes = await fetch(`${baseUrl}${this.object.type}/history/${this.object.id}/${page}`, options);
-            console.log(historyRes);
             const historyJson = await historyRes.json();
-            console.log(historyJson);
             this.rawHistory = this.rawHistory.concat(historyJson.data);
             page++;
             if (historyJson.meta.pagination.page === historyJson.meta.pagination.page_count) {

--- a/resources/js/app/components/history/history-changes.vue
+++ b/resources/js/app/components/history/history-changes.vue
@@ -1,3 +1,28 @@
+<template>
+    <div class="history-content" :style="moduleColor()">
+        <div v-if="isLoading" class="is-loading-spinner"></div>
+        <details v-if="sortedDates.length" v-for="date in sortedDates" open>
+            <summary class="pb-05 is-uppercase has-font-weight-bold">{{ date }}</summary>
+            <ul class="history-items">
+                <li class="history-item is-expanded py-05 has-border-gray-600" v-for="item in history[date]">
+                    <div class="change-time">{{ getFormattedTime(item.meta.created) }} </div>
+                    <div class="is-flex">
+                        {{ getAuthor(item.meta) }}
+                    </div>
+                    <div class="is-flex">
+                        <button class="button button-text-white is-width-auto" @click.stop.prevent="showChanges(item, canSave)">info</button>
+                        <button v-if="canSave" class="button button-text-white is-width-auto" @click.stop.prevent="onRestore(item.id)">{{ msgRestore }}</button>
+                        <button v-if="canSave" class="button button-text-white is-width-auto" @click.stop.prevent="onClone(item.id)">{{ msgClone }}</button>
+                    </div>
+                </li>
+            </ul>
+        </details>
+        <div v-if="!isLoading && !sortedDates.length" open>
+            <label>{{ msgNoHistoryDataFound }}</label>
+        </div>
+    </div>
+</template>
+<script>
 import moment from 'moment';
 import { t } from 'ttag';
 import { PanelEvents } from '../panel-view';
@@ -9,41 +34,86 @@ const LOCALE = BEDITA.locale.slice(0, 2);
  * Component to fetch and display changes' history.
  */
 export default {
-    template: `<div class="history-content" style="--module-color: ${BEDITA.currentModule.color}">
-        <div v-if="isLoading" class="is-loading-spinner"></div>
-        <details v-if="sortedDates.length" v-for="date in sortedDates" open>
-            <summary class="pb-05 is-uppercase has-font-weight-bold"><: date :></summary>
-            <ul class="history-items">
-                <li class="history-item is-expanded py-05 has-border-gray-600" v-for="item in history[date]">
-                    <div class="change-time"><: getFormattedTime(item.meta.created) :></div>
-                    <div class="is-flex">
-                        <: getAuthor(item.meta) :>
-                    </div>
-                    <div class="is-flex">
-                        <button class="button button-text-white is-width-auto" @click.stop.prevent="showChanges(item, canSave)">info</button>
-                        <button v-if="canSave" class="button button-text-white is-width-auto" @click.stop.prevent="onRestore(item.id)">${t`Restore`}</button>
-                        <button v-if="canSave" class="button button-text-white is-width-auto" @click.stop.prevent="onClone(item.id)">${t`Clone`}</button>
-                    </div>
-                </li>
-            </ul>
-        </details>
-        <div v-if="!isLoading && !sortedDates.length" open>
-            <label>${t`No History data found`}</label>
-        </div>
-    </div>`,
+    name: 'HistoryChanges',
+
+    props: {
+        object: {
+            type: Object,
+            required: true,
+        },
+        cansave: {
+            type: Boolean,
+            default: true,
+        }
+    },
 
     data() {
         return {
-            history: [],
-            rawHistory: [],
-            isLoading: false,
             canSave: true,
+            history: [],
+            isLoading: false,
+            rawHistory: [],
+            msgClone: t`clone`,
+            msgNoHistoryDataFound: t`No history data found`,
+            msgRestore: t`restore`,
         };
     },
 
-    props: {
-        object: Object,
-        cansave: Boolean,
+    computed: {
+        /**
+         * Return sorted desc dates.
+         * @return {Array}
+         */
+        sortedDates: function () {
+            return Object.keys(this.history)
+                .sort((date1, date2) => moment(date1, 'DD MMM YYYY').diff(moment(date2, 'DD MMM YYYY')))
+                .reverse();
+        },
+    },
+
+    async created() {
+        moment.locale(LOCALE);
+        const baseUrl = new URL(BEDITA.base).pathname;
+        const options = {
+            credentials: 'same-origin',
+            headers: {
+                accept: 'application/json',
+            }
+        };
+
+        this.isLoading = true;
+        this.canSave = this.cansave;
+        let done = false;
+        let page = 1;
+        let count = 0;
+        while (!done) {
+            const historyRes = await fetch(`${baseUrl}${this.object.type}/history/${this.object.id}/${page}`, options);
+            console.log(historyRes);
+            const historyJson = await historyRes.json();
+            console.log(historyJson);
+            this.rawHistory = this.rawHistory.concat(historyJson.data);
+            page++;
+            if (historyJson.meta.pagination.page === historyJson.meta.pagination.page_count) {
+                done = true;
+                count = historyJson.meta.pagination.count;
+            }
+        }
+
+        // only if history data found, elaborate it
+        if (this.rawHistory.length) {
+            this.history = this.rawHistory.reduce((accumulator, item) => {
+                const createdDate = moment(item.meta.created).format('DD MMM YYYY');
+                accumulator[createdDate] = accumulator[createdDate] || [];
+                accumulator[createdDate].push(item);
+                return accumulator;
+            }, {});
+
+            // sort changes by time in descending order
+            Object.keys(this.history).forEach((date) => this.history[date].reverse());
+        }
+
+        this.$emit('count', count);
+        this.isLoading = false;
     },
 
     methods: {
@@ -74,6 +144,9 @@ export default {
             }
 
             return user?.attributes?.title || `${user?.attributes?.name || ''} ${user?.attributes?.surname || ''}`.trim() || user?.attributes?.username || '';
+        },
+        moduleColor() {
+            return `--module-color: ${BEDITA?.currentModule?.color}`;
         },
         /**
          * Open panel to show changes.
@@ -120,49 +193,5 @@ export default {
             });
         },
     },
-
-    computed: {
-        /**
-         * Return sorted desc dates.
-         * @return {Array}
-         */
-        sortedDates: function () {
-            return Object.keys(this.history)
-                .sort((date1, date2) => moment(date1, 'DD MMM YYYY').diff(moment(date2, 'DD MMM YYYY')))
-                .reverse();
-        },
-    },
-
-    async created() {
-        moment.locale(LOCALE);
-        const baseUrl = new URL(BEDITA.base).pathname;
-        const options = {
-            credentials: 'same-origin',
-            headers: {
-                accept: 'application/json',
-            }
-        };
-
-        this.isLoading = true;
-        this.canSave = this.cansave;
-        const historyRes = await fetch(`${baseUrl}${this.object.type}/history/${this.object.id}`, options);
-        const historyJson = await historyRes.json();
-        this.rawHistory = historyJson.data;
-
-        // only if history data found, elaborate it
-        if (this.rawHistory.length) {
-            this.history = this.rawHistory.reduce((accumulator, item) => {
-                const createdDate = moment(item.meta.created).format('DD MMM YYYY');
-                accumulator[createdDate] = accumulator[createdDate] || [];
-                accumulator[createdDate].push(item);
-                return accumulator;
-            }, {});
-
-            // sort changes by time in descending order
-            Object.keys(this.history).forEach((date) => this.history[date].reverse());
-        }
-
-        this.$emit('count', historyJson.meta.pagination.count);
-        this.isLoading = false;
-    },
 }
+</script>

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -30,7 +30,7 @@ export default {
         ResourceRelationView: () => import(/* webpackChunkName: "resource-relation-view" */'app/components/relation-view/resource-relation-view'),
         MapView: () => import(/* webpackChunkName: "map-view" */'app/components/map-view'),
         DateRangesView: () => import(/* webpackChunkName: "date-ranges-view" */'app/components/date-ranges-view/date-ranges-view'),
-        History: () => import(/* webpackChunkName: "history" */'app/components/history/history'),
+        HistoryChanges: () => import(/* webpackChunkName: "history-changes" */'app/components/history/history-changes'),
         CoordinatesView: () => import(/* webpackChunkName: "coordinates-view" */'app/components/coordinates-view'),
         TagPicker: () => import(/* webpackChunkName: "tag-picker" */'app/components/tag-picker/tag-picker'),
         KeyValueList: () => import(/* webpackChunkName: "key-value-list" */'app/components/json-fields/key-value-list'),

--- a/src/Controller/Component/HistoryComponent.php
+++ b/src/Controller/Component/HistoryComponent.php
@@ -173,8 +173,14 @@ class HistoryComponent extends Component
      */
     public function fetch($id, array $schema, array $options): array
     {
-        $options['filter'] = ['resource_id' => $id];
-        $response = (array)ApiClientProvider::getApiClient()->get('/history?include=user', $options);
+        $response = (array)ApiClientProvider::getApiClient()->get('/history', array_merge(
+            [
+                'filter' => ['resource_id' => $id],
+                'include' => 'user',
+                'page_size' => 100,
+            ],
+            $options
+        ));
         $this->formatResponseData($response, $schema);
 
         return $response;

--- a/src/Controller/Component/HistoryComponent.php
+++ b/src/Controller/Component/HistoryComponent.php
@@ -170,10 +170,10 @@ class HistoryComponent extends Component
      * @param array $schema The schema for object type
      * @return array
      */
-    public function fetch($id, array $schema): array
+    public function fetch($id, array $schema, array $options): array
     {
-        $filter = ['resource_id' => $id];
-        $response = (array)ApiClientProvider::getApiClient()->get('/history?include=user', compact('filter') + ['page_size' => 100]);
+        $options['filter'] = ['resource_id' => $id];
+        $response = (array)ApiClientProvider::getApiClient()->get('/history?include=user', $options);
         $this->formatResponseData($response, $schema);
 
         return $response;

--- a/src/Controller/Component/HistoryComponent.php
+++ b/src/Controller/Component/HistoryComponent.php
@@ -168,6 +168,7 @@ class HistoryComponent extends Component
      *
      * @param string|int $id The ID
      * @param array $schema The schema for object type
+     * @param array $options The options
      * @return array
      */
     public function fetch($id, array $schema, array $options): array

--- a/src/Controller/HistoryController.php
+++ b/src/Controller/HistoryController.php
@@ -27,14 +27,16 @@ class HistoryController extends AppController
      * Get history data by ID
      *
      * @param string|int $id Object ID.
+     * @param int $page Page number.
      * @return void
      */
-    public function info($id): void
+    public function info($id, int $page): void
     {
         $this->viewBuilder()->setClassName('Json');
         $this->getRequest()->allowMethod('get');
         $schema = (array)$this->Schema->getSchema($this->getRequest()->getParam('object_type'));
-        $response = $this->History->fetch($id, $schema);
+        $options = ['page_size' => 100, 'page' => $page];
+        $response = $this->History->fetch($id, $schema, $options);
         $data = $response['data'];
         $meta = $response['meta'];
         $this->set(compact('data', 'meta'));

--- a/src/Controller/HistoryController.php
+++ b/src/Controller/HistoryController.php
@@ -35,8 +35,7 @@ class HistoryController extends AppController
         $this->viewBuilder()->setClassName('Json');
         $this->getRequest()->allowMethod('get');
         $schema = (array)$this->Schema->getSchema($this->getRequest()->getParam('object_type'));
-        $options = ['page_size' => 100, 'page' => $page];
-        $response = $this->History->fetch($id, $schema, $options);
+        $response = $this->History->fetch($id, $schema, compact('page'));
         $data = $response['data'];
         $meta = $response['meta'];
         $this->set(compact('data', 'meta'));

--- a/templates/Element/Form/history.twig
+++ b/templates/Element/Form/history.twig
@@ -8,7 +8,7 @@
                 </span>
             </header>
             <div v-show="isOpen" class="tab-container">
-                <keep-alive><history v-if="isOpen" :object="{{ object|json_encode }}" @count="onCount" :cansave="{{ Perms.canSave()|json_encode }}"></history></keep-alive>
+                <keep-alive><history-changes v-if="isOpen" :object="{{ object|json_encode }}" @count="onCount" :cansave="{{ Perms.canSave()|json_encode }}"></history-changes></keep-alive>
             </div>
         </section>
     </section>

--- a/tests/TestCase/Controller/Component/HistoryComponentTest.php
+++ b/tests/TestCase/Controller/Component/HistoryComponentTest.php
@@ -259,7 +259,7 @@ class HistoryComponentTest extends TestCase
      */
     public function testFetch(array $data, $expected): void
     {
-        $response = $this->HistoryComponent->fetch($this->documentId, $data);
+        $response = $this->HistoryComponent->fetch($this->documentId, $data, ['page_size' => 100, 'page' => 1]);
         $actual = $response['data'][0]['meta']['changed'];
         static::assertEquals($expected, $actual);
     }

--- a/tests/TestCase/Controller/HistoryControllerTest.php
+++ b/tests/TestCase/Controller/HistoryControllerTest.php
@@ -100,7 +100,7 @@ class HistoryControllerTest extends TestCase
      */
     public function testInfo(): void
     {
-        $this->HistoryController->info($this->documentId);
+        $this->HistoryController->info($this->documentId, 1);
         $vars = ['data', 'meta'];
         foreach ($vars as $var) {
             static::assertNotEmpty($this->HistoryController->viewBuilder()->getVar($var));


### PR DESCRIPTION
This fixes a limit in object history view, to max 100 elements, by providing multiple api calls to obtain all history items per object.