### PR TITLE
Fix new category form columns

### DIFF
--- a/templates/Element/Modules/index_categories.twig
+++ b/templates/Element/Modules/index_categories.twig
@@ -59,7 +59,9 @@
             <nav class="table-header has-border-black">
                 <div>{{ __('Name') }}</div>
                 <div>{{ __('Label') }}</div>
+                {% if not object_types.0 %}
                 <div>{{ __('Type') }}</div>
+                {% endif %}
                 <div>{{ __('Parent') }}</div>
                 <div>{{ __('Enabled') }}</div>
                 <div></div>


### PR DESCRIPTION
This fixes a minor issue in category form, by not showing column `Type` if the form is inside a module (the type is hidden in this case).
![image](https://github.com/user-attachments/assets/9f49c484-325a-4a14-a379-8a238d24e72b)

The expected behavior
![image](https://github.com/user-attachments/assets/a2016511-7e0d-4947-8f02-b808311f7771)
