### PR TITLE
Delete stream per media

### DIFF
--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -173,10 +173,11 @@ class TrashController extends AppController
         foreach ($ids as $id) {
             try {
                 $response = $this->apiClient->get('/streams', ['filter' => ['object_id' => $id]]);
-                foreach ($response['data'] as $stream) {
+                $streams = (array)Hash::get($response, 'data');
+                $this->apiClient->remove($id);
+                foreach ($streams as $stream) {
                     $this->apiClient->delete(sprintf('/streams/%s', $stream['id']));
                 }
-                $this->apiClient->remove($id);
             } catch (BEditaClientException $e) {
                 // Error! Back to object view.
                 $this->log($e->getMessage(), LogLevel::ERROR);

--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -172,6 +172,10 @@ class TrashController extends AppController
         }
         foreach ($ids as $id) {
             try {
+                $response = $this->apiClient->get('/streams', ['filter' => ['object_id' => $id]]);
+                foreach ($response['data'] as $stream) {
+                    $this->apiClient->delete(sprintf('/streams/%s', $stream['id']));
+                }
                 $this->apiClient->remove($id);
             } catch (BEditaClientException $e) {
                 // Error! Back to object view.

--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -172,12 +172,7 @@ class TrashController extends AppController
         }
         foreach ($ids as $id) {
             try {
-                $response = $this->apiClient->get('/streams', ['filter' => ['object_id' => $id]]);
-                $streams = (array)Hash::get($response, 'data');
-                $this->apiClient->remove($id);
-                foreach ($streams as $stream) {
-                    $this->apiClient->delete(sprintf('/streams/%s', $stream['id']));
-                }
+                $this->deleteData($id);
             } catch (BEditaClientException $e) {
                 // Error! Back to object view.
                 $this->log($e->getMessage(), LogLevel::ERROR);
@@ -227,9 +222,9 @@ class TrashController extends AppController
         $response = $this->apiClient->getObjects('trash', $query);
         $counter = 0;
         while (Hash::get($response, 'meta.pagination.count', 0) > 0) {
-            foreach ($response['data'] as $index => $data) {
+            foreach ($response['data'] as $data) {
                 try {
-                    $this->apiClient->remove($data['id']);
+                    $this->deleteData($data['id']);
                     $counter++;
                 } catch (BEditaClientException $e) {
                     // Error! Back to trash index.
@@ -244,5 +239,21 @@ class TrashController extends AppController
         $this->Flash->success(__(sprintf('%d objects deleted from trash', $counter)));
 
         return $this->redirect(['_name' => 'trash:list'] + $this->listQuery());
+    }
+
+    /**
+     * Delete data and related streams, if any.
+     *
+     * @param string $id Object ID
+     * @return void
+     */
+    public function deleteData(string $id): void
+    {
+        $response = $this->apiClient->get('/streams', ['filter' => ['object_id' => $id]]);
+        $streams = (array)Hash::get($response, 'data');
+        $this->apiClient->remove($id);
+        foreach ($streams as $stream) {
+            $this->apiClient->delete(sprintf('/streams/%s', $stream['id']));
+        }
     }
 }

--- a/tests/TestCase/Controller/TrashControllerTest.php
+++ b/tests/TestCase/Controller/TrashControllerTest.php
@@ -111,8 +111,8 @@ class TrashControllerTest extends BaseControllerTest
     /**
      * Test `restore` method
      *
-     * @covers ::restore()
      * @return void
+     * @covers ::restore()
      */
     public function testRestore(): void
     {
@@ -132,8 +132,8 @@ class TrashControllerTest extends BaseControllerTest
     /**
      * Test `restore` method when unauthorized
      *
-     * @covers ::restore()
      * @return void
+     * @covers ::restore()
      */
     public function testRestoreUnauthorized(): void
     {
@@ -148,8 +148,8 @@ class TrashControllerTest extends BaseControllerTest
     /**
      * Test `restore` method with multiple items
      *
-     * @covers ::restore()
      * @return void
+     * @covers ::restore()
      */
     public function testRestoreMulti(): void
     {
@@ -163,8 +163,8 @@ class TrashControllerTest extends BaseControllerTest
     /**
      * Test `restore` method failure with multiple items
      *
-     * @covers ::restore()
      * @return void
+     * @covers ::restore()
      */
     public function testRestoreMultiFailure(): void
     {
@@ -179,10 +179,11 @@ class TrashControllerTest extends BaseControllerTest
     }
 
     /**
-     * Test `delete` method
+     * Test `delete` and `deleteData` methods
      *
-     * @covers ::delete()
      * @return void
+     * @covers ::delete()
+     * @covers ::deleteData()
      */
     public function testDelete(): void
     {
@@ -205,12 +206,13 @@ class TrashControllerTest extends BaseControllerTest
     }
 
     /**
-     * Test `deleteData` method
+     * Test `delete` and `deleteData` methods with media object
      *
-     * @covers ::deleteData()
      * @return void
+     * @covers ::delete()
+     * @covers ::deleteData()
      */
-    public function testDeleteData(): void
+    public function testDeleteMediaWithStream(): void
     {
         // setup and auth
         $this->setupApi();
@@ -260,8 +262,8 @@ class TrashControllerTest extends BaseControllerTest
     /**
      * Test `delete` method when unauthorized
      *
-     * @covers ::delete()
      * @return void
+     * @covers ::delete()
      */
     public function testDeleteUnauthorized(): void
     {
@@ -278,8 +280,8 @@ class TrashControllerTest extends BaseControllerTest
     /**
      * Test `restore` method with multiple items
      *
-     * @covers ::delete()
      * @return void
+     * @covers ::delete()
      */
     public function testDeleteMulti(): void
     {
@@ -295,8 +297,8 @@ class TrashControllerTest extends BaseControllerTest
     /**
      * Test `delete` method failure with multiple items
      *
-     * @covers ::delete()
      * @return void
+     * @covers ::delete()
      */
     public function testDeleteMultiFailure(): void
     {
@@ -313,9 +315,9 @@ class TrashControllerTest extends BaseControllerTest
     /**
      * Test `emptyTrash` method
      *
+     * @return void
      * @covers ::emptyTrash()
      * @covers ::listQuery()
-     * @return void
      */
     public function testEmpty(): void
     {
@@ -332,9 +334,9 @@ class TrashControllerTest extends BaseControllerTest
     /**
      * Test `emptyTrash` method with query filter
      *
+     * @return void
      * @covers ::emptyTrash()
      * @covers ::listQuery()
-     * @return void
      */
     public function testEmptyFilter(): void
     {
@@ -348,8 +350,8 @@ class TrashControllerTest extends BaseControllerTest
     /**
      * Test `emptyTrash` method when unauthorized
      *
-     * @covers ::emptyTrash()
      * @return void
+     * @covers ::emptyTrash()
      */
     public function testEmptyUnauthorized(): void
     {


### PR DESCRIPTION
This provides a fix in media delete by deleting media's related streams, if exist.