### PR TITLE
Admin Appearance sort json keys

### DIFF
--- a/resources/js/app/pages/admin/appearance.vue
+++ b/resources/js/app/pages/admin/appearance.vue
@@ -125,6 +125,8 @@ export default {
                     data[key] = property[key];
                 }
             }
+
+            return JSON.stringify(data, null, 2);
         },
         title(pKey) {
             const k = this.$helpers.humanize(pKey);

--- a/resources/js/app/pages/admin/appearance.vue
+++ b/resources/js/app/pages/admin/appearance.vue
@@ -5,7 +5,7 @@
             <div class="main-container">
                 <div>
                     <div :id="`container-${propertyKey}`" class="jsoneditor-container"></div>
-                    <json-editor :options="jsonEditorOptions" :target="`container-${propertyKey}`" :text="JSON.stringify(property, null, 2)" />
+                    <json-editor :options="jsonEditorOptions" :target="`container-${propertyKey}`" :text="text(propertyKey, property)" />
                 </div>
                 <div class="ml-05">
                     <button class="button button-primary button-primary-hover-module-admin is-width-auto" :class="loading && loadingKey === propertyKey ? 'is-loading-spinner' : ''" @click.prevent="save(propertyKey)">
@@ -25,6 +25,7 @@
 import { t } from 'ttag';
 
 export default {
+    name: 'AdminAppearance',
 
     components: {
         JsonEditor: () => import(/* webpackChunkName: "json-editor" */'app/components/json-editor/json-editor'),
@@ -94,6 +95,35 @@ export default {
             } finally {
                 this.loading = false;
                 this.loadingKey = '';
+            }
+        },
+        text(propertyKey, property) {
+            if (propertyKey === 'modules') {
+                const ordered = {};
+                for (const key of Object.keys(property)) {
+                    const child = property[key];
+                    ordered[key] = {};
+                    for (const subkey of Object.keys(child).sort()) {
+                        ordered[key][subkey] = child[subkey];
+                    }
+                }
+
+                return JSON.stringify(ordered, null, 2);
+            }
+            if (!['access_control', 'export', 'pagination', 'project', 'properties'].includes(propertyKey)) {
+                return JSON.stringify(property, null, 2);
+            }
+            let data = {};
+            for (const key of Object.keys(property).sort()) {
+                if (propertyKey === 'properties') {
+                    const ordered = {};
+                    for (const k of Object.keys(property[key]).sort()) {
+                        ordered[k] = property[key][k];
+                    }
+                    data[key] = ordered;
+                } else {
+                    data[key] = property[key];
+                }
             }
         },
         title(pKey) {

--- a/resources/js/app/pages/admin/appearance.vue
+++ b/resources/js/app/pages/admin/appearance.vue
@@ -101,10 +101,9 @@ export default {
             if (propertyKey === 'modules') {
                 const ordered = {};
                 for (const key of Object.keys(property)) {
-                    const child = property[key];
                     ordered[key] = {};
-                    for (const subkey of Object.keys(child).sort()) {
-                        ordered[key][subkey] = child[subkey];
+                    for (const subkey of Object.keys(property[key]).sort()) {
+                        ordered[key][subkey] = property[key][subkey];
                     }
                 }
 


### PR DESCRIPTION
This provides an enhancement in "Admin Appearance" page. Configurations are sort by keys (except for `Modules`, whose order is semantically relevant).

Alphabetically ordered by key configurations:

 - Access Control
 - Export
 - Pagination
 - Project
 - Properties

Modules configuration keys order is preserved, but its values are alphabetically ordered by key