### PR TITLE
Show Categories and Tags count

### DIFF
--- a/src/Controller/Component/CategoriesComponent.php
+++ b/src/Controller/Component/CategoriesComponent.php
@@ -120,12 +120,12 @@ class CategoriesComponent extends Component
     {
         $roots = ['' => ['id' => 0, 'label' => '-', 'name' => '', 'object_type_name' => '']];
         foreach ($map as $category) {
-            if (empty($category['attributes']['parent_id'])) {
-                $roots[$category['id']] = [
-                    'id' => $category['id'],
-                    'label' => $category['attributes']['label'] ?? $category['attributes']['name'],
-                    'name' => $category['attributes']['name'],
-                    'object_type_name' => $category['attributes']['object_type_name'],
+            if (empty(Hash::get($category, 'attributes.parent_id'))) {
+                $roots[Hash::get($category, 'id')] = [
+                    'id' => Hash::get($category, 'id'),
+                    'label' => Hash::get($category, 'attributes.label') ?? Hash::get($category, 'attributes.name'),
+                    'name' => Hash::get($category, 'attributes.name'),
+                    'object_type_name' => Hash::get($category, 'attributes.object_type_name'),
                 ];
             }
         }

--- a/templates/Element/Form/categories.twig
+++ b/templates/Element/Form/categories.twig
@@ -1,4 +1,6 @@
 {% if schema.categories is defined %}
+    {% set objectCategories = object.attributes.categories|default([]) %}
+    {% set schemaCategories = schema.categories|default([]) %}
     <property-view inline-template :tab-open="tabsOpen" tab-name="categories">
 
         <section class="fieldset">
@@ -6,13 +8,14 @@
                 class="tab unselectable"
                 :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
                 <h2>{{ __('Categories') }}</h2>
+                <span class="tag is-smallest is-black mx-05 {% if objectCategories|length == 0 %}empty{% endif %}">{{ objectCategories|length }} / {{ schemaCategories|length }}</span>
             </header>
 
             <div v-show="isOpen" class="tab-container">
                 <div class="categories-container">
                     <object-categories
-                        :model-categories="{{ schema.categories|json_encode }}"
-                        :value="{{ object.attributes.categories|default([])|json_encode }}"
+                        :model-categories="{{ schemaCategories|json_encode }}"
+                        :value="{{ objectCategories|json_encode }}"
                     >
                     </object-categories>
                     {% do Form.unlockField('categories') %}

--- a/templates/Element/Form/tags.twig
+++ b/templates/Element/Form/tags.twig
@@ -1,16 +1,18 @@
 {% if 'Tags' in schema.associations %}
+    {% set objectTags = object.attributes.tags|default([]) %}
     <property-view inline-template :tab-open="tabsOpen" tab-name="tags">
         <section class="fieldset">
             <header @click.prevent="toggleVisibility()"
                 class="tab unselectable"
                 :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
                 <h2>{{ __('Tags') }}</h2>
+                <span class="tag is-smallest is-black mx-05 {% if objectTags|length == 0 %}empty{% endif %}">{{ objectTags|length }}</span>
             </header>
             <div v-show="isOpen" class="tab-container">
                 <div class="tags-container">
                     <tag-picker
                         :id="`tagPick`"
-                        :initial-tags="{{ object.attributes.tags|default([])|json_encode }}"
+                        :initial-tags="{{ objectTags|default([])|json_encode }}"
                         :can-save="{{ Perms.canSave('tags')|json_encode }}">
                     </tag-picker>
                 </div>


### PR DESCRIPTION
This provides an UI enhancement in object view: show Categories and Tags count in the respective sections

![image](https://github.com/bedita/manager/assets/2227145/991f0e1a-f519-4221-b788-bf76aac940e5)
