### PR TITLE
Placeholders parameters

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -591,6 +591,30 @@ return [
     // ],
 
     /**
+     * Placeholders configuration.
+     */
+    // 'Placeholders' => [
+    //     'audio' => [
+    //         'controls' => 'boolean',
+    //         'autoplay' => 'boolean',
+    //     ],
+    //     'files' => [
+    //         'download' => 'boolean',
+    //     ],
+    //     'images' => [
+    //         'width' => 'integer',
+    //         'height' => 'integer',
+    //         'bearing' => 'integer',
+    //         'pitch' => 'integer',
+    //         'zoom' => 'integer',
+    //     ],
+    //     'videos' => [
+    //         'controls' => 'boolean',
+    //         'autoplay' => 'boolean',
+    //     ],
+    // ],
+
+    /**
      * Upload configurations.
      */
     // 'uploadAccepted' => [

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -602,8 +602,8 @@ return [
     //         'download' => 'boolean',
     //     ],
     //     'images' => [
-    //         'width' => 'integer',
-    //         'height' => 'integer',
+    //         'width' => ['small', 'medium', 'large'],
+    //         'height' => ['small', 'medium', 'large'],
     //         'bearing' => 'integer',
     //         'pitch' => 'integer',
     //         'zoom' => 'integer',

--- a/config/i18n_strings.php
+++ b/config/i18n_strings.php
@@ -115,3 +115,13 @@
 
 // Publications
 // __('Publications')
+
+// Placeholders parameters
+// __('autoplay');
+// __('bearing');
+// __('controls');
+// __('download');
+// __('height');
+// __('pitch');
+// __('width');
+// __('zoom');

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-06-11 16:09:09 \n"
+"POT-Creation-Date: 2024-06-14 12:50:32 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -925,6 +925,12 @@ msgstr ""
 msgid "application_id"
 msgstr ""
 
+msgid "autoplay"
+msgstr ""
+
+msgid "bearing"
+msgstr ""
+
 msgid "cancel"
 msgstr ""
 
@@ -940,6 +946,9 @@ msgstr ""
 msgid "context"
 msgstr ""
 
+msgid "controls"
+msgstr ""
+
 msgid "create"
 msgstr ""
 
@@ -953,6 +962,9 @@ msgid "current password"
 msgstr ""
 
 msgid "description"
+msgstr ""
+
+msgid "download"
 msgstr ""
 
 msgid "elements to"
@@ -971,6 +983,9 @@ msgid "expires"
 msgstr ""
 
 msgid "from"
+msgstr ""
+
+msgid "height"
 msgstr ""
 
 msgid "id"
@@ -1013,6 +1028,9 @@ msgid "parent"
 msgstr ""
 
 msgid "phone"
+msgstr ""
+
+msgid "pitch"
 msgstr ""
 
 msgid "remove"
@@ -1067,6 +1085,12 @@ msgid "view parent"
 msgstr ""
 
 msgid "warning"
+msgstr ""
+
+msgid "width"
+msgstr ""
+
+msgid "zoom"
 msgstr ""
 
 #, javascript-format
@@ -1350,6 +1374,9 @@ msgid "Title or #id uname"
 msgstr ""
 
 msgid "(deleted)"
+msgstr ""
+
+msgid "placeholders"
 msgstr ""
 
 msgid "You can modify the permissions"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-06-11 16:09:09 \n"
+"POT-Creation-Date: 2024-06-14 12:50:32 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -928,6 +928,12 @@ msgstr ""
 msgid "application_id"
 msgstr ""
 
+msgid "autoplay"
+msgstr ""
+
+msgid "bearing"
+msgstr ""
+
 msgid "cancel"
 msgstr ""
 
@@ -943,6 +949,9 @@ msgstr ""
 msgid "context"
 msgstr ""
 
+msgid "controls"
+msgstr ""
+
 msgid "create"
 msgstr ""
 
@@ -956,6 +965,9 @@ msgid "current password"
 msgstr ""
 
 msgid "description"
+msgstr ""
+
+msgid "download"
 msgstr ""
 
 msgid "elements to"
@@ -974,6 +986,9 @@ msgid "expires"
 msgstr ""
 
 msgid "from"
+msgstr ""
+
+msgid "height"
 msgstr ""
 
 msgid "id"
@@ -1016,6 +1031,9 @@ msgid "parent"
 msgstr ""
 
 msgid "phone"
+msgstr ""
+
+msgid "pitch"
 msgstr ""
 
 msgid "remove"
@@ -1070,6 +1088,12 @@ msgid "view parent"
 msgstr ""
 
 msgid "warning"
+msgstr ""
+
+msgid "width"
+msgstr ""
+
+msgid "zoom"
 msgstr ""
 
 #, javascript-format
@@ -1353,6 +1377,9 @@ msgid "Title or #id uname"
 msgstr ""
 
 msgid "(deleted)"
+msgstr ""
+
+msgid "placeholders"
 msgstr ""
 
 msgid "You can modify the permissions"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-06-11 16:09:09 \n"
+"POT-Creation-Date: 2024-06-14 12:50:32 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -933,6 +933,12 @@ msgstr "id applicazione"
 msgid "application_id"
 msgstr "id applicazione"
 
+msgid "autoplay"
+msgstr ""
+
+msgid "bearing"
+msgstr ""
+
 msgid "cancel"
 msgstr "annulla"
 
@@ -948,6 +954,9 @@ msgstr "contenuto"
 msgid "context"
 msgstr "contesto"
 
+msgid "controls"
+msgstr ""
+
 msgid "create"
 msgstr "crea"
 
@@ -962,6 +971,9 @@ msgstr "password corrente"
 
 msgid "description"
 msgstr "descrizione"
+
+msgid "download"
+msgstr ""
 
 msgid "elements to"
 msgstr "elementi a"
@@ -980,6 +992,9 @@ msgstr "scade"
 
 msgid "from"
 msgstr "da"
+
+msgid "height"
+msgstr ""
 
 msgid "id"
 msgstr ""
@@ -1022,6 +1037,9 @@ msgstr "genitore"
 
 msgid "phone"
 msgstr "telefono"
+
+msgid "pitch"
+msgstr ""
 
 msgid "remove"
 msgstr "rimuovi"
@@ -1076,6 +1094,12 @@ msgstr "visualizza genitore"
 
 msgid "warning"
 msgstr "attenzione"
+
+msgid "width"
+msgstr ""
+
+msgid "zoom"
+msgstr ""
 
 #, javascript-format
 msgid "Please insert a new title on \"${ title }\" clone"
@@ -1368,6 +1392,9 @@ msgstr "Titolo o #id nome univoco"
 
 msgid "(deleted)"
 msgstr "(eliminato)"
+
+msgid "placeholders"
+msgstr "segnaposto"
 
 msgid "You can modify the permissions"
 msgstr "Puoi modificare i permessi"

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -7,6 +7,7 @@ import '../../style.scss';
 
 import { BELoader } from 'libs/bedita';
 
+import { EventBus } from 'app/components/event-bus';
 import { PanelView, PanelEvents } from 'app/components/panel-view';
 import { confirm, error, info, success, prompt, warning } from 'app/components/dialog/dialog';
 
@@ -31,6 +32,7 @@ const _vueInstance = new Vue({
     el: 'main',
 
     components: {
+        EventBus,
         PanelView,
         Autocomplete,
         LoginPassword: () => import(/* webpackChunkName: "login-password" */'app/components/login-password/login-password'),
@@ -84,6 +86,7 @@ const _vueInstance = new Vue({
         LanguageSelector:() => import(/* webpackChunkName: "language-selector" */'app/components/language-selector/language-selector'),
         ClipboardItem: () => import(/* webpackChunkName: "clipboard-item" */'app/components/clipboard-item/clipboard-item'),
         ObjectCategories: () => import(/* webpackChunkName: "object-categories" */'app/components/object-categories/object-categories'),
+        PlaceholderList: () => import(/* webpackChunkName: "placeholder-list" */'app/components/placeholder-list/placeholder-list'),
         AppIcon,
     },
 

--- a/resources/js/app/components/event-bus.vue
+++ b/resources/js/app/components/event-bus.vue
@@ -1,0 +1,19 @@
+<script>
+import Vue from 'vue';
+
+export const EventBus = new Vue({
+    methods: {
+        listen(name, callback) {
+            this.$on(name, callback);
+        },
+        send(name, data) {
+            this.$emit(name, data);
+        },
+        stop(name, callback) {
+            this.$off(name, callback);
+        },
+    }
+});
+
+export default EventBus;
+</script>

--- a/resources/js/app/components/panel-view.js
+++ b/resources/js/app/components/panel-view.js
@@ -104,6 +104,10 @@ export const PanelEvents = new Vue({
         closePanel() {
             this.$emit('panel:close');
         },
+
+        refreshPlaceholders(id) {
+            this.$emit('refresh-placeholders', id);
+        },
     }
 });
 

--- a/resources/js/app/components/panel-view.js
+++ b/resources/js/app/components/panel-view.js
@@ -104,10 +104,6 @@ export const PanelEvents = new Vue({
         closePanel() {
             this.$emit('panel:close');
         },
-
-        refreshPlaceholders(id) {
-            this.$emit('refresh-placeholders', id);
-        },
     }
 });
 

--- a/resources/js/app/components/placeholder-list/placeholder-list.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-list.vue
@@ -37,20 +37,22 @@ export default {
     },
     data() {
         return {
+            richtextContent: '',
             items: [],
         };
     },
     mounted() {
         this.$nextTick(async () => {
-            await this.extractPlaceholders(this.value);
+            this.richtextContent = this.value || document.getElementById(this.field).value || '';
+            await this.extractPlaceholders();
             EventBus.listen('refresh-placeholders', this.refresh);
         });
     },
     methods: {
-        async extractPlaceholders(content) {
+        async extractPlaceholders() {
             const regex = /BE-PLACEHOLDER\.(\d+)(?:\.([-A-Za-z0-9+=]{1,100}|=[^=]|={3,}))?/;
             const tmpDom = document.createElement('div');
-            tmpDom.innerHTML = content || document.getElementById(this.field).value || '';
+            tmpDom.innerHTML = this.richtextContent;
             tmpDom.querySelectorAll('*[data-placeholder]').forEach(async (item) => {
                 for (const subnode of item.childNodes) {
                     if (!subnode.textContent || subnode.nodeType !== Node.COMMENT_NODE) {
@@ -88,8 +90,12 @@ export default {
             if (id !== this.field) {
                 return;
             }
+            if (payload?.content === this.richtextContent) {
+                return;
+            }
+            this.richtextContent = payload.content;
             this.items = [];
-            await this.extractPlaceholders(payload.content);
+            await this.extractPlaceholders();
             this.$forceUpdate();
         },
     },

--- a/resources/js/app/components/placeholder-list/placeholder-list.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-list.vue
@@ -53,7 +53,7 @@ export default {
             tmpDom.innerHTML = content || document.getElementById(this.field).value || '';
             tmpDom.querySelectorAll('*[data-placeholder]').forEach(async (item) => {
                 for (const subnode of item.childNodes) {
-                    if (subnode.textContent && subnode.nodeType !== Node.COMMENT_NODE) {
+                    if (!subnode.textContent || subnode.nodeType !== Node.COMMENT_NODE) {
                         continue;
                     }
                     const m = subnode.textContent.match(regex);

--- a/resources/js/app/components/placeholder-list/placeholder-list.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-list.vue
@@ -4,7 +4,7 @@
         v-if="items?.length > 0"
     >
         <div class="header">
-            <span>{{ items?.length }} placeholders</span>
+            <span>{{ items?.length }} {{ msgPlaceholders }}</span>
         </div>
         <div
             class="placeholder-item"
@@ -36,6 +36,7 @@
 </template>
 <script>
 import { EventBus } from 'app/components/event-bus';
+import { t } from 'ttag';
 
 export default {
     name: 'PlaceholderList',
@@ -57,6 +58,7 @@ export default {
             debounceRefreshHandle: null,
             items: [],
             richtextContent: '',
+            msgPlaceholders: t`placeholders`,
         };
     },
     mounted() {

--- a/resources/js/app/components/placeholder-list/placeholder-list.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-list.vue
@@ -23,7 +23,7 @@
             <app-icon v-if="item.obj?.type === 'publications'" icon="carbon:wikis" height="24" />
             <app-icon v-if="item.obj?.type === 'videos'" icon="carbon:video" height="24" />
 
-            <span>{{ item.obj?.attributes?.title }}</span>
+            <span>{{ item.obj?.title }}</span>
             <placeholder-params
                 :id="item.id"
                 :field="field"
@@ -55,6 +55,7 @@ export default {
     },
     data() {
         return {
+            cache: {},
             debounceRefreshHandle: null,
             items: [],
             richtextContent: '',
@@ -98,6 +99,9 @@ export default {
             }
         },
         async fetchObject(id) {
+            if (this.cache[id]) {
+                return this.cache[id];
+            }
             const baseUrl = new URL(BEDITA.base).pathname;
             const response = await fetch(`${baseUrl}api/objects/${id}`, {
                 credentials: 'same-origin',
@@ -106,8 +110,13 @@ export default {
                 }
             });
             const responseJson = await response.json();
+            const data = responseJson?.data || {};
+            this.cache[id] = {
+                type: data?.type,
+                title: data?.attributes?.title,
+            };
 
-            return responseJson?.data || null;
+            return this.cache[id];
         },
         itemKey(item) {
             return `${item.id}-${item.params_raw}`;

--- a/resources/js/app/components/placeholder-list/placeholder-list.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-list.vue
@@ -1,0 +1,112 @@
+<template>
+    <div class="placeholdersList input title text" v-if="items?.length > 0">
+        <div>
+            <app-icon icon="carbon:image" height="24"></app-icon>
+            <span>{{ items?.length }} placeholders</span>
+        </div>
+        <template v-for="item in items">
+            <div class="placeholder-item">
+                <span>{{ item.obj?.attributes?.title }}</span>
+                <placeholder-params
+                    :field="field"
+                    :id="item.id"
+                    :text="item.text"
+                    :value="item.params_raw"
+                />
+            </div>
+        </template>
+    </div>
+</template>
+<script>
+import { EventBus } from 'app/components/event-bus';
+
+export default {
+    name: 'PlaceholderList',
+    components: {
+        PlaceholderParams: () => import('./placeholder-params.vue'),
+    },
+    props: {
+        field: {
+            type: String,
+            required: true,
+        },
+        value: {
+            type: String,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            items: [],
+        };
+    },
+    mounted() {
+        this.$nextTick(async () => {
+            await this.extractPlaceholders(this.value);
+            EventBus.listen('refresh-placeholders', this.refresh);
+        });
+    },
+    methods: {
+        async extractPlaceholders(content) {
+            const regex = /BE-PLACEHOLDER\.(\d+)(?:\.([-A-Za-z0-9+=]{1,100}|=[^=]|={3,}))?/;
+            const tmpDom = document.createElement('div');
+            if (content) {
+                tmpDom.innerHTML = content;
+            } else {
+                tmpDom.innerHTML = document.getElementById(this.field).value || '';
+            }
+            tmpDom.querySelectorAll('*[data-placeholder]').forEach(async (item) => {
+                for (const subnode of item.childNodes) {
+                    if (subnode.textContent && subnode.nodeType === 8) {
+                        const m = subnode.textContent.match(regex);
+                        if (m) {
+                            const o = await this.fetchObject(m[1]);
+                            this.items.push({
+                                text: m[0],
+                                id: m[1],
+                                obj: o,
+                                params_raw: m[2],
+                                params: atob(m[2]),
+                            });
+                        }
+                    }
+                }
+            });
+        },
+        async fetchObject(id) {
+            const baseUrl = new URL(BEDITA.base).pathname;
+            const options = {
+                credentials: 'same-origin',
+                headers: {
+                    accept: 'application/json',
+                }
+            };
+            const response = await fetch(`${baseUrl}api/objects/${id}`, options);
+            const responseJson = await response.json();
+
+            return responseJson?.data || null;
+        },
+        async refresh(payload) {
+            console.log('refresh', payload);
+            const id = payload?.id;
+            if (id !== this.field) {
+                return;
+            }
+            this.items = [];
+            await this.extractPlaceholders(payload.content);
+            this.$forceUpdate();
+        },
+    },
+}
+</script>
+<style>
+div.placeholdersList > div.placeholder-item {
+    display: grid;
+    grid-template-columns: 50% 1fr;
+    text-align: left;
+    align-items: center;
+    gap: 8px;
+    margin: 4px 0;
+    border-bottom: dotted 1px #ccc;
+}
+</style>

--- a/resources/js/app/components/placeholder-list/placeholder-list.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-list.vue
@@ -4,10 +4,6 @@
         v-if="items?.length > 0"
     >
         <div class="header">
-            <app-icon
-                icon="carbon:image"
-                height="24"
-            />
             <span>{{ items?.length }} placeholders</span>
         </div>
         <div
@@ -15,11 +11,24 @@
             v-for="item in items"
             :key="itemKey(item)"
         >
+            <app-icon v-if="item.obj?.type === 'audio'" icon="carbon:document-audio" height="24" />
+            <app-icon v-if="item.obj?.type === 'documents'" icon="carbon:document" height="24" />
+            <app-icon v-if="item.obj?.type === 'events'" icon="carbon:event" height="24" />
+            <app-icon v-if="item.obj?.type === 'files'" icon="carbon:document-blank" height="24" />
+            <app-icon v-if="item.obj?.type === 'images'" icon="carbon:image" height="24" />
+            <app-icon v-if="item.obj?.type === 'links'" icon="carbon:link" height="24" />
+            <app-icon v-if="item.obj?.type === 'locations'" icon="carbon:location" height="24" />
+            <app-icon v-if="item.obj?.type === 'news'" icon="carbon:calendar" height="24" />
+            <app-icon v-if="item.obj?.type === 'profiles'" icon="carbon:person" height="24" />
+            <app-icon v-if="item.obj?.type === 'publications'" icon="carbon:wikis" height="24" />
+            <app-icon v-if="item.obj?.type === 'videos'" icon="carbon:video" height="24" />
+
             <span>{{ item.obj?.attributes?.title }}</span>
             <placeholder-params
                 :id="item.id"
                 :field="field"
                 :text="item.text"
+                :type="item.obj?.type"
                 :value="item.params_raw"
             />
         </div>
@@ -143,7 +152,7 @@ div.placeholdersList > div.header {
 }
 div.placeholdersList > div.placeholder-item {
     display: grid;
-    grid-template-columns: 60% 1fr;
+    grid-template-columns: 5% 60% 1fr;
     text-align: left;
     align-items: center;
     gap: 8px;

--- a/resources/js/app/components/placeholder-list/placeholder-list.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-list.vue
@@ -59,7 +59,7 @@ export default {
     },
     methods: {
         async extractPlaceholders(content) {
-            const regex = /BE-PLACEHOLDER\.(\d+)(?:\.([-A-Za-z0-9+=]{1,100}|=[^=]|={3,}))?/;
+            const regex = /BE-PLACEHOLDER\.(\d+)(?:\.([a-zA-Z0-9+/]+={0,2}))?/;
             const tmpDom = document.createElement('div');
             tmpDom.innerHTML = content || this.richtextContent;
             let matches = [];

--- a/resources/js/app/components/placeholder-list/placeholder-list.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-list.vue
@@ -50,44 +50,40 @@ export default {
         async extractPlaceholders(content) {
             const regex = /BE-PLACEHOLDER\.(\d+)(?:\.([-A-Za-z0-9+=]{1,100}|=[^=]|={3,}))?/;
             const tmpDom = document.createElement('div');
-            if (content) {
-                tmpDom.innerHTML = content;
-            } else {
-                tmpDom.innerHTML = document.getElementById(this.field).value || '';
-            }
+            tmpDom.innerHTML = content || document.getElementById(this.field).value || '';
             tmpDom.querySelectorAll('*[data-placeholder]').forEach(async (item) => {
                 for (const subnode of item.childNodes) {
-                    if (subnode.textContent && subnode.nodeType === 8) {
-                        const m = subnode.textContent.match(regex);
-                        if (m) {
-                            const o = await this.fetchObject(m[1]);
-                            this.items.push({
-                                text: m[0],
-                                id: m[1],
-                                obj: o,
-                                params_raw: m[2],
-                                params: atob(m[2]),
-                            });
-                        }
+                    if (subnode.textContent && subnode.nodeType !== Node.COMMENT_NODE) {
+                        continue;
                     }
+                    const m = subnode.textContent.match(regex);
+                    if (!m) {
+                        continue;
+                    }
+                    const o = await this.fetchObject(m[1]);
+                    this.items.push({
+                        text: m[0],
+                        id: m[1],
+                        obj: o,
+                        params_raw: m[2],
+                        params: atob(m[2]),
+                    });
                 }
             });
         },
         async fetchObject(id) {
             const baseUrl = new URL(BEDITA.base).pathname;
-            const options = {
+            const response = await fetch(`${baseUrl}api/objects/${id}`, {
                 credentials: 'same-origin',
                 headers: {
                     accept: 'application/json',
                 }
-            };
-            const response = await fetch(`${baseUrl}api/objects/${id}`, options);
+            });
             const responseJson = await response.json();
 
             return responseJson?.data || null;
         },
         async refresh(payload) {
-            console.log('refresh', payload);
             const id = payload?.id;
             if (id !== this.field) {
                 return;

--- a/resources/js/app/components/placeholder-list/placeholder-params.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-params.vue
@@ -1,0 +1,91 @@
+<template>
+    <div class="placeholderParams">
+        <span>Bearing</span>
+        <span>Pitch</span>
+        <span>Zoom</span>
+        <div><input type="number" @change="changeParams" v-model="bearing" placeholder="bearing" /></div><!-- [min: -180, max: +180] -->
+        <div><input type="number" @change="changeParams" v-model="pitch" placeholder="pitch" /></div><!-- [0-60] -->
+        <div><input type="number" @change="changeParams" v-model="zoom" placeholder="zoom" /></div><!-- [2-20] -->
+    </div>
+</template>
+<script>
+import { EventBus } from 'app/components/event-bus';
+
+export default {
+    name: 'PlaceholderParams',
+    props: {
+        field: {
+            type: String,
+            required: true,
+        },
+        id: {
+            type: String,
+            required: true,
+        },
+        text: {
+            type: String,
+            required: true,
+        },
+        value: {
+            type: String,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            bearing: null,
+            pitch: null,
+            zoom: null,
+            newValue: null,
+        };
+    },
+    mounted() {
+        this.$nextTick(() => {
+            const decoded = this.decoded(this.value);
+            if (decoded === 'undefined') {
+                this.newValue = btoa('undefined');
+
+                return;
+            }
+            try {
+                const params = JSON.parse(decoded);
+                this.bearing = params?.bearing || null;
+                this.pitch = params?.pitch || null;
+                this.zoom = params?.zoom || null;
+            } catch(e) {
+                console.error(e, decoded, this.value);
+            }
+        });
+    },
+    methods: {
+        changeParams() {
+            this.oldValue = this.newValue ?? this.value;
+            this.newValue = btoa(JSON.stringify({
+                bearing: this.bearing || null,
+                pitch: this.pitch || null,
+                zoom: this.zoom || null,
+            }));
+            EventBus.send('replace-placeholder', {
+                id: this.id,
+                field: this.field,
+                oldValue: this.oldValue,
+                newValue: this.newValue,
+            });
+            this.oldValue = this.newValue;
+        },
+        decoded(item) {
+            return atob(item);
+        },
+    },
+};
+</script>
+<style>
+div.placeholderParams {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    text-align: center;
+    align-items: center;
+    gap: 8px;
+    margin: 4px 0;
+}
+</style>

--- a/resources/js/app/components/placeholder-list/placeholder-params.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-params.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="placeholderParams">
         <div v-for="column in Object.keys(parameters)">
-            <span v-if="['boolean', 'integer', 'string'].includes(parameters[column])">{{ tr(column) }}</span>
+            <span v-if="['boolean', 'integer', 'string'].includes(parameters[column])">{{ t(column) }}</span>
             <template v-if="parameters[column] === 'integer'">
                 <input type="number" :placeholder="column" v-model="decodedValue[column]" @change="changeParams" />
             </template>
@@ -16,7 +16,6 @@
 </template>
 <script>
 import { EventBus } from 'app/components/event-bus';
-import { t } from 'ttag';
 
 export default {
     name: 'PlaceholderParams',
@@ -80,9 +79,6 @@ export default {
         },
         decoded(item) {
             return atob(item);
-        },
-        tr(item) {
-            return t(item);
         },
     },
 };

--- a/resources/js/app/components/placeholder-list/placeholder-params.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-params.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="placeholderParams">
         <div v-for="column in Object.keys(parameters)">
-            <span v-if="['boolean', 'integer', 'string'].includes(parameters[column])">{{ t(column) }}</span>
+            <span>{{ t(column) }}</span>
             <template v-if="parameters[column] === 'integer'">
                 <input type="number" :placeholder="column" v-model="decodedValue[column]" @change="changeParams" />
             </template>
@@ -10,6 +10,11 @@
             </template>
             <template v-if="parameters[column] === 'boolean'">
                 <input type="checkbox" v-model="decodedValue[column]" @click="changeParams" />
+            </template>
+            <template v-if="typeof parameters[column] === 'object' ">
+                <select v-model="decodedValue[column]" @change="changeParams">
+                    <option v-for="option in parameters[column]" :value="option">{{ t(option) }}</option>
+                </select>
             </template>
         </div>
     </div>

--- a/resources/js/app/components/placeholder-list/placeholder-params.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-params.vue
@@ -3,9 +3,30 @@
         <span>Bearing</span>
         <span>Pitch</span>
         <span>Zoom</span>
-        <div><input type="number" @change="changeParams" v-model="bearing" placeholder="bearing" /></div><!-- [min: -180, max: +180] -->
-        <div><input type="number" @change="changeParams" v-model="pitch" placeholder="pitch" /></div><!-- [0-60] -->
-        <div><input type="number" @change="changeParams" v-model="zoom" placeholder="zoom" /></div><!-- [2-20] -->
+        <div>
+            <input
+                type="number"
+                placeholder="bearing"
+                v-model="bearing"
+                @change="changeParams"
+            >
+        </div><!-- [min: -180, max: +180] -->
+        <div>
+            <input
+                type="number"
+                placeholder="pitch"
+                v-model="pitch"
+                @change="changeParams"
+            >
+        </div><!-- [0-60] -->
+        <div>
+            <input
+                type="number"
+                placeholder="zoom"
+                v-model="zoom"
+                @change="changeParams"
+            >
+        </div><!-- [2-20] -->
     </div>
 </template>
 <script>

--- a/resources/js/app/components/placeholder-list/placeholder-params.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-params.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="placeholderParams">
         <div v-for="column in Object.keys(parameters)">
-            <span v-if="['boolean', 'integer', 'string'].includes(parameters[column])">{{ column }}</span>
+            <span v-if="['boolean', 'integer', 'string'].includes(parameters[column])">{{ tr(column) }}</span>
             <template v-if="parameters[column] === 'integer'">
                 <input type="number" :placeholder="column" v-model="decodedValue[column]" @change="changeParams" />
             </template>
@@ -16,6 +16,7 @@
 </template>
 <script>
 import { EventBus } from 'app/components/event-bus';
+import { t } from 'ttag';
 
 export default {
     name: 'PlaceholderParams',
@@ -79,6 +80,9 @@ export default {
         },
         decoded(item) {
             return atob(item);
+        },
+        tr(item) {
+            return t(item);
         },
     },
 };

--- a/resources/js/app/components/placeholder-list/placeholder-params.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-params.vue
@@ -37,6 +37,7 @@ export default {
             pitch: null,
             zoom: null,
             newValue: null,
+            oldValue: null,
         };
     },
     mounted() {
@@ -59,7 +60,7 @@ export default {
     },
     methods: {
         changeParams() {
-            this.oldValue = this.newValue ?? this.value;
+            this.oldValue = this.newValue || this.value;
             this.newValue = btoa(JSON.stringify({
                 bearing: this.bearing || null,
                 pitch: this.pitch || null,
@@ -68,8 +69,8 @@ export default {
             EventBus.send('replace-placeholder', {
                 id: this.id,
                 field: this.field,
-                oldValue: this.oldValue,
-                newValue: this.newValue,
+                oldParams: this.oldValue,
+                newParams: this.newValue,
             });
             this.oldValue = this.newValue;
         },

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -45,6 +45,7 @@ export default {
         LanguageSelector:() => import(/* webpackChunkName: "language-selector" */'app/components/language-selector/language-selector'),
         ClipboardItem: () => import(/* webpackChunkName: "clipboard-item" */'app/components/clipboard-item/clipboard-item'),
         ObjectCategories: () => import(/* webpackChunkName: "object-categories" */'app/components/object-categories/object-categories'),
+        PlaceholderList: () => import(/* webpackChunkName: "placeholder-list" */'app/components/placeholder-list/placeholder-list'),
     },
 
     props: {

--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -120,6 +120,11 @@ export default {
                     add_unload_trigger: false, // fix populating textarea elements with garbage when the user initiates a navigation with unsaved changes, but cancels it when the alert is shown
                     readonly: element.getAttribute('readonly') === 'readonly' ? 1 : 0,
                     ... BEDITA?.richeditorConfig,
+                    setup: (editor) => {
+                        editor.on('change', () => {
+                            EventBus.send('refresh-placeholders', {id: editor.id, content: editor.getContent()});
+                        });
+                    }
                 });
 
                 element.editor = editor;

--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -45,6 +45,8 @@ const DEFAULT_TOOLBAR = [
     'code',
 ].join(' ');
 
+import { EventBus } from 'app/components/event-bus';
+
 const emit = (vnode, name, data) => {
     let handlers = (vnode.data && vnode.data.on) || (vnode.componentOptions && vnode.componentOptions.listeners);
     if (handlers && handlers[name]) {
@@ -140,6 +142,16 @@ export default {
                         },
                     }));
                     changing = false;
+                });
+
+                EventBus.listen('replace-placeholder', (data) => {
+                    if (editor.id !== data?.field) {
+                        return;
+                    }
+                    const from = `<!--BE-PLACEHOLDER.${data.id}.${data.oldValue}-->`;
+                    const to = `<!--BE-PLACEHOLDER.${data.id}.${data.newValue}-->`;
+                    element.value = element.value.replace(from, to);
+                    editor.setContent(element.value);
                 });
             },
 

--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -148,8 +148,8 @@ export default {
                     if (editor.id !== data?.field) {
                         return;
                     }
-                    const from = `<!--BE-PLACEHOLDER.${data.id}.${data.oldValue}-->`;
-                    const to = `<!--BE-PLACEHOLDER.${data.id}.${data.newValue}-->`;
+                    const from = `<!--BE-PLACEHOLDER.${data.id}.${data.oldParams}-->`;
+                    const to = `<!--BE-PLACEHOLDER.${data.id}.${data.newParams}-->`;
                     element.value = element.value.replace(from, to);
                     editor.setContent(element.value);
                 });

--- a/resources/js/app/plugins/tinymce/placeholders.js
+++ b/resources/js/app/plugins/tinymce/placeholders.js
@@ -5,7 +5,7 @@ import { PanelEvents } from 'app/components/panel-view';
 import tinymce from 'tinymce/tinymce';
 
 const cache = {};
-const regex = /BE-PLACEHOLDER\.(\d+)(?:\.([-A-Za-z0-9+=]{1,50}|=[^=]|={3,}))?/;
+const regex = /BE-PLACEHOLDER\.(\d+)(?:\.([-A-Za-z0-9+=]{1,100}|=[^=]|={3,}))?/;
 const baseUrl = new URL(BEDITA.base).pathname;
 const options = {
     credentials: 'same-origin',
@@ -78,7 +78,7 @@ tinymce.util.Tools.resolve('tinymce.PluginManager').add('placeholders', function
                     return;
                 }
                 let [, id, params] = match;
-                node.attr('style', params || '');
+                node.attr('data-params', params ? atob(params) : '');
                 node.attr('contenteditable', 'false');
                 loadPreview(editor, node, id);
             });
@@ -86,7 +86,7 @@ tinymce.util.Tools.resolve('tinymce.PluginManager').add('placeholders', function
         editor.serializer.addAttributeFilter('data-placeholder', function(nodes) {
             nodes.forEach((node) => {
                 let id = node.attributes.map['data-placeholder'];
-                let params = node.attributes.map['style'];
+                let params = node.attributes.map['data-params'];
                 node.empty();
                 let comment = tinymce.html.Node.create('#comment');
                 comment.value = `BE-PLACEHOLDER.${id}.${btoa(params)}`;
@@ -118,7 +118,7 @@ tinymce.util.Tools.resolve('tinymce.PluginManager').add('placeholders', function
                     let isEmptyBlock = node && node.children.length === 1 && node.children[0].tagName === 'BR';
                     let view = editor.dom.create(isEmptyBlock ? 'div' : 'span', {
                         'data-placeholder': data.id,
-                        'style': data.params,
+                        'data-params': data.params,
                     }, `<!-- BE-PLACEHOLDER.${data.id}.${btoa(data.params)} -->`);
                     editor.insertContent(view.outerHTML);
                     if (isEmptyBlock) {

--- a/resources/js/app/plugins/tinymce/placeholders.js
+++ b/resources/js/app/plugins/tinymce/placeholders.js
@@ -5,7 +5,7 @@ import { PanelEvents } from 'app/components/panel-view';
 import tinymce from 'tinymce/tinymce';
 
 const cache = {};
-const regex = /BE-PLACEHOLDER\.(\d+)(?:\.([-A-Za-z0-9+=]{1,100}|=[^=]|={3,}))?/;
+const regex = /BE-PLACEHOLDER\.(\d+)(?:\.([a-zA-Z0-9+/]+={0,2}))?/;
 const baseUrl = new URL(BEDITA.base).pathname;
 const options = {
     credentials: 'same-origin',

--- a/resources/js/app/plugins/tinymce/placeholders.js
+++ b/resources/js/app/plugins/tinymce/placeholders.js
@@ -1,5 +1,6 @@
 import { t } from 'ttag';
 import 'tinymce/tinymce';
+import { EventBus } from 'app/components/event-bus';
 import { PanelEvents } from 'app/components/panel-view';
 import tinymce from 'tinymce/tinymce';
 
@@ -124,6 +125,7 @@ tinymce.util.Tools.resolve('tinymce.PluginManager').add('placeholders', function
                         tinymce.dom.DOMUtils.DOM.remove(node);
                     }
                 });
+                EventBus.send('refresh-placeholders', {id: editor.id, content: editor.getContent()});
             };
 
             let onClose = () => {

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -332,6 +332,7 @@ class LayoutHelper extends Helper
             'canReadUsers' => $this->Perms->canRead('users'),
             'canSave' => $this->Perms->canSave(),
             'cloneConfig' => (array)Configure::read('Clone'),
+            'placeholdersConfig' => $this->System->placeholdersConfig(),
             'uploadConfig' => $this->System->uploadConfig(),
             'relationsSchema' => $this->getView()->get('relationsSchema', []),
             'richeditorConfig' => (array)Configure::read('Richeditor'),

--- a/src/View/Helper/SystemHelper.php
+++ b/src/View/Helper/SystemHelper.php
@@ -14,6 +14,18 @@ use Cake\View\Helper;
 class SystemHelper extends Helper
 {
     /**
+     * Default placeholders configuration for media types
+     *
+     * @var array
+     */
+    protected $defaultPlaceholders = [
+        'audio' => ['controls' => 'boolean', 'autoplay' => 'boolean'],
+        'files' => ['download' => 'boolean'],
+        'images' => ['width' => 'integer', 'height' => 'integer', 'bearing' => 'integer', 'pitch' => 'integer', 'zoom' => 'integer'],
+        'videos' => ['controls' => 'boolean', 'autoplay' => 'boolean'],
+    ];
+
+    /**
      * Accepted mime types for upload
      *
      * @var array
@@ -111,6 +123,16 @@ class SystemHelper extends Helper
         }
 
         return false;
+    }
+
+    /**
+     * Placeholders config
+     *
+     * @return array
+     */
+    public function placeholdersConfig(): array
+    {
+        return (array)Configure::read('Placeholders', $this->defaultPlaceholders);
     }
 
     /**

--- a/templates/Element/Form/group_properties.twig
+++ b/templates/Element/Form/group_properties.twig
@@ -1,21 +1,19 @@
-
-    {% set customElement = Element.custom(group, 'group') %}
-    {% if customElement %}
-        {{ element(customElement, {'properties' : properties}) }}
-    {% else %}
-        {% set locked = object.meta.locked or (object.id and Perms.isLockedByParents(object.id)) %}
-        {% for key, value in properties %}
-            {% if locked and key == 'uname' %}
-                {{ Property.control(key, value, {'readonly': 'readonly'})|raw }}
-            {% elseif locked and key == 'status' %}
-                {{ Property.control(key, value, {'disabled': 'disabled'})|raw }}
-                <input type="hidden" name="status" id="status" value="{{ value }}" />
-            {% else %}
-                {{ Property.control(key, value)|raw }}
-                {% if schema.properties[key].placeholders %}
-                    <placeholder-list field="{{ key }}" :value="{{ value|default('')|json_encode }}"></placeholder-list>
-                {% endif %}
+{% set customElement = Element.custom(group, 'group') %}
+{% if customElement %}
+    {{ element(customElement, {'properties' : properties}) }}
+{% else %}
+    {% set locked = object.meta.locked or (object.id and Perms.isLockedByParents(object.id)) %}
+    {% for key, value in properties %}
+        {% if locked and key == 'uname' %}
+            {{ Property.control(key, value, {'readonly': 'readonly'})|raw }}
+        {% elseif locked and key == 'status' %}
+            {{ Property.control(key, value, {'disabled': 'disabled'})|raw }}
+            <input type="hidden" name="status" id="status" value="{{ value }}" />
+        {% else %}
+            {{ Property.control(key, value)|raw }}
+            {% if schema.properties[key].placeholders %}
+                <placeholder-list field="{{ key }}" :value="{{ value|default('')|json_encode }}"></placeholder-list>
             {% endif %}
-        {% endfor %}
-
-    {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endif %}

--- a/templates/Element/Form/group_properties.twig
+++ b/templates/Element/Form/group_properties.twig
@@ -3,7 +3,6 @@
     {% if customElement %}
         {{ element(customElement, {'properties' : properties}) }}
     {% else %}
-
         {% set locked = object.meta.locked or (object.id and Perms.isLockedByParents(object.id)) %}
         {% for key, value in properties %}
             {% if locked and key == 'uname' %}
@@ -13,6 +12,9 @@
                 <input type="hidden" name="status" id="status" value="{{ value }}" />
             {% else %}
                 {{ Property.control(key, value)|raw }}
+                {% if schema.properties[key].placeholders %}
+                    <placeholder-list field="{{ key }}" :value="{{ value|default('')|json_encode }}"></placeholder-list>
+                {% endif %}
             {% endif %}
         {% endfor %}
 

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -578,6 +578,7 @@ class LayoutHelperTest extends TestCase
             'canReadUsers' => false,
             'canSave' => true,
             'cloneConfig' => (array)Configure::read('Clone'),
+            'placeholderConfig' => $system->placeholdersConfig(),
             'uploadConfig' => $system->uploadConfig(),
             'relationsSchema' => ['whatever'],
             'richeditorConfig' => (array)Configure::read('Richeditor'),

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -578,7 +578,7 @@ class LayoutHelperTest extends TestCase
             'canReadUsers' => false,
             'canSave' => true,
             'cloneConfig' => (array)Configure::read('Clone'),
-            'placeholderConfig' => $system->placeholdersConfig(),
+            'placeholdersConfig' => $system->placeholdersConfig(),
             'uploadConfig' => $system->uploadConfig(),
             'relationsSchema' => ['whatever'],
             'richeditorConfig' => (array)Configure::read('Richeditor'),

--- a/tests/TestCase/View/Helper/SystemHelperTest.php
+++ b/tests/TestCase/View/Helper/SystemHelperTest.php
@@ -112,8 +112,7 @@ class SystemHelperTest extends TestCase
         $reflectionClass = new \ReflectionClass($this->System);
         $property = $reflectionClass->getProperty('defaultPlaceholders');
         $property->setAccessible(true);
-        $placeholders = $property->getValue($this->System);
-        $expected = compact('placeholders');
+        $expected = $property->getValue($this->System);
         $actual = $this->System->placeholdersConfig();
         static::assertSame($expected, $actual);
     }

--- a/tests/TestCase/View/Helper/SystemHelperTest.php
+++ b/tests/TestCase/View/Helper/SystemHelperTest.php
@@ -101,6 +101,24 @@ class SystemHelperTest extends TestCase
     }
 
     /**
+     * Test `placeholdersConfig`
+     *
+     * @return void
+     * @covers ::placeholdersConfig()
+     */
+    public function testPlaceholdersConfig(): void
+    {
+        // empty config, defaultUploadAccepted
+        $reflectionClass = new \ReflectionClass($this->System);
+        $property = $reflectionClass->getProperty('defaultPlaceholders');
+        $property->setAccessible(true);
+        $placeholders = $property->getValue($this->System);
+        $expected = compact('placeholders');
+        $actual = $this->System->placeholdersConfig();
+        static::assertSame($expected, $actual);
+    }
+
+    /**
      * Test `uploadConfig`
      *
      * @return void


### PR DESCRIPTION
This provides a new feature to handle placeholders parameters.

Richtext  editors provide already the placeholder utility: you can add BEdita object placeholders inside the rich text.
With this, you will have a list of placeholders after each richtext editor, with the possibility to set "bearing", "pitch" and "zoom" parameters.

![image](https://github.com/bedita/manager/assets/2227145/6e8d6bc7-3c76-42bc-9c8b-1e5c76cc6396)

Each object type can have its own parameters structure: you can define it using `Placeholders` configuration. For example:
```php
'Placeholders' => [
    'audio' => [
        'controls' => 'boolean',
        'autoplay' => 'boolean',
    ],
    'files' => [
        'download' => 'boolean',
    ],
    'images' => [
        'width' => ['small', 'medium', 'large'],
        'height' => ['small', 'medium', 'large'],
        'bearing' => 'integer',
        'pitch' => 'integer',
        'zoom' => 'integer',
    ],
    'videos' => [
        'controls' => 'boolean',
        'autoplay' => 'boolean',
    ],
],
```

Bonus: this introduces `EventBus` component, that allows developers to handle global events among components.
Usage:
```javascript
import { EventBus } from 'app/components/event-bus';

// this listen to "my-event-name", lauch callback function when event is triggered
EventBus.listen('my-event-name', callback);

// trigger event "my-event-name" with some data
EventBus.send('my-event-name', data);
```