### PR TITLE
Fix show modules counter

### DIFF
--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -56,7 +56,7 @@ class DashboardController extends AppController
         if ($counters === 'none') {
             return;
         }
-        $counters = in_array($counters, ['none', 'all']) ? $counters : ['trash'];
+        $counters = is_array($counters) || in_array($counters, ['none', 'all']) ? $counters : ['trash'];
         $modules = array_keys((array)$this->viewBuilder()->getVar('modules'));
         $modules = $counters === 'all' ? $modules : array_intersect($modules, $counters);
         foreach ($modules as $name) {

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -130,7 +130,7 @@ class LayoutHelper extends Helper
         $param = empty($route) ? ['_name' => 'modules:list', 'object_type' => $name, 'plugin' => null] : $route;
         $counters = Configure::read('UI.modules.counters', ['trash']);
         $showCounter = is_array($counters) ? in_array($name, $counters) : $counters === 'all';
-        $count = $showCounter ? '' : $this->moduleCount($name);
+        $count = !$showCounter ? '' : $this->moduleCount($name);
 
         return sprintf(
             '<a href="%s" class="%s"><span>%s</span>%s%s</a>',
@@ -239,7 +239,7 @@ class LayoutHelper extends Helper
             $label = Hash::get($currentModule, 'label', $name);
             $counters = Configure::read('UI.modules.counters', ['trash']);
             $showCounter = is_array($counters) ? in_array($name, $counters) : $counters === 'all';
-            $count = $showCounter ? '' : $this->moduleCount($name);
+            $count = !$showCounter ? '' : $this->moduleCount($name);
 
             return sprintf(
                 '<a href="%s" class="%s"><span class="mr-05">%s</span>%s%s</a>',

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -244,7 +244,7 @@ class LayoutHelperTest extends TestCase
                 ],
             ],
             'objects' => [
-                '<a href="/objects" class="module-item has-background-module-objects"><span class="mr-05">Objects</span><span class="tag mx-05 module-items-counter has-background-module-objects">-</span></a>',
+                '<a href="/objects" class="module-item has-background-module-objects"><span class="mr-05">Objects</span></a>',
                 'Module',
                 [
                     'currentModule' => ['name' => 'objects'],
@@ -735,7 +735,7 @@ class LayoutHelperTest extends TestCase
             'documents' => [
                 'documents',
                 [],
-                '<a href="/documents" class="dashboard-item has-background-module-documents "><span>Documents</span><app-icon icon="carbon:document"></app-icon><span class="tag mx-05 module-items-counter has-background-module-documents">-</span></a>',
+                '<a href="/documents" class="dashboard-item has-background-module-documents "><span>Documents</span><app-icon icon="carbon:document"></app-icon></a>',
             ],
         ];
     }


### PR DESCRIPTION
This fixes a wrong check in layout helper: show/hide counters (depending on `UI.modules.counters` configuration)