### PR TITLE
Remove stream on delete, retrocompatibility

### DIFF
--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -258,10 +258,9 @@ class TrashController extends AppController
         foreach ($streams as $stream) {
             $search = $this->apiClient->get('/streams', ['filter' => ['uuid' => $stream['id']]]);
             $count = (int)Hash::get($search, 'meta.pagination.count', 0);
-            if ($count === 0) {
-                continue;
+            if ($count === 1) {
+                $this->apiClient->delete(sprintf('/streams/%s', $stream['id']));
             }
-            $this->apiClient->delete(sprintf('/streams/%s', $stream['id']));
         }
     }
 }


### PR DESCRIPTION
With https://github.com/bedita/bedita/pull/2083 BE API provides the fix for "media delete will remove streams too".

This handles remove stream for BEM when BE API doesn't remove streams on deleting media.