### PR TITLE
Remove `sort` if query string `q` is set

### DIFF
--- a/src/Controller/Component/QueryComponent.php
+++ b/src/Controller/Component/QueryComponent.php
@@ -65,20 +65,14 @@ class QueryComponent extends Component
      */
     protected function handleSort(string $sort, array &$query): void
     {
-        // set sort order from query string
-        if (!empty($sort)) {
-            $query['sort'] = $sort;
-
-            return;
-        }
         // remove sort from query if `q` search is set: order is done by search engine
         if (!empty($query['q'])) {
             unset($query['sort']);
 
             return;
         }
-        // set default sort order
-        $query['sort'] = '-id';
+        // set sort order from query string or default '-id'
+        $query['sort'] = !empty($sort) ? $sort : '-id';
     }
 
     /**

--- a/src/Controller/Component/QueryComponent.php
+++ b/src/Controller/Component/QueryComponent.php
@@ -30,7 +30,7 @@ class QueryComponent extends Component
         $query = $this->getController()->getRequest()->getQueryParams();
         if (array_key_exists('sort', $query)) {
             $sort = (string)Hash::get($query, 'sort');
-            $query['sort'] = !empty($sort) ? $sort : '-id';
+            $this->handleSort($sort, $query);
         }
 
         // set include, if set in config
@@ -51,9 +51,34 @@ class QueryComponent extends Component
         // set sort order: use `currentModule.sort` or default '-id'
         $module = (array)$this->getController()->viewBuilder()->getVar('currentModule');
         $sort = (string)Hash::get($module, 'sort');
-        $query['sort'] = !empty($sort) ? $sort : '-id';
+        $this->handleSort($sort, $query);
 
         return $query;
+    }
+
+    /**
+     * Handle sort order
+     *
+     * @param string $sort Sort order
+     * @param array $query Query string
+     * @return void
+     */
+    protected function handleSort(string $sort, array &$query): void
+    {
+        // set sort order from query string
+        if (!empty($sort)) {
+            $query['sort'] = $sort;
+
+            return;
+        }
+        // remove sort from query if `q` search is set: order is done by search engine
+        if (!empty($query['q'])) {
+            unset($query['sort']);
+
+            return;
+        }
+        // set default sort order
+        $query['sort'] = '-id';
     }
 
     /**

--- a/tests/TestCase/Controller/Component/QueryComponentTest.php
+++ b/tests/TestCase/Controller/Component/QueryComponentTest.php
@@ -84,6 +84,7 @@ class QueryComponentTest extends TestCase
      *
      * @return void
      * @covers ::index()
+     * @covers ::handleSort()
      * @dataProvider indexProvider()
      */
     public function testIndex(array $queryParams, array $config, array $expected): void

--- a/tests/TestCase/Controller/Component/QueryComponentTest.php
+++ b/tests/TestCase/Controller/Component/QueryComponentTest.php
@@ -76,6 +76,11 @@ class QueryComponentTest extends TestCase
                 ['include' => 'object'],
                 ['sort' => '-id', 'include' => 'object'],
             ],
+            'unset query sort' => [
+                ['sort' => 'whatever', 'q' => 'search'],
+                ['include' => 'object'],
+                ['q' => 'search', 'include' => 'object'],
+            ],
         ];
     }
 


### PR DESCRIPTION
This provides a fix on `sort` query param.
When search by `q=...` is performed, search engine is responsible for sorting, so `sort=` is not passed to API get call.