### PR TITLE
Richeditor configuration to use custom style formats in Tinymce

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -573,4 +573,18 @@ return [
     //         'copy2clipboard' => true,
     //     ],
     // ],
+
+    /**
+     * Richeditor configuration.
+     */
+    // 'Richeditor' => [
+    //     'styleFormats' => [
+    //         [
+    //             'title' => 'Custom Blocks',
+    //             'items' => [
+    //                 ['title' => 'Highlight', 'block' => 'div', 'classes' => ['be-highlight']],
+    //             ],
+    //         ],
+    //     ],
+    // ],
 ];

--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -98,6 +98,8 @@ export default {
                     toolbar_mode: 'wrap',
                     block_formats: 'Paragraph=p; Header 1=h1; Header 2=h2; Header 3=h3',
                     entity_encoding: 'raw',
+                    style_formats: BEDITA?.richeditorConfig?.styleFormats || [],
+                    style_formats_merge: true,
                     plugins: [
                         'paste',
                         'autoresize',

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -297,7 +297,7 @@ class LayoutHelper extends Helper
             'cloneConfig' => (array)Configure::read('Clone'),
             'uploadConfig' => $this->System->uploadConfig(),
             'relationsSchema' => $this->getView()->get('relationsSchema', []),
-            'richeditorConfig' =>(array)Configure::read('Richeditor'),
+            'richeditorConfig' => (array)Configure::read('Richeditor'),
         ];
     }
 

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -297,6 +297,7 @@ class LayoutHelper extends Helper
             'cloneConfig' => (array)Configure::read('Clone'),
             'uploadConfig' => $this->System->uploadConfig(),
             'relationsSchema' => $this->getView()->get('relationsSchema', []),
+            'richeditorConfig' => Configure::read('Richeditor'),
         ];
     }
 

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -297,7 +297,7 @@ class LayoutHelper extends Helper
             'cloneConfig' => (array)Configure::read('Clone'),
             'uploadConfig' => $this->System->uploadConfig(),
             'relationsSchema' => $this->getView()->get('relationsSchema', []),
-            'richeditorConfig' => Configure::read('Richeditor'),
+            'richeditorConfig' =>(array) Configure::read('Richeditor'),
         ];
     }
 

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -297,7 +297,7 @@ class LayoutHelper extends Helper
             'cloneConfig' => (array)Configure::read('Clone'),
             'uploadConfig' => $this->System->uploadConfig(),
             'relationsSchema' => $this->getView()->get('relationsSchema', []),
-            'richeditorConfig' =>(array) Configure::read('Richeditor'),
+            'richeditorConfig' =>(array)Configure::read('Richeditor'),
         ];
     }
 

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -442,7 +442,7 @@ class LayoutHelperTest extends TestCase
             'cloneConfig' => (array)Configure::read('Clone'),
             'uploadConfig' => $system->uploadConfig(),
             'relationsSchema' => ['whatever'],
-            'richeditorConfig' => null,
+            'richeditorConfig' => (array)Configure::read('Richeditor'),
         ];
         static::assertSame($expected, $conf);
     }

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -442,6 +442,7 @@ class LayoutHelperTest extends TestCase
             'cloneConfig' => (array)Configure::read('Clone'),
             'uploadConfig' => $system->uploadConfig(),
             'relationsSchema' => ['whatever'],
+            'richeditorConfig' => null,
         ];
         static::assertSame($expected, $conf);
     }


### PR DESCRIPTION
This PR introduce a config to add custom style formats showed in drop menu like this:

![immagine](https://github.com/bedita/manager/assets/57118410/0574e3cf-e4fd-479c-b235-8857225da83c)

Adding with:
```
    'Richeditor' => [
        'styleFormats' => [
            [
                'title' => 'Custom Blocks',
                'items' => [
                    [ 'title' => 'Highlight', 'block' => 'div', 'classes' => [ 'be-highlight' ] ],
                ],
            ],
        ],
    ]
```
