### PR TITLE
Filter box optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ bundle-report.*.html
 /webroot/css/flash-message*
 /webroot/css/import-result*
 /webroot/css/index-cell*
+/webroot/css/labels-form*
 /webroot/css/map-view*
 /webroot/css/menu*
 /webroot/css/object-categories*

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-06-17 09:09:51 \n"
+"POT-Creation-Date: 2024-06-24 10:27:53 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -410,6 +410,9 @@ msgid "List"
 msgstr ""
 
 msgid "List view"
+msgstr ""
+
+msgid "Loading ..."
 msgstr ""
 
 msgid "Locations"
@@ -1248,7 +1251,7 @@ msgid "Items"
 msgstr ""
 
 #, javascript-format
-msgid "Search by ${ selectedType }"
+msgid "Search by ${ searchType }"
 msgstr ""
 
 msgid "NULL"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-06-17 09:09:51 \n"
+"POT-Creation-Date: 2024-06-24 10:27:53 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -413,6 +413,9 @@ msgid "List"
 msgstr ""
 
 msgid "List view"
+msgstr ""
+
+msgid "Loading ..."
 msgstr ""
 
 msgid "Locations"
@@ -1251,7 +1254,7 @@ msgid "Items"
 msgstr ""
 
 #, javascript-format
-msgid "Search by ${ selectedType }"
+msgid "Search by ${ searchType }"
 msgstr ""
 
 msgid "NULL"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-06-17 09:09:51 \n"
+"POT-Creation-Date: 2024-06-24 10:27:53 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -416,6 +416,9 @@ msgstr "Lista"
 
 msgid "List view"
 msgstr "Vista a lista"
+
+msgid "Loading ..."
+msgstr "Caricamento ..."
 
 msgid "Locations"
 msgstr "Posizioni"
@@ -1267,8 +1270,8 @@ msgid "Items"
 msgstr "Elementi"
 
 #, javascript-format
-msgid "Search by ${ selectedType }"
-msgstr "Cerca per ${ selectedType }"
+msgid "Search by ${ searchType }"
+msgstr "Cerca per ${ searchType }"
 
 msgid "NULL"
 msgstr ""

--- a/resources/js/app/components/filter-box.js
+++ b/resources/js/app/components/filter-box.js
@@ -377,6 +377,7 @@ export default {
          * @emits Event#filter-reset
          */
         resetFilter() {
+            this.folder = null;
             this.selectedSearchType = 'q';
             this.queryFilter = this.getCleanQuery();
             this.$emit('filter-reset');
@@ -418,6 +419,7 @@ export default {
             }
         },
         onChangeTypeFilter() {
+            this.folder = null;
             this.availableFilters = this.filtersByType?.[this.queryFilter.filter.type] || [];
         },
         onPageKeydown(e) {

--- a/resources/js/app/components/filter-box.js
+++ b/resources/js/app/components/filter-box.js
@@ -79,6 +79,7 @@ export default {
              * This will switch the API filter between `parent` and `ancestor`.
              */
             filterByDescendants: false,
+            folder: null,
             moreFilters: this.filterActive,
             pageSize: this.pagination.page_size,
             queryFilter: {},
@@ -218,7 +219,7 @@ export default {
         },
 
         positionFilterName() {
-            return this.filterByDescendants ? 'ancestor' : 'parent';
+            return this.filterByDescendants === true ? 'ancestor' : 'parent';
         }
     },
 
@@ -322,10 +323,13 @@ export default {
          */
         prepareFilters() {
             const filter = { ...this.queryFilter.filter };
+            if (this.folder) {
+                filter[this.positionFilterName] = this.folder.id;
+            }
 
             Object.entries(filter).forEach(([key, filterValue]) => {
                 // do nothing allowed filters, if value is set
-                if (['id', 'uname', 'status', 'type', 'ancestor', 'history_editor'].includes(key) && filterValue) {
+                if (['id', 'uname', 'status', 'type', 'ancestor', 'parent', 'history_editor'].includes(key) && filterValue) {
                     return;
                 }
 
@@ -434,20 +438,18 @@ export default {
         },
 
         onFolderChange(folder) {
+            this.folder = folder;
             this.queryFilter.filter[this.positionFilterName] = folder?.id;
         },
 
         /**
          * Switch between descendants and children filter.
-         * @param {Event} event Change event of the switch input.
          */
-        onPositionFilterChange(event) {
-            const value = event.target.checked;
-            const newFilter = value ? 'ancestor' : 'parent';
-            const oldFilter = value ? 'parent' : 'ancestor';
-
-            this.queryFilter.filter[newFilter] = this.queryFilter.filter[oldFilter];
+        onPositionFilterChange() {
+            const newFilter = this.positionFilterName;
+            const oldFilter = newFilter === 'ancestor' ? 'parent' : 'ancestor';
             delete this.queryFilter.filter[oldFilter];
+            this.queryFilter.filter[newFilter] = this.folder?.id || null;
         },
     }
 };

--- a/resources/js/app/components/filter-box.js
+++ b/resources/js/app/components/filter-box.js
@@ -152,12 +152,6 @@ export default {
             return this.pagination.page_count > 1 && this.pagination.page_count <= 7;
         },
 
-        initHistoryEditor() {
-            this.queryFilter.filter['history_editor'] = Boolean(this.initFilter?.filter?.history_editor);
-
-            return Boolean(this.initFilter?.filter?.history_editor) || false;
-        },
-
         initCategories() {
             const categories = [];
             let filterCategories = this.initFilter?.filter?.categories || '';

--- a/resources/js/app/mixins/paginated-content.js
+++ b/resources/js/app/mixins/paginated-content.js
@@ -219,7 +219,7 @@ export const PaginatedContentMixin = {
         toPage(page, query = {}) {
             this.pagination.page = page || 1;
             const q = { ...query };
-            if (q.filter.history_editor === true) {
+            if (q?.filter?.history_editor === true) {
                 q.filter.history_editor = BEDITA.userId;
             }
 

--- a/resources/js/app/mixins/paginated-content.js
+++ b/resources/js/app/mixins/paginated-content.js
@@ -218,7 +218,12 @@ export const PaginatedContentMixin = {
          */
         toPage(page, query = {}) {
             this.pagination.page = page || 1;
-            return this.getPaginatedObjects(true, query);
+            const q = { ...query };
+            if (q.filter.history_editor === true) {
+                q.filter.history_editor = BEDITA.userId;
+            }
+
+            return this.getPaginatedObjects(true, q);
         },
 
         /**

--- a/resources/js/app/mixins/paginated-content.js
+++ b/resources/js/app/mixins/paginated-content.js
@@ -16,6 +16,7 @@ export const DEFAULT_PAGINATION = {
 export const getDefaultFilter = () => ({
     q: '',
     filter: {
+        status: [],
         type: '',
     }
 });

--- a/templates/Element/FilterBox/filter_box_common.twig
+++ b/templates/Element/FilterBox/filter_box_common.twig
@@ -82,7 +82,7 @@
         {# only my contents filter #}
         <div class="filter-container" v-if="showAdvanced">
             <label>
-                <input type="checkbox" form="_filters" v-model="queryFilter.filter['history_editor']" :initvalue="initHistoryEditor">{{ __('Only my contents') }}</input>
+                <input type="checkbox" form="_filters" v-model="queryFilter.filter['history_editor']">{{ __('Only my contents') }}</input>
             </label>
         </div>
 

--- a/templates/Element/FilterBox/filter_box_common.twig
+++ b/templates/Element/FilterBox/filter_box_common.twig
@@ -69,7 +69,8 @@
         {# object type filter #}
         <div class="filter-container search-types" v-if="rightTypes.length > 1">
             <label>{{ __('Type') }}</label>
-            <select v-model="selectedType"
+            <select v-model="queryFilter.filter.type"
+                @change="onChangeTypeFilter"
                 form="_filters"
                 class="has-background-gray-700 has-border-gray-700 has-font-weight-light has-text-gray-200 has-text-size-smallest"
             >
@@ -89,7 +90,13 @@
         <div class="filter-container" v-if="statusFilter.options">
             <label>{{ __('Status') }}</label>
             <label v-for="s in statusFilter.options">
-                <input type="checkbox" form="_filters" :id="s.value" :name="statusFilter.name" :value="s.value" v-model="selectedStatuses">
+                <input
+                    type="checkbox"
+                    form="_filters"
+                    :id="s.value"
+                    :name="statusFilter.name"
+                    :value="s.value"
+                    v-model="queryFilter.filter.status">
                 <: s.text :>
             </label>
         </div>

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -71,6 +71,8 @@
 
             {% set dragAndDrop = relationName != 'children' or (relationName == 'children' and mainObject.attributes.children_order in [null, 'position', '-position']) %}
             {# RELATED OBJECTS #}
+            <div class="ml-05 mb-1" v-if="loading">{{ __('Loading ...') }}</div>
+            <div class="ml-05 mb-1" v-if="!loading && objects.length === 0">{{ __('No items found') }}</div>
             <div class="related-objects mb-1" v-show="objects.length || addedRelations.length">
                 <div :data-list="dataList" class="columns" {%- if dragAndDrop %}droppable sortable{%- endif %}>
                     <div

--- a/templates/Element/Panel/relations_add.twig
+++ b/templates/Element/Panel/relations_add.twig
@@ -112,9 +112,13 @@
 
         <div class="px-1 shrinks">
             <div class="columns">
-                <div class="related-item-column column is-3 is-one-quarter-fullhd" v-for="related in objects" v-if="relationName !== 'children' || related.type !== 'folders'">
-                    {{ element('Form/related_item', { 'add': true }) }}
-                </div>
+                <div class="ml-05 mb-1" v-if="loading">{{ __('Loading ...') }}</div>
+                <div class="ml-05 mb-1" v-if="!loading && objects.length === 0">{{ __('No items found') }}</div>
+                <template v-else>
+                    <div class="related-item-column column is-3 is-one-quarter-fullhd" v-for="related in objects" v-if="relationName !== 'children' || related.type !== 'folders'">
+                        {{ element('Form/related_item', { 'add': true }) }}
+                    </div>
+                </template>
             </div>
         </div>
 

--- a/templates/Element/json_meta_config.twig
+++ b/templates/Element/json_meta_config.twig
@@ -1,5 +1,5 @@
 <script type="text/javascript">
 
-    const BEDITA = {{ Layout.metaConfig() | json_encode | raw }};
+    const BEDITA = {{ Layout.metaConfig() | merge({ userId: user.id }) | json_encode | raw }};
 
 </script>


### PR DESCRIPTION
This optmizes filter box, enhancing status and type filters.

Previous behaviour
===============
When "type" changes, a new search is performed, using filter type only. When text search is performed, type filter is ignored.
"Only my contents" search returns contents created or modified by user "1" instead of current user.
Search per folder ("parent" or "ancestor"), if performed multiple times, doesn't work as expected.

New behaviour
============
When "type" changes, search is not triggered: "search" button click triggers the search and uses all active filters.
"Only my contents" search returns contents created or modified by current user.
Search per folder ("parent" or "ancestor") can be performed multiple times.

Filter box is used in multiple parts of BEM:

 - modules index page
 - modules view page, relation section
 - modules view page, relation add side panel

Bonus: show "loading" and "no items found" on search.