### PR TITLE
Check image resolution: warning when image could not load

### DIFF
--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-06-11 16:09:09 \n"
+"POT-Creation-Date: 2024-06-17 09:09:51 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1147,6 +1147,12 @@ msgstr ""
 msgid ""
 "File \"${ filename }\" too big (${ fileSizeMb } MB), please select a file "
 "less than max file size (${ maxFileSizeMb } MB)"
+msgstr ""
+
+#, javascript-format
+msgid ""
+"We could not calculate the resolution of the file ${ filename }. Please "
+"select a file with a resolution less than or equal to ${ resolution }"
 msgstr ""
 
 #, javascript-format

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-06-11 16:09:09 \n"
+"POT-Creation-Date: 2024-06-17 09:09:51 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1150,6 +1150,12 @@ msgstr ""
 msgid ""
 "File \"${ filename }\" too big (${ fileSizeMb } MB), please select a file "
 "less than max file size (${ maxFileSizeMb } MB)"
+msgstr ""
+
+#, javascript-format
+msgid ""
+"We could not calculate the resolution of the file ${ filename }. Please "
+"select a file with a resolution less than or equal to ${ resolution }"
 msgstr ""
 
 #, javascript-format

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-06-11 16:09:09 \n"
+"POT-Creation-Date: 2024-06-17 09:09:51 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1161,6 +1161,14 @@ msgid ""
 msgstr ""
 "File \"${ filename }\" troppo grande (${ fileSizeMb } MB), selezionare un "
 "file che non superi la dimensione massima (${ maxFileSizeMb } MB)"
+
+#, javascript-format
+msgid ""
+"We could not calculate the resolution of the file ${ filename }. Please "
+"select a file with a resolution less than or equal to ${ resolution }"
+msgstr ""
+"Non è stato possibile calcolare la risoluzione del file ${ filename }. "
+"Selezionare un file con risoluzione inferiore o uguale a ${ resolution }"
 
 #, javascript-format
 msgid ""

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -106,6 +106,12 @@ export default {
                 const maxY = parts[1];
                 const img = new Image();
                 img.src = window.URL.createObjectURL(file);
+                img.onerror = (e) => {
+                    window.URL.revokeObjectURL(img.src);console.error('error', e);
+                    const filename = file.name;
+                    const message = t`We could not calculate the resolution of the file ${filename}. Please select a file with a resolution less than or equal to ${resolution}`;
+                    warning(message);
+                };
                 img.onload = () => {
                     const resolutionOk = (img.width <= maxX && img.height <= maxY) || (img.width <= maxY && img.height <= maxX);
                     window.URL.revokeObjectURL(img.src);

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -107,7 +107,8 @@ export default {
                 const img = new Image();
                 img.src = window.URL.createObjectURL(file);
                 img.onerror = (e) => {
-                    window.URL.revokeObjectURL(img.src);console.error('error', e);
+                    window.URL.revokeObjectURL(img.src);
+                    console.error('error', e);
                     const filename = file.name;
                     const message = t`We could not calculate the resolution of the file ${filename}. Please select a file with a resolution less than or equal to ${resolution}`;
                     warning(message);


### PR DESCRIPTION
The image resolution check, on image upload, sometimes cannot verify the image resolution, because the image "onload" fails.
In these cases, a proper warning pops up.