### PR TITLE
Github workflow: cs, stan and psalm with php 8.3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,17 +18,17 @@ jobs:
   cs:
     uses: bedita/github-workflows/.github/workflows/php-cs.yml@v2
     with:
-      php_versions: '["7.4", "8.1", "8.2", "8.3"]'
+      php_versions: '["8.3"]'
 
   psalm:
     uses: bedita/github-workflows/.github/workflows/php-psalm.yml@v2
     with:
-      php_versions: '["7.4", "8.1", "8.2", "8.3"]'
+      php_versions: '["8.3"]'
 
   stan:
     uses: bedita/github-workflows/.github/workflows/php-stan.yml@v2
     with:
-      php_versions: '["7.4", "8.1", "8.2", "8.3"]'
+      php_versions: '["8.3"]'
 
   unit-4:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v2


### PR DESCRIPTION
This changes github workflow to run cs, stan and psalm against php 8.3 (and not other previous versions).