### PR TITLE
Fix: avoid error on `SchemaHelper.filterList`

### DIFF
--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -359,6 +359,7 @@ class SchemaHelper extends Helper
         foreach ($filtersByType as $type => $filters) {
             $noSchema = empty($schemasByType) || !array_key_exists($type, $schemasByType);
             $schemaProperties = $noSchema ? null : Hash::get($schemasByType, $type);
+            $schemaProperties = $schemaProperties !== false ? $schemaProperties : null;
             $list[$type] = self::filterList($filters, $schemaProperties);
         }
 


### PR DESCRIPTION
When API cache is deleted, `SchemaHelper` could present glitches with the function `filterList`. This solves the issues.