### PR TITLE
Fix trashcan error: default to empty array if no custom filter is defined

### DIFF
--- a/templates/Element/Modules/index_header.twig
+++ b/templates/Element/Modules/index_header.twig
@@ -1,6 +1,6 @@
 <div class="module-header">
     {% set filterActive = (_view.request.getQuery('filter') or _view.request.getQuery('q')) %}
-    {% set list = Schema.filterList(filter, schema.properties) %}
+    {% set list = Schema.filterList(filter | default([]), schema.properties) %}
     <filter-box-view
         :pagination="{{ meta.pagination|json_encode|escape('html_attr') }}"
         :init-filter="urlFilterQuery"


### PR DESCRIPTION
This PR fixes an error when no custom filter is defined and the view variable `filter` is `null` (ex. in trash page)