### PR TITLE
Do not save numeric uname

### DIFF
--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-10-01 11:08:05 \n"
+"POT-Creation-Date: 2024-10-15 07:31:20 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -407,6 +407,9 @@ msgid "Internal Server Error"
 msgstr ""
 
 msgid "Invalid data"
+msgstr ""
+
+msgid "Invalid numeric uname. Change it to a valid string"
 msgstr ""
 
 msgid "Invalid username or password"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-10-01 11:08:05 \n"
+"POT-Creation-Date: 2024-10-15 07:31:20 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -410,6 +410,9 @@ msgid "Internal Server Error"
 msgstr ""
 
 msgid "Invalid data"
+msgstr ""
+
+msgid "Invalid numeric uname. Change it to a valid string"
 msgstr ""
 
 msgid "Invalid username or password"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-10-01 11:08:05 \n"
+"POT-Creation-Date: 2024-10-15 07:31:20 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -413,6 +413,9 @@ msgstr "Errore interno del server"
 
 msgid "Invalid data"
 msgstr "Dati non validi"
+
+msgid "Invalid numeric uname. Change it to a valid string"
+msgstr "Nome univoco numerico non è valido. Cambialo in una stringa non numerica"
 
 msgid "Invalid username or password"
 msgstr "Username o password non validi"

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -286,6 +286,16 @@ class ModulesController extends AppController
         unset($requestData['_api']);
 
         try {
+            $uname = Hash::get($requestData, 'uname');
+            if (!empty($uname) && is_numeric($uname)) {
+                $this->set(['error' => __('Invalid numeric uname. Change it to a valid string')]);
+                $this->setSerialize(['error']);
+
+                // set session data to recover form
+                $this->Modules->setDataFromFailedSave($this->objectType, $requestData);
+
+                return;
+            }
             $id = Hash::get($requestData, 'id');
             // skip save if no data changed
             if (empty($relatedData) && count($requestData) === 1 && !empty($id)) {

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -451,6 +451,46 @@ class ModulesControllerTest extends BaseControllerTest
     }
 
     /**
+     * Test `save` method when uname is numeric
+     *
+     * @return void
+     * @covers ::save()
+     */
+    public function testSaveUnameNumeric(): void
+    {
+        // Setup controller for test
+        $this->setupController();
+
+        $o = $this->getTestObject();
+        $id = (string)Hash::get($o, 'id');
+        $type = (string)Hash::get($o, 'type');
+
+        // get object for test
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [
+                'id' => $id,
+                'uname' => '123456789',
+            ],
+            'params' => [
+                'object_type' => $type,
+            ],
+        ];
+        $request = new ServerRequest($config);
+        $this->controller = new ModulesControllerSample($request);
+
+        // do controller call
+        $this->controller->save();
+
+        // verify page has data, meta and links keys
+        $vars = $this->controller->viewBuilder()->getVars();
+        static::assertArrayHasKey('error', $vars);
+        static::assertEquals('Invalid numeric uname. Change it to a valid string', $vars['error']);
+    }
+
+    /**
      * Test `save` method when there's only 'id' in post data
      *
      * @return void

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -16,6 +16,7 @@ namespace App\Test\TestCase\View\Helper;
 use App\View\Helper\SchemaHelper;
 use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
+use Cake\I18n\FrozenTime;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 use Cake\View\View;
@@ -558,6 +559,11 @@ class SchemaHelperTest extends TestCase
      */
     public function formatProvider(): array
     {
+        $d = new FrozenTime('2019-09-08');
+        $dateExpected = $d->i18nFormat();
+        $d = new FrozenTime('2019-09-08T16:35:15+00');
+        $dateTimeExpected = $d->i18nFormat();
+
         return [
             'dummy' => [
                 'dummy',
@@ -589,7 +595,7 @@ class SchemaHelperTest extends TestCase
                 ],
             ],
             'date' => [
-                '9/8/19, 12:00 AM',
+                $dateExpected,
                 '2019-09-08',
                 [
                     'type' => 'string',
@@ -605,7 +611,7 @@ class SchemaHelperTest extends TestCase
                 ],
             ],
             'date time' => [
-                '9/8/19, 4:35 PM',
+                $dateTimeExpected,
                 '2019-09-08T16:35:15+00',
                 [
                     'type' => 'string',


### PR DESCRIPTION
This introduces a check to avoid save data if `uname` is numeric.

Bonus: fix unrelated `SchemaHelperTest::testFormat`; `Cake\View\Helper\TimeHelper::i18nFormat` has changed something in string representation (a different "space" character). 