### PR TITLE
Date ranges data: fix params on save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ bundle-report.*.html
 /webroot/css/admin-index*
 /webroot/css/app*
 /webroot/css/category*
+/webroot/css/date-ranges*
 /webroot/css/date-input*
 /webroot/css/email-input*
 /webroot/css/flash-message*

--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ bundle-report.*.html
 /webroot/css/admin-index*
 /webroot/css/app*
 /webroot/css/category*
-/webroot/css/date-ranges*
+/webroot/css/date-range*
 /webroot/css/date-input*
 /webroot/css/email-input*
 /webroot/css/flash-message*

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-06-05 07:26:21 \n"
+"POT-Creation-Date: 2024-06-05 10:20:33 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1489,6 +1489,9 @@ msgid "date"
 msgstr ""
 
 msgid "Trashed"
+msgstr ""
+
+msgid "Insert date(s)"
 msgstr ""
 
 msgid "Every day"

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-05-28 09:39:32 \n"
+"POT-Creation-Date: 2024-06-05 07:26:21 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1048,6 +1048,9 @@ msgstr ""
 msgid "undo remove"
 msgstr ""
 
+msgid "untitled"
+msgstr ""
+
 msgid "username"
 msgstr ""
 
@@ -1488,9 +1491,6 @@ msgstr ""
 msgid "Trashed"
 msgstr ""
 
-msgid "untitled"
-msgstr ""
-
 msgid "Every day"
 msgstr ""
 
@@ -1513,6 +1513,9 @@ msgid "Thursday"
 msgstr ""
 
 msgid "Tuesday"
+msgstr ""
+
+msgid "Undo"
 msgstr ""
 
 msgid "Wednesday"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-06-05 07:26:21 \n"
+"POT-Creation-Date: 2024-06-05 10:20:33 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1492,6 +1492,9 @@ msgid "date"
 msgstr ""
 
 msgid "Trashed"
+msgstr ""
+
+msgid "Insert date(s)"
 msgstr ""
 
 msgid "Every day"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-05-28 09:39:32 \n"
+"POT-Creation-Date: 2024-06-05 07:26:21 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1051,6 +1051,9 @@ msgstr ""
 msgid "undo remove"
 msgstr ""
 
+msgid "untitled"
+msgstr ""
+
 msgid "username"
 msgstr ""
 
@@ -1491,9 +1494,6 @@ msgstr ""
 msgid "Trashed"
 msgstr ""
 
-msgid "untitled"
-msgstr ""
-
 msgid "Every day"
 msgstr ""
 
@@ -1516,6 +1516,9 @@ msgid "Thursday"
 msgstr ""
 
 msgid "Tuesday"
+msgstr ""
+
+msgid "Undo"
 msgstr ""
 
 msgid "Wednesday"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-06-05 07:26:21 \n"
+"POT-Creation-Date: 2024-06-05 10:20:33 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1507,6 +1507,9 @@ msgstr "data"
 
 msgid "Trashed"
 msgstr "Rimosso"
+
+msgid "Insert date(s)"
+msgstr "Inserire data(e)"
 
 msgid "Every day"
 msgstr "Tutti i giorni"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-05-28 09:39:32 \n"
+"POT-Creation-Date: 2024-06-05 07:26:21 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1056,6 +1056,9 @@ msgstr "annulla"
 msgid "undo remove"
 msgstr "annulla rimozione"
 
+msgid "untitled"
+msgstr "senza titolo"
+
 msgid "username"
 msgstr "nome utente"
 
@@ -1505,9 +1508,6 @@ msgstr "data"
 msgid "Trashed"
 msgstr "Rimosso"
 
-msgid "untitled"
-msgstr "senza titolo"
-
 msgid "Every day"
 msgstr "Tutti i giorni"
 
@@ -1531,6 +1531,9 @@ msgstr "Giovedì"
 
 msgid "Tuesday"
 msgstr "Martedì"
+
+msgid "Undo"
+msgstr "Annulla"
 
 msgid "Wednesday"
 msgstr "Mercoledì"

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -42,6 +42,7 @@ const _vueInstance = new Vue({
         TagForm: () => import(/* webpackChunkName: "tag-form" */'app/components/tag-form/tag-form'),
         FolderPicker: () => import(/* webpackChunkName: "folder-picker" */'app/components/folder-picker/folder-picker'),
         Dashboard: () => import(/* webpackChunkName: "modules-index" */'app/pages/dashboard/index'),
+        DateRange: () => import(/* webpackChunkName: "date-range" */'app/components/date-range/date-range'),
         DateRangesView: () => import(/* webpackChunkName: "date-ranges-view" */'app/components/date-ranges-view/date-ranges-view'),
         DateRangesList: () => import(/* webpackChunkName: "date-ranges-list" */'app/components/date-ranges-list/date-ranges-list'),
         TreeView: () => import(/* webpackChunkName: "tree-view" */'app/components/tree-view/tree-view'),

--- a/resources/js/app/components/date-range/date-range.vue
+++ b/resources/js/app/components/date-range/date-range.vue
@@ -202,7 +202,11 @@ export default {
         dateRangeClass() {
             return this.msdiff() < 0 ? 'invalid' : '';
         },
-        hasChanged() {
+        hasChanged(skip) {
+            if (skip) {
+                return true;
+            }
+
             return this.start_date !== this.range.start_date
                 || this.end_date !== this.range.end_date
                 || this.all_day !== this.range.params.all_day
@@ -329,8 +333,8 @@ export default {
             this.range.removed = false;
             this.$emit('undoRemove', this.range);
         },
-        update() {
-            if (this.hasChanged() === false) {
+        update(skip) {
+            if (this.hasChanged(skip) === false) {
                 return;
             }
             this.range.start_date = this.start_date;
@@ -338,19 +342,19 @@ export default {
             this.range.params.all_day = this.all_day;
             this.range.params.every_day = this.every_day;
             this.range.params.weekdays = this.weekdays;
-            if (!this.validate()) {
+            if (!this.validate(this.range, skip)) {
                 return;
             }
             this.$emit('update', this.range);
         },
         updateWeekDays(day, { target: { checked } }) {
             this.range.params.weekdays[day] = checked;
-            this.update();
+            this.update(true);
         },
-        validate(dateRange) {
+        validate(dateRange, skip) {
             const input = dateRange || this.range;
             const button = document.querySelector('button[form=form-main]');
-            const valid = input?.start_date ? true : this.msdiff(input) > 0;
+            const valid = skip || input?.start_date ? true : this.msdiff(input) > 0;
             if (input?.start_date && !valid) {
                 button.disabled = 'disabled';
             } else {

--- a/resources/js/app/components/date-range/date-range.vue
+++ b/resources/js/app/components/date-range/date-range.vue
@@ -202,6 +202,13 @@ export default {
         dateRangeClass() {
             return this.msdiff() < 0 ? 'invalid' : '';
         },
+        hasChanged() {
+            return this.start_date !== this.range.start_date
+                || this.end_date !== this.range.end_date
+                || this.all_day !== this.range.params.all_day
+                || this.every_day !== this.range.params.every_day
+                || JSON.stringify(this.weekdays) !== JSON.stringify(this.range.params.weekdays);
+        },
         isDaysInterval() {
             if (!this.start_date) {
                 return false;
@@ -323,13 +330,14 @@ export default {
             this.$emit('undoRemove', this.range);
         },
         update() {
+            if (this.hasChanged() === false) {
+                return;
+            }
             this.range.start_date = this.start_date;
             this.range.end_date = this.end_date;
-            this.range.params = {
-                all_day: this.all_day,
-                every_day: this.every_day,
-                weekdays: this.weekdays,
-            };
+            this.range.params.all_day = this.all_day;
+            this.range.params.every_day = this.every_day;
+            this.range.params.weekdays = this.weekdays;
             if (!this.validate()) {
                 return;
             }

--- a/resources/js/app/components/date-range/date-range.vue
+++ b/resources/js/app/components/date-range/date-range.vue
@@ -1,0 +1,344 @@
+<template>
+    <div
+        class="dateRange date-ranges-item mb-1"
+        :class="removed ? 'removed' : 'active'"
+    >
+        <div>
+            <span>{{ msgFrom }}</span>
+            <div :class="dateRangeClass()">
+                <input
+                    type="text"
+                    date="true"
+                    :time="!all_day"
+                    daterange="true"
+                    v-model="start_date"
+                    v-datepicker="true"
+                    @change="onDateChanged(true, $event)"
+                >
+            </div>
+        </div>
+        <div :class="dateRangeClass()">
+            <span>{{ msgTo }}</span>
+            <div>
+                <input
+                    type="text"
+                    date="true"
+                    :time="!all_day"
+                    daterange="true"
+                    v-model="end_date"
+                    v-datepicker="true"
+                    @change="onDateChanged(false, $event)"
+                    v-if="start_date"
+                >
+                <input
+                    type="text"
+                    disabled="disabled"
+                    v-else
+                >
+            </div>
+        </div>
+        <div v-show="!optionIsSet('all_day')">
+            <label class="m-0 nowrap has-text-size-smaller">
+                <input
+                    type="checkbox"
+                    :disabled="!start_date"
+                    :checked="all_day"
+                    @change="onAllDayChanged($event)"
+                >
+                {{ msgAllDay }}
+            </label>
+        </div>
+        <div v-show="!optionIsSet('every_day')">
+            <label class="m-0 nowrap has-text-size-smaller">
+                <input
+                    type="checkbox"
+                    :disabled="!isDaysInterval()"
+                    :checked="every_day"
+                    @change="onEveryDayChanged($event)"
+                >
+                {{ msgEveryDay }}
+            </label>
+        </div>
+        <div>
+            <button
+                class="button button-primary"
+                @click.prevent="remove($event)"
+                v-if="!removed"
+            >
+                <app-icon icon="carbon:trash-can" />
+                <span class="ml-05">{{ msgRemove }}</span>
+            </button>
+            <button
+                class="button button-primary"
+                @click.prevent="undoRemove($event)"
+                v-else
+            >
+                <app-icon icon="carbon:undo" />
+                <span class="ml-05">{{ msgUndo }}</span>
+            </button>
+        </div>
+        <div
+            class="m-0 nowrap has-text-size-smaller weekdays"
+            v-show="every_day === false"
+        >
+            <label>
+                <input
+                    type="checkbox"
+                    v-model="weekdays.sunday"
+                    @click="updateWeekDays('sunday', $event)"
+                >{{ msgSunday }}
+            </label>
+            <label>
+                <input
+                    type="checkbox"
+                    v-model="weekdays.monday"
+                    @click="updateWeekDays('monday', $event)"
+                >{{ msgMonday }}
+            </label>
+            <label>
+                <input
+                    type="checkbox"
+                    v-model="weekdays.tuesday"
+                    @click="updateWeekDays('tuesday', $event)"
+                >{{ msgTuesday }}
+            </label>
+            <label>
+                <input
+                    type="checkbox"
+                    v-model="weekdays.wednesday"
+                    @click="updateWeekDays('wednesday', $event)"
+                >{{ msgWednesday }}
+            </label>
+            <label>
+                <input
+                    type="checkbox"
+                    v-model="weekdays.thursday"
+                    @click="updateWeekDays('thursday', $event)"
+                >{{ msgThursday }}
+            </label>
+            <label>
+                <input
+                    type="checkbox"
+                    v-model="weekdays.friday"
+                    @click="updateWeekDays('friday', $event)"
+                >{{ msgFriday }}
+            </label>
+            <label>
+                <input
+                    type="checkbox"
+                    v-model="weekdays.saturday"
+                    @click="updateWeekDays('saturday', $event)"
+                >{{ msgSaturday }}
+            </label>
+        </div>
+        <div
+            class="icon-error"
+            v-show="msdiff() < 0"
+        >
+            {{ msgInvalidDateRange }}
+        </div>
+    </div>
+</template>
+<script>
+import moment from 'moment';
+import { t } from 'ttag';
+
+export default {
+    name: 'DateRange',
+    props: {
+        options: {
+            type: Object,
+            default: () => ({}),
+        },
+        source: {
+            type: Object,
+            required: true
+        },
+    },
+
+    data() {
+        return {
+            every_day: true,
+            start_date: '',
+            all_day: '',
+            end_date: '',
+            weekdays: [],
+            range: null,
+            removed: false,
+            msgAllDay: t`All day`,
+            msgEveryDay: t`Every day`,
+            msgFriday: t`Friday`,
+            msgFrom: t`From`,
+            msgInvalidDateRange: t`Invalid date range`,
+            msgMonday: t`Monday`,
+            msgRemove: t`Remove`,
+            msgSaturday: t`Saturday`,
+            msgSunday: t`Sunday`,
+            msgThursday: t`Thursday`,
+            msgTo: t`To`,
+            msgTuesday: t`Tuesday`,
+            msgUndo: t`Undo`,
+            msgWednesday: t`Wednesday`,
+        }
+    },
+
+    mounted() {
+        this.range = this.source;
+        this.start_date = this.range?.start_date;
+        this.end_date = this.range?.end_date;
+        this.all_day = this.range?.params?.all_day;
+        this.every_day = this.range?.params?.every_day;
+        this.weekdays = this.range?.params?.weekdays;
+    },
+
+    methods: {
+        dateRangeClass() {
+            return this.msdiff() < 0 ? 'invalid' : '';
+        },
+        isDaysInterval() {
+            if (!this.start_date) {
+                return false;
+            }
+            if (!this.end_date) {
+                return false;
+            }
+            const sd = moment(this.start_date);
+            const ed = moment(this.end_date);
+            const diff = moment.duration(ed.diff(sd)).asDays();
+
+            return diff >= 1;
+        },
+        msdiff() {
+            if (this.start_date === '' || this.end_date === '') {
+                return 0;
+            }
+            const sd = moment(this.start_date);
+            const ed = moment(this.end_date);
+
+            return moment.duration(ed.diff(sd)).asMilliseconds();
+        },
+        onAllDayChanged({ target: { checked } }) {
+            this.all_day = checked;
+            if (!checked) {
+                this.update();
+                return;
+            }
+            this.setAllDayRange();
+            this.update();
+        },
+        onDateChanged(isStartDate, ev) {
+            const value = ev.target.value;
+            const dr = {};
+            if (isStartDate) {
+                dr.start_date = value;
+                if (value.length === 0) {
+                    this.end_date = '';
+                }
+                dr.end_date = this.end_date;
+            } else {
+                dr.start_date = this.start_date;
+                dr.end_date = value;
+            }
+            this.validate(dr);
+            if (isStartDate) {
+                this.start_date = value;
+            } else {
+                this.end_date = value;
+            }
+            if (this.isDaysInterval() && !this.optionIsSet('all_day')) {
+                this.all_day = false;
+            }
+            if (this.options?.all_day === true) {
+                this.setAllDayRange();
+            }
+            this.update();
+        },
+        onEveryDayChanged({ target: { checked } }) {
+            this.every_day = checked;
+            if (!checked) {
+                this.resetWeekdays();
+            } else {
+                this.setAllWeekdays();
+            }
+            this.update();
+        },
+        optionIsSet(option) {
+            return this.options[option] !== undefined;
+        },
+        remove() {
+            this.removed = true;
+            this.range.removed = true;
+            this.$emit('remove', this.range);
+        },
+        resetWeekdays() {
+            this.weekdays = {
+                sunday: false,
+                monday: false,
+                tuesday: false,
+                wednesday: false,
+                thursday: false,
+                friday: false,
+                saturday: false
+            };
+        },
+        setAllDayRange() {
+            if (!this.start_date) {
+                return;
+            }
+            let date = moment(this.start_date);
+            date.set({ hour: 0, minute: 0 });
+            this.start_date = date.format('YYYY-MM-DDTHH:mm');
+            if (!this.end_date) {
+                this.end_date = date.endOf('day').format('YYYY-MM-DDTHH:mm');
+            } else {
+                date = moment(this.end_date);
+                date.set({ hour: 23, minute: 59 });
+                this.end_date = date.format('YYYY-MM-DDTHH:mm');
+            }
+        },
+        setAllWeekdays() {
+            this.weekdays = {
+                sunday: true,
+                monday: true,
+                tuesday: true,
+                wednesday: true,
+                thursday: true,
+                friday: true,
+                saturday: true
+            };
+        },
+        undoRemove() {
+            this.removed = false;
+            this.range.removed = false;
+            this.$emit('undoRemove', this.range);
+        },
+        update() {
+            this.range.start_date = this.start_date;
+            this.range.end_date = this.end_date;
+            this.range.params = {
+                all_day: this.all_day,
+                every_day: this.every_day,
+                weekdays: this.weekdays,
+            };
+            this.$emit('update', this.range);
+        },
+        updateWeekDays(day, { target: { checked } }) {
+            this.range.params.weekdays[day] = checked;
+            this.update();
+        },
+        valid() {
+            return (this.start_date === '' || this.end_date === '') ? true : this.msdiff() > 0;
+        },
+        validate() {
+            const button = document.querySelector('button[form=form-main]');
+            const valid = this.valid(this.range);
+            button.disabled = valid ? false : 'disabled';
+        },
+    },
+}
+</script>
+<style>
+div.removed {
+    opacity: 0.5;
+}
+</style>

--- a/resources/js/app/components/date-ranges-view/date-ranges-view.vue
+++ b/resources/js/app/components/date-ranges-view/date-ranges-view.vue
@@ -1,154 +1,39 @@
 <template>
     <div>
         <div class="date-ranges-list">
-            <div class="date-ranges-item mb-1"
-                 v-for="(dateRange, index) in dateRanges"
-                 :key="index"
-            >
-                <div>
-                    <span>{{ msgFrom }}</span>
-                    <div :class="dateRangeClass(dateRange)">
-                        <input type="text"
-                               :name="getName(index, 'start_date')"
-                               date="true"
-                               :time="!dateRange.params.all_day"
-                               daterange="true"
-                               v-model="dateRange.start_date"
-                               v-datepicker="true"
-                               @change="onDateChanged(dateRange, $event)"
-                        >
-                    </div>
-                </div>
-                <div :class="dateRangeClass(dateRange)">
-                    <span>{{ msgTo }}</span>
-                    <div>
-                        <input type="text"
-                               :name="getName(index, 'end_date')"
-                               date="true"
-                               :time="!dateRange.params.all_day"
-                               daterange="true"
-                               v-model="dateRange.end_date"
-                               v-datepicker="true"
-                               @change="onDateChanged(dateRange, $event)"
-                               v-if="dateRange.start_date"
-                        >
-                        <input type="text"
-                               disabled="disabled"
-                               v-else
-                        >
-                    </div>
-                </div>
-                <div v-show="!optionIsSet('all_day')">
-                    <label class="m-0 nowrap has-text-size-smaller">
-                        <input type="checkbox"
-                               :disabled="!dateRange.start_date"
-                               :name="getNameAllDay(index)"
-                               v-model="dateRange.params.all_day"
-                               @change="onAllDayChanged(dateRange, $event)"
-                        >
-                        {{ msgAllDay }}
-                    </label>
-                </div>
-                <div v-show="!optionIsSet('every_day')">
-                    <label class="m-0 nowrap has-text-size-smaller">
-                        <input type="checkbox"
-                               :disabled="!isDaysInterval(dateRange)"
-                               :name="getNameEveryDay(index)"
-                               checked="dateRange.params.every_day"
-                               v-model="dateRange.params.every_day"
-                               @change="onEveryDayChanged(dateRange, $event)"
-                        >
-                        {{ msgEveryDay }}
-                    </label>
-                </div>
-                <div>
-                    <button :disabled="dateRanges.length < 2"
-                            class="button button-primary"
-                            @click.prevent="remove(index, $event)"
-                    >
-                        <app-icon icon="carbon:trash-can" />
-                        <span class="ml-05">{{ msgRemove }}</span>
-                    </button>
-                </div>
-                <div class="m-0 nowrap has-text-size-smaller weekdays"
-                     v-if="dateRange.params.every_day === false"
-                >
-                    <label>
-                        <input
-                            type="checkbox"
-                            :name="getNameWeekday(index, 'sunday')"
-                            v-model="dateRange.params.weekdays.sunday"
-                        >{{ msgSunday }}
-                    </label>
-                    <label>
-                        <input
-                            type="checkbox"
-                            :name="getNameWeekday(index, 'monday')"
-                            v-model="dateRange.params.weekdays.monday"
-                        >{{ msgMonday }}
-                    </label>
-                    <label>
-                        <input
-                            type="checkbox"
-                            :name="getNameWeekday(index, 'tuesday')"
-                            v-model="dateRange.params.weekdays.tuesday"
-                        >{{ msgTuesday }}
-                    </label>
-                    <label>
-                        <input
-                            type="checkbox"
-                            :name="getNameWeekday(index, 'wednesday')"
-                            v-model="dateRange.params.weekdays.wednesday"
-                        >{{ msgWednesday }}
-                    </label>
-                    <label>
-                        <input
-                            type="checkbox"
-                            :name="getNameWeekday(index, 'thursday')"
-                            v-model="dateRange.params.weekdays.thursday"
-                        >{{ msgThursday }}
-                    </label>
-                    <label>
-                        <input
-                            type="checkbox"
-                            :name="getNameWeekday(index, 'friday')"
-                            v-model="dateRange.params.weekdays.friday"
-                        >{{ msgFriday }}
-                    </label>
-                    <label>
-                        <input
-                            type="checkbox"
-                            :name="getNameWeekday(index, 'saturday')"
-                            v-model="dateRange.params.weekdays.saturday"
-                        >{{ msgSaturday }}
-                    </label>
-                    <input
-                        type="hidden"
-                        :name="getName(index, 'params')"
-                        :value="jsonParams(index)"
-                    >
-                </div>
-                <div class="icon-error"
-                     v-if="msdiff(dateRange) < 0"
-                >
-                    {{ msgInvalidDateRange }}
-                </div>
-            </div>
+            <DateRange
+                v-for="(dateRange, index) in dateRanges"
+                :key="index"
+                :options="options"
+                :source="dateRanges[index]"
+                @remove="remove"
+                @undoRemove="undoRemove"
+                @update="update"
+            />
         </div>
-
-        <button class="button button-primary"
-                @click.prevent="add"
+        <button
+            class="button button-primary"
+            @click.prevent="add"
         >
             <app-icon icon="carbon:add" />
             <span class="ml-05">{{ msgAdd }}</span>
         </button>
+        <input
+            type="hidden"
+            name="date_ranges"
+            v-model="dateRangesJson"
+        >
     </div>
 </template>
 <script>
-import moment from 'moment';
 import { t } from 'ttag';
 
 export default {
+    name: 'DateRangesView',
+
+    components: {
+        DateRange: () => import(/* webpackChunkName: "date-range" */ '../date-range/date-range.vue'),
+    },
 
     props: {
         ranges: {
@@ -164,20 +49,8 @@ export default {
     data() {
         return {
             dateRanges: [],
+            dateRangesJson: '',
             msgAdd: t`Add`,
-            msgAllDay: t`All day`,
-            msgEveryDay: t`Every day`,
-            msgFriday: t`Friday`,
-            msgFrom: t`From`,
-            msgInvalidDateRange: t`Invalid date range`,
-            msgMonday: t`Monday`,
-            msgRemove: t`Remove`,
-            msgSaturday: t`Saturday`,
-            msgSunday: t`Sunday`,
-            msgThursday: t`Thursday`,
-            msgTo: t`To`,
-            msgTuesday: t`Tuesday`,
-            msgWednesday: t`Wednesday`,
         }
     },
 
@@ -191,18 +64,21 @@ export default {
         if (ranges) {
             this.dateRanges = ranges;
             this.dateRanges.forEach((range) => {
+                range.uuid = this.uuid();
                 if (range.params?.length > 0) {
                     range.params = JSON.parse(range.params) || false;
                 }
+                range.originalParams = range.params;
                 range.params = range.params || defaultOptions;
                 if (!this.optionIsSet('every_day')) {
                     range.params.every_day = !range.params?.weekdays || Object.keys(range.params?.weekdays).length === 0;
-                    range.params.weekdays = range?.params?.weekdays ? this.normalizeWeekdays(range?.params?.weekdays) : {};
+                    range.params.weekdays = range?.originalParams?.weekdays ? this.normalizeWeekdays(range?.params?.weekdays) : {};
                 }
                 if (!range.start_date) {
                     range.end_date = '';
                 }
             });
+            this.dateRangesJson = JSON.stringify(this.dateRanges);
         }
         if (!this.dateRanges.length) {
             this.add();
@@ -210,33 +86,19 @@ export default {
     },
 
     methods: {
-        getName(index, field) {
-            return `date_ranges[${index}][${field}]`;
-        },
-        getNameAllDay(index) {
-            return `date_ranges[${index}][params][all_day]`;
-        },
-        getNameEveryDay(index) {
-            return `date_ranges[${index}][params][every_day]`;
-        },
-        getNameWeekday(index, weekday) {
-            return `date_ranges[${index}][params][weekdays][${weekday}]`;
-        },
-        jsonParams(index) {
-            return JSON.stringify(this.dateRanges[index]?.params);
-        },
-        isDaysInterval(range) {
-            if (!range.start_date) {
-                return false;
-            }
-            if (!range.end_date) {
-                return false;
-            }
-            const sd = moment(range.start_date);
-            const ed = moment(range.end_date);
-            const diff = moment.duration(ed.diff(sd)).asDays();
-
-            return diff >= 1;
+        add() {
+            const newRange = {
+                start_date: '',
+                end_date: '',
+                params: {
+                    all_day: this.options?.all_day || false,
+                    every_day: this.options?.every_day || true,
+                    weekdays: {},
+                },
+            };
+            newRange.uuid = this.uuid();
+            this.dateRanges.push(newRange);
+            this.dateRangesJson = JSON.stringify(this.dateRanges);
         },
         normalizeWeekdays(wdays) {
             if (wdays.constructor !== Array) {
@@ -260,164 +122,47 @@ export default {
                 saturday: wdays.includes('saturday'),
             };
         },
-        /**
-         * Add an empty date range to list.
-         *
-         * @returns {void}
-         */
-        add() {
-            this.dateRanges.push({
-                start_date: '',
-                end_date: '',
-                params: {
-                    all_day: this.options?.all_day || false,
-                },
-            });
-        },
-        onDateChanged(dateRange, ev) {
-            const value = ev.target.value;
-            const dr = {};
-            const isStartDate = ev.target.name.indexOf('start_date') > 0;
-            if (isStartDate) {
-                dr.start_date = value;
-                if (value.length === 0) {
-                    dateRange.end_date = '';
-                }
-                dr.end_date = dateRange.end_date;
-            } else {
-                dr.start_date = dateRange.start_date;
-                dr.end_date = value;
-            }
-            this.validate(dr);
-            if (this.isDaysInterval(dateRange) && !this.optionIsSet('all_day')) {
-                dateRange.params.all_day = false;
-            }
-            if (this.options?.all_day === true) {
-                if (isStartDate) {
-                    dateRange.start_date = value;
-                } else {
-                    dateRange.end_date = value;
-                }
-                this.setAllDayRange(dateRange);
-            }
-        },
-        onAllDayChanged(dateRange, { target: { checked } }) {
-            if (!checked) {
-                return;
-            }
-            this.setAllDayRange(dateRange);
-        },
-        onEveryDayChanged(dateRange, { target: { checked } }) {
-            if (!checked) {
-                this.resetWeekdays(dateRange);
-            } else {
-                this.setAllWeekdays(dateRange);
-            }
-        },
-        resetWeekdays(dateRange) {
-            dateRange.params.weekdays = {
-                sunday: false,
-                monday: false,
-                tuesday: false,
-                wednesday: false,
-                thursday: false,
-                friday: false,
-                saturday: false
-            };
-            this.$forceUpdate();
-        },
-        setAllWeekdays(dateRange) {
-            dateRange.params.weekdays = {
-                sunday: true,
-                monday: true,
-                tuesday: true,
-                wednesday: true,
-                thursday: true,
-                friday: true,
-                saturday: true
-            };
-            this.$forceUpdate();
-        },
-        setAllDayRange(dateRange) {
-            if (!dateRange.start_date) {
-                return;
-            }
-            let date = moment(dateRange.start_date);
-            date.set({ hour: 0, minute: 0 });
-            dateRange.start_date = date.format('YYYY-MM-DDTHH:mm');
-            if (!dateRange.end_date) {
-                dateRange.end_date = date.endOf('day').format('YYYY-MM-DDTHH:mm');
-            } else {
-                date = moment(dateRange.end_date);
-                date.set({ hour: 23, minute: 59 });
-                dateRange.end_date = date.format('YYYY-MM-DDTHH:mm');
-            }
-        },
-        /**
-         * Remove date range from list.
-         *
-         * @param {Integer} index The index
-         * @returns {void}
-         */
-        remove(index) {
-            this.dateRanges.splice(index, 1);
-        },
-        /**
-         * Validate date range
-         *
-         * @param {Object} dateRange Date range object.
-         * @returns {void}
-         */
-        validate(dateRange) {
-            const button = document.querySelector('button[form=form-main]');
-            const valid = this.valid(dateRange);
-            button.disabled = valid ? false : 'disabled';
-        },
-        /**
-         * Check date range is valid
-         *
-         * @param {Object} dateRange Date range object.
-         * @returns {Boolean}
-         */
-        valid(dateRange) {
-            if (dateRange.start_date === '' || dateRange.end_date === '') {
-                return true;
-            }
-
-            return this.msdiff(dateRange) > 0;
-        },
-        /**
-         * Milliseconds diff between end_date and start_date in a dateRange.
-         * When negative, it means that start_date is after end_date.
-         *
-         * @param {Object} dateRange
-         * @returns {Integer}
-         */
-        msdiff(dateRange) {
-            if (dateRange.start_date === '' || dateRange.end_date === '') {
-                return 0;
-            }
-            const sd = moment(dateRange.start_date);
-            const ed = moment(dateRange.end_date);
-
-            return moment.duration(ed.diff(sd)).asMilliseconds();
-        },
-        /**
-         * Return class for dateRange text field
-         *
-         * @param {Object} dateRange Date range object.
-         * @returns
-         */
-        dateRangeClass(dateRange) {
-            if (this.msdiff(dateRange) < 0) {
-                return 'invalid';
-            }
-
-            return '';
-        },
-
         optionIsSet(option) {
             return this.options[option] !== undefined;
+        },
+        remove(range) {
+            this.update(range);
+        },
+        undoRemove(range) {
+            this.dateRangesJson = JSON.stringify(this.dateRanges);
+            this.update(range);
+        },
+        update(range) {
+            let json = JSON.parse(this.dateRangesJson);
+            const dr = [];
+            for (let data of json) {
+                if (data.removed === true) {
+                    if (data.uuid === range.uuid && range.removed === false) {
+                        dr.push(this.updateData(range));
+                    }
+                    continue;
+                }
+                if (data.uuid !== range.uuid) {
+                    dr.push(this.updateData(data));
+                    continue;
+                }
+                if (!range?.removed) {
+                    dr.push(this.updateData(range));
+                }
+            }
+            this.dateRangesJson = JSON.stringify(dr);
+        },
+        updateData(data) {
+            return {
+                uuid: data.uuid,
+                removed: data.removed,
+                start_date: data.start_date,
+                end_date: data.end_date,
+                params: data.params,
+            }
+        },
+        uuid() {
+            return Math.random().toString(36).substring(2) + Date.now().toString(36);
         },
     },
 }

--- a/resources/js/app/components/date-ranges-view/date-ranges-view.vue
+++ b/resources/js/app/components/date-ranges-view/date-ranges-view.vue
@@ -73,30 +73,59 @@
                 <div class="m-0 nowrap has-text-size-smaller weekdays"
                      v-if="dateRange.params.every_day === false"
                 >
-                    <label><input type="checkbox"
-                                  v-model="dateRange.params.weekdays.sunday"
-                    >{{ msgSunday }}</label>
-                    <label><input type="checkbox"
-                                  v-model="dateRange.params.weekdays.monday"
-                    >{{ msgMonday }}</label>
-                    <label><input type="checkbox"
-                                  v-model="dateRange.params.weekdays.tuesday"
-                    >{{ msgTuesday }}</label>
-                    <label><input type="checkbox"
-                                  v-model="dateRange.params.weekdays.wednesday"
-                    >{{ msgWednesday }}</label>
-                    <label><input type="checkbox"
-                                  v-model="dateRange.params.weekdays.thursday"
-                    >{{ msgThursday }}</label>
-                    <label><input type="checkbox"
-                                  v-model="dateRange.params.weekdays.friday"
-                    >{{ msgFriday }}</label>
-                    <label><input type="checkbox"
-                                  v-model="dateRange.params.weekdays.saturday"
-                    >{{ msgSaturday }}</label>
-                    <input type="hidden"
-                           :name="getName(index, 'params')"
-                           :value="JSON.stringify(dateRange.params)"
+                    <label>
+                        <input
+                            type="checkbox"
+                            :name="getNameWeekday(index, 'sunday')"
+                            v-model="dateRange.params.weekdays.sunday"
+                        >{{ msgSunday }}
+                    </label>
+                    <label>
+                        <input
+                            type="checkbox"
+                            :name="getNameWeekday(index, 'monday')"
+                            v-model="dateRange.params.weekdays.monday"
+                        >{{ msgMonday }}
+                    </label>
+                    <label>
+                        <input
+                            type="checkbox"
+                            :name="getNameWeekday(index, 'tuesday')"
+                            v-model="dateRange.params.weekdays.tuesday"
+                        >{{ msgTuesday }}
+                    </label>
+                    <label>
+                        <input
+                            type="checkbox"
+                            :name="getNameWeekday(index, 'wednesday')"
+                            v-model="dateRange.params.weekdays.wednesday"
+                        >{{ msgWednesday }}
+                    </label>
+                    <label>
+                        <input
+                            type="checkbox"
+                            :name="getNameWeekday(index, 'thursday')"
+                            v-model="dateRange.params.weekdays.thursday"
+                        >{{ msgThursday }}
+                    </label>
+                    <label>
+                        <input
+                            type="checkbox"
+                            :name="getNameWeekday(index, 'friday')"
+                            v-model="dateRange.params.weekdays.friday"
+                        >{{ msgFriday }}
+                    </label>
+                    <label>
+                        <input
+                            type="checkbox"
+                            :name="getNameWeekday(index, 'saturday')"
+                            v-model="dateRange.params.weekdays.saturday"
+                        >{{ msgSaturday }}
+                    </label>
+                    <input
+                        type="hidden"
+                        :name="getName(index, 'params')"
+                        :value="jsonParams(index)"
                     >
                 </div>
                 <div class="icon-error"
@@ -152,12 +181,6 @@ export default {
         }
     },
 
-    computed: {
-        emptyStartDate() {
-            return this.dateRanges.length === 1 && !this.dateRanges[0].start_date;
-        },
-    },
-
     created() {
         const ranges = JSON.parse(this.ranges);
         const defaultOptions = {
@@ -174,6 +197,7 @@ export default {
                 range.params = range.params || defaultOptions;
                 if (!this.optionIsSet('every_day')) {
                     range.params.every_day = !range.params?.weekdays || Object.keys(range.params?.weekdays).length === 0;
+                    range.params.weekdays = range?.params?.weekdays ? this.normalizeWeekdays(range?.params?.weekdays) : {};
                 }
                 if (!range.start_date) {
                     range.end_date = '';
@@ -195,6 +219,12 @@ export default {
         getNameEveryDay(index) {
             return `date_ranges[${index}][params][every_day]`;
         },
+        getNameWeekday(index, weekday) {
+            return `date_ranges[${index}][params][weekdays][${weekday}]`;
+        },
+        jsonParams(index) {
+            return JSON.stringify(this.dateRanges[index]?.params);
+        },
         isDaysInterval(range) {
             if (!range.start_date) {
                 return false;
@@ -207,6 +237,28 @@ export default {
             const diff = moment.duration(ed.diff(sd)).asDays();
 
             return diff >= 1;
+        },
+        normalizeWeekdays(wdays) {
+            if (wdays.constructor !== Array) {
+                return {
+                    sunday: false,
+                    monday: false,
+                    tuesday: false,
+                    wednesday: false,
+                    thursday: false,
+                    friday: false,
+                    saturday: false
+                };
+            }
+            return {
+                sunday: wdays.includes('sunday'),
+                monday: wdays.includes('monday'),
+                tuesday: wdays.includes('tuesday'),
+                wednesday: wdays.includes('wednesday'),
+                thursday: wdays.includes('thursday'),
+                friday: wdays.includes('friday'),
+                saturday: wdays.includes('saturday'),
+            };
         },
         /**
          * Add an empty date range to list.
@@ -258,6 +310,8 @@ export default {
         onEveryDayChanged(dateRange, { target: { checked } }) {
             if (!checked) {
                 this.resetWeekdays(dateRange);
+            } else {
+                this.setAllWeekdays(dateRange);
             }
         },
         resetWeekdays(dateRange) {
@@ -270,6 +324,19 @@ export default {
                 friday: false,
                 saturday: false
             };
+            this.$forceUpdate();
+        },
+        setAllWeekdays(dateRange) {
+            dateRange.params.weekdays = {
+                sunday: true,
+                monday: true,
+                tuesday: true,
+                wednesday: true,
+                thursday: true,
+                friday: true,
+                saturday: true
+            };
+            this.$forceUpdate();
         },
         setAllDayRange(dateRange) {
             if (!dateRange.start_date) {

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -29,6 +29,7 @@ export default {
         RelationView: () => import(/* webpackChunkName: "relation-view" */'app/components/relation-view/relation-view'),
         ResourceRelationView: () => import(/* webpackChunkName: "resource-relation-view" */'app/components/relation-view/resource-relation-view'),
         MapView: () => import(/* webpackChunkName: "map-view" */'app/components/map-view'),
+        DateRange: () => import(/* webpackChunkName: "date-range" */'app/components/date-range/date-range'),
         DateRangesView: () => import(/* webpackChunkName: "date-ranges-view" */'app/components/date-ranges-view/date-ranges-view'),
         HistoryChanges: () => import(/* webpackChunkName: "history-changes" */'app/components/history/history-changes'),
         CoordinatesView: () => import(/* webpackChunkName: "coordinates-view" */'app/components/coordinates-view'),

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -288,6 +288,7 @@ class AppController extends Controller
         if (empty($data['date_ranges'])) {
             return;
         }
+        $data['date_ranges'] = json_decode($data['date_ranges'], true);
         $data['date_ranges'] = DateRangesTools::prepare(Hash::get($data, 'date_ranges'));
     }
 

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -285,6 +285,9 @@ class AppController extends Controller
      */
     protected function prepareDateRanges(array &$data): void
     {
+        if (empty($data['date_ranges'])) {
+            return;
+        }
         $data['date_ranges'] = DateRangesTools::prepare(Hash::get($data, 'date_ranges'));
     }
 

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -13,6 +13,7 @@
 namespace App\Controller;
 
 use App\Form\Form;
+use App\Utility\DateRangesTools;
 use Authentication\Identity;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Controller\Controller;
@@ -284,27 +285,7 @@ class AppController extends Controller
      */
     protected function prepareDateRanges(array &$data): void
     {
-        if (empty($data['date_ranges'])) {
-            return;
-        }
-        $data['date_ranges'] = array_filter(
-            (array)$data['date_ranges'],
-            function ($item) {
-                return !empty($item['start_date']) || !empty($item['end_date']);
-            }
-        );
-        $data['date_ranges'] = array_map(
-            function ($item) {
-                if (empty($item['end_date'])) {
-                    return $item;
-                }
-                $item['end_date'] = str_replace(':59:00.000', ':59:59.000', $item['end_date']);
-
-                return $item;
-            },
-            $data['date_ranges']
-        );
-        $data['date_ranges'] = array_values($data['date_ranges']);
+        $data['date_ranges'] = DateRangesTools::prepare(Hash::get($data, 'date_ranges'));
     }
 
     /**

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -70,7 +70,7 @@ class DateRangesTools
 
                     continue;
                 }
-                // all_day is true, no need for weekdays
+                // all_day is true, no need for weekdays, and every_day MUST be true
                 $item['params'] = json_encode([
                     'all_day' => true,
                     'every_day' => true,

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -105,7 +105,7 @@ class DateRangesTools
         if (!empty($weekdays)) {
             $params['weekdays'] = $weekdays;
         }
-        if (($everyDay || count($weekdays) === 7) || (!$everyDay && count($weekdays) === 0)) {
+        if (($everyDay && count($weekdays) === 7) || (!$everyDay && count($weekdays) === 0)) {
             $params['every_day'] = 'on';
             $params = array_filter(
                 $params,

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -56,7 +56,7 @@ class DateRangesTools
             if (empty(Hash::get($item, 'params'))) {
                 continue;
             }
-            $item['params'] = self::parseParams((array)Hash::get($item, 'params'), self::isOneDayRange($item));
+            $item['params'] = self::parseParams((array)Hash::get($item, 'params'), self::isOneDayRange((array)$item));
         }
         $dateRanges = array_values($dateRanges);
 

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -142,22 +142,4 @@ class DateRangesTools
 
         return empty($data) ? null : $data;
     }
-
-    /**
-     * Get days from form input.
-     *
-     * @param array $input Input.
-     * @return array
-     */
-    public static function weekdays(array $input): array
-    {
-        $days = [];
-        foreach ($input as $key => $value) {
-            if ($value === true) {
-                $days[] = $key;
-            }
-        }
-
-        return $days;
-    }
 }

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Utility;
+
+use Cake\Utility\Hash;
+
+/**
+ * Date Ranges tools
+ */
+class DateRangesTools
+{
+    /**
+     * Prepare date ranges.
+     *
+     * @param array|null $inputDateRanges Date ranges to format.
+     * @return array|null
+     */
+    public static function prepare(?array $inputDateRanges): ?array
+    {
+        if (empty($inputDateRanges)) {
+            return $inputDateRanges;
+        }
+        $dateRanges = $inputDateRanges;
+        $dateRanges = array_filter(
+            (array)$dateRanges,
+            function ($item) {
+                $sd = (string)Hash::get($item, 'start_date');
+                $ed = (string)Hash::get($item, 'end_date');
+
+                return !empty($sd) || !empty($ed);
+            }
+        );
+        $dateRanges = array_map(
+            function ($item) {
+                $ed = (string)Hash::get($item, 'end_date');
+                if (empty($ed)) {
+                    return $item;
+                }
+                $item['end_date'] = str_replace(':59:00.000', ':59:59.000', $ed);
+
+                return $item;
+            },
+            $dateRanges
+        );
+        foreach ($dateRanges as &$item) {
+            $params = (string)Hash::get($item, 'params');
+            if (empty($params)) {
+                continue;
+            }
+            $params = json_decode($params, true);
+            $sd = (string)Hash::get($item, 'start_date');
+            $ed = (string)Hash::get($item, 'end_date');
+            $allDay = Hash::get($params, 'all_day');
+            if (!empty($sd) && empty($ed)) {
+                if (!array_key_exists('all_day', $params) || $allDay === false) {
+                    $item['params'] = null;
+                } else { // all_day is true
+                    $newParams = [
+                        'all_day' => true,
+                        'every_day' => true,
+                    ];
+                    $item['params'] = json_encode($newParams);
+                }
+            }
+        }
+        $dateRanges = array_values($dateRanges);
+
+        return $dateRanges;
+    }
+}

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -56,7 +56,7 @@ class DateRangesTools
             if (empty(Hash::get($item, 'params'))) {
                 continue;
             }
-            $item['params'] = self::parseParams(Hash::get($item, 'params'), self::isOneDayRange($item));
+            $item['params'] = self::parseParams((array)Hash::get($item, 'params'), self::isOneDayRange($item));
         }
         $dateRanges = array_values($dateRanges);
 
@@ -80,16 +80,12 @@ class DateRangesTools
     /**
      * Parse params.
      *
-     * @param array|null $params Params to parse.
+     * @param array $params Params to parse.
      * @param bool $oneDayRange Is one day range.
      * @return array|null
      */
-    public static function parseParams(?array $params, bool $oneDayRange): ?array
+    public static function parseParams(array $params, bool $oneDayRange): ?array
     {
-        // empty params
-        if (empty($params)) {
-            return $params;
-        }
         // remove all_day and every_day if not needed
         $params = self::filterNotOn($params, 'all_day');
         $params = self::filterNotOn($params, 'every_day');

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -94,14 +94,6 @@ class DateRangesTools
         if ($oneDayRange) {
             return $allDayOn ? ['all_day' => 'on', 'every_day' => 'on'] : null;
         }
-        // if multi day, all_day has no sense: remove it
-        $params = array_filter(
-            $params,
-            function ($key) {
-                return $key !== 'all_day';
-            },
-            ARRAY_FILTER_USE_KEY
-        );
         // multi days range
         $everyDayOn = Hash::get($params, 'every_day') === 'on';
         $weekdays = (array)Hash::get($params, 'weekdays');

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -112,6 +112,16 @@ class DateRangesTools
                 ARRAY_FILTER_USE_KEY
             );
         }
+        if (!$everyDayOn && count($weekdays) === 0) {
+            $params['every_day'] = 'on';
+            $params = array_filter(
+                $params,
+                function ($key) {
+                    return $key !== 'weekdays';
+                },
+                ARRAY_FILTER_USE_KEY
+            );
+        }
 
         return $params === ['every_day' => 'on'] ? null : $params;
     }

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -60,6 +60,12 @@ class DateRangesTools
         return $dateRanges;
     }
 
+    /**
+     * Check if date range is one day only.
+     *
+     * @param array $dateRange Date range.
+     * @return bool
+     */
     public static function isOneDayRange(array $dateRange): bool
     {
         $sd = (string)Hash::get($dateRange, 'start_date');

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -94,13 +94,13 @@ class DateRangesTools
         }
         // one day range
         if ($oneDayRange) {
-            $allDay = Hash::get($params, 'all_day') === 'on';
+            $allDay = Hash::get($params, 'all_day') === true;
 
-            return $allDay ? ['all_day' => 'on', 'every_day' => 'on'] : null;
+            return $allDay ? ['all_day' => true, 'every_day' => true] : null;
         }
         // multi days range
 
-        return $params === ['every_day' => 'on'] ? null : $params;
+        return $params === ['every_day' => true] ? null : $params;
     }
 
     /**
@@ -114,12 +114,12 @@ class DateRangesTools
         $data = [];
         foreach ($params as $key => $value) {
             if ($key === 'all_day' && $value === true) {
-                $data[$key] = 'on';
+                $data[$key] = true;
 
                 continue;
             }
             if ($key === 'every_day' && $value === true) {
-                $data[$key] = 'on';
+                $data[$key] = true;
 
                 continue;
             }
@@ -132,7 +132,7 @@ class DateRangesTools
                     }
                 }
                 if ($count === 7 || $count === 0) {
-                    $data['every_day'] = 'on';
+                    $data['every_day'] = true;
                     unset($data[$key]);
                 } elseif ($params['every_day'] === true) {
                     unset($data[$key]);

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -104,7 +104,7 @@ class DateRangesTools
         );
         // multi days range
         $everyDayOn = Hash::get($params, 'every_day') === 'on';
-        $weekdays = Hash::get($params, 'weekdays');
+        $weekdays = (array)Hash::get($params, 'weekdays');
         if ($everyDayOn || count($weekdays) === 7) {
             $params['every_day'] = 'on';
             $params = array_filter(

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -67,13 +67,14 @@ class DateRangesTools
             if (!empty($sd) && empty($ed)) {
                 if (!array_key_exists('all_day', $params) || $allDay === false) {
                     $item['params'] = null;
-                } else { // all_day is true
-                    $newParams = [
-                        'all_day' => true,
-                        'every_day' => true,
-                    ];
-                    $item['params'] = json_encode($newParams);
+
+                    continue;
                 }
+                // all_day is true, no need for weekdays
+                $item['params'] = json_encode([
+                    'all_day' => true,
+                    'every_day' => true,
+                ]);
             }
         }
         $dateRanges = array_values($dateRanges);

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -53,6 +53,9 @@ class DateRangesTools
             $dateRanges
         );
         foreach ($dateRanges as &$item) {
+            if (empty(Hash::get($item, 'params'))) {
+                continue;
+            }
             $item['params'] = self::parseParams(Hash::get($item, 'params'), self::isOneDayRange($item));
         }
         $dateRanges = array_values($dateRanges);

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -56,7 +56,9 @@ class DateRangesTools
             if (empty(Hash::get($item, 'params'))) {
                 continue;
             }
-            $item['params'] = self::parseParams((array)Hash::get($item, 'params'), self::isOneDayRange((array)$item));
+            $params = Hash::get($item, 'params');
+            $params = is_string($params) ? json_decode($params, true) : (array)$params;
+            $item['params'] = self::parseParams($params, self::isOneDayRange((array)$item));
         }
         $dateRanges = array_values($dateRanges);
 
@@ -96,7 +98,10 @@ class DateRangesTools
         }
         // multi days range
         $everyDayOn = Hash::get($params, 'every_day') === 'on';
-        $weekdays = (array)Hash::get($params, 'weekdays');
+        $weekdays = self::weekdays((array)Hash::get($params, 'weekdays'));
+        if (!empty($weekdays)) {
+            $params['weekdays'] = $weekdays;
+        }
         if ($everyDayOn || count($weekdays) === 7) {
             $params['every_day'] = 'on';
             $params = array_filter(
@@ -127,5 +132,23 @@ class DateRangesTools
             },
             ARRAY_FILTER_USE_KEY
         );
+    }
+
+    /**
+     * Get days from form input.
+     *
+     * @param array $input Input.
+     * @return array
+     */
+    public static function weekdays(array $input): array
+    {
+        $days = [];
+        foreach ($input as $key => $value) {
+            if ($value === true) {
+                $days[] = $key;
+            }
+        }
+
+        return $days;
     }
 }

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -471,7 +471,7 @@ class AppControllerTest extends TestCase
                 ],
                 [ // data provided
                     'id' => '7',
-                    'date_ranges' => [
+                    'date_ranges' => json_encode([
                         [
                             'start_date' => '',
                             'end_date' => '',
@@ -484,7 +484,7 @@ class AppControllerTest extends TestCase
                             'start_date' => '2020-01-01T00:00:00.000Z',
                             'end_date' => '',
                         ],
-                    ],
+                    ]),
                 ],
             ],
             'relations' => [

--- a/tests/TestCase/Controller/TreeControllerTest.php
+++ b/tests/TestCase/Controller/TreeControllerTest.php
@@ -170,7 +170,7 @@ class TreeControllerTest extends BaseControllerTest
         $parent = $this->createTestFolder();
         $response = $this->client->save('folders', [
             'title' => 'controller test folder child',
-            'parent_id' => (string)Hash::get($parent, 'id'),
+            'parent_id' => (int)Hash::get($parent, 'id'),
         ]);
         $child = $response['data'];
         $id = (string)Hash::get($child, 'id');

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -73,12 +73,12 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'one day + params every_day off' => [
+            'one day + params every_day false' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => ['every_day' => 'off'],
+                        'params' => ['every_day' => false],
                     ],
                 ],
                 [
@@ -89,12 +89,12 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'one day + params every_day off and all_day off' => [
+            'one day + params every_day false and all_day false' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => ['every_day' => 'off', 'all_day' => false],
+                        'params' => ['every_day' => false, 'all_day' => false],
                     ],
                 ],
                 [
@@ -105,7 +105,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'one day + params every_day off and all_day on' => [
+            'one day + params every_day false and all_day true' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -117,11 +117,11 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => ['all_day' => 'on', 'every_day' => 'on'],
+                        'params' => ['all_day' => true, 'every_day' => true],
                     ],
                 ],
             ],
-            'one day + params every_day on and all_day off' => [
+            'one day + params every_day true and all_day false' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -137,7 +137,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'multi days + params every_day on and all_day off' => [
+            'multi days + params every_day true and all_day false' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -153,7 +153,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'multi days + params every_day off and all_day on' => [
+            'multi days + params every_day false and all_day true' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -165,11 +165,11 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['all_day' => 'on', 'weekdays' => ['monday']],
+                        'params' => ['all_day' => true, 'weekdays' => ['monday']],
                     ],
                 ],
             ],
-            'multi days + params every_day off and all_day off' => [
+            'multi days + params every_day false and all_day false' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -185,7 +185,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'multi days + params every_day on and all_day on' => [
+            'multi days + params every_day true and all_day true' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -197,7 +197,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['every_day' => 'on', 'all_day' => 'on'],
+                        'params' => ['every_day' => true, 'all_day' => true],
                     ],
                 ],
             ],
@@ -217,7 +217,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'range with all weekdays and every_day on' => [
+            'range with all weekdays and every_day true' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -233,7 +233,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'range with no weekdays and every_day off' => [
+            'range with no weekdays and every_day false' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -217,6 +217,22 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
+            'range with no weekdays and every_day off' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => ['every_day' => 'off', 'all_day' => 'off', 'weekdays' => []],
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => null,
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -29,7 +29,7 @@ class DateRangesToolsTest extends TestCase
                 [],
                 [],
             ],
-            'start date, params null' => [
+            'start date, end_date null, params null' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -61,7 +61,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'end date :59:00.000' => [
+            'start date, end date :59:00.000, params null' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -77,7 +77,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'start date only, every day false' => [
+            'start date, end date null, params every_day false' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -93,7 +93,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'start date only, every day false and all day false' => [
+            'start date, end date null, params every_day false and all_day false' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -109,7 +109,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'start date only, every day false and all day true' => [
+            'start date, end date null, params every_day false and all_day true' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -122,6 +122,22 @@ class DateRangesToolsTest extends TestCase
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
                         'params' => json_encode(['all_day' => true, 'every_day' => true]),
+                    ],
+                ],
+            ],
+            'start date, end date null, params every_day true and all_day false' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => null,
+                        'params' => json_encode(['every_day' => true, 'all_day' => false, 'weekdays' => ['monday']]),
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => null,
+                        'params' => null,
                     ],
                 ],
             ],

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -94,7 +94,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => ['every_day' => 'off', 'all_day' => 'off'],
+                        'params' => ['every_day' => 'off', 'all_day' => false],
                     ],
                 ],
                 [
@@ -110,7 +110,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => ['every_day' => 'on', 'all_day' => 'on', 'weekdays' => ['monday' => true]],
+                        'params' => ['every_day' => true, 'all_day' => true, 'weekdays' => ['monday' => true]],
                     ],
                 ],
                 [
@@ -126,7 +126,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => ['every_day' => 'on', 'all_day' => 'off', 'weekdays' => ['monday' => true]],
+                        'params' => ['every_day' => true, 'all_day' => false, 'weekdays' => ['monday' => true]],
                     ],
                 ],
                 [
@@ -142,7 +142,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['every_day' => 'on', 'all_day' => 'off', 'weekdays' => ['monday' => true]],
+                        'params' => ['every_day' => true, 'all_day' => false, 'weekdays' => ['monday' => true]],
                     ],
                 ],
                 [
@@ -158,7 +158,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['every_day' => 'off', 'all_day' => 'on', 'weekdays' => ['monday' => true]],
+                        'params' => ['every_day' => false, 'all_day' => true, 'weekdays' => ['monday' => true]],
                     ],
                 ],
                 [
@@ -174,7 +174,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['every_day' => 'off', 'all_day' => 'off', 'weekdays' => ['monday' => true]],
+                        'params' => ['every_day' => false, 'all_day' => false, 'weekdays' => ['monday' => true]],
                     ],
                 ],
                 [
@@ -190,7 +190,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['every_day' => 'on', 'all_day' => 'on', 'weekdays' => ['monday' => true]],
+                        'params' => ['every_day' => true, 'all_day' => true, 'weekdays' => ['monday' => true]],
                     ],
                 ],
                 [
@@ -206,7 +206,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['every_day' => 'off', 'all_day' => 'off', 'weekdays' => ['monday' => true, 'tuesday' => true]],
+                        'params' => ['every_day' => false, 'all_day' => false, 'weekdays' => ['monday' => true, 'tuesday' => true]],
                     ],
                 ],
                 [
@@ -222,7 +222,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['every_day' => 'off', 'all_day' => 'off', 'weekdays' => []],
+                        'params' => ['every_day' => false, 'all_day' => false, 'weekdays' => []],
                     ],
                 ],
                 [
@@ -245,9 +245,9 @@ class DateRangesToolsTest extends TestCase
      * @dataProvider prepareProvider()
      * @covers ::prepare()
      * @covers ::parseParams()
+     * @covers ::cleanParams()
      * @covers ::filterNotOn()
      * @covers ::isOneDayRange()
-     * @covers ::weekdays()
      */
     public function testPrepare(array $dateRanges, array $expected): void
     {

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase;
+
+use App\Utility\DateRangesTools;
+use Cake\TestSuite\TestCase;
+
+/**
+ * App\Utility\DateRangesTools Test Case
+ *
+ * @coversDefaultClass App\Utility\DateRangesTools
+ */
+class DateRangesToolsTest extends TestCase
+{
+    /**
+     * Data provider for `testPrepare` test case.
+     *
+     * @return array
+     */
+    public function prepareProvider(): array
+    {
+        return [
+            'null data' => [
+                null,
+                null,
+            ],
+            'empty data' => [
+                [],
+                [],
+            ],
+            'start date, params null' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => null,
+                        'params' => null,
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => null,
+                        'params' => null,
+                    ],
+                ],
+            ],
+            'start date, end date, params null' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-01 23:59:00',
+                        'params' => null,
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-01 23:59:00',
+                        'params' => null,
+                    ],
+                ],
+            ],
+            'end date :59:00.000' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-01 23:59:00.000',
+                        'params' => null,
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-01 23:59:59.000',
+                        'params' => null,
+                    ],
+                ],
+            ],
+            'start date only, every day false' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => null,
+                        'params' => json_encode(['every_day' => false]),
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => null,
+                        'params' => null,
+                    ],
+                ],
+            ],
+            'start date only, every day false and all day false' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => null,
+                        'params' => json_encode(['every_day' => false, 'all_day' => false]),
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => null,
+                        'params' => null,
+                    ],
+                ],
+            ],
+            'start date only, every day false and all day true' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => null,
+                        'params' => json_encode(['every_day' => false, 'all_day' => true, 'weekdays' => ['monday']]),
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => null,
+                        'params' => json_encode(['all_day' => true, 'every_day' => true]),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `prepare` method.
+     *
+     * @return void
+     * @dataProvider prepareProvider()
+     * @covers ::prepare()
+     */
+    public function testPrepare(?array $dateRanges, ?array $expected): void
+    {
+        $actual = DateRangesTools::prepare($dateRanges);
+        static::assertEquals($expected, $actual);
+    }
+}

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -21,15 +21,11 @@ class DateRangesToolsTest extends TestCase
     public function prepareProvider(): array
     {
         return [
-            'null data' => [
-                null,
-                null,
-            ],
-            'empty data' => [
+            'empty ranges' => [
                 [],
                 [],
             ],
-            'start date, end_date null, params null' => [
+            'one date only + params null' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -45,7 +41,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'start date, end date, params null' => [
+            'same day + params null' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -61,7 +57,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'start date, end date :59:00.000, params null' => [
+            'same day + end date :59:00.000 + params null' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -77,12 +73,12 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'start date, end date null, params every_day false' => [
+            'one day + params every_day off' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => json_encode(['every_day' => false]),
+                        'params' => ['every_day' => 'off'],
                     ],
                 ],
                 [
@@ -93,12 +89,12 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'start date, end date null, params every_day false and all_day false' => [
+            'one day + params every_day off and all_day off' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => json_encode(['every_day' => false, 'all_day' => false]),
+                        'params' => ['every_day' => 'off', 'all_day' => 'off'],
                     ],
                 ],
                 [
@@ -109,28 +105,28 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'start date, end date null, params every_day false and all_day true' => [
+            'one day + params every_day off and all_day on' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => json_encode(['every_day' => false, 'all_day' => true, 'weekdays' => ['monday']]),
+                        'params' => ['every_day' => 'on', 'all_day' => 'on', 'weekdays' => ['monday']],
                     ],
                 ],
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => json_encode(['all_day' => true, 'every_day' => true]),
+                        'params' => ['all_day' => 'on', 'every_day' => 'on'],
                     ],
                 ],
             ],
-            'start date, end date null, params every_day true and all_day false' => [
+            'one day + params every_day on and all_day off' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => json_encode(['every_day' => true, 'all_day' => false, 'weekdays' => ['monday']]),
+                        'params' => ['every_day' => 'on', 'all_day' => 'off', 'weekdays' => ['monday']],
                     ],
                 ],
                 [
@@ -138,6 +134,86 @@ class DateRangesToolsTest extends TestCase
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
                         'params' => null,
+                    ],
+                ],
+            ],
+            'multi days + params every_day on and all_day off' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => ['every_day' => 'on', 'all_day' => 'off', 'weekdays' => ['monday']],
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => null,
+                    ],
+                ],
+            ],
+            'multi days + params every_day off and all_day on (ignore all day, as multi days)' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => ['every_day' => 'off', 'all_day' => 'on', 'weekdays' => ['monday']],
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => ['weekdays' => ['monday']],
+                    ],
+                ],
+            ],
+            'multi days + params every_day off and all_day off' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => ['every_day' => 'off', 'all_day' => 'off', 'weekdays' => ['monday']],
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => ['weekdays' => ['monday']],
+                    ],
+                ],
+            ],
+            'multi days + params every_day on and all_day on' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => ['every_day' => 'on', 'all_day' => 'on', 'weekdays' => ['monday']],
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => null,
+                    ],
+                ],
+            ],
+            'range with weekdays' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => ['every_day' => 'off', 'all_day' => 'off', 'weekdays' => ['monday', 'tuesday']],
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => ['weekdays' => ['monday', 'tuesday']],
                     ],
                 ],
             ],
@@ -147,11 +223,15 @@ class DateRangesToolsTest extends TestCase
     /**
      * Test `prepare` method.
      *
+     * @param array $dateRanges Date ranges to format.
+     * @param array $expected Expected result.
      * @return void
      * @dataProvider prepareProvider()
      * @covers ::prepare()
+     * @covers ::parseParams()
+     * @covers ::filterNotOn()
      */
-    public function testPrepare(?array $dateRanges, ?array $expected): void
+    public function testPrepare(array $dateRanges, array $expected): void
     {
         $actual = DateRangesTools::prepare($dateRanges);
         static::assertEquals($expected, $actual);

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -231,6 +231,7 @@ class DateRangesToolsTest extends TestCase
      * @covers ::parseParams()
      * @covers ::filterNotOn()
      * @covers ::isOneDayRange()
+     * @covers ::weekdays()
      */
     public function testPrepare(array $dateRanges, array $expected): void
     {

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -217,6 +217,22 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
+            'range with all weekdays and every_day on' => [
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => ['every_day' => true, 'all_day' => false, 'weekdays' => ['monday' => true, 'tuesday' => true, 'wednesday' => true, 'thursday' => true, 'friday' => true, 'saturday' => true, 'sunday' => true]],
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2021-01-01 00:00:00',
+                        'end_date' => '2021-01-02 00:00:00',
+                        'params' => null,
+                    ],
+                ],
+            ],
             'range with no weekdays and every_day off' => [
                 [
                     [

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -230,6 +230,7 @@ class DateRangesToolsTest extends TestCase
      * @covers ::prepare()
      * @covers ::parseParams()
      * @covers ::filterNotOn()
+     * @covers ::isOneDayRange()
      */
     public function testPrepare(array $dateRanges, array $expected): void
     {

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -153,7 +153,7 @@ class DateRangesToolsTest extends TestCase
                     ],
                 ],
             ],
-            'multi days + params every_day off and all_day on (ignore all day, as multi days)' => [
+            'multi days + params every_day off and all_day on' => [
                 [
                     [
                         'start_date' => '2021-01-01 00:00:00',
@@ -165,7 +165,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['weekdays' => ['monday']],
+                        'params' => ['all_day' => 'on', 'weekdays' => ['monday']],
                     ],
                 ],
             ],
@@ -197,7 +197,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => null,
+                        'params' => ['every_day' => 'on', 'all_day' => 'on'],
                     ],
                 ],
             ],

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -110,7 +110,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => ['every_day' => 'on', 'all_day' => 'on', 'weekdays' => ['monday']],
+                        'params' => ['every_day' => 'on', 'all_day' => 'on', 'weekdays' => ['monday' => true]],
                     ],
                 ],
                 [
@@ -126,7 +126,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => null,
-                        'params' => ['every_day' => 'on', 'all_day' => 'off', 'weekdays' => ['monday']],
+                        'params' => ['every_day' => 'on', 'all_day' => 'off', 'weekdays' => ['monday' => true]],
                     ],
                 ],
                 [
@@ -142,7 +142,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['every_day' => 'on', 'all_day' => 'off', 'weekdays' => ['monday']],
+                        'params' => ['every_day' => 'on', 'all_day' => 'off', 'weekdays' => ['monday' => true]],
                     ],
                 ],
                 [
@@ -158,7 +158,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['every_day' => 'off', 'all_day' => 'on', 'weekdays' => ['monday']],
+                        'params' => ['every_day' => 'off', 'all_day' => 'on', 'weekdays' => ['monday' => true]],
                     ],
                 ],
                 [
@@ -174,7 +174,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['every_day' => 'off', 'all_day' => 'off', 'weekdays' => ['monday']],
+                        'params' => ['every_day' => 'off', 'all_day' => 'off', 'weekdays' => ['monday' => true]],
                     ],
                 ],
                 [
@@ -190,7 +190,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['every_day' => 'on', 'all_day' => 'on', 'weekdays' => ['monday']],
+                        'params' => ['every_day' => 'on', 'all_day' => 'on', 'weekdays' => ['monday' => true]],
                     ],
                 ],
                 [
@@ -206,7 +206,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['every_day' => 'off', 'all_day' => 'off', 'weekdays' => ['monday', 'tuesday']],
+                        'params' => ['every_day' => 'off', 'all_day' => 'off', 'weekdays' => ['monday' => true, 'tuesday' => true]],
                     ],
                 ],
                 [


### PR DESCRIPTION
We noticed that sometimes values in `params` of a date range are not consistent with the date range interval and internal data.
This provides a way to fix data using a new class `DateRangesTools` (method `prepare`).

All imagined cases are handled in unit tests.

Note: params can be `null` or a json object.
Accepted keys are: `all_day`, `every_day` and `weekdays`.

 - all_day: if checked, then `true`
 - every_day: if checked, then `true`
 - weekdays: string array of checked days

Params saved examples follow.

All day and every day:
```json
{
    "all_day": true,
    "every_day": true
}
```

All day and some days only
```json
{
    "all_day": true,
    "weekdays": ["sunday", "monday"]
}
```

Bonus: Undo button on remove. 