### PR TITLE
Edit children parameters

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -719,45 +719,47 @@ return [
      * - `format` - The format of the parameter. Supported formats are: `date`, `date-time`.
      * - `value` - The default value of the parameter.
      * - `enum` - The list of possible values for the parameter. Required if the type is `enum`.
+     *
+     *  An example follows. Note: "author", "summary" etc. are examples, you can define your own parameters. They will be saved in `meta.relation.params`.
      */
     // 'ChildrenParams' => [
-    //     'string' => [
-    //         'description' => 'The string',
+    //     'author' => [
+    //         'description' => 'The author',
     //         'type' => 'string',
-    //         'value' => 'something',
+    //         'value' => 'john doe',
     //     ],
-    //     'text' => [
-    //         'description' => 'The text',
+    //     'summary' => [
+    //         'description' => 'The summary',
     //         'type' => 'text',
     //         'value' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
     //     ],
-    //     'date' => [
-    //         'description' => 'The date',
+    //     'validation_date"' => [
+    //         'description' => 'The validation date',
     //         'type' => 'string',
     //         'format' => 'date',
     //         'value' => '2024-06-30',
     //     ],
-    //     'date-time' => [
-    //         'description' => 'The date-time',
+    //     'validation_date_time' => [
+    //         'description' => 'The validation date time',
     //         'type' => 'string',
     //         'format' => 'date-time',
     //         'value' => '2020-01-01T00:00:00Z',
     //     ],
-    //     'integer' => [
-    //         'description' => 'The integer',
+    //     'score' => [
+    //         'description' => 'The score',
     //         'type' => 'integer',
-    //         'value' => 81025,
+    //         'value' => 8,
     //     ],
-    //     'boolean' => [
-    //         'description' => 'The boolean',
+    //     'visible' => [
+    //         'description' => 'The visible flag',
     //         'type' => 'boolean',
     //         'value' => true,
     //     ],
-    //     'enum' => [
-    //         'description' => 'The enum',
-    //         'enum' => ['a', 'b', 'c'],
+    //     'status' => [
+    //         'description' => 'The status',
+    //         'enum' => ['draft', 'ready', 'done'],
     //         'type' => 'string',
-    //         'value' => 'b',
+    //         'value' => 'draft',
     //     ],
     // ],
 ];

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -706,4 +706,58 @@ return [
     //     ],
     // ],
     // 'uploadMaxResolution' => '1920x1080',
+
+    /**
+     * Configuration for "Children" association parameters.
+     *
+     * This allows to define a set of parameters that can be used in children association between a folder and an object.
+     * The configuration is an associative array where keys are the parameter names and values are
+     * arrays with the following keys:
+     *
+     * - `description` - The description of the parameter.
+     * - `type` - The type of the parameter. Supported types are: `string`, `text`, `date`, `date-time`, `integer`, `boolean`, `enum`.
+     * - `format` - The format of the parameter. Supported formats are: `date`, `date-time`.
+     * - `value` - The default value of the parameter.
+     * - `enum` - The list of possible values for the parameter. Required if the type is `enum`.
+     */
+    // 'ChildrenParams' => [
+    //     'string' => [
+    //         'description' => 'The string',
+    //         'type' => 'string',
+    //         'value' => 'something',
+    //     ],
+    //     'text' => [
+    //         'description' => 'The text',
+    //         'type' => 'text',
+    //         'value' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    //     ],
+    //     'date' => [
+    //         'description' => 'The date',
+    //         'type' => 'string',
+    //         'format' => 'date',
+    //         'value' => '2024-06-30',
+    //     ],
+    //     'date-time' => [
+    //         'description' => 'The date-time',
+    //         'type' => 'string',
+    //         'format' => 'date-time',
+    //         'value' => '2020-01-01T00:00:00Z',
+    //     ],
+    //     'integer' => [
+    //         'description' => 'The integer',
+    //         'type' => 'integer',
+    //         'value' => 81025,
+    //     ],
+    //     'boolean' => [
+    //         'description' => 'The boolean',
+    //         'type' => 'boolean',
+    //         'value' => true,
+    //     ],
+    //     'enum' => [
+    //         'description' => 'The enum',
+    //         'enum' => ['a', 'b', 'c'],
+    //         'type' => 'string',
+    //         'value' => 'b',
+    //     ],
+    // ],
 ];

--- a/config/relations.php
+++ b/config/relations.php
@@ -6,7 +6,6 @@ return [
      *  - `children` relation linking folders to objects
      */
     'DefaultRelations' => [
-
         'children' => [
             'type' => 'relations',
             'attributes' => [
@@ -14,6 +13,7 @@ return [
                 'inverse_name' => 'children',
                 'label' => 'Folder children',
                 'inverse_label' => 'Folder children',
+                'params' => null,
             ],
             'left' => ['folders'],
             'right' => ['objects'],

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-09-25 14:27:54 \n"
+"POT-Creation-Date: 2024-10-01 11:08:05 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1304,13 +1304,25 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
+msgid "Canonical"
+msgstr ""
+
 msgid "In relation with"
 msgstr ""
 
-msgid "Priority"
+msgid "Menu"
 msgstr ""
 
 msgid "Relation parameters"
+msgstr ""
+
+msgid "(empty)"
+msgstr ""
+
+msgid "(not available)"
+msgstr ""
+
+msgid "Priority"
 msgstr ""
 
 msgid "Mail to"
@@ -1359,9 +1371,6 @@ msgstr ""
 msgid "User"
 msgstr ""
 
-msgid "Canonical"
-msgstr ""
-
 msgid "Loading branches for position"
 msgstr ""
 
@@ -1378,9 +1387,6 @@ msgid "Loading positions for object"
 msgstr ""
 
 msgid "Loading root folders"
-msgstr ""
-
-msgid "Menu"
 msgstr ""
 
 msgid "page"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-09-25 14:27:54 \n"
+"POT-Creation-Date: 2024-10-01 11:08:05 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1307,13 +1307,25 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
+msgid "Canonical"
+msgstr ""
+
 msgid "In relation with"
 msgstr ""
 
-msgid "Priority"
+msgid "Menu"
 msgstr ""
 
 msgid "Relation parameters"
+msgstr ""
+
+msgid "(empty)"
+msgstr ""
+
+msgid "(not available)"
+msgstr ""
+
+msgid "Priority"
 msgstr ""
 
 msgid "Mail to"
@@ -1362,9 +1374,6 @@ msgstr ""
 msgid "User"
 msgstr ""
 
-msgid "Canonical"
-msgstr ""
-
 msgid "Loading branches for position"
 msgstr ""
 
@@ -1381,9 +1390,6 @@ msgid "Loading positions for object"
 msgstr ""
 
 msgid "Loading root folders"
-msgstr ""
-
-msgid "Menu"
 msgstr ""
 
 msgid "page"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-09-25 14:27:54 \n"
+"POT-Creation-Date: 2024-10-01 11:08:05 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1323,14 +1323,26 @@ msgstr "Interrompi"
 msgid "Cancel"
 msgstr "Annulla"
 
+msgid "Canonical"
+msgstr "Canonica"
+
 msgid "In relation with"
 msgstr "In relazione con"
 
-msgid "Priority"
-msgstr "Priorità"
+msgid "Menu"
+msgstr "Menù"
 
 msgid "Relation parameters"
 msgstr "Parametri della relazione"
+
+msgid "(empty)"
+msgstr "(vuoto)"
+
+msgid "(not available)"
+msgstr "(non disponibile)"
+
+msgid "Priority"
+msgstr "Priorità"
 
 msgid "Mail to"
 msgstr "Invia mail a"
@@ -1378,9 +1390,6 @@ msgstr "Data di inizio"
 msgid "User"
 msgstr "Utente"
 
-msgid "Canonical"
-msgstr "Canonica"
-
 msgid "Loading branches for position"
 msgstr "Caricamento rami per posizione"
 
@@ -1398,9 +1407,6 @@ msgstr "Caricamento posizioni per oggetto"
 
 msgid "Loading root folders"
 msgstr "Caricamento cartelle principali"
-
-msgid "Menu"
-msgstr "Menù"
 
 msgid "page"
 msgstr "pagina"

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -65,6 +65,7 @@ const _vueInstance = new Vue({
         AdminIndex: () => import(/* webpackChunkName: "admin-index" */'app/pages/admin/index'),
         AdminAppearance: () => import(/* webpackChunkName: "admin-appearance" */'app/pages/admin/appearance'),
         RelationsAdd: () => import(/* webpackChunkName: "relations-add" */'app/components/relation-view/relations-add'),
+        EditChildrenParams: () => import(/* webpackChunkName: "edit-children-params" */'app/components/edit-children-params'),
         EditRelationParams: () => import(/* webpackChunkName: "edit-relation-params" */'app/components/edit-relation-params'),
         HistoryInfo: () => import(/* webpackChunkName: "history-info" */'app/components/history/history-info'),
         FilterBoxView: () => import(/* webpackChunkName: "filter-box-view" */'app/components/filter-box'),

--- a/resources/js/app/components/edit-children-params.vue
+++ b/resources/js/app/components/edit-children-params.vue
@@ -198,9 +198,9 @@ export default {
             }
             this.objectColorClass = `has-background-module-${this.object.type}`;
             this.relatedColorClass = `has-background-module-${this.related.type}`;
-            this.relatedName = this.related?.attributes?.title || t('(empty)');
-            this.relatedStatus = this.related?.attributes?.status || t('(empty)');
-            this.relatedType = this.related?.type || t('(not available)');
+            this.relatedName = this.related?.attributes?.title || t`(empty)`;
+            this.relatedStatus = this.related?.attributes?.status || t`(empty)`;
+            this.relatedType = this.related?.type || t`(not available)`;
         });
     },
 

--- a/resources/js/app/components/edit-children-params.vue
+++ b/resources/js/app/components/edit-children-params.vue
@@ -1,0 +1,267 @@
+<template>
+    <div
+        class="edit-children-params"
+        v-if="relationName"
+    >
+        <section>
+            <header class="mx-1 mt-1 mb-1 tab unselectable">
+                <h2><span>{{ msgRelationParameters }} - {{ relationLabel }}</span></h2>
+            </header>
+
+            <div class="mx-1">
+                <p class="mb-05">
+                    {{ relatedName }}
+                </p>
+                <div>
+                    <span
+                        class="tag"
+                        :class="relatedColorClass"
+                    >
+                        {{ relatedType }}
+                    </span>
+                    <span class="tag">{{ relatedStatus }}</span>
+                </div>
+
+                <p class="mt-1 mb-05">{{ msgInRelationWith }} “{{ object?.attributes?.title }}”</p>
+                <div>
+                    <span
+                        class="tag"
+                        :class="objectColorClass"
+                    >
+                        {{ object?.type }}
+                    </span>
+                    <span class="tag">
+                        {{ object?.attributes?.status }}
+                    </span>
+                </div>
+            </div>
+
+            <form
+                class="mt-2 mx-1"
+                ref="paramsForm"
+            >
+                <div class="mb-1">
+                    <span>
+                        {{ msgPosition }}
+                    </span>
+                    <div class="position-params params">
+                        <input
+                            type="number"
+                            name="position"
+                            step="1"
+                            v-model.number="position"
+                        >
+                        <span class="param">
+                            <input
+                                id="paramMenu"
+                                :class="paramClass('menu')"
+                                type="checkbox"
+                                v-model="menu"
+                            >
+                            <label
+                                :class="paramClass('menu')"
+                                for="paramMenu"
+                            >
+                                {{ msgMenu }}
+                            </label>
+                        </span>
+                        <span class="param" v-if="relatedType !== 'folders'">
+                            <input
+                                id="paramCanonical"
+                                :class="paramClass('canonical')"
+                                type="checkbox"
+                                v-model="canonical"
+                            >
+                            <label
+                                :class="paramClass('canonical')"
+                                for="paramCanonical"
+                            >
+                                {{ msgCanonical }}
+                            </label>
+                        </span>
+                    </div>
+                </div>
+                <div
+                    class="mb-1"
+                    v-for="(property, key) in properties"
+                    :key="key"
+                >
+                    <PropertyField
+                        :property="property"
+                        :property-key="key"
+                        v-model="editingParams[key]"
+                    />
+                </div>
+            </form>
+
+            <footer class="p-1">
+                <button
+                    class="has-background-info has-text-white"
+                    @click.prevent="save()"
+                >
+                    {{ msgSave }}
+                </button>
+                <button
+                    class="mx-1"
+                    href="#"
+                    @click="closeParamsView()"
+                >
+                    {{ msgCancel }}
+                </button>
+            </footer>
+        </section>
+    </div>
+</template>
+<script>
+import { PanelEvents } from 'app/components/panel-view';
+import PropertyField from 'app/components/edit-relation-param';
+import { t } from 'ttag';
+
+export default {
+    name: 'EditChildrenParams',
+
+    components: {
+        PropertyField,
+    },
+
+    props: {
+        relationName: {
+            type: String,
+            default: '',
+        },
+        relationLabel: {
+            type: String,
+            default: '',
+        },
+        object: {
+            type: Object,
+            default: () => {},
+        },
+        related: {
+            type: Object,
+            default: () => {},
+        },
+        schema: {
+            type: Object,
+            default: () => {},
+        },
+    },
+
+    data() {
+        return {
+            canonical: null,
+            editingParams: {},
+            menu: null,
+            oldParams: {},
+            objectColorClass: '',
+            position: null,
+            properties: [],
+            relatedColorClass: '',
+            relatedName: '',
+            relatedStatus: '',
+            relatedType: '',
+            msgCancel: t`Cancel`,
+            msgCanonical: t`Canonical`,
+            msgInRelationWith: t`In relation with`,
+            msgMenu: t`Menu`,
+            msgPosition: t`Position`,
+            msgRelationParameters: t`Relation parameters`,
+            msgSave: t`Save`,
+        }
+    },
+
+    watch: {
+        related: {
+            handler: function(object) {
+                if (object) {
+                    this.setInternalValues();
+                }
+            },
+            deep: true,
+            immediate: true,
+        }
+    },
+
+    mounted() {
+        this.$nextTick(() => {
+            this.properties = this.schema?.attributes?.params || [];
+            this.canonical = this.related?.meta?.relation?.canonical || null;
+            this.menu = this.related?.meta?.relation?.menu || null;
+            this.position = this.related?.meta?.relation?.position || '';
+            for (let key in this.properties) {
+                if (this.related.meta.relation.params && this.related.meta.relation.params[key]) {
+                    this.editingParams[key] = this.related.meta.relation.params[key];
+
+                    continue;
+                }
+                this.editingParams[key] = this.properties[key].value || null;
+            }
+            this.objectColorClass = `has-background-module-${this.object.type}`;
+            this.relatedColorClass = `has-background-module-${this.related.type}`;
+            this.relatedName = this.related?.attributes?.title || t('(empty)');
+            this.relatedStatus = this.related?.attributes?.status || t('(empty)');
+            this.relatedType = this.related?.type || t('(not available)');
+        });
+    },
+
+    methods: {
+
+        closeParamsView() {
+            PanelEvents.closePanel();
+        },
+
+        paramClass(name) {
+            if (['canonical', 'menu'].includes(name)) {
+                if (name === 'canonical' && this.canonical) {
+                    return this.relatedColorClass;
+                }
+                if (name === 'menu' && this.menu) {
+                    return this.relatedColorClass;
+                }
+            }
+        },
+
+        save() {
+            const related = {...this.related};
+            related.meta.relation.position = this.position;
+            related.meta.relation.params = this.editingParams;
+            PanelEvents.sendBack('edit-params:save', related);
+        },
+
+        setInternalValues() {
+            Object.assign(this.oldParams, this.related.meta.relation.params);
+            Object.assign(this.editingParams, this.related.meta.relation.params);
+            this.position = this.related.meta.relation.position;
+        },
+    },
+}
+</script>
+<style>
+.edit-children-params .position-params {
+    display: grid;
+    grid-template-columns: 80px 60px 80px;
+    grid-gap: 0.5em;
+    text-align: center;
+    align-items: center;
+}
+.edit-children-params .params > .param > input {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    appearance: none;
+}
+.edit-children-params .params > .param > label {
+    display: flex !important;
+    align-items: center;
+    margin: 0;
+    padding: 0.25em 0.5em;
+    color: #CCCCCC;
+    line-height: 1 !important;
+    border-radius: 2em;
+    border: solid 1px currentColor;
+    cursor: pointer;
+}
+</style>

--- a/resources/js/app/components/edit-children-params.vue
+++ b/resources/js/app/components/edit-children-params.vue
@@ -189,7 +189,7 @@ export default {
             this.menu = this.related?.meta?.relation?.menu || null;
             this.position = this.related?.meta?.relation?.position || '';
             for (let key in this.properties) {
-                if (this.related.meta.relation.params && this.related.meta.relation.params[key]) {
+                if (this.related.meta.relation.params && Object.keys(this.related.meta.relation.params).includes(key)) {
                     this.editingParams[key] = this.related.meta.relation.params[key];
 
                     continue;

--- a/resources/js/app/components/edit-children-params.vue
+++ b/resources/js/app/components/edit-children-params.vue
@@ -250,6 +250,9 @@ export default {
             }
             for (let key in this.editingParams) {
                 if (this.editingParams[key] != this.originalParams[key]) {
+                    if (related.meta.relation.params == null) {
+                        related.meta.relation.params = {};
+                    }
                     related.meta.relation.params[key] = this.editingParams[key];
                     changed = true;
                 }

--- a/resources/js/app/components/edit-children-params.vue
+++ b/resources/js/app/components/edit-children-params.vue
@@ -104,7 +104,7 @@
                 <button
                     class="mx-1"
                     href="#"
-                    @click="closeParamsView()"
+                    @click="close()"
                 >
                     {{ msgCancel }}
                 </button>
@@ -206,7 +206,7 @@ export default {
 
     methods: {
 
-        closeParamsView() {
+        close() {
             PanelEvents.closePanel();
         },
 
@@ -223,6 +223,11 @@ export default {
 
         save() {
             const related = {...this.related};
+            for (const key in this.editingParams) {
+                if (this.editingParams[key] === '') {
+                    this.editingParams[key] = null;
+                }
+            }
             related.meta.relation.position = this.position;
             related.meta.relation.params = this.editingParams;
             PanelEvents.sendBack('edit-params:save', related);

--- a/resources/js/app/components/edit-relation-param.vue
+++ b/resources/js/app/components/edit-relation-param.vue
@@ -15,19 +15,19 @@
             >
         </div>
 
-        <!-- String (date, enum, text) --->
+        <!-- String (date, enum, string, text) --->
         <div
-            :class="{ datepicker: propertyFormat == 'date-time' }"
+            :class="{ datepicker: ['date', 'date-time'].includes(propertyFormat) }"
             v-if="propertyType == 'string'"
         >
             <input
-                time="true"
+                date="true"
+                :time="propertyFormat == 'date-time'"
                 :value="value"
                 v-datepicker
                 @change="update($event.target.value)"
-                v-if="propertyFormat == 'date-time'"
+                v-if="['date', 'date-time'].includes(propertyFormat)"
             >
-
             <select
                 :value="value"
                 @change="update($event.target.value)"
@@ -41,13 +41,18 @@
                     {{ item }}
                 </option>
             </select>
-
             <input
                 type="text"
                 :value="value"
                 @change="update($event.target.value)"
                 v-else
             >
+        </div>
+        <div v-if="propertyType == 'text'">
+            <textarea
+                :value="value"
+                @change="update($event.target.value)"
+            ></textarea>
         </div>
 
         <!-- Number --->

--- a/resources/js/app/components/relation-view/relation-view.vue
+++ b/resources/js/app/components/relation-view/relation-view.vue
@@ -444,16 +444,10 @@ export default {
             this.enableDrop();
         },
 
-        /**
-         * request panel for edit relation params
-         * data object has to match edit-relation-params component property
-         *
-         * @param {Object} data
-         */
-        editRelationParams(data) {
+        editRelationParams(data, action = 'edit-relation-params') {
             this.requesterId = data.related.id;
             PanelEvents.requestPanel({
-                action: 'edit-relation-params',
+                action,
                 from: this,
                 data,
             });

--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -321,8 +321,12 @@ class SchemaComponent extends Component
             ];
         }
         Configure::load('relations');
+        $schema = $relations + Configure::read('DefaultRelations');
+        if (Configure::read('ChildrenParams')) {
+            $schema['children']['attributes']['params'] = Configure::read('ChildrenParams');
+        }
 
-        return $relations + Configure::read('DefaultRelations');
+        return $schema;
     }
 
     /**

--- a/templates/Element/Form/related_item.twig
+++ b/templates/Element/Form/related_item.twig
@@ -148,6 +148,7 @@
     </div>
     {% endif %}
     {% if not readonly and children and config('ChildrenParams') %}
+    <div class="params p-05 has-text-size-smaller">
         <button
             class="is-small icon-th-list-1"
             :disabled="isPanelOpen()"
@@ -160,6 +161,7 @@
             }, 'edit-children-params')">
             {{ __('Edit params') }}
         </button>
+    </div>
     {% endif %}
 
     {# BUTTONS #}

--- a/templates/Element/Form/related_item.twig
+++ b/templates/Element/Form/related_item.twig
@@ -147,6 +147,20 @@
         {% endif %}
     </div>
     {% endif %}
+    {% if not readonly and children and config('ChildrenParams') %}
+        <button
+            class="is-small icon-th-list-1"
+            :disabled="isPanelOpen()"
+            @click.prevent.stop="editRelationParams({
+                object: {{ object|json_encode }},
+                related: related,
+                relationName: relationName,
+                relationLabel: relationLabel,
+                schema: {{ foldersSchema|json_encode }},
+            }, 'edit-children-params')">
+            {{ __('Edit params') }}
+        </button>
+    {% endif %}
 
     {# BUTTONS #}
     {% if Perms.canSave() %}

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -87,7 +87,7 @@
                         >
 
                         {% if relationName == 'children' %}
-                            {{ element('Form/related_item', { 'children': true }) }}
+                            {{ element('Form/related_item', { 'children': true, 'foldersSchema': relationsSchema[relationName] }) }}
                         {% else %}
                             {{ element('Form/related_item', { 'common': true, 'readonly': readonly }) }}
                         {% endif %}

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -8,7 +8,9 @@ use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Cache\Cache;
 use Cake\Controller\Controller;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * {@see \App\Controller\Component\SchemaComponent} Test Case
@@ -340,6 +342,24 @@ class SchemaComponentTest extends TestCase
                 ->willReturn($relations);
 
         ApiClientProvider::setApiClient($apiClient);
+        $expected = [
+            'string' => [
+                'description' => 'The string',
+                'type' => 'string',
+                'value' => 'something',
+            ],
+            'text' => [
+                'description' => 'The text',
+                'type' => 'text',
+                'value' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+            ],
+            'date' => [
+                'description' => 'The date',
+                'type' => 'string',
+                'format' => 'date',
+            ],
+        ];
+        Configure::write('ChildrenParams', $expected);
         $result = $this->Schema->getRelationsSchema();
         static::assertNotEmpty($result);
         // count is 3 because `children` relation is automatically added
@@ -347,6 +367,8 @@ class SchemaComponentTest extends TestCase
         static::assertArrayHasKey('poster', $result);
         static::assertArrayHasKey('poster_of', $result);
         static::assertArrayHasKey('children', $result);
+        $actual = Hash::get($result, 'children.attributes.params');
+        static::assertSame($expected, $actual);
     }
 
     /**


### PR DESCRIPTION
This provides a way to handle children association parameters.

To use it, set `ChildrenParams` configuration in your `config/app_local.php`, i.e.:
```php
'ChildrenParams' => [
    'author' => [
        'description' => 'The author',
        'type' => 'string',
        'value' => 'john doe', // if value is set, it is used as default
    ],
    'summary' => [
        'description' => 'The summary',
        'type' => 'text',
        'value' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
    ],
    'validation_date"' => [
        'description' => 'The validation date',
        'type' => 'string',
        'format' => 'date',
        'value' => '2024-06-30',
    ],
    'validation_date_time' => [
        'description' => 'The validation date time',
        'type' => 'string',
        'format' => 'date-time',
        'value' => '2020-01-01T00:00:00Z',
    ],
    'score' => [
        'description' => 'The score',
        'type' => 'integer',
        'value' => 8,
    ],
    'visible' => [
        'description' => 'The visible flag',
        'type' => 'boolean',
        'value' => true,
    ],
    'status' => [
        'description' => 'The status',
        'enum' => ['draft', 'ready', 'done'],
        'type' => 'string',
        'value' => 'draft',
    ],
],
```
In folder view, children section, related objects will have an "edit params" button; when you click it, side panel opens and shows form data coming from your conf.

The key `value` is optional, if present, default value is set in form.

![image](https://github.com/user-attachments/assets/941dcbdf-0bef-4407-a5d5-0ce3960dc05d)
