### PR TITLE
Fix i18n date format

### DIFF
--- a/resources/js/app/components/objects-history/objects-history.vue
+++ b/resources/js/app/components/objects-history/objects-history.vue
@@ -31,7 +31,7 @@
                 <i class="ml-05">{{ msgChange }}</i>
             </span>
             <template v-for="item in items">
-                <span>{{ formatDate(item?.meta?.created) }}</span>
+                <span>{{ this.$helpers.formatDate(item?.meta?.created) }}</span>
                 <span>
                     {{ msgAction }}
                     <b class="action">{{ item?.meta?.user_action || '' }}</b>
@@ -114,9 +114,6 @@ export default {
         },
         changePageSize(pageSize) {
             this.loadHistory(pageSize);
-        },
-        formatDate(d) {
-            return d ?  new Date(d).toLocaleDateString() + ' ' + new Date(d).toLocaleTimeString() : '';
         },
         async getHistory(pageSize = 20, page = 1) {
             const filterDate = this.filterDate ? new Date(this.filterDate).toISOString() : '';

--- a/resources/js/app/components/objects-history/objects-history.vue
+++ b/resources/js/app/components/objects-history/objects-history.vue
@@ -31,7 +31,7 @@
                 <i class="ml-05">{{ msgChange }}</i>
             </span>
             <template v-for="item in items">
-                <span>{{ this.$helpers.formatDate(item?.meta?.created) }}</span>
+                <span>{{ $helpers.formatDate(item?.meta?.created) }}</span>
                 <span>
                     {{ msgAction }}
                     <b class="action">{{ item?.meta?.user_action || '' }}</b>

--- a/resources/js/app/components/recent-activity/recent-activity.vue
+++ b/resources/js/app/components/recent-activity/recent-activity.vue
@@ -60,14 +60,14 @@
                     <div class="type-cell"><span :class="`tag has-background-module-${item.object_type}`">{{ t(item.object_type || '?') }}</span></div>
                     <div class="narrow">{{ item.meta.user_action }}</div>
                     <div class="narrow" :title="changes(item, false)">{{ changes(item) }}</div>
-                    <div class="narrow">{{ this.$helpers.formatDate(item.meta.created) }}</div>
+                    <div class="narrow">{{ $helpers.formatDate(item.meta.created) }}</div>
                 </a>
                 <div class="table-row object-status-deleted" v-else>
                     <div class="narrow">{{ title(item) }}</div>
                     <div class="type-cell"><span :class="`tag`">?</span></div>
                     <div class="narrow">{{ item.meta.user_action }}</div>
                     <div class="narrow" :title="changes(item, false)">{{ changes(item) }}</div>
-                    <div class="narrow">{{ this.$helpers.formatDate(item.meta.created) }}</div>
+                    <div class="narrow">{{ $helpers.formatDate(item.meta.created) }}</div>
                 </div>
             </template>
         </div>

--- a/resources/js/app/components/recent-activity/recent-activity.vue
+++ b/resources/js/app/components/recent-activity/recent-activity.vue
@@ -60,14 +60,14 @@
                     <div class="type-cell"><span :class="`tag has-background-module-${item.object_type}`">{{ t(item.object_type || '?') }}</span></div>
                     <div class="narrow">{{ item.meta.user_action }}</div>
                     <div class="narrow" :title="changes(item, false)">{{ changes(item) }}</div>
-                    <div class="narrow">{{ formatDate(item.meta.created) }}</div>
+                    <div class="narrow">{{ this.$helpers.formatDate(item.meta.created) }}</div>
                 </a>
                 <div class="table-row object-status-deleted" v-else>
                     <div class="narrow">{{ title(item) }}</div>
                     <div class="type-cell"><span :class="`tag`">?</span></div>
                     <div class="narrow">{{ item.meta.user_action }}</div>
                     <div class="narrow" :title="changes(item, false)">{{ changes(item) }}</div>
-                    <div class="narrow">{{ formatDate(item.meta.created) }}</div>
+                    <div class="narrow">{{ this.$helpers.formatDate(item.meta.created) }}</div>
                 </div>
             </template>
         </div>
@@ -170,9 +170,6 @@ export default {
             } finally {
                 this.loading = false;
             }
-        },
-        formatDate(d) {
-            return d ?  new Date(d).toLocaleDateString() + ' ' + new Date(d).toLocaleTimeString() : '';
         },
         pageButtonClass() {
             return 'has-text-size-smallest button is-width-auto button-outlined';

--- a/resources/js/app/components/user-accesses/user-accesses.vue
+++ b/resources/js/app/components/user-accesses/user-accesses.vue
@@ -27,7 +27,7 @@
                 <i class="ml-05">{{ msgUser }}</i>
             </span>
             <template v-for="user in accesses">
-                <span>{{ this.$helpers.formatDate(user?.meta?.last_login) }}</span>
+                <span>{{ $helpers.formatDate(user?.meta?.last_login) }}</span>
                 <span>
                     <a class="tag has-background-module-users" :href="`/users/view/${user.id}`" target="_new">
                         {{ user?.attributes?.title || user?.attributes?.username }}

--- a/resources/js/app/components/user-accesses/user-accesses.vue
+++ b/resources/js/app/components/user-accesses/user-accesses.vue
@@ -27,7 +27,7 @@
                 <i class="ml-05">{{ msgUser }}</i>
             </span>
             <template v-for="user in accesses">
-                <span>{{ formatDate(user?.meta?.last_login) }}</span>
+                <span>{{ this.$helpers.formatDate(user?.meta?.last_login) }}</span>
                 <span>
                     <a class="tag has-background-module-users" :href="`/users/view/${user.id}`" target="_new">
                         {{ user?.attributes?.title || user?.attributes?.username }}
@@ -72,9 +72,6 @@ export default {
         },
         changePageSize(pageSize) {
             this.loadAccesses(pageSize);
-        },
-        formatDate(d) {
-            return d ?  new Date(d).toLocaleDateString() + ' ' + new Date(d).toLocaleTimeString() : '';
         },
         async getAccesses(pageSize = 20, page = 1) {
             const filterDate = this.filterDate ? new Date(this.filterDate).toISOString() : '';

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -318,6 +318,12 @@ export default {
                 let [lon, lat] = input.split(/\s*,\s*/);
                 return `POINT(${lon} ${lat})`;
             },
+
+            formatDate(d) {
+                const locale = BEDITA?.locale?.slice(0, 2) || 'en';
+
+                return d ?  new Date(d).toLocaleDateString(locale) + ' ' + new Date(d).toLocaleTimeString(locale) : '';
+            },
         }
     }
 };


### PR DESCRIPTION
This refactorizes code to have a common `formatDate` function. The new version of `formatDate` considers locale set in `BEDITA.locale` (default `en`).
Refactor done for:

- objects history (in admin > objects history and in last section of each object view)
- recent activity (in dashboard)
- users accesses (in admin > user accesses)
