### PR TITLE
Richtext fields preserve anchor urls

### DIFF
--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -115,6 +115,7 @@ export default {
                         'visualblocks',
                     ].join(' '),
                     autoresize_bottom_margin: 50,
+                    convert_urls: false,
                     relative_urls: false,
                     paste_block_drop: true,
                     add_unload_trigger: false, // fix populating textarea elements with garbage when the user initiates a navigation with unsaved changes, but cancels it when the alert is shown


### PR DESCRIPTION
This fixes an issue in richtext fields with anchors.

An example follows. When in a document view a body field contains text like `<a href="{{ url }}">Go</a>`, Tinymce transforms it into `<a href="/documents/view/{{ url }}">Go</a>`.
Setting `convert_urls` to `false` in Tinymce configuration, Tinymce doesn't perform the transformation, so the content is still `<a href="{{ url }}">Go</a>`, as expected.

Ref: https://www.tiny.cloud/docs/tinymce/latest/url-handling 