### PR TITLE
Fix admin endpoint permissions, nullable columns

### DIFF
--- a/src/Controller/Admin/EndpointPermissionsController.php
+++ b/src/Controller/Admin/EndpointPermissionsController.php
@@ -54,12 +54,36 @@ class EndpointPermissionsController extends AdministrationBaseController
     {
         parent::index();
         $applications = $this->apiClient->get('/admin/applications', []);
-        $this->set('applications', Hash::combine((array)$applications, 'data.{n}.id', 'data.{n}.attributes.name'));
+        $applications = Hash::combine((array)$applications, 'data.{n}.id', 'data.{n}.attributes.name');
+        $applications['-'] = '-';
+        $this->set('applications', $applications);
         $endpoints = $this->apiClient->get('/admin/endpoints', []);
-        $this->set('endpoints', Hash::combine((array)$endpoints, 'data.{n}.id', 'data.{n}.attributes.name'));
+        $endpoints = Hash::combine((array)$endpoints, 'data.{n}.id', 'data.{n}.attributes.name');
+        $endpoints['-'] = '-';
+        $this->set('endpoints', $endpoints);
         $roles = $this->apiClient->get('/roles', []);
-        $this->set('roles', Hash::combine((array)$roles, 'data.{n}.id', 'data.{n}.attributes.name'));
+        $roles = Hash::combine((array)$roles, 'data.{n}.id', 'data.{n}.attributes.name');
+        $roles['-'] = '-';
+        $this->set('roles', $roles);
 
         return null;
+    }
+
+    /**
+     * Save data
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function save(): ?Response
+    {
+        // check '-' values and set to null
+        $data = $this->request->getData();
+        foreach ($data as $key => $value) {
+            if ($value === '-') {
+                $data[$key] = null;
+            }
+        }
+
+        return parent::save();
     }
 }

--- a/src/View/Helper/AdminHelper.php
+++ b/src/View/Helper/AdminHelper.php
@@ -95,6 +95,7 @@ class AdminHelper extends Helper
 
         if (in_array($type, ['applications', 'endpoints', 'roles'])) {
             $options = (array)$this->_View->get($type);
+            $value = $value ?? '-';
 
             return $this->Form->control($property, $this->options['combo'] + compact('options', 'value'));
         }

--- a/tests/TestCase/Controller/Admin/EndpointPermissionsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/EndpointPermissionsControllerTest.php
@@ -3,6 +3,7 @@ namespace App\Test\TestCase\Controller\Admin;
 
 use App\Controller\Admin\EndpointPermissionsController;
 use BEdita\WebTools\ApiClientProvider;
+use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 
@@ -55,6 +56,7 @@ class EndpointPermissionsControllerTest extends TestCase
         $adminPassword = getenv('BEDITA_ADMIN_PWD');
         $response = $this->client->authenticate($adminUser, $adminPassword);
         $this->client->setupTokens($response['meta']);
+        $this->loadRoutes();
     }
 
     /**
@@ -83,5 +85,30 @@ class EndpointPermissionsControllerTest extends TestCase
         }
         static::assertEquals('endpoint_permissions', $viewVars['resourceType']);
         static::assertEquals(['endpoint_id', 'application_id'], $viewVars['properties']);
+    }
+
+    /**
+     * Test `save`
+     *
+     * @return void
+     */
+    public function testSave(): void
+    {
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [
+                'name' => 'dummy',
+            ],
+        ];
+        $request = new ServerRequest($config);
+        $this->EndPermsController = new class ($request) extends EndpointPermissionsController
+        {
+            protected $resourceType = 'endpoint_permissions';
+            protected $properties = ['endpoint_id', 'application_id'];
+        };
+        $response = $this->EndPermsController->save();
+        static::assertSame(Response::class, get_class($response));
     }
 }

--- a/tests/TestCase/Controller/Admin/EndpointPermissionsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/EndpointPermissionsControllerTest.php
@@ -99,7 +99,10 @@ class EndpointPermissionsControllerTest extends TestCase
                 'REQUEST_METHOD' => 'POST',
             ],
             'post' => [
-                'name' => 'dummy',
+                'endpoint_id' => 1,
+                'application_id' => '-',
+                'role_id' => '-',
+                'permission' => 15,
             ],
         ];
         $request = new ServerRequest($config);


### PR DESCRIPTION
This fixes a buggy behaviour in "Administration -> Endpoint Permissions" page: NULL values were displayed as first value of the correspondant dropdown. With this, `-` is shown when value is `null`.

An example:
![image](https://github.com/user-attachments/assets/83c526aa-4786-43ec-8e7b-c9789348da8a)
