### PR TITLE
UI modules counters config

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -617,14 +617,14 @@ return [
     /**
      * UI settings.
      * - index: index settings. 'copy2clipboard' enables "onmouseover" of index general cells showing copy to clipboard button
-     * - modules: modules settings. 'counters' to show counters in modules; 'all', 'none' (default), '<comma separated list of modules>' to show all, none or custom modules
+     * - modules: modules settings. 'counters' to show counters in modules; 'all', 'none', <list of modules> to show all, none or custom modules. Default is ['trash']
      */
     // 'UI' => [
     //     'index' => [
     //         'copy2clipboard' => true,
     //     ],
     //     'modules' => [
-    //         'counters' => 'documents,events,locations,media,news,objects',
+    //         'counters' => ['objects', 'media', 'images', 'videos', 'audio', 'files', 'trash', 'users'],
     //     ],
     // ],
 

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -615,6 +615,16 @@ return [
     // ],
 
     /**
+     * UI settings.
+     * - modules: modules settings. 'counters' to show counters in modules; 'all', 'none' (default), '<comma separated list of modules>' to show all, none or custom modules
+     */
+    // 'UI' => [
+    //     'modules' => [
+    //         'counters' => 'documents,events,locations,media,news,objects',
+    //     ],
+    // ],
+
+    /**
      * Upload configurations.
      */
     // 'uploadAccepted' => [

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -616,9 +616,13 @@ return [
 
     /**
      * UI settings.
+     * - index: index settings. 'copy2clipboard' enables "onmouseover" of index general cells showing copy to clipboard button
      * - modules: modules settings. 'counters' to show counters in modules; 'all', 'none' (default), '<comma separated list of modules>' to show all, none or custom modules
      */
     // 'UI' => [
+    //     'index' => [
+    //         'copy2clipboard' => true,
+    //     ],
     //     'modules' => [
     //         'counters' => 'documents,events,locations,media,news,objects',
     //     ],

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -52,9 +52,13 @@ class DashboardController extends AppController
         );
 
         // set modules counters
-        $counters = Configure::read('UI.modules.counters', 'none');
-        $modules = $counters === 'none' ? [] : array_keys((array)$this->viewBuilder()->getVar('modules'));
-        $modules = $counters === 'all' ? $modules : array_intersect($modules, (array)explode(',', $counters));
+        $counters = Configure::read('UI.modules.counters', ['trash']);
+        if ($counters === 'none') {
+            return;
+        }
+        $counters = in_array($counters, ['none', 'all']) ? $counters : ['trash'];
+        $modules = array_keys((array)$this->viewBuilder()->getVar('modules'));
+        $modules = $counters === 'all' ? $modules : array_intersect($modules, $counters);
         foreach ($modules as $name) {
             if (CacheTools::existsCount($name)) {
                 continue;

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -14,6 +14,7 @@ namespace App\Controller;
 
 use App\Utility\CacheTools;
 use App\Utility\SchemaTrait;
+use Cake\Core\Configure;
 use Cake\Utility\Hash;
 
 /**
@@ -51,7 +52,12 @@ class DashboardController extends AppController
         );
 
         // set modules counters
+        $counters = Configure::read('UI.modules.counters', 'none');
+        if ($counters === 'none') {
+            return;
+        }
         $modules = array_keys((array)$this->viewBuilder()->getVar('modules'));
+        $modules = $counters === 'all' ? $counters : array_intersect($modules, (array)explode(',', $counters));
         foreach ($modules as $name) {
             if (CacheTools::existsCount($name)) {
                 continue;

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -53,10 +53,7 @@ class DashboardController extends AppController
 
         // set modules counters
         $counters = Configure::read('UI.modules.counters', 'none');
-        if ($counters === 'none') {
-            return;
-        }
-        $modules = array_keys((array)$this->viewBuilder()->getVar('modules'));
+        $modules = $counters === 'none' ? [] : array_keys((array)$this->viewBuilder()->getVar('modules'));
         $modules = $counters === 'all' ? $modules : array_intersect($modules, (array)explode(',', $counters));
         foreach ($modules as $name) {
             if (CacheTools::existsCount($name)) {

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -57,7 +57,7 @@ class DashboardController extends AppController
             return;
         }
         $modules = array_keys((array)$this->viewBuilder()->getVar('modules'));
-        $modules = $counters === 'all' ? $counters : array_intersect($modules, (array)explode(',', $counters));
+        $modules = $counters === 'all' ? $modules : array_intersect($modules, (array)explode(',', $counters));
         foreach ($modules as $name) {
             if (CacheTools::existsCount($name)) {
                 continue;

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -128,8 +128,9 @@ class LayoutHelper extends Helper
         $label = $name === 'objects' ? __('All objects') : Hash::get($module, 'label', $name);
         $route = (array)Hash::get($module, 'route');
         $param = empty($route) ? ['_name' => 'modules:list', 'object_type' => $name, 'plugin' => null] : $route;
-        $counters = Configure::read('UI.modules.counters', 'none');
-        $count = $counters === 'none' ? '' : $this->moduleCount($name);
+        $counters = Configure::read('UI.modules.counters', ['trash']);
+        $showCounter = is_array($counters) ? in_array($name, $counters) : $counters === 'all';
+        $count = $showCounter ? '' : $this->moduleCount($name);
 
         return sprintf(
             '<a href="%s" class="%s"><span>%s</span>%s%s</a>',
@@ -236,8 +237,9 @@ class LayoutHelper extends Helper
         if (!empty($currentModule) && !empty($currentModule['name'])) {
             $name = $currentModule['name'];
             $label = Hash::get($currentModule, 'label', $name);
-            $counters = Configure::read('UI.modules.counters', 'none');
-            $count = $counters === 'none' ? '' : $this->moduleCount($name);
+            $counters = Configure::read('UI.modules.counters', ['trash']);
+            $showCounter = is_array($counters) ? in_array($name, $counters) : $counters === 'all';
+            $count = $showCounter ? '' : $this->moduleCount($name);
 
             return sprintf(
                 '<a href="%s" class="%s"><span class="mr-05">%s</span>%s%s</a>',

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -128,6 +128,8 @@ class LayoutHelper extends Helper
         $label = $name === 'objects' ? __('All objects') : Hash::get($module, 'label', $name);
         $route = (array)Hash::get($module, 'route');
         $param = empty($route) ? ['_name' => 'modules:list', 'object_type' => $name, 'plugin' => null] : $route;
+        $counters = Configure::read('UI.modules.counters', 'none');
+        $count = $counters === 'none' ? '' : $this->moduleCount($name);
 
         return sprintf(
             '<a href="%s" class="%s"><span>%s</span>%s%s</a>',
@@ -135,7 +137,7 @@ class LayoutHelper extends Helper
             sprintf('dashboard-item has-background-module-%s %s', $name, Hash::get($module, 'class', '')),
             $this->tr($label),
             $this->moduleIcon($name, $module),
-            $this->moduleCount($name)
+            $count
         );
     }
 
@@ -234,6 +236,8 @@ class LayoutHelper extends Helper
         if (!empty($currentModule) && !empty($currentModule['name'])) {
             $name = $currentModule['name'];
             $label = Hash::get($currentModule, 'label', $name);
+            $counters = Configure::read('UI.modules.counters', 'none');
+            $count = $counters === 'none' ? '' : $this->moduleCount($name);
 
             return sprintf(
                 '<a href="%s" class="%s"><span class="mr-05">%s</span>%s%s</a>',
@@ -241,7 +245,7 @@ class LayoutHelper extends Helper
                 sprintf('module-item has-background-module-%s', $name),
                 $this->tr($label),
                 $this->moduleIcon($name, $currentModule),
-                $this->moduleCount($name)
+                $count
             );
         }
 

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -244,7 +244,7 @@ class LayoutHelperTest extends TestCase
                 ],
             ],
             'objects' => [
-                '<a href="/objects" class="module-item has-background-module-objects"><span class="mr-05">Objects</span><span class="tag mx-05 module-items-counter has-background-module-objects">-</span></a>',
+                '<a href="/objects" class="module-item has-background-module-objects"><span class="mr-05">Objects</span></a>',
                 'Module',
                 [
                     'currentModule' => ['name' => 'objects'],
@@ -735,7 +735,7 @@ class LayoutHelperTest extends TestCase
             'documents' => [
                 'documents',
                 [],
-                '<a href="/documents" class="dashboard-item has-background-module-documents "><span>Documents</span><app-icon icon="carbon:document"></app-icon><span class="tag mx-05 module-items-counter has-background-module-documents">-</span></a>',
+                '<a href="/documents" class="dashboard-item has-background-module-documents "><span>Documents</span><app-icon icon="carbon:document"></app-icon></a>',
             ],
         ];
     }

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -244,7 +244,7 @@ class LayoutHelperTest extends TestCase
                 ],
             ],
             'objects' => [
-                '<a href="/objects" class="module-item has-background-module-objects"><span class="mr-05">Objects</span></a>',
+                '<a href="/objects" class="module-item has-background-module-objects"><span class="mr-05">Objects</span><span class="tag mx-05 module-items-counter has-background-module-objects">-</span></a>',
                 'Module',
                 [
                     'currentModule' => ['name' => 'objects'],
@@ -735,7 +735,7 @@ class LayoutHelperTest extends TestCase
             'documents' => [
                 'documents',
                 [],
-                '<a href="/documents" class="dashboard-item has-background-module-documents "><span>Documents</span><app-icon icon="carbon:document"></app-icon></a>',
+                '<a href="/documents" class="dashboard-item has-background-module-documents "><span>Documents</span><app-icon icon="carbon:document"></app-icon><span class="tag mx-05 module-items-counter has-background-module-documents">-</span></a>',
             ],
         ];
     }


### PR DESCRIPTION
This introduces a configuration to set modules counters.

`UI.modules.counters` can be `all`, `none` (default) or `[<modules list>]`.

- `all`: show module counters on all module boxes
- `none` (default): do not show counters in module boxes
- `<module list>`: show module counter in specified modules

```
'UI' => [
    'modules' => [
        'counters' => ['objects', 'media', 'images', 'videos', 'audio', 'files', 'trash', 'users'],
    ],
],
```