### PR TITLE
Update web-tools

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - '**/*.php'
       - '.github/workflows/php.yml'
-      - 'composer.json'
+      - 'composer.json' # test
       - 'psalm.xml'
 
 jobs:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - '**/*.php'
       - '.github/workflows/php.yml'
-      - 'composer.json' # test
+      - 'composer.json'
       - 'psalm.xml'
 
 jobs:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.4",
         "bedita/i18n": "^4.4.3",
-        "bedita/web-tools": "^4.0.0",
+        "bedita/web-tools": "^4.0.1",
         "cakephp/authentication": "^2.9",
         "cakephp/cakephp": "~4.5.0",
         "cakephp/plugin-installer": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.4",
         "bedita/i18n": "^4.4.3",
-        "bedita/web-tools": "^3.10.1",
+        "bedita/web-tools": "dev-feat/new-bedita-client",
         "cakephp/authentication": "^2.9",
         "cakephp/cakephp": "~4.5.0",
         "cakephp/plugin-installer": "^1.3",
@@ -75,6 +75,7 @@
         "coverage": "vendor/bin/phpunit --colors=always --coverage-html coverage"
     },
     "prefer-stable": true,
+    "minimum-stability": "dev",
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -99,5 +100,15 @@
             "merge-extra-deep": false,
             "merge-scripts": false
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/didoda/php-sdk"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/didoda/web-tools"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     "require": {
         "php": ">=7.4",
         "bedita/i18n": "^4.4.3",
-        "bedita/php-sdk": "dev-refactor/bedita-client",
         "bedita/web-tools": "dev-feat/new-bedita-client",
         "cakephp/authentication": "^2.9",
         "cakephp/cakephp": "~4.5.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.4",
         "bedita/i18n": "^4.4.3",
-        "bedita/web-tools": "dev-feat/new-bedita-client",
+        "bedita/web-tools": "^4.0.0",
         "cakephp/authentication": "^2.9",
         "cakephp/cakephp": "~4.5.0",
         "cakephp/plugin-installer": "^1.3",
@@ -100,11 +100,5 @@
             "merge-extra-deep": false,
             "merge-scripts": false
         }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/didoda/web-tools"
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -104,10 +104,6 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/didoda/php-sdk"
-        },
-        {
-            "type": "vcs",
             "url": "https://github.com/didoda/web-tools"
         }
     ]

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "php": ">=7.4",
         "bedita/i18n": "^4.4.3",
         "bedita/web-tools": "^3.10.1",
+        "bedita/web-tools": "dev-feat/new-bedita-client",
         "cakephp/authentication": "^2.9",
         "cakephp/cakephp": "~4.5.0",
         "cakephp/plugin-installer": "^1.3",
@@ -75,6 +76,7 @@
         "coverage": "vendor/bin/phpunit --colors=always --coverage-html coverage"
     },
     "prefer-stable": true,
+    "minimum-stability": "dev",
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -99,5 +101,15 @@
             "merge-extra-deep": false,
             "merge-scripts": false
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/didoda/php-sdk"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/didoda/web-tools"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.4",
         "bedita/i18n": "^4.4.3",
-        "bedita/web-tools": "^4.0.1",
+        "bedita/web-tools": "^4.0.2",
         "cakephp/authentication": "^2.9",
         "cakephp/cakephp": "~4.5.0",
         "cakephp/plugin-installer": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "php": ">=7.4",
         "bedita/i18n": "^4.4.3",
         "bedita/web-tools": "^3.10.1",
-        "bedita/web-tools": "dev-feat/new-bedita-client",
         "cakephp/authentication": "^2.9",
         "cakephp/cakephp": "~4.5.0",
         "cakephp/plugin-installer": "^1.3",
@@ -76,7 +75,6 @@
         "coverage": "vendor/bin/phpunit --colors=always --coverage-html coverage"
     },
     "prefer-stable": true,
-    "minimum-stability": "dev",
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -101,15 +99,5 @@
             "merge-extra-deep": false,
             "merge-scripts": false
         }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/didoda/php-sdk"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/didoda/web-tools"
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,6 @@
         "coverage": "vendor/bin/phpunit --colors=always --coverage-html coverage"
     },
     "prefer-stable": true,
-    "minimum-stability": "dev",
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": ">=7.4",
         "bedita/i18n": "^4.4.3",
+        "bedita/php-sdk": "dev-refactor/bedita-client",
         "bedita/web-tools": "dev-feat/new-bedita-client",
         "cakephp/authentication": "^2.9",
         "cakephp/cakephp": "~4.5.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.4",
         "bedita/i18n": "^4.4.3",
-        "bedita/web-tools": "dev-feat/new-bedita-client",
+        "bedita/web-tools": "^3.10.1",
         "cakephp/authentication": "^2.9",
         "cakephp/cakephp": "~4.5.0",
         "cakephp/plugin-installer": "^1.3",
@@ -75,7 +75,6 @@
         "coverage": "vendor/bin/phpunit --colors=always --coverage-html coverage"
     },
     "prefer-stable": true,
-    "minimum-stability": "dev",
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -100,15 +99,5 @@
             "merge-extra-deep": false,
             "merge-scripts": false
         }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/didoda/php-sdk"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/didoda/web-tools"
-        }
-    ]
+    }
 }

--- a/src/Controller/Model/TagsController.php
+++ b/src/Controller/Model/TagsController.php
@@ -54,12 +54,15 @@ class TagsController extends ModelBaseController
     public function index(): ?Response
     {
         $this->getRequest()->allowMethod(['get']);
-        $options = $this->getRequest()->getQueryParams();
+        $params = $this->getRequest()->getQueryParams();
+        $options = $params;
         $options['page_size'] = empty($options['page_size']) ? 20 : $options['page_size'];
         $options['sort'] = empty($options['sort']) ? 'name' : $options['sort'];
         $response = ApiClientProvider::getApiClient()->get('/model/tags', $options);
         $resources = Hash::combine((array)Hash::get($response, 'data'), '{n}.id', '{n}');
-        CacheTools::setModuleCount((array)$response, 'tags');
+        if (empty($params['q']) && empty($params['filter'])) {
+            CacheTools::setModuleCount((array)$response, 'tags');
+        }
         $roots = $this->Categories->getAvailableRoots($resources);
         $tagsTree = $this->Categories->tree($resources);
         $this->set(compact('resources', 'roots', 'tagsTree'));

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -103,8 +103,11 @@ class ModulesController extends AppController
         }
 
         try {
-            $response = $this->apiClient->getObjects($this->objectType, $this->Query->index());
-            CacheTools::setModuleCount((array)$response, $this->Modules->getConfig('currentModuleName'));
+            $params = $this->Query->index();
+            $response = $this->apiClient->getObjects($this->objectType, $params);
+            if (empty($params['q']) && empty($params['filter'])) {
+                CacheTools::setModuleCount((array)$response, $this->Modules->getConfig('currentModuleName'));
+            }
         } catch (BEditaClientException $e) {
             $this->log($e->getMessage(), LogLevel::ERROR);
             $this->Flash->error($e->getMessage(), ['params' => $e]);

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -387,20 +387,20 @@ class ModulesController extends AppController
         } elseif (!empty($this->getRequest()->getData('id'))) {
             $ids = [$this->getRequest()->getData('id')];
         }
-        foreach ($ids as $id) {
-            try {
-                $this->apiClient->deleteObject($id, $this->objectType);
+        try {
+            $this->apiClient->deleteObjects($ids, $this->objectType);
+            foreach ($ids as $id) {
                 $event = new Event('Controller.afterDelete', $this, ['id' => $id, 'type' => $this->objectType]);
                 $this->getEventManager()->dispatch($event);
-            } catch (BEditaClientException $e) {
-                $this->log($e->getMessage(), LogLevel::ERROR);
-                $this->Flash->error($e->getMessage(), ['params' => $e]);
-                if (!empty($this->getRequest()->getData('id'))) {
-                    return $this->redirect(['_name' => 'modules:view', 'object_type' => $this->objectType, 'id' => $this->getRequest()->getData('id')]);
-                }
-
-                return $this->redirect(['_name' => 'modules:view', 'object_type' => $this->objectType, 'id' => $id]);
             }
+        } catch (BEditaClientException $e) {
+            $this->log($e->getMessage(), LogLevel::ERROR);
+            $this->Flash->error($e->getMessage(), ['params' => $e]);
+            if (!empty($this->getRequest()->getData('id'))) {
+                return $this->redirect(['_name' => 'modules:view', 'object_type' => $this->objectType, 'id' => $this->getRequest()->getData('id')]);
+            }
+
+            return $this->redirect($this->referer());
         }
         $this->Flash->success(__('Object(s) deleted'));
 

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -379,19 +379,16 @@ class ModulesController extends AppController
     public function delete(): ?Response
     {
         $this->getRequest()->allowMethod(['post']);
-        $ids = [];
-        if (!empty($this->getRequest()->getData('ids'))) {
-            if (is_string($this->getRequest()->getData('ids'))) {
-                $ids = explode(',', (string)$this->getRequest()->getData('ids'));
-            }
-        } elseif (!empty($this->getRequest()->getData('id'))) {
-            $ids = [$this->getRequest()->getData('id')];
-        }
+        $id = $this->getRequest()->getData('id');
+        $ids = $this->getRequest()->getData('ids');
+        $ids = is_string($ids) ? explode(',', $ids) : $ids;
+        $ids = empty($ids) ? [$id] : $ids;
         try {
             $this->apiClient->deleteObjects($ids, $this->objectType);
+            $eventManager = $this->getEventManager();
             foreach ($ids as $id) {
                 $event = new Event('Controller.afterDelete', $this, ['id' => $id, 'type' => $this->objectType]);
-                $this->getEventManager()->dispatch($event);
+                $eventManager->dispatch($event);
             }
         } catch (BEditaClientException $e) {
             $this->log($e->getMessage(), LogLevel::ERROR);

--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -63,8 +63,11 @@ class TrashController extends AppController
         $this->getRequest()->allowMethod(['get']);
 
         try {
-            $response = $this->apiClient->getObjects('trash', $this->getRequest()->getQueryParams());
-            CacheTools::setModuleCount($response, 'trash');
+            $params = $this->getRequest()->getQueryParams();
+            $response = $this->apiClient->getObjects('trash', $params);
+            if (empty($params['q']) && empty($params['filter'])) {
+                CacheTools::setModuleCount($response, 'trash');
+            }
         } catch (BEditaClientException $e) {
             // Error! Back to dashboard.
             $this->log($e->getMessage(), LogLevel::ERROR);

--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -216,13 +216,7 @@ class TrashController extends AppController
         $this->apiClient->remove($id);
         // this for BE versions < 5.25.1, where streams are not deleted with media on delete
         $streams = (array)Hash::get($response, 'data');
-        foreach ($streams as $stream) {
-            $search = $this->apiClient->get('/streams', ['filter' => ['uuid' => $stream['id']]]);
-            $count = (int)Hash::get($search, 'meta.pagination.count', 0);
-            if ($count === 1) {
-                $this->apiClient->delete(sprintf('/streams/%s', $stream['id']));
-            }
-        }
+        $this->removeStreams($streams);
     }
 
     /**

--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -259,9 +259,9 @@ class TrashController extends AppController
         // this for BE versions < 5.25.1, where streams are not deleted with media on delete
         $uuids = (array)Hash::extract($streams, '{n}.id');
         $search = $this->apiClient->get('/streams', ['filter' => ['uuid' => $uuids]]);
-        $count = (int)Hash::get($search, 'meta.pagination.count', 0);
-        if ($count === 1) {
-            $this->apiClient->deleteObjects($uuids, 'streams');
+        $search = (array)Hash::get($search, 'data');
+        foreach ($search as $stream) {
+            $this->apiClient->delete(sprintf('/streams/%s', $stream['id']));
         }
     }
 }

--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -165,7 +165,10 @@ class TrashController extends AppController
             $ids = [$this->getRequest()->getData('id')];
         }
         try {
+            $response = $this->apiClient->get('/streams', ['filter' => ['object_id' => $ids]]);
             $this->apiClient->removeObjects($ids);
+            $streams = (array)Hash::get($response, 'data');
+            $this->removeStreams($streams);
             $this->Flash->success(__('Object(s) deleted from trash'));
         } catch (BEditaClientException $e) {
             // Error! Back to object view.

--- a/src/Utility/PermissionsTrait.php
+++ b/src/Utility/PermissionsTrait.php
@@ -75,9 +75,7 @@ trait PermissionsTrait
      */
     public function removePermissions(array $objectPermissionIds): void
     {
-        foreach ($objectPermissionIds as $id) {
-            ApiClientProvider::getApiClient()->deleteObject($id, 'object_permissions');
-        }
+        ApiClientProvider::getApiClient()->deleteObjects($objectPermissionIds, 'object_permissions');
     }
 
     /**

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -195,11 +195,9 @@ class AppControllerTest extends TestCase
         /** @var \Authentication\Identity|null $user */
         $user = $this->AppController->Authentication->getIdentity();
         $expectedtokens = $user->get('tokens');
-
-        $event = $this->AppController->dispatchEvent('Controller.initialize');
-
+        $this->AppController->dispatchEvent('Controller.initialize');
         $apiClient = $this->accessProperty($this->AppController, 'apiClient');
-        $apiClientTokens = $this->accessProperty($apiClient, 'tokens');
+        $apiClientTokens = $apiClient->getTokens();
 
         static::assertEquals($expectedtokens, $apiClientTokens);
     }

--- a/tests/TestCase/Controller/TrashControllerTest.php
+++ b/tests/TestCase/Controller/TrashControllerTest.php
@@ -179,11 +179,10 @@ class TrashControllerTest extends BaseControllerTest
     }
 
     /**
-     * Test `delete` and `deleteData` methods
+     * Test `delete` method
      *
      * @return void
      * @covers ::delete()
-     * @covers ::deleteData()
      */
     public function testDelete(): void
     {
@@ -206,11 +205,36 @@ class TrashControllerTest extends BaseControllerTest
     }
 
     /**
-     * Test `delete` and `deleteData` methods with media object
+     * Test `deleteData` method. For coverage and retrocompatibility only.
+     *
+     * @return void
+     * @covers ::deleteData()
+     */
+    public function testDeleteData(): void
+    {
+        $id = $this->setupControllerAndData();
+        $this->Trash->deleteData($id);
+
+        try {
+            $this->client->getObject($id);
+        } catch (BEditaClientException $e) {
+            $expected = new BEditaClientException('Not Found', 404);
+            static::assertEquals($expected->getCode(), $e->getCode());
+        }
+
+        try {
+            $this->client->get(sprintf('/trash/%d', $id));
+        } catch (BEditaClientException $e) {
+            $expected = new BEditaClientException('Not Found', 404);
+            static::assertEquals($expected->getCode(), $e->getCode());
+        }
+    }
+
+    /**
+     * Test `delete` method with media object
      *
      * @return void
      * @covers ::delete()
-     * @covers ::deleteData()
      */
     public function testDeleteMediaWithStream(): void
     {

--- a/tests/TestCase/Controller/TrashControllerTest.php
+++ b/tests/TestCase/Controller/TrashControllerTest.php
@@ -214,7 +214,7 @@ class TrashControllerTest extends BaseControllerTest
     public function testDeleteData(): void
     {
         $id = $this->setupControllerAndData();
-        $this->Trash->deleteData($id);
+        $this->Trash->deleteData((string)$id);
 
         try {
             $this->client->getObject($id);

--- a/tests/TestCase/Controller/TrashControllerTest.php
+++ b/tests/TestCase/Controller/TrashControllerTest.php
@@ -260,6 +260,19 @@ class TrashControllerTest extends BaseControllerTest
     }
 
     /**
+     * Test `deleteMulti` method with exception
+     *
+     * @return void
+     * @covers ::deleteMulti()
+     */
+    public function testDeleteMultiException(): void
+    {
+        $this->setupControllerAndData(true, false, true);
+        $actual = $this->Trash->deleteMulti(['abc']);
+        static::assertFalse($actual);
+    }
+
+    /**
      * Test `delete` method with media object
      *
      * @return void

--- a/tests/TestCase/Controller/TrashControllerTest.php
+++ b/tests/TestCase/Controller/TrashControllerTest.php
@@ -183,6 +183,7 @@ class TrashControllerTest extends BaseControllerTest
      *
      * @return void
      * @covers ::delete()
+     * @covers ::deleteMulti()
      * @covers ::removeStreams()
      */
     public function testDelete(): void
@@ -215,6 +216,33 @@ class TrashControllerTest extends BaseControllerTest
     {
         $id = $this->setupControllerAndData();
         $this->Trash->deleteData((string)$id);
+
+        try {
+            $this->client->getObject($id);
+        } catch (BEditaClientException $e) {
+            $expected = new BEditaClientException('Not Found', 404);
+            static::assertEquals($expected->getCode(), $e->getCode());
+        }
+
+        try {
+            $this->client->get(sprintf('/trash/%d', $id));
+        } catch (BEditaClientException $e) {
+            $expected = new BEditaClientException('Not Found', 404);
+            static::assertEquals($expected->getCode(), $e->getCode());
+        }
+    }
+
+    /**
+     * Test `deleteMulti` method.
+     *
+     * @return void
+     * @covers ::deleteMulti()
+     */
+    public function testDeleteMulti(): void
+    {
+        $id = $this->setupControllerAndData(true, false, true);
+        $actual = $this->Trash->deleteMulti([$id]);
+        static::assertTrue($actual);
 
         try {
             $this->client->getObject($id);
@@ -304,16 +332,15 @@ class TrashControllerTest extends BaseControllerTest
     }
 
     /**
-     * Test `restore` method with multiple items
+     * Test `delete` method passing ids in POST data
      *
      * @return void
      * @covers ::delete()
      */
-    public function testDeleteMulti(): void
+    public function testDeleteByIds(): void
     {
         $id = $this->setupControllerAndData(true, false, true);
         $this->Trash->delete();
-
         $expected = new BEditaClientException('Not Found', 404);
         static::expectException(get_class($expected));
         static::expectExceptionCode($expected->getCode());
@@ -326,7 +353,7 @@ class TrashControllerTest extends BaseControllerTest
      * @return void
      * @covers ::delete()
      */
-    public function testDeleteMultiFailure(): void
+    public function testDeleteByIdsFailure(): void
     {
         $id = $this->setupControllerAndData(true, false, true);
         $this->client->remove($id);
@@ -350,6 +377,7 @@ class TrashControllerTest extends BaseControllerTest
      * @return void
      * @covers ::emptyTrash()
      * @covers ::listQuery()
+     * @covers ::deleteMulti()
      * @covers ::removeStreams()
      */
     public function testEmpty(): void

--- a/tests/TestCase/Controller/TrashControllerTest.php
+++ b/tests/TestCase/Controller/TrashControllerTest.php
@@ -309,7 +309,13 @@ class TrashControllerTest extends BaseControllerTest
         static::assertEquals('/trash', $response->getHeaderLine('Location'));
 
         $message = $this->Trash->getRequest()->getSession()->read('Flash.flash.0.message');
-        static::assertEquals('Object(s) deleted from trash', $message);
+        $beditaApiVersion = (string)Hash::get((array)$this->client->get('/home'), 'meta.version');
+        $apiMajor = substr($beditaApiVersion, 0, strpos($beditaApiVersion, '.'));
+        if ($apiMajor === '4') {
+            static::assertEquals('[404] Not Found', $message);
+        } else {
+            static::assertEquals('Object(s) deleted from trash', $message);
+        }
     }
 
     /**

--- a/tests/TestCase/Controller/TrashControllerTest.php
+++ b/tests/TestCase/Controller/TrashControllerTest.php
@@ -309,7 +309,7 @@ class TrashControllerTest extends BaseControllerTest
         static::assertEquals('/trash', $response->getHeaderLine('Location'));
 
         $message = $this->Trash->getRequest()->getSession()->read('Flash.flash.0.message');
-        static::assertEquals('[404] Not Found', $message);
+        static::assertEquals('Object(s) deleted from trash', $message);
     }
 
     /**

--- a/tests/TestCase/Controller/TrashControllerTest.php
+++ b/tests/TestCase/Controller/TrashControllerTest.php
@@ -183,6 +183,7 @@ class TrashControllerTest extends BaseControllerTest
      *
      * @return void
      * @covers ::delete()
+     * @covers ::removeStreams()
      */
     public function testDelete(): void
     {
@@ -235,6 +236,7 @@ class TrashControllerTest extends BaseControllerTest
      *
      * @return void
      * @covers ::delete()
+     * @covers ::removeStreams()
      */
     public function testDeleteMediaWithStream(): void
     {
@@ -348,6 +350,7 @@ class TrashControllerTest extends BaseControllerTest
      * @return void
      * @covers ::emptyTrash()
      * @covers ::listQuery()
+     * @covers ::removeStreams()
      */
     public function testEmpty(): void
     {


### PR DESCRIPTION
This updates webtools introducing the possibility to use new BeditaClient functions for multi delete and restore.

Bulk delete and restore are much faster (one API call instead of N).

Bonus: fix the module(s) count so that it's done on empty filter only.