### PR TITLE
Fix route and form for new resource creation

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -192,7 +192,7 @@ $routes->scope('/', function (RouteBuilder $routes) {
             );
 
             $routes->get(
-                "/$controller/view/new",
+                "/$controller/view",
                 ['controller' => $name, 'action' => 'create'],
                 'create:' . $controller
             );
@@ -297,7 +297,7 @@ $routes->scope('/', function (RouteBuilder $routes) {
         ['_name' => 'modules:list']
     );
     $routes->connect(
-        '/{object_type}/view/new',
+        '/{object_type}/view',
         ['controller' => 'Modules', 'action' => 'create'],
         ['_name' => 'modules:create']
     );

--- a/resources/js/app/mixins/paginated-content.js
+++ b/resources/js/app/mixins/paginated-content.js
@@ -63,6 +63,7 @@ export const PaginatedContentMixin = {
                 };
 
                 requestUrl = this.getUrlWithPaginationAndQuery(requestUrl);
+                // if url contains view/related, it means that request comes from new object page: ignore it
                 if (requestUrl.indexOf('view/related') >= 0) {
                     this.objects = [];
 

--- a/resources/js/app/mixins/paginated-content.js
+++ b/resources/js/app/mixins/paginated-content.js
@@ -63,6 +63,11 @@ export const PaginatedContentMixin = {
                 };
 
                 requestUrl = this.getUrlWithPaginationAndQuery(requestUrl);
+                if (requestUrl.indexOf('view/related') >= 0) {
+                    this.objects = [];
+
+                    return Promise.resolve();
+                }
 
                 // if requestQueue is populated then abort all fetch request and start over
                 if (this.requestsQueue.length > 0) {

--- a/templates/Element/Form/categories.twig
+++ b/templates/Element/Form/categories.twig
@@ -12,7 +12,7 @@
                 <div class="categories-container">
                     <object-categories
                         :model-categories="{{ schema.categories|json_encode }}"
-                        :value="{{ object.attributes.categories|json_encode }}"
+                        :value="{{ object.attributes.categories|default([])|json_encode }}"
                     >
                     </object-categories>
                     {% do Form.unlockField('categories') %}

--- a/tests/TestCase/Controller/Model/ModelBaseControllerTest.php
+++ b/tests/TestCase/Controller/Model/ModelBaseControllerTest.php
@@ -341,7 +341,7 @@ class ModelBaseControllerTest extends TestCase
         $result = $this->ModelController->save();
         static::assertInstanceOf(Response::class, $result);
         $location = $result->getHeaderLine('Location');
-        $expected = '/new';
+        $expected = '/view';
         static::assertStringEndsWith($expected, $location);
     }
 


### PR DESCRIPTION
This PR fixes routes used for new object/resource creation removing `/new` from the end of the url path. Indeed using `/view/new` could collide with object `uname`.

This also fixes two bugs in new object view:

 - show categories from schema model (there was a javascript error, in browser console)
 - do not try to load related data per relation (no data at the beginning)