### PR TITLE
Fix custom event calendar for date_ranges / custom upload form

### DIFF
--- a/templates/Pages/Modules/view.twig
+++ b/templates/Pages/Modules/view.twig
@@ -37,7 +37,7 @@
 
             <div class="main-view-column is-flex is-flex-column">
                 {# Upload available only for new media objects #}
-                {% if objectType in uploadable and (object.id is empty or (not streams and not object.attributes.provider_extra.html)) %}
+                {% if not Element.custom('upload', 'group') and objectType in uploadable and (object.id is empty or (not streams and not object.attributes.provider_extra.html)) %}
                     {{ element('Form/upload') }}
                 {% endif %}
 

--- a/templates/Pages/Modules/view.twig
+++ b/templates/Pages/Modules/view.twig
@@ -50,7 +50,9 @@
                 {{ element('Form/custom_left') }}
 
                 {# calendar using `date_ranges` #}
-                {{ element('Form/calendar') }}
+                {% if not Element.custom('calendar', 'group') %}
+                    {{ element('Form/calendar') }}
+                {% endif %}
 
                 {{ element(Element.categories()) }}
 


### PR DESCRIPTION
This provides a fix, when using a custom twig template for date_ranges and/or upload form. Buggy behaviour: even when a custom template is set, default form is shown.
The fix: if custom template is set, default form is not shown.