### PR TITLE
Date range `params.weekdays` as json

### DIFF
--- a/resources/js/app/components/date-ranges-view/date-ranges-view.vue
+++ b/resources/js/app/components/date-ranges-view/date-ranges-view.vue
@@ -71,8 +71,9 @@ export default {
                 range.originalParams = range.params;
                 range.params = range.params || defaultOptions;
                 if (!this.optionIsSet('every_day')) {
-                    range.params.every_day = !range.params?.weekdays || Object.keys(range.params?.weekdays).length === 0;
-                    range.params.weekdays = range?.originalParams?.weekdays || this.emptyWeekdays();
+                    range.params.weekdays = this.formatWeekdays(range?.originalParams?.weekdays);
+                    const daysCount = Object.values(range.params.weekdays).filter((v) => v === true).length;
+                    range.params.every_day = daysCount === 0;
                 }
                 if (!range.start_date) {
                     range.end_date = '';
@@ -100,15 +101,26 @@ export default {
             this.dateRanges.push(newRange);
             this.dateRangesJson = JSON.stringify(this.dateRanges);
         },
-        emptyWeekdays() {
+        formatWeekdays(wdays) {
+            if (!wdays) {
+                return {
+                    sunday: false,
+                    monday: false,
+                    tuesday: false,
+                    wednesday: false,
+                    thursday: false,
+                    friday: false,
+                    saturday: false
+                };
+            }
             return {
-                sunday: false,
-                monday: false,
-                tuesday: false,
-                wednesday: false,
-                thursday: false,
-                friday: false,
-                saturday: false
+                sunday: wdays?.sunday || false,
+                monday: wdays?.monday || false,
+                tuesday: wdays?.tuesday || false,
+                wednesday: wdays?.wednesday || false,
+                thursday: wdays?.thursday || false,
+                friday: wdays?.friday || false,
+                saturday: wdays?.saturday || false
             };
         },
         optionIsSet(option) {

--- a/resources/js/app/components/date-ranges-view/date-ranges-view.vue
+++ b/resources/js/app/components/date-ranges-view/date-ranges-view.vue
@@ -72,7 +72,7 @@ export default {
                 range.params = range.params || defaultOptions;
                 if (!this.optionIsSet('every_day')) {
                     range.params.every_day = !range.params?.weekdays || Object.keys(range.params?.weekdays).length === 0;
-                    range.params.weekdays = range?.originalParams?.weekdays ? this.normalizeWeekdays(range?.params?.weekdays) : {};
+                    range.params.weekdays = range?.originalParams?.weekdays || this.emptyWeekdays();
                 }
                 if (!range.start_date) {
                     range.end_date = '';
@@ -100,26 +100,15 @@ export default {
             this.dateRanges.push(newRange);
             this.dateRangesJson = JSON.stringify(this.dateRanges);
         },
-        normalizeWeekdays(wdays) {
-            if (wdays.constructor !== Array) {
-                return {
-                    sunday: false,
-                    monday: false,
-                    tuesday: false,
-                    wednesday: false,
-                    thursday: false,
-                    friday: false,
-                    saturday: false
-                };
-            }
+        emptyWeekdays() {
             return {
-                sunday: wdays.includes('sunday'),
-                monday: wdays.includes('monday'),
-                tuesday: wdays.includes('tuesday'),
-                wednesday: wdays.includes('wednesday'),
-                thursday: wdays.includes('thursday'),
-                friday: wdays.includes('friday'),
-                saturday: wdays.includes('saturday'),
+                sunday: false,
+                monday: false,
+                tuesday: false,
+                wednesday: false,
+                thursday: false,
+                friday: false,
+                saturday: false
             };
         },
         optionIsSet(option) {

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -124,12 +124,12 @@ class DateRangesTools
                 continue;
             }
             if ($key === 'weekdays' && !empty($value)) {
-                $count = 0;
-                foreach ($value as $kk => $vv) {
-                    if ($vv === true) {
-                        $data[$key][] = $kk;
-                        $count++;
-                    }
+                $checked = array_filter($value, function ($v) {
+                    return $v === true;
+                });
+                $count = count($checked);
+                if ($count > 0) {
+                    $data['weekdays'] = $value;
                 }
                 if ($count === 7 || $count === 0) {
                     $data['every_day'] = true;

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -165,7 +165,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['all_day' => true, 'weekdays' => ['monday']],
+                        'params' => ['all_day' => true, 'weekdays' => ['monday' => true]],
                     ],
                 ],
             ],
@@ -181,7 +181,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['weekdays' => ['monday']],
+                        'params' => ['weekdays' => ['monday' => true]],
                     ],
                 ],
             ],
@@ -213,7 +213,7 @@ class DateRangesToolsTest extends TestCase
                     [
                         'start_date' => '2021-01-01 00:00:00',
                         'end_date' => '2021-01-02 00:00:00',
-                        'params' => ['weekdays' => ['monday', 'tuesday']],
+                        'params' => ['weekdays' => ['monday' => true, 'tuesday' => true]],
                     ],
                 ],
             ],


### PR DESCRIPTION
This provides a fix for `params.weekdays` structure in a date range.
Weekdays structure example follows:
```json
{
    "sunday": true,
    "monday": false,
    "tuesday": false,
    "wednesday": true,
    "thursday": false,
    "friday": true,
    "saturday": false
}
``` 
Previous (non retro-compatible) structure was: only "true" days array, i.e.: 
```json
["sunday", "wednesday", "friday"]
```