### PR TITLE
More readable API error messages

### DIFF
--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-06-24 10:27:53 \n"
+"POT-Creation-Date: 2024-07-10 10:08:33 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -169,6 +169,9 @@ msgstr ""
 msgid "Confirm new password"
 msgstr ""
 
+msgid "Conflict"
+msgstr ""
+
 msgid "Copy to"
 msgstr ""
 
@@ -262,6 +265,9 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+msgid "Email is in use"
+msgstr ""
+
 msgid "Embed online content"
 msgstr ""
 
@@ -328,6 +334,9 @@ msgstr ""
 msgid "Folders"
 msgstr ""
 
+msgid "Forbidden"
+msgstr ""
+
 msgid "Forgot your password?"
 msgstr ""
 
@@ -377,6 +386,12 @@ msgid "Import filter not selected"
 msgstr ""
 
 msgid "Inherited properties"
+msgstr ""
+
+msgid "Internal Server Error"
+msgstr ""
+
+msgid "Invalid data"
 msgstr ""
 
 msgid "Invalid username or password"
@@ -448,6 +463,9 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
+msgid "Method Not Allowed"
+msgstr ""
+
 msgid "Missing import file"
 msgstr ""
 
@@ -515,6 +533,9 @@ msgid "No items found"
 msgstr ""
 
 msgid "No language configuration found"
+msgstr ""
+
+msgid "Not Found"
 msgstr ""
 
 msgid "Number of created objects"
@@ -841,6 +862,9 @@ msgstr ""
 msgid "Uname"
 msgstr ""
 
+msgid "Unauthorized"
+msgstr ""
+
 msgid "Undo Change File"
 msgstr ""
 
@@ -875,6 +899,12 @@ msgid "User profile saved"
 msgstr ""
 
 msgid "Username"
+msgstr ""
+
+msgid "Username is in use"
+msgstr ""
+
+msgid "Username is required"
 msgstr ""
 
 msgid "Users"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-06-24 10:27:53 \n"
+"POT-Creation-Date: 2024-07-10 10:08:33 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -172,6 +172,9 @@ msgstr ""
 msgid "Confirm new password"
 msgstr ""
 
+msgid "Conflict"
+msgstr ""
+
 msgid "Copy to"
 msgstr ""
 
@@ -265,6 +268,9 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
+msgid "Email is in use"
+msgstr ""
+
 msgid "Embed online content"
 msgstr ""
 
@@ -331,6 +337,9 @@ msgstr ""
 msgid "Folders"
 msgstr ""
 
+msgid "Forbidden"
+msgstr ""
+
 msgid "Forgot your password?"
 msgstr ""
 
@@ -380,6 +389,12 @@ msgid "Import filter not selected"
 msgstr ""
 
 msgid "Inherited properties"
+msgstr ""
+
+msgid "Internal Server Error"
+msgstr ""
+
+msgid "Invalid data"
 msgstr ""
 
 msgid "Invalid username or password"
@@ -451,6 +466,9 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
+msgid "Method Not Allowed"
+msgstr ""
+
 msgid "Missing import file"
 msgstr ""
 
@@ -518,6 +536,9 @@ msgid "No items found"
 msgstr ""
 
 msgid "No language configuration found"
+msgstr ""
+
+msgid "Not Found"
 msgstr ""
 
 msgid "Number of created objects"
@@ -844,6 +865,9 @@ msgstr ""
 msgid "Uname"
 msgstr ""
 
+msgid "Unauthorized"
+msgstr ""
+
 msgid "Undo Change File"
 msgstr ""
 
@@ -878,6 +902,12 @@ msgid "User profile saved"
 msgstr ""
 
 msgid "Username"
+msgstr ""
+
+msgid "Username is in use"
+msgstr ""
+
+msgid "Username is required"
 msgstr ""
 
 msgid "Users"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-06-24 10:27:53 \n"
+"POT-Creation-Date: 2024-07-10 10:08:33 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -174,6 +174,9 @@ msgstr "Configurazioni"
 msgid "Confirm new password"
 msgstr "Conferma nuova password"
 
+msgid "Conflict"
+msgstr "Conflitto"
+
 msgid "Copy to"
 msgstr "Copia in"
 
@@ -267,6 +270,9 @@ msgstr "Modifica parametri"
 msgid "Email"
 msgstr "E-mail"
 
+msgid "Email is in use"
+msgstr "Email in uso"
+
 msgid "Embed online content"
 msgstr "Incorpora contenuti online"
 
@@ -333,6 +339,9 @@ msgstr "Cartella"
 msgid "Folders"
 msgstr "Cartelle"
 
+msgid "Forbidden"
+msgstr "Non consentito"
+
 msgid "Forgot your password?"
 msgstr "Hai dimenticato la password?"
 
@@ -383,6 +392,12 @@ msgstr "Filtro di importazione non selezionato"
 
 msgid "Inherited properties"
 msgstr "Proprietà ereditate"
+
+msgid "Internal Server Error"
+msgstr "Errore interno del server"
+
+msgid "Invalid data"
+msgstr "Dati non validi"
 
 msgid "Invalid username or password"
 msgstr "Username o password non validi"
@@ -453,6 +468,9 @@ msgstr ""
 msgid "Metadata"
 msgstr "Metadati"
 
+msgid "Method Not Allowed"
+msgstr "Metodo non consentito"
+
 msgid "Missing import file"
 msgstr "File di importazione mancante"
 
@@ -521,6 +539,9 @@ msgstr "Nessun elemento trovato"
 
 msgid "No language configuration found"
 msgstr "Lingue non configurate a sistema"
+
+msgid "Not Found"
+msgstr "Non trovato"
 
 msgid "Number of created objects"
 msgstr "Numero di oggetti creati"
@@ -849,6 +870,9 @@ msgstr "Tipo"
 msgid "Uname"
 msgstr "Nome univoco"
 
+msgid "Unauthorized"
+msgstr "Non autorizzato"
+
 msgid "Undo Change File"
 msgstr "Annulla Cambio File"
 
@@ -884,6 +908,12 @@ msgstr "Profilo utente salvato"
 
 msgid "Username"
 msgstr "Nome utente"
+
+msgid "Username is in use"
+msgstr "Nome utente in uso"
+
+msgid "Username is required"
+msgstr "Nome utente obbligatorio"
 
 msgid "Users"
 msgstr "Utenti"

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -22,6 +22,7 @@ use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\InternalErrorException;
+use Cake\I18n\I18n;
 use Cake\Utility\Hash;
 
 /**
@@ -641,8 +642,10 @@ class ModulesComponent extends Component
         if ($relation === 'children' && $type === 'folders') {
             return $this->Children->{$method}($id, $related);
         }
+        $lang = I18n::getLocale();
+        $headers = ['Accept-Language' => $lang];
 
-        return ApiClientProvider::getApiClient()->{$method}($id, $type, $relation, $related);
+        return ApiClientProvider::getApiClient()->{$method}($id, $type, $relation, $related, $headers);
     }
 
     /**

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
+use Cake\I18n\I18n;
 use Cake\Utility\Hash;
 use Psr\Log\LogLevel;
 
@@ -297,7 +298,9 @@ class ModulesController extends AppController
             $this->Modules->upload($requestData);
 
             // save data
-            $response = $this->apiClient->save($this->objectType, $requestData);
+            $lang = I18n::getLocale();
+            $headers = ['Accept-Language' => $lang];
+            $response = $this->apiClient->save($this->objectType, $requestData, $headers);
             $this->savePermissions(
                 (array)$response,
                 (array)$this->Schema->getSchema($this->objectType),

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -13,6 +13,7 @@
 namespace App\Controller;
 
 use App\Utility\CacheTools;
+use App\Utility\Message;
 use App\Utility\PermissionsTrait;
 use BEdita\SDK\BEditaClientException;
 use Cake\Core\Configure;
@@ -313,10 +314,10 @@ class ModulesController extends AppController
             $this->getEventManager()->dispatch($event);
             $this->getRequest()->getSession()->delete(sprintf('failedSave.%s.%s', $this->objectType, $id));
         } catch (BEditaClientException $error) {
-            $this->log($error->getMessage(), LogLevel::ERROR);
-            $this->Flash->error($error->getMessage(), ['params' => $error]);
-
-            $this->set(['error' => $error->getAttributes()]);
+            $message = new Message($error);
+            $this->log($message->get(), LogLevel::ERROR);
+            $this->Flash->error($message->get(), ['params' => $error]);
+            $this->set(['error' => $message->get()]);
             $this->setSerialize(['error']);
 
             // set session data to recover form

--- a/src/Utility/Message.php
+++ b/src/Utility/Message.php
@@ -87,6 +87,7 @@ class Message
     public function prepareDetail(string $detail): string
     {
         $detail = trim($detail);
+        $detail = str_replace('[0]: ', '', $detail);
         if (strpos($detail, '._required]') !== false) {
             $detail = str_replace('._required', ' is required', $detail);
             $detailonly = substr($detail, 1, strpos($detail, ']') - 1);

--- a/src/Utility/Message.php
+++ b/src/Utility/Message.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Utility;
+
+use BEdita\SDK\BEditaClientException;
+use Cake\Utility\Hash;
+
+/**
+ * Utility class to handle system messages and translate them for the final user.
+ */
+class Message
+{
+    /**
+     * Message main text.
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * Message detail text.
+     *
+     * @var string
+     */
+    protected $detail;
+
+    /**
+     * Remap of error messages.
+     *
+     * @var array
+     */
+    protected $remap;
+
+    /**
+     * Constructor
+     *
+     * @param \BEdita\SDK\BEditaClientException $error Error object.
+     */
+    public function __construct(BEditaClientException $error)
+    {
+        $this->remap = [
+            '[400] Invalid data' => __('Invalid data'),
+            '[401] Unauthorized' => __('Unauthorized'),
+            '[403] Forbidden' => __('Forbidden'),
+            '[404] Not Found' => __('Not Found'),
+            '[405] Method Not Allowed' => __('Method Not Allowed'),
+            '[409] Conflict' => __('Conflict'),
+            '[500] Internal Server Error' => __('Internal Server Error'),
+            '[email is unique]: The provided value is invalid' => __('Email is in use'),
+            '[username is unique]: The provided value is invalid' => __('Username is in use'),
+            '[username is required]: This field is required' => __('Username is required'),
+        ];
+        $title = trim($error->getMessage());
+        $this->title = Hash::get($this->remap, $title, __($title));
+        $detail = Hash::get($error->getAttributes(), 'detail');
+        if (empty($detail)) {
+            return;
+        }
+        $matches = [];
+        preg_match_all('/\[[a-zA-Z0-9._]+\]: [^[]+/', $detail, $matches);
+        $details = [];
+        foreach ($matches[0] as $matchDetail) {
+            $details[] = $this->prepareDetail($matchDetail);
+        }
+        $this->detail = implode('. ', $details);
+    }
+
+    /**
+     * Prepare detail message.
+     *
+     * @param string $detail Detail message.
+     * @return string
+     */
+    public function prepareDetail(string $detail): string
+    {
+        $detail = trim($detail);
+        if (strpos($detail, '._required]') !== false) {
+            $detail = str_replace('._required', ' is required', $detail);
+
+            return $this->remap[$detail] ?? $detail;
+        }
+        if (strpos($detail, '.unique]') !== false) {
+            $detail = str_replace('.unique', ' is unique', $detail);
+
+            return $this->remap[$detail] ?? $detail;
+        }
+
+        return $this->remap[$detail] ?? $detail;
+    }
+
+    /**
+     * Get the message.
+     *
+     * @return string
+     */
+    public function get(): string
+    {
+        return empty($this->detail) ? $this->title : trim($this->title . '. ' . $this->detail);
+    }
+}

--- a/src/Utility/Message.php
+++ b/src/Utility/Message.php
@@ -89,13 +89,15 @@ class Message
         $detail = trim($detail);
         if (strpos($detail, '._required]') !== false) {
             $detail = str_replace('._required', ' is required', $detail);
+            $detailonly = substr($detail, 1, strpos($detail, ']') - 1);
 
-            return $this->remap[$detail] ?? $detail;
+            return $this->remap[$detail] ?? $detailonly;
         }
         if (strpos($detail, '.unique]') !== false) {
             $detail = str_replace('.unique', ' is unique', $detail);
+            $detailonly = str_replace('is unique', 'is in use', substr($detail, 1, strpos($detail, ']') - 1));
 
-            return $this->remap[$detail] ?? $detail;
+            return $this->remap[$detail] ?? $detailonly;
         }
 
         return $this->remap[$detail] ?? $detail;

--- a/tests/TestCase/Utility/MessageTest.php
+++ b/tests/TestCase/Utility/MessageTest.php
@@ -101,6 +101,14 @@ class MessageTest extends TestCase
                 ]),
                 'Invalid data. [dummy is required]: This field is required',
             ],
+            '400 other not translated' => [
+                new BEditaClientException([
+                    'status' => 400,
+                    'title' => 'Invalid data',
+                    'detail' => '[dummy.wrong]: This field is wrong',
+                ]),
+                'Invalid data. [dummy.wrong]: This field is wrong',
+            ],
         ];
     }
 

--- a/tests/TestCase/Utility/MessageTest.php
+++ b/tests/TestCase/Utility/MessageTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Test\TestCase;
+
+use App\Utility\Message;
+use BEdita\SDK\BEditaClientException;
+use Cake\TestSuite\TestCase;
+
+/**
+ * App\Utility\Message Test Case
+ *
+ * @coversDefaultClass App\Utility\Message
+ */
+class MessageTest extends TestCase
+{
+    /**
+     * Data provider for `testGet` test case.
+     *
+     * @return array
+     */
+    public function getProvider(): array
+    {
+        return [
+            '400 invalid data' => [
+                new BEditaClientException('[400] Invalid data', 400),
+                'Invalid data',
+            ],
+            '401 unauthorized' => [
+                new BEditaClientException('[401] Unauthorized', 401),
+                'Unauthorized',
+            ],
+            '403 forbidden' => [
+                new BEditaClientException('[403] Forbidden', 403),
+                'Forbidden',
+            ],
+            '404 not found' => [
+                new BEditaClientException('[404] Not Found', 404),
+                'Not Found',
+            ],
+            '405 method not allowed' => [
+                new BEditaClientException('[405] Method Not Allowed', 405),
+                'Method Not Allowed',
+            ],
+            '409 conflict' => [
+                new BEditaClientException('[409] Conflict', 409),
+                'Conflict',
+            ],
+            '500 internal server error' => [
+                new BEditaClientException('[500] Internal Server Error', 500),
+                'Internal Server Error',
+            ],
+            '400 username.unique' => [
+                new BEditaClientException([
+                    'status' => 400,
+                    'title' => 'Invalid data',
+                    'detail' => '[username.unique]: The provided value is invalid',
+                ]),
+                'Invalid data. Username is in use',
+            ],
+            '400 email.unique' => [
+                new BEditaClientException([
+                    'status' => 400,
+                    'title' => 'Invalid data',
+                    'detail' => '[email.unique]: The provided value is invalid',
+                ]),
+                'Invalid data. Email is in use',
+            ],
+            '400 username._required' => [
+                new BEditaClientException([
+                    'status' => 400,
+                    'title' => 'Invalid data',
+                    'detail' => '[username._required]: This field is required',
+                ]),
+                'Invalid data. Username is required',
+            ],
+            '400 email.unique and username._required' => [
+                new BEditaClientException([
+                    'status' => 400,
+                    'title' => 'Invalid data',
+                    'detail' => '[email.unique]: The provided value is invalid [username._required]: This field is required',
+                ]),
+                'Invalid data. Email is in use. Username is required',
+            ],
+        ];
+    }
+
+    /**
+     * Test `get` method
+     *
+     * @param \BEdita\SDK\BEditaClientException $error The error
+     * @param string $expected The expected result
+     * @return void
+     * @covers ::get()
+     * @covers ::__construct()
+     * @covers ::prepareDetail()
+     * @dataProvider getProvider
+     */
+    public function testGet(BEditaClientException $error, string $expected): void
+    {
+        $message = new Message($error);
+        $actual = $message->get();
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/TestCase/Utility/MessageTest.php
+++ b/tests/TestCase/Utility/MessageTest.php
@@ -99,7 +99,15 @@ class MessageTest extends TestCase
                     'title' => 'Invalid data',
                     'detail' => '[dummy._required]: This field is required',
                 ]),
-                'Invalid data. [dummy is required]: This field is required',
+                'Invalid data. dummy is required',
+            ],
+            '400 dummy.unique (not translated)' => [
+                new BEditaClientException([
+                    'status' => 400,
+                    'title' => 'Invalid data',
+                    'detail' => '[dummy.unique]: The provided value is invalid',
+                ]),
+                'Invalid data. dummy is in use',
             ],
             '400 other not translated' => [
                 new BEditaClientException([

--- a/tests/TestCase/Utility/MessageTest.php
+++ b/tests/TestCase/Utility/MessageTest.php
@@ -93,6 +93,14 @@ class MessageTest extends TestCase
                 ]),
                 'Invalid data. Email is in use. Username is required',
             ],
+            '400 dummy._required (not translated)' => [
+                new BEditaClientException([
+                    'status' => 400,
+                    'title' => 'Invalid data',
+                    'detail' => '[dummy._required]: This field is required',
+                ]),
+                'Invalid data. [dummy is required]: This field is required',
+            ],
         ];
     }
 


### PR DESCRIPTION
This provides an enhancement by translating some API error messages into more readable contents for the BEM user.

Server messages translated as follows:
```
'[400] Invalid data' => __('Invalid data'),
'[401] Unauthorized' => __('Unauthorized'),
'[403] Forbidden' => __('Forbidden'),
'[404] Not Found' => __('Not Found'),
'[405] Method Not Allowed' => __('Method Not Allowed'),
'[409] Conflict' => __('Conflict'),
'[500] Internal Server Error' => __('Internal Server Error'),
'[email is unique]: The provided value is invalid' => __('Email is in use'),
'[username is unique]: The provided value is invalid' => __('Username is in use'),
'[username is required]: This field is required' => __('Username is required'),
'[_some_field_ is unique]: The provided value is invalid' => __('_some_field_ is in use'), // generic
'[_some_field_ is required]: This field is required' => __('_some_field_ is required'), // generic
```

Note: final message can contain multiple submessages, i.e.: `Invalid data. Email is in use. Username is required`

Bonus: pass current language in header `Accept-Language` in save data `POST` for object save and add related save. So API can send a response with translated data; not necessary but useful sometimes, for example on validation errors.