### PR TITLE
Labels translations via plugin

### DIFF
--- a/templates/Element/Form/calendar.twig
+++ b/templates/Element/Form/calendar.twig
@@ -2,7 +2,8 @@
 
 {% if in_array('DateRanges', schema.associations) %}
 {% set key = 'Properties.%s.options.date_ranges.label'|format(object.type) %}
-{% set label = config(key)|default('Calendar') %}
+{% set plugin = config('Properties.%s.options.date_ranges.plugin'|format(object.type)) %}
+{% set label = plugin ? __d(plugin, config(key)) : __(config(key)|default('Calendar')) %}
 {% set key2 = 'Properties.%s.options.date_ranges.options'|format(object.type) %}
 {% set options = config(key2)|default({"weekdays":{}}) %}
 <property-view inline-template :tab-open="tabsOpen" tab-name="calendar">
@@ -10,7 +11,7 @@
         <header @click.prevent="toggleVisibility()"
             class="tab unselectable"
             :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
-            <h2>{{ __(label) }}</h2>
+            <h2>{{ label }}</h2>
         </header>
 
         <div v-show="isOpen" class="tab-container">

--- a/templates/Element/Modules/sidebar.twig
+++ b/templates/Element/Modules/sidebar.twig
@@ -22,9 +22,16 @@
 {% if currentModule.sidebar.index %}
 {% for item in currentModule.sidebar.index %}
     {% set url = item.url is iterable ? Url.build(item.url) : item.url %}
+    {% set plugin = item.plugin is defined ? item.plugin : null %}
+    {% set itemLabel = '' %}
+    {% if plugin and item.label %}
+        {% set itemLabel = __d(plugin, item.label) %}
+    {% else %}
+        {% set itemLabel = item.label is defined ? item.label : __(item.labelKey) %}
+    {% endif %}
     {% do _view.append(
         'app-module-buttons',
-        '<a href="' ~ url ~ '" class="' ~ item.class|default('button button-outlined button-outlined-hover-module-' ~ currentModule.name) ~ '"><app-icon icon="' ~ item.icon|default('carbon:save') ~ '"></app-icon><span class="ml-05">' ~ __(item.label) ~ '</span></a>',
+        '<a href="' ~ url ~ '" class="' ~ item.class|default('button button-outlined button-outlined-hover-module-' ~ currentModule.name) ~ '"><app-icon icon="' ~ item.icon|default('carbon:save') ~ '"></app-icon><span class="ml-05">' ~ itemLabel ~ '</span></a>',
     ) %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
This provides a fix to i18n gettext translations for specific keys, when the gettext handling is in a plugin.

Example 1 - Modules configuration sidebar index for "users":
```json
{
  "users": {
    "color": "#494960",
    "sidebar": {
      "index": [
        {
          "label": "Supplier",
          "plugin": "Customer",
          "url": {
            "_name": "users:supplier"
          },
          "icon": "carbon:add"
        }
      ]
    }
  },
}
```
Label will be translated via `__d('Customer', 'Supplier')` call, with default `__('Supplier')`.

Example 2 - Properties object type options configuration:
```json
{
  "locations": {
    "options": {
      "address": {
        "type": "plaintext"
      },
      "date_ranges": {
        "label": "Closing Calendar",
        "plugin": "Customer"
      }
    },
  }
}
```
Label will be translated via `__d('Customer', 'Closing Calendar')` call, with default `__('Closing Calendar')`.