### PR TITLE
Max resolution check for images upload

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -589,4 +589,83 @@ return [
     //     'style_formats_merge' => true,
     //     'content_style' => '.be-highlight { background-color: #F6F6F6; }',
     // ],
+
+    /**
+     * Upload configurations.
+     */
+    // 'uploadAccepted' => [
+    //     'audio' => [
+    //         'audio/*',
+    //     ],
+    //     'files' => [
+    //         'application/msword', // .doc, .dot
+    //         'application/pdf', // .pdf
+    //         'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // .docx
+    //         'application/vnd.ms-excel', // .xls, .xlt, .xla
+    //         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // .xlsx
+    //         'application/vnd.ms-powerpoint', // .ppt, .pot, .pps, .ppa
+    //         'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx
+    //         'application/x-mpegURL',
+    //         'audio/*',
+    //         'text/csv',
+    //         'text/html',
+    //         'text/plain',
+    //         'text/rtf',
+    //         'text/xml',
+    //         'image/*',
+    //         'video/*',
+    //     ],
+    //     'images' => [
+    //         'image/*',
+    //     ],
+    //     'videos' => [
+    //         'application/x-mpegURL',
+    //         'video/*',
+    //     ],
+    //     'media' => [
+    //         'application/msword', // .doc, .dot
+    //         'application/pdf', // .pdf
+    //         'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // .docx
+    //         'application/vnd.ms-excel', // .xls, .xlt, .xla
+    //         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // .xlsx
+    //         'application/vnd.ms-powerpoint', // .ppt, .pot, .pps, .ppa
+    //         'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx
+    //         'application/x-mpegURL',
+    //         'audio/*',
+    //         'image/*',
+    //         'text/csv',
+    //         'text/html',
+    //         'text/plain',
+    //         'text/rtf',
+    //         'text/xml',
+    //         'video/*',
+    //     ],
+    // ],
+    // 'uploadForbidden' => [
+    //     'mimetypes' => [
+    //         'application/javascript',
+    //         'application/x-cgi',
+    //         'application/x-perl',
+    //         'application/x-php',
+    //         'application/x-ruby',
+    //         'application/x-shellscript',
+    //         'text/javascript',
+    //         'text/x-perl',
+    //         'text/x-php',
+    //         'text/x-python',
+    //         'text/x-ruby',
+    //         'text/x-shellscript',
+    //     ],
+    //     'extensions' => [
+    //         'cgi',
+    //         'exe',
+    //         'js',
+    //         'perl',
+    //         'php',
+    //         'py',
+    //         'rb',
+    //         'sh',
+    //     ],
+    // ],
+    // 'uploadMaxResolution' => '1920x1080',
 ];

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-06-05 10:20:33 \n"
+"POT-Creation-Date: 2024-06-11 16:09:09 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -407,6 +407,9 @@ msgid "Less"
 msgstr ""
 
 msgid "List"
+msgstr ""
+
+msgid "List view"
 msgstr ""
 
 msgid "Locations"
@@ -826,6 +829,9 @@ msgstr ""
 msgid "Trashd"
 msgstr ""
 
+msgid "Tree view"
+msgstr ""
+
 msgid "Type"
 msgstr ""
 
@@ -1141,6 +1147,13 @@ msgstr ""
 msgid ""
 "File \"${ filename }\" too big (${ fileSizeMb } MB), please select a file "
 "less than max file size (${ maxFileSizeMb } MB)"
+msgstr ""
+
+#, javascript-format
+msgid ""
+"Resolution of ${ filename } is too big (${ img.width }x${ img.height }), "
+"please select a file whose resolution is less than or equal to "
+"${ resolution }"
 msgstr ""
 
 msgid "File type forbidden"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-06-05 10:20:33 \n"
+"POT-Creation-Date: 2024-06-11 16:09:09 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -410,6 +410,9 @@ msgid "Less"
 msgstr ""
 
 msgid "List"
+msgstr ""
+
+msgid "List view"
 msgstr ""
 
 msgid "Locations"
@@ -829,6 +832,9 @@ msgstr ""
 msgid "Trashd"
 msgstr "Trashed"
 
+msgid "Tree view"
+msgstr ""
+
 msgid "Type"
 msgstr ""
 
@@ -1144,6 +1150,13 @@ msgstr ""
 msgid ""
 "File \"${ filename }\" too big (${ fileSizeMb } MB), please select a file "
 "less than max file size (${ maxFileSizeMb } MB)"
+msgstr ""
+
+#, javascript-format
+msgid ""
+"Resolution of ${ filename } is too big (${ img.width }x${ img.height }), "
+"please select a file whose resolution is less than or equal to "
+"${ resolution }"
 msgstr ""
 
 msgid "File type forbidden"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-06-05 10:20:33 \n"
+"POT-Creation-Date: 2024-06-11 16:09:09 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -413,6 +413,9 @@ msgstr "Meno"
 
 msgid "List"
 msgstr "Lista"
+
+msgid "List view"
+msgstr "Vista a lista"
 
 msgid "Locations"
 msgstr "Posizioni"
@@ -834,6 +837,9 @@ msgstr "Cestino"
 msgid "Trashd"
 msgstr "Cancellato"
 
+msgid "Tree view"
+msgstr "Vista ad albero"
+
 msgid "Type"
 msgstr "Tipo"
 
@@ -1155,6 +1161,15 @@ msgid ""
 msgstr ""
 "File \"${ filename }\" troppo grande (${ fileSizeMb } MB), selezionare un "
 "file che non superi la dimensione massima (${ maxFileSizeMb } MB)"
+
+#, javascript-format
+msgid ""
+"Resolution of ${ filename } is too big (${ img.width }x${ img.height }), "
+"please select a file whose resolution is less than or equal to "
+"${ resolution }"
+msgstr ""
+"Risoluzione di ${ filename } troppo grande (${ img.width }x${ img.height }), "
+"selezionare un file con risoluzione inferiore o uguale a ${ resolution }"
 
 msgid "File type forbidden"
 msgstr "Tipo file non consentito"

--- a/resources/js/app/components/drop-upload.vue
+++ b/resources/js/app/components/drop-upload.vue
@@ -98,10 +98,13 @@ export default {
         },
 
         inputFiles(e) {
-            if (this.$helpers.checkMimeForUpload(event.target.files[0], this.objectType) === false) {
+            if (this.$helpers.checkMimeForUpload(e.target.files[0], this.objectType) === false) {
                 return;
             }
-            if (this.$helpers.checkMaxFileSize(event.target.files[0]) === false) {
+            if (this.objectType === 'images') {
+                this.$helpers.checkImageResolution(e.target.files[0]);
+            }
+            if (this.$helpers.checkMaxFileSize(e.target.files[0]) === false) {
                 return false;
             }
 
@@ -122,6 +125,9 @@ export default {
                 if (this.$helpers.checkMimeForUpload(file, this.objectType) === false) {
                     continue;
                 }
+                if (this.objectType === 'images') {
+                    this.$helpers.checkImageResolution(file);
+                }
                 if (this.$helpers.checkMaxFileSize(file) === false) {
                     continue;
                 }
@@ -141,6 +147,9 @@ export default {
                     this.removeProgressItem(file);
                     return;
                 }
+                if (this.objectType === 'images') {
+                    this.$helpers.checkImageResolution(file);
+                }
                 this.upload(file).then((object) => this.uploadSuccessful(file, object));
             });
 
@@ -150,6 +159,9 @@ export default {
                 if (this.$helpers.checkMaxFileSize(file) === false) {
                     this.removeProgressItem(file);
                     continue;
+                }
+                if (this.objectType === 'images') {
+                    this.$helpers.checkImageResolution(file);
                 }
                 const object = await this.upload(file);
                 this.uploadSuccessful(file, object);

--- a/resources/js/app/components/form-file-upload.js
+++ b/resources/js/app/components/form-file-upload.js
@@ -27,6 +27,9 @@ export default {
             if (this.$helpers.checkMimeForUpload(e.target.files[0], type) === false) {
                 return;
             }
+            if (type === 'images') {
+                this.$helpers.checkImageResolution(e.target.files[0]);
+            }
             if (this.$helpers.checkMaxFileSize(e.target.files[0]) === false) {
                 return;
             }

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -220,6 +220,9 @@ export default {
             if (this.$helpers.checkMimeForUpload(files[0], type) === false) {
                 return;
             }
+            if (type === 'images') {
+                this.$helpers.checkImageResolution(e.target.files[0]);
+            }
             if (this.$helpers.checkMaxFileSize(files[0]) === false) {
                 return;
             }

--- a/resources/js/app/components/relation-view/relations-add.js
+++ b/resources/js/app/components/relation-view/relations-add.js
@@ -478,6 +478,9 @@ export default {
             if (this.$helpers.checkMimeForUpload(event.target.files[0], type) === false) {
                 return;
             }
+            if (type === 'images') {
+                this.$helpers.checkImageResolution(event.target.files[0]);
+            }
             if (this.$helpers.checkMaxFileSize(event.target.files[0]) === false) {
                 return false;
             }

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -94,6 +94,31 @@ export default {
             },
 
             /**
+             * Check image resolution.
+             * Open a warning dialog, if too big.
+             * @param {Object} file The image file to check
+             * @returns {void}
+             */
+            checkImageResolution(file) {
+                const resolution = BEDITA.uploadConfig.maxResolution;
+                const parts = resolution.split('x');
+                const maxX = parts[0];
+                const maxY = parts[1];
+                const img = new Image();
+                img.src = window.URL.createObjectURL(file);
+                img.onload = () => {
+                    const resolutionOk = (img.width <= maxX && img.height <= maxY) || (img.width <= maxY && img.height <= maxX);
+                    window.URL.revokeObjectURL(img.src);
+                    if (resolutionOk) {
+                        return;
+                    }
+                    const filename = file.name;
+                    const message = t`Resolution of ${filename} is too big (${img.width}x${img.height}), please select a file whose resolution is less than or equal to ${resolution}`;
+                    warning(message);
+                };
+            },
+
+            /**
              * Get file name without extension
              * @param {Object} file file
              * @returns {String} basename file

--- a/src/View/Helper/SystemHelper.php
+++ b/src/View/Helper/SystemHelper.php
@@ -70,6 +70,13 @@ class SystemHelper extends Helper
     ];
 
     /**
+     * Maximum resolution for images
+     *
+     * @var string
+     */
+    protected $defaultUploadMaxResolution = '4096x2160'; // 4K
+
+    /**
      * Get the minimum value between post_max_size and upload_max_filesize.
      *
      * @return int
@@ -115,8 +122,9 @@ class SystemHelper extends Helper
     {
         $accepted = (array)Configure::read('uploadAccepted', $this->defaultUploadAccepted);
         $forbidden = (array)Configure::read('uploadForbidden', $this->defaultUploadForbidden);
+        $maxResolution = (string)Configure::read('uploadMaxResolution', $this->defaultUploadMaxResolution);
 
-        return compact('accepted', 'forbidden');
+        return compact('accepted', 'forbidden', 'maxResolution');
     }
 
     /**

--- a/tests/TestCase/View/Helper/SystemHelperTest.php
+++ b/tests/TestCase/View/Helper/SystemHelperTest.php
@@ -116,7 +116,10 @@ class SystemHelperTest extends TestCase
         $property = $reflectionClass->getProperty('defaultUploadForbidden');
         $property->setAccessible(true);
         $forbidden = $property->getValue($this->System);
-        $expected = compact('accepted', 'forbidden');
+        $property = $reflectionClass->getProperty('defaultUploadMaxResolution');
+        $property->setAccessible(true);
+        $maxResolution = $property->getValue($this->System);
+        $expected = compact('accepted', 'forbidden', 'maxResolution');
         $actual = $this->System->uploadConfig();
         static::assertSame($expected, $actual);
     }


### PR DESCRIPTION
This introduces a non-blocking check on images upload: if image resolution is bigger than `uploadMaxResolution` configuration (whose default is "4096x2160", 4K), a warning pops up with the message `Resolution of ${filename} is too big (${img.width}x${img.height}), please select a file whose resolution is less than or equal to ${resolution}`.