### PR TITLE
Module items count

### DIFF
--- a/resources/styles/_elements.scss
+++ b/resources/styles/_elements.scss
@@ -337,3 +337,8 @@ nav.pagination {
 .drop-area-double {
     min-height: $gutter * 16;
 }
+
+.module-items-counter {
+    position: absolute;
+    bottom: 1rem;
+}

--- a/resources/styles/_elements.scss
+++ b/resources/styles/_elements.scss
@@ -341,4 +341,5 @@ nav.pagination {
 .module-items-counter {
     position: absolute;
     bottom: 1rem;
+    background: transparent;
 }

--- a/src/Controller/Model/TagsController.php
+++ b/src/Controller/Model/TagsController.php
@@ -12,6 +12,7 @@
  */
 namespace App\Controller\Model;
 
+use App\Utility\CacheTools;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Http\Response;
 use Cake\Utility\Hash;
@@ -59,6 +60,7 @@ class TagsController extends ModelBaseController
         $options['sort'] = empty($options['sort']) ? 'name' : $options['sort'];
         $response = ApiClientProvider::getApiClient()->get('/model/tags', $options);
         $resources = Hash::combine((array)Hash::get($response, 'data'), '{n}.id', '{n}');
+        CacheTools::setModuleCount((array)$response, 'tags');
         $roots = $this->Categories->getAvailableRoots($resources);
         $tagsTree = $this->Categories->tree($resources);
         $this->set(compact('resources', 'roots', 'tagsTree'));

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -12,6 +12,7 @@
  */
 namespace App\Controller;
 
+use App\Utility\CacheTools;
 use App\Utility\PermissionsTrait;
 use BEdita\SDK\BEditaClientException;
 use Cake\Core\Configure;
@@ -102,6 +103,7 @@ class ModulesController extends AppController
 
         try {
             $response = $this->apiClient->getObjects($this->objectType, $this->Query->index());
+            CacheTools::setModuleCount((array)$response, $this->Modules->getConfig('currentModuleName'));
         } catch (BEditaClientException $e) {
             $this->log($e->getMessage(), LogLevel::ERROR);
             $this->Flash->error($e->getMessage(), ['params' => $e]);

--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -12,6 +12,7 @@
  */
 namespace App\Controller;
 
+use App\Utility\CacheTools;
 use BEdita\SDK\BEditaClientException;
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
@@ -63,6 +64,7 @@ class TrashController extends AppController
 
         try {
             $response = $this->apiClient->getObjects('trash', $this->getRequest()->getQueryParams());
+            CacheTools::setModuleCount($response, 'trash');
         } catch (BEditaClientException $e) {
             // Error! Back to dashboard.
             $this->log($e->getMessage(), LogLevel::ERROR);

--- a/src/Utility/CacheTools.php
+++ b/src/Utility/CacheTools.php
@@ -14,6 +14,8 @@
 namespace App\Utility;
 
 use BEdita\WebTools\ApiClientProvider;
+use Cake\Cache\Cache;
+use Cake\Utility\Hash;
 
 /**
  * Add cache related utility methods
@@ -31,5 +33,33 @@ class CacheTools
         $apiSignature = md5(ApiClientProvider::getApiClient()->getApiBaseUrl());
 
         return sprintf('%s_%s', $name, $apiSignature);
+    }
+
+    /**
+     * Get module count from cache.
+     *
+     * @param string $moduleName Module name.
+     * @return int
+     */
+    public static function getModuleCount(string $moduleName): int
+    {
+        $cacheKey = sprintf('statistics_%s_count', $moduleName);
+        $count = Cache::read($cacheKey);
+
+        return $count !== false ? (int)$count : 0;
+    }
+
+    /**
+     * Set module count in cache.
+     *
+     * @param array $response API response.
+     * @param string $moduleName Module name.
+     * @return void
+     */
+    public static function setModuleCount(array $response, string $moduleName): void
+    {
+        $count = Hash::get($response, 'meta.pagination.count', 0);
+        $cacheKey = sprintf('statistics_%s_count', $moduleName);
+        Cache::write($cacheKey, $count);
     }
 }

--- a/src/Utility/CacheTools.php
+++ b/src/Utility/CacheTools.php
@@ -36,18 +36,32 @@ class CacheTools
     }
 
     /**
+     * Check if module count exists in cache.
+     *
+     * @param string $moduleName Module name.
+     * @return bool
+     */
+    public static function existsCount(string $moduleName): bool
+    {
+        $name = sprintf('statistics_%s_count', $moduleName);
+        $cacheKey = self::cacheKey($name);
+
+        return Cache::read($cacheKey) !== null;
+    }
+
+    /**
      * Get module count from cache.
      *
      * @param string $moduleName Module name.
-     * @return int
+     * @return string
      */
-    public static function getModuleCount(string $moduleName): int
+    public static function getModuleCount(string $moduleName): string
     {
         $name = sprintf('statistics_%s_count', $moduleName);
         $cacheKey = self::cacheKey($name);
         $count = Cache::read($cacheKey);
 
-        return $count !== false ? (int)$count : 0;
+        return $count !== false ? (int)$count : '-';
     }
 
     /**

--- a/src/Utility/CacheTools.php
+++ b/src/Utility/CacheTools.php
@@ -43,7 +43,8 @@ class CacheTools
      */
     public static function getModuleCount(string $moduleName): int
     {
-        $cacheKey = sprintf('statistics_%s_count', $moduleName);
+        $name = sprintf('statistics_%s_count', $moduleName);
+        $cacheKey = self::cacheKey($name);
         $count = Cache::read($cacheKey);
 
         return $count !== false ? (int)$count : 0;
@@ -59,7 +60,8 @@ class CacheTools
     public static function setModuleCount(array $response, string $moduleName): void
     {
         $count = Hash::get($response, 'meta.pagination.count', 0);
-        $cacheKey = sprintf('statistics_%s_count', $moduleName);
+        $name = sprintf('statistics_%s_count', $moduleName);
+        $cacheKey = self::cacheKey($name);
         Cache::write($cacheKey, $count);
     }
 }

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -143,13 +143,17 @@ class LayoutHelper extends Helper
      * Return module count span.
      *
      * @param string $name The module name
+     * @param string|null $moduleClass The module class
      * @return string
      */
-    public function moduleCount(string $name): string
+    public function moduleCount(string $name, ?string $moduleClass = null): string
     {
         $count = CacheTools::getModuleCount($name);
+        $base = 'tag mx-05 module-items-counter';
+        $defaultModuleClass = sprintf('has-background-module-%s', $name);
+        $cssClasses = empty($moduleClass) ? sprintf('%s %s', $base, $defaultModuleClass) : sprintf('%s %s', $base, $moduleClass);
 
-        return empty($count) ? '' : sprintf('<span class="tag mx-05 has-background-module-%s module-items-counter">%s</span>', $name, $count);
+        return empty($count) ? '' : sprintf('<span class="%s">%s</span>', $cssClasses, $count);
     }
 
     /**

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -153,7 +153,7 @@ class LayoutHelper extends Helper
         $defaultModuleClass = sprintf('has-background-module-%s', $name);
         $cssClasses = empty($moduleClass) ? sprintf('%s %s', $base, $defaultModuleClass) : sprintf('%s %s', $base, $moduleClass);
 
-        return empty($count) ? '' : sprintf('<span class="%s">%s</span>', $cssClasses, $count);
+        return $count === '-' ? '-' : sprintf('<span class="%s">%s</span>', $cssClasses, $count);
     }
 
     /**

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -149,7 +149,7 @@ class LayoutHelper extends Helper
     {
         $count = CacheTools::getModuleCount($name);
 
-        return empty($count) ? '' : sprintf('<span class="tag mx-05 has-background-module-%s" style="position:absolute; bottom: 1rem;">%s</span>', $name, $count);
+        return empty($count) ? '' : sprintf('<span class="tag mx-05 has-background-module-%s module-items-counter">%s</span>', $name, $count);
     }
 
     /**

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -12,6 +12,7 @@
  */
 namespace App\View\Helper;
 
+use App\Utility\CacheTools;
 use App\Utility\Translate;
 use Cake\Core\Configure;
 use Cake\Utility\Hash;
@@ -129,12 +130,26 @@ class LayoutHelper extends Helper
         $param = empty($route) ? ['_name' => 'modules:list', 'object_type' => $name, 'plugin' => null] : $route;
 
         return sprintf(
-            '<a href="%s" class="%s"><span>%s</span>%s</a>',
+            '<a href="%s" class="%s"><span>%s</span>%s%s</a>',
             $this->Url->build($param),
             sprintf('dashboard-item has-background-module-%s %s', $name, Hash::get($module, 'class', '')),
             $this->tr($label),
-            $this->moduleIcon($name, $module)
+            $this->moduleIcon($name, $module),
+            $this->moduleCount($name)
         );
+    }
+
+    /**
+     * Return module count span.
+     *
+     * @param string $name The module name
+     * @return string
+     */
+    public function moduleCount(string $name): string
+    {
+        $count = CacheTools::getModuleCount($name);
+
+        return empty($count) ? '' : sprintf('<span class="tag mx-05 has-background-module-%s" style="position:absolute; bottom: 1rem;">%s</span>', $name, $count);
     }
 
     /**
@@ -217,11 +232,12 @@ class LayoutHelper extends Helper
             $label = Hash::get($currentModule, 'label', $name);
 
             return sprintf(
-                '<a href="%s" class="%s"><span class="mr-05">%s</span>%s</a>',
+                '<a href="%s" class="%s"><span class="mr-05">%s</span>%s%s</a>',
                 $this->Url->build(['_name' => 'modules:list', 'object_type' => $name]),
                 sprintf('module-item has-background-module-%s', $name),
                 $this->tr($label),
-                $this->moduleIcon($name, $currentModule)
+                $this->moduleIcon($name, $currentModule),
+                $this->moduleCount($name)
             );
         }
 

--- a/templates/Pages/Dashboard/index.twig
+++ b/templates/Pages/Dashboard/index.twig
@@ -22,7 +22,7 @@
                 {% if modules.trash %}
                     <a href="{{ Url.build({ '_name': 'trash:list' }) }}" title="{{ __('Trash') }}" class="dashboard-item has-background-black">
                         <span>{{ __('Trash can') }}</span>
-                        {{ Layout.moduleCount('trash')|raw }}
+                        {{ Layout.moduleCount('trash', 'has-background-black')|raw }}
                         <app-icon icon="carbon:trash-can"></app-icon>
                     </a>
                 {% endif %}

--- a/templates/Pages/Dashboard/index.twig
+++ b/templates/Pages/Dashboard/index.twig
@@ -22,6 +22,7 @@
                 {% if modules.trash %}
                     <a href="{{ Url.build({ '_name': 'trash:list' }) }}" title="{{ __('Trash') }}" class="dashboard-item has-background-black">
                         <span>{{ __('Trash can') }}</span>
+                        {{ Layout.moduleCount('trash')|raw }}
                         <app-icon icon="carbon:trash-can"></app-icon>
                     </a>
                 {% endif %}
@@ -29,6 +30,7 @@
                 {% if modules.users %}
                     <a href="{{ Url.build({'_name': 'modules:list', 'object_type': 'users'}) }}" title="{{ __('System users') }}" class="dashboard-item has-background-black">
                         <span>{{ __('System users') }}</span>
+                        {{ Layout.moduleCount('users')|raw }}
                         <app-icon icon="carbon:user-admin"></app-icon>
                     </a>
                 {% endif %}

--- a/tests/TestCase/Controller/DashboardControllerTest.php
+++ b/tests/TestCase/Controller/DashboardControllerTest.php
@@ -14,6 +14,7 @@
 namespace App\Test\TestCase\Controller;
 
 use App\Controller\DashboardController;
+use App\Utility\CacheTools;
 use Authentication\AuthenticationService;
 use Authentication\AuthenticationServiceInterface;
 use Authentication\Identifier\IdentifierInterface;
@@ -21,6 +22,7 @@ use Authentication\Identity;
 use Authentication\IdentityInterface;
 use BEdita\WebTools\ApiClientProvider;
 use BEdita\WebTools\Identifier\ApiIdentifier;
+use Cake\Cache\Cache;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -41,6 +43,24 @@ class DashboardControllerTest extends TestCase
      * @var \App\Controller\DashboardController
      */
     public $Dashboard;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        Cache::enable();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Cache::disable();
+    }
 
     /**
      * Setup controller to test with request config
@@ -184,6 +204,8 @@ class DashboardControllerTest extends TestCase
 
         $this->setupControllerAndLogin($requestConfig);
 
+        $this->Dashboard->set('modules', ['abcde' => [], 'wrong' => [], 'documents' => [], 'images' => [], 'media' => [], 'objects' => [], 'tags' => [], 'trash' => [], 'users' => []]);
+        CacheTools::setModuleCount(['meta' => ['pagination' => ['count' => 0]]], 'abcde');
         $this->Dashboard->index();
         $response = $this->Dashboard->getResponse();
 

--- a/tests/TestCase/Utility/CacheToolsTest.php
+++ b/tests/TestCase/Utility/CacheToolsTest.php
@@ -14,6 +14,7 @@ namespace App\Test\TestCase;
 
 use App\Utility\CacheTools;
 use BEdita\WebTools\ApiClientProvider;
+use Cake\Cache\Cache;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -23,6 +24,24 @@ use Cake\TestSuite\TestCase;
  */
 class CacheToolsTest extends TestCase
 {
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        Cache::enable();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Cache::disable();
+    }
+
     /**
      * Test `cacheKey` method.
      *
@@ -34,6 +53,46 @@ class CacheToolsTest extends TestCase
         $apiSignature = md5(ApiClientProvider::getApiClient()->getApiBaseUrl());
         $expected = sprintf('%s_%s', 'test', $apiSignature);
         $actual = CacheTools::cacheKey('test');
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `getModuleCount` method.
+     *
+     * @return void
+     * @covers ::getModuleCount()
+     */
+    public function testGetModuleCount(): void
+    {
+        $moduleName = 'test';
+        $cacheKey = sprintf('statistics_%s_count', $moduleName);
+        $count = 42;
+        Cache::write($cacheKey, $count);
+        $expected = $count;
+        $actual = CacheTools::getModuleCount($moduleName);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `setModuleCount` method.
+     *
+     * @return void
+     * @covers ::setModuleCount()
+     * @covers ::getModuleCount()
+     */
+    public function testSetModuleCount(): void
+    {
+        $moduleName = 'test';
+        $response = [
+            'meta' => [
+                'pagination' => [
+                    'count' => 42,
+                ],
+            ],
+        ];
+        CacheTools::setModuleCount($response, $moduleName);
+        $expected = 42;
+        $actual = CacheTools::getModuleCount($moduleName);
         static::assertEquals($expected, $actual);
     }
 }

--- a/tests/TestCase/Utility/CacheToolsTest.php
+++ b/tests/TestCase/Utility/CacheToolsTest.php
@@ -60,6 +60,7 @@ class CacheToolsTest extends TestCase
      * Test `getModuleCount` and `setModuleCount` methods.
      *
      * @return void
+     * @covers ::existsCount()
      * @covers ::setModuleCount()
      * @covers ::getModuleCount()
      */
@@ -73,6 +74,8 @@ class CacheToolsTest extends TestCase
                 ],
             ],
         ];
+        $exists = CacheTools::existsCount($moduleName);
+        static::assertFalse($exists);
         CacheTools::setModuleCount($response, $moduleName);
         $expected = 42;
         $actual = CacheTools::getModuleCount($moduleName);

--- a/tests/TestCase/Utility/CacheToolsTest.php
+++ b/tests/TestCase/Utility/CacheToolsTest.php
@@ -57,30 +57,13 @@ class CacheToolsTest extends TestCase
     }
 
     /**
-     * Test `getModuleCount` method.
-     *
-     * @return void
-     * @covers ::getModuleCount()
-     */
-    public function testGetModuleCount(): void
-    {
-        $moduleName = 'test';
-        $cacheKey = sprintf('statistics_%s_count', $moduleName);
-        $count = 42;
-        Cache::write($cacheKey, $count);
-        $expected = $count;
-        $actual = CacheTools::getModuleCount($moduleName);
-        static::assertEquals($expected, $actual);
-    }
-
-    /**
-     * Test `setModuleCount` method.
+     * Test `getModuleCount` and `setModuleCount` methods.
      *
      * @return void
      * @covers ::setModuleCount()
      * @covers ::getModuleCount()
      */
-    public function testSetModuleCount(): void
+    public function testGetSetModuleCount(): void
     {
         $moduleName = 'test';
         $response = [

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -843,7 +843,7 @@ class LayoutHelperTest extends TestCase
         Cache::enable();
         $count = 42;
         CacheTools::setModuleCount(['meta' => ['pagination' => ['count' => $count]]], $moduleName);
-        $expected = sprintf('<span class="tag mx-05 has-background-module-%s" style="position:absolute; bottom: 1rem;">%s</span>', $moduleName, $count);
+        $expected = sprintf('<span class="tag mx-05 has-background-module-%s module-items-counter">%s</span>', $moduleName, $count);
         $actual = $layout->moduleCount($moduleName);
         static::assertEquals($expected, $actual);
         Cache::disable();

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -13,10 +13,12 @@
 
 namespace App\Test\TestCase\View\Helper;
 
+use App\Utility\CacheTools;
 use App\View\Helper\EditorsHelper;
 use App\View\Helper\LayoutHelper;
 use App\View\Helper\PermsHelper;
 use App\View\Helper\SystemHelper;
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieCollection;
@@ -820,5 +822,30 @@ class LayoutHelperTest extends TestCase
         $layout = new LayoutHelper($view);
         $actual = $layout->moduleIcon($name, $module);
         static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `moduleCount` method.
+     *
+     * @return void
+     * @covers moduleCount()
+     */
+    public function testModuleCount(): void
+    {
+        $moduleName = 'test';
+        $viewVars = [];
+        $request = new ServerRequest();
+        $view = new View($request, null, null, compact('viewVars'));
+        $layout = new LayoutHelper($view);
+        $actual = $layout->moduleCount($moduleName);
+        static::assertEmpty($actual);
+
+        Cache::enable();
+        $count = 42;
+        CacheTools::setModuleCount(['meta' => ['pagination' => ['count' => $count]]], $moduleName);
+        $expected = sprintf('<span class="tag mx-05 has-background-module-%s" style="position:absolute; bottom: 1rem;">%s</span>', $moduleName, $count);
+        $actual = $layout->moduleCount($moduleName);
+        static::assertEquals($expected, $actual);
+        Cache::disable();
     }
 }

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -843,9 +843,11 @@ class LayoutHelperTest extends TestCase
         Cache::enable();
         $count = 42;
         CacheTools::setModuleCount(['meta' => ['pagination' => ['count' => $count]]], $moduleName);
-        $expected = sprintf('<span class="tag mx-05 has-background-module-%s module-items-counter">%s</span>', $moduleName, $count);
+        $expected = sprintf('<span class="tag mx-05 module-items-counter has-background-module-test">%s</span>', $count);
         $actual = $layout->moduleCount($moduleName);
         static::assertEquals($expected, $actual);
+        $actual = $layout->moduleCount($moduleName, 'my-dummy-css-class');
+        $expected = sprintf('<span class="tag mx-05 module-items-counter my-dummy-css-class">%s</span>', $count);
         Cache::disable();
     }
 }

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -838,7 +838,7 @@ class LayoutHelperTest extends TestCase
         $view = new View($request, null, null, compact('viewVars'));
         $layout = new LayoutHelper($view);
         $actual = $layout->moduleCount($moduleName);
-        static::assertEmpty($actual);
+        static::assertEquals('-', $actual);
 
         Cache::enable();
         $count = 42;

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -838,7 +838,7 @@ class LayoutHelperTest extends TestCase
         $view = new View($request, null, null, compact('viewVars'));
         $layout = new LayoutHelper($view);
         $actual = $layout->moduleCount($moduleName);
-        static::assertEquals('-', $actual);
+        static::assertEquals('<span class="tag mx-05 module-items-counter has-background-module-test">0</span>', $actual);
 
         Cache::enable();
         $count = 42;

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -244,7 +244,7 @@ class LayoutHelperTest extends TestCase
                 ],
             ],
             'objects' => [
-                '<a href="/objects" class="module-item has-background-module-objects"><span class="mr-05">Objects</span></a>',
+                '<a href="/objects" class="module-item has-background-module-objects"><span class="mr-05">Objects</span><span class="tag mx-05 module-items-counter has-background-module-objects">0</span></a>',
                 'Module',
                 [
                     'currentModule' => ['name' => 'objects'],
@@ -734,7 +734,7 @@ class LayoutHelperTest extends TestCase
             'documents' => [
                 'documents',
                 [],
-                '<a href="/documents" class="dashboard-item has-background-module-documents "><span>Documents</span><app-icon icon="carbon:document"></app-icon></a>',
+                '<a href="/documents" class="dashboard-item has-background-module-documents "><span>Documents</span><app-icon icon="carbon:document"></app-icon><span class="tag mx-05 module-items-counter has-background-module-documents">0</span></a>',
             ],
         ];
     }
@@ -828,7 +828,7 @@ class LayoutHelperTest extends TestCase
      * Test `moduleCount` method.
      *
      * @return void
-     * @covers moduleCount()
+     * @covers ::moduleCount()
      */
     public function testModuleCount(): void
     {


### PR DESCRIPTION
This provides a feature: showing items count in modules.
Counters are loaded on first access to dashboard.
Cache data is updated per module when accessing the module index.
Examples follow.

Dashboard
![image](https://github.com/bedita/manager/assets/2227145/955f5fe3-2d03-4939-9f90-3fc9622939cf)

Object view:
![image](https://github.com/bedita/manager/assets/2227145/c83cf4c7-193b-4b3b-882c-65e3545be497)
