### PR TITLE
Input default value, min and max from json schema

### DIFF
--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -100,7 +100,7 @@ class Control
         $oneOf = array_filter(
             (array)Hash::get($schema, 'oneOf'),
             function ($item) {
-                return $item['type'] !== 'null';
+                return !empty($item) && Hash::get($item, 'type') !== 'null';
             }
         );
 

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -42,6 +42,7 @@ class Control
      * Map JSON schema properties to HTML attributes
      */
     public const JSON_SCHEMA_HTML_PROPERTIES_MAP = [
+        'default' => 'value',
         'minimum' => 'min',
         'maximum' => 'max',
     ];
@@ -63,13 +64,14 @@ class Control
                 $controlOptions[$attribute] = $oneOf[$key];
             }
         }
+        $defaultValue = Hash::get($controlOptions, 'value');
         if ($type === 'text' && in_array($format, ['email', 'uri'])) {
             $result = call_user_func_array(Form::getMethod(self::class, $type, $format), [$options]);
 
             return array_merge($controlOptions, $result);
         }
         if (!in_array($type, self::CONTROL_TYPES)) {
-            $result = compact('type') + ['value' => $options['value']];
+            $result = compact('type') + ['value' => $options['value'] === null && $defaultValue ? $defaultValue : $options['value']];
 
             return array_merge($controlOptions, $result);
         }

--- a/tests/TestCase/Form/ControlTest.php
+++ b/tests/TestCase/Form/ControlTest.php
@@ -305,6 +305,28 @@ class ControlTest extends TestCase
                     'value' => 'www.gustavosupport.com',
                 ],
             ],
+            'integer with minimum and maximum' => [
+                [
+                    'oneOf' => [
+                        [
+                            'type' => 'null',
+                        ],
+                        [
+                            'type' => 'integer',
+                            'minimum' => 1,
+                            'maximum' => 10,
+                        ],
+                    ],
+                ],
+                'integer',
+                5,
+                [
+                    'type' => 'integer',
+                    'min' => 1,
+                    'max' => 10,
+                    'value' => 5,
+                ],
+            ],
         ];
     }
 

--- a/tests/TestCase/Form/ControlTest.php
+++ b/tests/TestCase/Form/ControlTest.php
@@ -449,7 +449,7 @@ class ControlTest extends TestCase
      * Test `oneOf` method
      *
      * @param array $schema Object schema array.
-     * @param string $expected The expected val.
+     * @param array $expected The expected val.
      * @return void
      * @dataProvider oneOfProvider()
      * @covers ::oneOf()

--- a/tests/TestCase/Form/ControlTest.php
+++ b/tests/TestCase/Form/ControlTest.php
@@ -305,7 +305,7 @@ class ControlTest extends TestCase
                     'value' => 'www.gustavosupport.com',
                 ],
             ],
-            'integer with minimum and maximum' => [
+            'integer with no value, default, minimum and maximum' => [
                 [
                     'oneOf' => [
                         [
@@ -313,6 +313,30 @@ class ControlTest extends TestCase
                         ],
                         [
                             'type' => 'integer',
+                            'default' => 8,
+                            'minimum' => 1,
+                            'maximum' => 10,
+                        ],
+                    ],
+                ],
+                'integer',
+                null,
+                [
+                    'type' => 'integer',
+                    'min' => 1,
+                    'max' => 10,
+                    'value' => 8,
+                ],
+            ],
+            'integer with value, default, minimum and maximum' => [
+                [
+                    'oneOf' => [
+                        [
+                            'type' => 'null',
+                        ],
+                        [
+                            'type' => 'integer',
+                            'default' => 8,
                             'minimum' => 1,
                             'maximum' => 10,
                         ],

--- a/tests/TestCase/Form/ControlTest.php
+++ b/tests/TestCase/Form/ControlTest.php
@@ -414,6 +414,54 @@ class ControlTest extends TestCase
     }
 
     /**
+     * Data provider for `testOneOf` test case.
+     *
+     * @return array
+     */
+    public function oneOfProvider(): array
+    {
+        return [
+            'empty schema' => [
+                [],
+                [],
+            ],
+            'no oneOf' => [
+                [
+                    'type' => 'text',
+                ],
+                [],
+            ],
+            'oneOf' => [
+                [
+                    'oneOf' => [
+                        ['type' => 'null'],
+                        ['type' => 'text'],
+                    ],
+                ],
+                [
+                    'type' => 'text',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `oneOf` method
+     *
+     * @param array $schema Object schema array.
+     * @param string $expected The expected val.
+     * @return void
+     * @dataProvider oneOfProvider()
+     * @covers ::oneOf()
+     */
+    public function testOneOf(array $schema, array $expected): void
+    {
+        $actual = Control::oneOf($schema);
+
+        static::assertSame($expected, $actual);
+    }
+
+    /**
      * Provider for testLabel
      *
      * @return array


### PR DESCRIPTION
This introduces "default value", "min" and "max" for an input field, from json schema's "default", "minimum" and "maximum" (if set).

When an input field has "min" and "max", most browsers handle natively the validation on submit.