### PR TITLE
Refactor categories to handle parents per type

### DIFF
--- a/resources/js/app/components/category-form/category-form.vue
+++ b/resources/js/app/components/category-form/category-form.vue
@@ -14,20 +14,22 @@
             >
             </labels-form>
         </div>
+        <template v-if="options?.showType">
+            <div class="object_type_name-cell" v-show="!selectTypes">
+                <input type="hidden" name="object_type_name" v-model="type" />
+                <span :class="typeClass()">{{ type }}</span>
+            </div>
+            <div class="object_type_name-cell" v-show="selectTypes">
+                <select v-model="type" @change="updateType(type, $event)">
+                    <option v-for="t in original.types" :value="t">{{ t }}</option>
+                </select>
+            </div>
+        </template>
         <div class="parent_id-cell">
-            <select v-model="parent" @change="onChangeParent" class="parent">
-                <template v-for="pLabel,pId in parents">
-                    <option :value="pId" v-if="pId != source.id">{{ pLabel }}</option>
+            <select v-model="parent" @change="onChangeParent" class="parent" :disabled="!type">
+                <template v-for="parent,pId in parentsByType()">
+                    <option :value="parent.id" v-if="parent.id != source.id">{{ parent.label }}</option>
                 </template>
-            </select>
-        </div>
-        <div class="object_type_name-cell" v-show="!selectTypes">
-            <input type="hidden" name="object_type_name" v-model="type" />
-            <span :class="typeClass()">{{ type }}</span>
-        </div>
-        <div class="object_type_name-cell" v-show="selectTypes">
-            <select v-model="type" @change="updateType(type, $event)">
-                <option v-for="t in original.types" :value="t">{{ t }}</option>
             </select>
         </div>
         <div class="enabled-cell">
@@ -39,9 +41,11 @@
                 <span class="ml-05">{{ msgCreate }}</span>
             </button>
         </div>
-        <div v-show="id">
-            {{ id }}
-        </div>
+        <template v-if="options?.showId">
+            <div v-show="id">
+                {{ id }}
+            </div>
+        </template>
         <div v-show="id" class="buttons-cell narrow">
             <button
                 :disabled="loading || saveDisabled"
@@ -95,6 +99,15 @@ export default {
         allnames: {
             type: Object,
             default: () => {},
+        },
+        options: {
+            type: Object,
+            default: () => {
+                return {
+                    'showId': false,
+                    'showType': false
+                };
+            },
         },
     },
 
@@ -160,6 +173,24 @@ export default {
 
         onChangeParent() {
             this.saveDisabled = this.unchanged() || !this.valid();
+        },
+
+        parentsByType() {
+            if (!this.type) {
+                return [];
+            }
+            let parents = Object.values(this.parents) || [];
+            if (!parents) {
+                return [];
+            }
+            parents = parents.filter((parent) => parent?.object_type_name === this.type) || [];
+
+            return parents.sort((a, b) => {
+                if (a.label && b.label) {
+                    return a.label.localeCompare(b.label);
+                }
+                return a.name.localeCompare(b.name);
+            });
         },
 
         updateType() {

--- a/resources/js/app/components/category-form/category-form.vue
+++ b/resources/js/app/components/category-form/category-form.vue
@@ -27,7 +27,7 @@
         </template>
         <div class="parent_id-cell">
             <select v-model="parent" @change="onChangeParent" class="parent" :disabled="!type">
-                <template v-for="parent,pId in parentsByType()">
+                <template v-for="parent in parentsByType()">
                     <option :value="parent.id" v-if="parent.id != source.id">{{ parent.label }}</option>
                 </template>
             </select>

--- a/src/Controller/Component/CategoriesComponent.php
+++ b/src/Controller/Component/CategoriesComponent.php
@@ -93,15 +93,18 @@ class CategoriesComponent extends Component
             if (empty($category['attributes']['parent_id'])) {
                 $tree['_'][] = $category['id'];
             } else {
-                $tree[$category['attributes']['parent_id']][] = $category['id'];
+                $tree[$category['attributes']['parent_id']][] = $category;
             }
         }
         // sort by label or name
         foreach ($tree as $key => $children) {
-            usort($children, function ($a, $b) use ($map) {
-                return strcasecmp($map[$a]['attributes']['label'] ?? $map[$a]['attributes']['name'], $map[$b]['attributes']['label'] ?? $map[$b]['attributes']['name']);
+            usort($children, function ($a, $b) {
+                $tmpA = Hash::get($a, 'attributes.label') ?? Hash::get($a, 'attributes.name');
+                $tmpB = Hash::get($b, 'attributes.label') ?? Hash::get($b, 'attributes.name');
+
+                return strcasecmp($tmpA, $tmpB);
             });
-            $tree[$key] = $children;
+            $tree[$key] = Hash::extract($children, '{n}.id');
         }
 
         return $tree;

--- a/src/Controller/Component/CategoriesComponent.php
+++ b/src/Controller/Component/CategoriesComponent.php
@@ -91,7 +91,7 @@ class CategoriesComponent extends Component
         ];
         foreach ($map as $category) {
             if (empty($category['attributes']['parent_id'])) {
-                $tree['_'][] = $category['id'];
+                $tree['_'][] = $category;
             } else {
                 $tree[$category['attributes']['parent_id']][] = $category;
             }

--- a/src/Controller/Component/CategoriesComponent.php
+++ b/src/Controller/Component/CategoriesComponent.php
@@ -79,6 +79,7 @@ class CategoriesComponent extends Component
 
     /**
      * Create an id-based categories tree.
+     * Sort children by label or name.
      *
      * @param array $map The categories map returned by the map function.
      * @return array The categories tree.
@@ -95,6 +96,13 @@ class CategoriesComponent extends Component
                 $tree[$category['attributes']['parent_id']][] = $category['id'];
             }
         }
+        // sort by label or name
+        foreach ($tree as $key => $children) {
+            usort($children, function ($a, $b) use ($map) {
+                return strcasecmp($map[$a]['attributes']['label'] ?? $map[$a]['attributes']['name'], $map[$b]['attributes']['label'] ?? $map[$b]['attributes']['name']);
+            });
+            $tree[$key] = $children;
+        }
 
         return $tree;
     }
@@ -107,10 +115,15 @@ class CategoriesComponent extends Component
      */
     public function getAvailableRoots(?array $map): array
     {
-        $roots = ['' => '-'];
+        $roots = ['' => ['id' => 0, 'label' => '-', 'name' => '', 'object_type_name' => '']];
         foreach ($map as $category) {
             if (empty($category['attributes']['parent_id'])) {
-                $roots[$category['id']] = empty($category['attributes']['label']) ? $category['attributes']['name'] : $category['attributes']['label'];
+                $roots[$category['id']] = [
+                    'id' => $category['id'],
+                    'label' => $category['attributes']['label'] ?? $category['attributes']['name'],
+                    'name' => $category['attributes']['name'],
+                    'object_type_name' => $category['attributes']['object_type_name'],
+                ];
             }
         }
 

--- a/templates/Element/Modules/index_categories.twig
+++ b/templates/Element/Modules/index_categories.twig
@@ -1,5 +1,14 @@
 {% set language = config('Project.config.I18n.default')|json_encode %}
-{% set languages = config('Project.config.I18n.languages')|default([])|json_encode %}
+{% set languages = config('Project.config.I18n.languages')|json_encode %}
+{% if languages == 'null' %}{% set languages = '{}' %}{% endif %}
+{% set options = {} %}
+{% if showId %}
+	{% set options = options|merge({'showId': 1}) %}
+{% endif %}
+{% if showType %}
+    {% set options = options|merge({'showType': 1}) %}
+{% endif %}
+{% set options = options is empty ? '{}' : options|json_encode %}
 
 <div class="categories-container">
 
@@ -13,10 +22,14 @@
             <nav class="table-header has-border-black">
                 <div>{{ __('Name') }}</div>
                 <div>{{ __('Label') }}</div>
-                <div>{{ __('Parent') }}</div>
+                {% if showType %}
                 <div>{{ __('Type') }}</div>
+                {% endif %}
+                <div>{{ __('Parent') }}</div>
                 <div>{{ __('Enabled') }}</div>
+                {% if showId %}
                 <div>{{ __('Id') }}</div>
+                {% endif %}
                 <div></div>
                 <div></div>
             </nav>
@@ -30,6 +43,7 @@
                     :source="{{ resource.attributes|merge({'id': resource.id, 'type': type})|json_encode }}"
                     :parents="{{ roots|json_encode }}"
                     :names="{{ names[type]|json_encode }}"
+                    :options="{{ options }}"
                 >
                 </category-form>
 
@@ -45,8 +59,8 @@
             <nav class="table-header has-border-black">
                 <div>{{ __('Name') }}</div>
                 <div>{{ __('Label') }}</div>
-                <div>{{ __('Parent') }}</div>
                 <div>{{ __('Type') }}</div>
+                <div>{{ __('Parent') }}</div>
                 <div>{{ __('Enabled') }}</div>
                 <div></div>
             </nav>
@@ -57,16 +71,20 @@
 	                :languages="{{ languages }}"
                     :source="{{ source|json_encode }}"
                     :parents="{{ roots|json_encode }}"
-                    :names="{{ names[object_types.0]|json_encode }}">
+                    :names="{{ names[object_types.0]|json_encode }}"
+                >
                 </category-form>
             {% else %}
                 {% set source = {'types': object_types|keys} %}
+                {% set optionsNew = {'showType': true} %}
                 <category-form
                     :language="{{ language }}"
 	                :languages="{{ languages }}"
                     :source="{{ source|json_encode }}"
                     :parents="{{ roots|json_encode }}"
-                    :allnames="{{ names|json_encode }}">
+                    :allnames="{{ names|json_encode }}"
+                    :options="{{ optionsNew|json_encode }}"
+                >
                 </category-form>
             {% endif %}
         </div>

--- a/templates/Pages/Model/Categories/index.twig
+++ b/templates/Pages/Model/Categories/index.twig
@@ -11,7 +11,7 @@
 
 <div class="module-index">
 
-    {{ element('Modules/index_categories') }}
+    {{ element('Modules/index_categories', { showType: 1 }) }}
     {{ element('Model/sidebar_links') }}
 
 </div> {# end module-content #}

--- a/tests/TestCase/Controller/Component/CategoriesComponentTest.php
+++ b/tests/TestCase/Controller/Component/CategoriesComponentTest.php
@@ -156,7 +156,7 @@ class CategoriesComponentTest extends TestCase
             ['id' => 999, 'attributes' => ['label' => 'Dummy 0', 'name' => 'dummy-0', 'parent_id' => 456]],
         ];
         $expected = [
-            '_' => [],
+            '_' => [123],
             123 => [456],
             456 => [999, 789],
         ];

--- a/tests/TestCase/Controller/Component/CategoriesComponentTest.php
+++ b/tests/TestCase/Controller/Component/CategoriesComponentTest.php
@@ -173,20 +173,20 @@ class CategoriesComponentTest extends TestCase
     {
         // empty map
         $map = [];
-        $expected = ['' => '-'];
+        $expected = ['' => ['id' => 0, 'label' => '-', 'name' => '', 'object_type_name' => '']];
         $actual = $this->Categories->getAvailableRoots($map);
         static::assertEquals($expected, $actual);
 
         // not empty map
         $map = [
-            ['id' => 123, 'attributes' => ['label' => 'Dummy 123', 'name' => 'dummy-123']],
-            ['id' => 456, 'attributes' => ['name' => 'dummy-456']],
-            ['id' => 789, 'attributes' => ['label' => 'Dummy 789', 'name' => 'dummy-789', 'parent_id' => 456]],
+            ['id' => 123, 'attributes' => ['label' => 'Dummy 123', 'name' => 'dummy-123', 'object_type_name' => 'documents']],
+            ['id' => 456, 'attributes' => ['name' => 'dummy-456', 'object_type_name' => 'documents']],
+            ['id' => 789, 'attributes' => ['label' => 'Dummy 789', 'name' => 'dummy-789', 'object_type_name' => 'documents', 'parent_id' => 456]],
         ];
         $expected = [
-            '' => '-',
-            123 => 'Dummy 123',
-            456 => 'dummy-456',
+            '' => ['id' => 0, 'label' => '-', 'name' => '', 'object_type_name' => ''],
+            123 => ['id' => 123, 'label' => 'Dummy 123', 'name' => 'dummy-123', 'object_type_name' => 'documents'],
+            456 => ['id' => 456, 'label' => 'dummy-456', 'name' => 'dummy-456', 'object_type_name' => 'documents'],
         ];
         $actual = $this->Categories->getAvailableRoots($map);
         static::assertEquals($expected, $actual);

--- a/tests/TestCase/Controller/Component/CategoriesComponentTest.php
+++ b/tests/TestCase/Controller/Component/CategoriesComponentTest.php
@@ -153,11 +153,12 @@ class CategoriesComponentTest extends TestCase
             ['id' => 123, 'attributes' => ['label' => 'Dummy 123', 'name' => 'dummy-123']],
             ['id' => 456, 'attributes' => ['label' => 'Dummy 456', 'name' => 'dummy-456', 'parent_id' => 123]],
             ['id' => 789, 'attributes' => ['label' => 'Dummy 789', 'name' => 'dummy-789', 'parent_id' => 456]],
+            ['id' => 999, 'attributes' => ['label' => 'Dummy 0', 'name' => 'dummy-0', 'parent_id' => 456]],
         ];
         $expected = [
-            '_' => [123],
+            '_' => [],
             123 => [456],
-            456 => [789],
+            456 => [999, 789],
         ];
         $actual = $this->Categories->tree($map);
         static::assertEquals($expected, $actual);

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -262,7 +262,6 @@ class DateRangesToolsTest extends TestCase
      * @covers ::prepare()
      * @covers ::parseParams()
      * @covers ::cleanParams()
-     * @covers ::filterNotOn()
      * @covers ::isOneDayRange()
      */
     public function testPrepare(array $dateRanges, array $expected): void


### PR DESCRIPTION
This introduces an optimization in categories: you can select only parents that belong to the proper type.
Other improvements:

 - order categories by label / name
 - in new category form, change parents when changing type
 - do not show id and type columns, in `/:type/categories`