### PR TITLE
Sort button for related contents

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -762,4 +762,21 @@ return [
     //         'value' => 'draft',
     //     ],
     // ],
+
+    /**
+     * Relations sort fields.
+     * Define sortable fields per relation.
+     */
+    // 'RelationsSortFields' => [
+    //     'composed_by' => [
+    //         ['label' => 'Short title', 'value' => 'short_title'],
+    //         ['label' => 'Title', 'value' => 'title'],
+    //     ],
+    //     'composed_by_default' => 'short_title',
+    //     'part_of' => [
+    //         ['label' => 'Short title', 'value' => 'short_title'],
+    //         ['label' => 'Title', 'value' => 'title'],
+    //     ],
+    //     'part_of_default' => 'short_title',
+    // ],
 ];

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-10-24 09:29:55 \n"
+"POT-Creation-Date: 2024-10-24 09:51:55 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -850,6 +850,9 @@ msgstr ""
 msgid "Thumbnail is not ready"
 msgstr ""
 
+msgid "Title"
+msgstr ""
+
 msgid "Title ↑"
 msgstr ""
 
@@ -1414,19 +1417,19 @@ msgstr ""
 msgid "Error on deleting tag"
 msgstr ""
 
-msgid "Title"
-msgstr ""
-
 msgid "Ascending"
-msgstr ""
-
-msgid "Sort"
 msgstr ""
 
 msgid "Descending"
 msgstr ""
 
 msgid "Sort by"
+msgstr ""
+
+msgid "Related items order will be changed."
+msgstr ""
+
+msgid "Continue?"
 msgstr ""
 
 msgid "Hide"

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-10-16 09:12:45 \n"
+"POT-Creation-Date: 2024-10-24 09:29:55 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1417,7 +1417,16 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
+msgid "Ascending"
+msgstr ""
+
 msgid "Sort"
+msgstr ""
+
+msgid "Descending"
+msgstr ""
+
+msgid "Sort by"
 msgstr ""
 
 msgid "Hide"

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-10-15 07:31:20 \n"
+"POT-Creation-Date: 2024-10-16 09:12:45 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1414,6 +1414,12 @@ msgstr ""
 msgid "Error on deleting tag"
 msgstr ""
 
+msgid "Title"
+msgstr ""
+
+msgid "Sort"
+msgstr ""
+
 msgid "Hide"
 msgstr ""
 
@@ -1540,9 +1546,6 @@ msgid "edit"
 msgstr ""
 
 msgid "Pitch"
-msgstr ""
-
-msgid "Title"
 msgstr ""
 
 msgid "Zoom"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-10-24 09:29:55 \n"
+"POT-Creation-Date: 2024-10-24 09:51:55 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -853,6 +853,9 @@ msgstr ""
 msgid "Thumbnail is not ready"
 msgstr ""
 
+msgid "Title"
+msgstr ""
+
 msgid "Title ↑"
 msgstr ""
 
@@ -1417,19 +1420,19 @@ msgstr ""
 msgid "Error on deleting tag"
 msgstr ""
 
-msgid "Title"
-msgstr ""
-
 msgid "Ascending"
-msgstr ""
-
-msgid "Sort"
 msgstr ""
 
 msgid "Descending"
 msgstr ""
 
 msgid "Sort by"
+msgstr ""
+
+msgid "Related items order will be changed."
+msgstr ""
+
+msgid "Continue?"
 msgstr ""
 
 msgid "Hide"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-10-15 07:31:20 \n"
+"POT-Creation-Date: 2024-10-16 09:12:45 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1417,6 +1417,12 @@ msgstr ""
 msgid "Error on deleting tag"
 msgstr ""
 
+msgid "Title"
+msgstr ""
+
+msgid "Sort"
+msgstr ""
+
 msgid "Hide"
 msgstr ""
 
@@ -1543,9 +1549,6 @@ msgid "edit"
 msgstr ""
 
 msgid "Pitch"
-msgstr ""
-
-msgid "Title"
 msgstr ""
 
 msgid "Zoom"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-10-16 09:12:45 \n"
+"POT-Creation-Date: 2024-10-24 09:29:55 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1420,7 +1420,16 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
+msgid "Ascending"
+msgstr ""
+
 msgid "Sort"
+msgstr ""
+
+msgid "Descending"
+msgstr ""
+
+msgid "Sort by"
 msgstr ""
 
 msgid "Hide"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-10-24 09:29:55 \n"
+"POT-Creation-Date: 2024-10-24 09:51:55 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -859,6 +859,9 @@ msgstr "Miniatura non pronta: in lavorazione"
 msgid "Thumbnail is not ready"
 msgstr "La miniatura non è pronta"
 
+msgid "Title"
+msgstr "Titolo"
+
 msgid "Title ↑"
 msgstr "Titolo ↑"
 
@@ -1434,20 +1437,20 @@ msgstr "Errore nel salvataggio del tag"
 msgid "Error on deleting tag"
 msgstr "Errore nell'eliminazione del tag"
 
-msgid "Title"
-msgstr "Titolo"
-
 msgid "Ascending"
 msgstr "Ascendente"
-
-msgid "Sort"
-msgstr "Ordina"
 
 msgid "Descending"
 msgstr "Discendente"
 
 msgid "Sort by"
 msgstr "Ordina per"
+
+msgid "Related items order will be changed."
+msgstr "L'ordine degli elementi correlati verrà modificato."
+
+msgid "Continue?"
+msgstr "Vuoi continuare?"
 
 msgid "Hide"
 msgstr "Nascondi"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-10-16 09:12:45 \n"
+"POT-Creation-Date: 2024-10-24 09:29:55 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1437,8 +1437,17 @@ msgstr "Errore nell'eliminazione del tag"
 msgid "Title"
 msgstr "Titolo"
 
+msgid "Ascending"
+msgstr "Ascendente"
+
 msgid "Sort"
 msgstr "Ordina"
+
+msgid "Descending"
+msgstr "Discendente"
+
+msgid "Sort by"
+msgstr "Ordina per"
 
 msgid "Hide"
 msgstr "Nascondi"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-10-15 07:31:20 \n"
+"POT-Creation-Date: 2024-10-16 09:12:45 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -415,7 +415,8 @@ msgid "Invalid data"
 msgstr "Dati non validi"
 
 msgid "Invalid numeric uname. Change it to a valid string"
-msgstr "Nome univoco numerico non è valido. Cambialo in una stringa non numerica"
+msgstr ""
+"Nome univoco numerico non è valido. Cambialo in una stringa non numerica"
 
 msgid "Invalid username or password"
 msgstr "Username o password non validi"
@@ -1433,6 +1434,12 @@ msgstr "Errore nel salvataggio del tag"
 msgid "Error on deleting tag"
 msgstr "Errore nell'eliminazione del tag"
 
+msgid "Title"
+msgstr "Titolo"
+
+msgid "Sort"
+msgstr "Ordina"
+
 msgid "Hide"
 msgstr "Nascondi"
 
@@ -1560,9 +1567,6 @@ msgstr "modifica"
 
 msgid "Pitch"
 msgstr ""
-
-msgid "Title"
-msgstr "Titolo"
 
 msgid "Zoom"
 msgstr ""

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -88,6 +88,7 @@ const _vueInstance = new Vue({
         ClipboardItem: () => import(/* webpackChunkName: "clipboard-item" */'app/components/clipboard-item/clipboard-item'),
         ObjectCategories: () => import(/* webpackChunkName: "object-categories" */'app/components/object-categories/object-categories'),
         PlaceholderList: () => import(/* webpackChunkName: "placeholder-list" */'app/components/placeholder-list/placeholder-list'),
+        SortRelated: () => import(/* webpackChunkName: "sort-related" */'app/components/sort-related/sort-related'),
         AppIcon,
     },
 

--- a/resources/js/app/components/relation-view/relation-view.vue
+++ b/resources/js/app/components/relation-view/relation-view.vue
@@ -33,6 +33,7 @@ export default {
         LocationsView: () => import(/* webpackChunkName: "locations-view" */'app/components/locations-view/locations-view'),
         Thumbnail:() => import(/* webpackChunkName: "thumbnail" */'app/components/thumbnail/thumbnail'),
         ClipboardItem: () => import(/* webpackChunkName: "clipboard-item" */'app/components/clipboard-item/clipboard-item'),
+        SortRelated: () => import(/* webpackChunkName: "sort-related" */'app/components/sort-related/sort-related'),
     },
 
     mixins: [

--- a/resources/js/app/components/sort-related/sort-related.vue
+++ b/resources/js/app/components/sort-related/sort-related.vue
@@ -1,0 +1,87 @@
+<template>
+    <div class="mb-05">
+        <select v-model="field">
+            <option v-for="item in sortFields" :value="item.value" :key="item.value">{{ item.label }}</option>
+        </select>
+        <select v-model="direction">
+            <option value="asc">↑</option>
+            <option value="desc">↓</option>
+        </select>
+        <span v-if="loading" class="is-loading-spinner"></span>
+        <button
+            class="button button-primary"
+            @click.prevent="changeOrder()"
+            v-else
+        >
+            <app-icon icon="carbon:save"></app-icon>
+            <span class="ml-05">{{ msgChangeOrder }}</span>
+        </button>
+    </div>
+</template>
+<script>
+import { t } from 'ttag';
+
+export default {
+    name: 'SortRelated',
+    props: {
+        objectId: {
+            type: String,
+            required: true,
+        },
+        objectType: {
+            type: String,
+            required: true,
+        },
+        relationName: {
+            type: String,
+            required: true,
+        },
+        sortFields: {
+            type: Array,
+            default: () => [{label: t`Title`, value: 'title'}],
+        },
+    },
+    data() {
+        return {
+            direction: 'asc',
+            field: 'title',
+            loading: false,
+            msgChangeOrder: t`Sort`,
+        };
+    },
+    methods: {
+        async changeOrder() {
+            try {
+                this.loading = true;
+                const url = `${BEDITA.base}/api/${this.objectType}/${this.objectId}/relationships/${this.relationName}/sort`;
+                const payload = {
+                    meta: {
+                        field: this.field,
+                        direction: this.direction,
+                    }
+                };
+                const options = {
+                    method: 'PATCH',
+                    credentials: 'same-origin',
+                    headers: {
+                        'accept': 'application/json',
+                        'content-type': 'application/json',
+                        'X-CSRF-Token': BEDITA.csrfToken,
+                    },
+                    body: JSON.stringify(payload),
+                };
+                const response = await fetch(url, options);
+                if (response.status === 200) {
+                    this.$emit('reload-related', true);
+                } else if (response.error) {
+                    BEDITA.showError(response.error);
+                }
+            } catch (error) {
+                BEDITA.showError(error);
+            } finally {
+                this.loading = false;
+            }
+        },
+    },
+};
+</script>

--- a/resources/js/app/components/sort-related/sort-related.vue
+++ b/resources/js/app/components/sort-related/sort-related.vue
@@ -11,7 +11,7 @@
         <span v-if="loading" class="is-loading-spinner"></span>
         <button
             class="button button-primary"
-            @click.prevent="changeOrder()"
+            @click.prevent="save()"
             v-else
         >
             <app-icon icon="carbon:save"></app-icon>
@@ -48,6 +48,7 @@ export default {
     },
     data() {
         return {
+            dialog: null,
             direction: 'asc',
             field: '',
             loading: false,
@@ -94,6 +95,16 @@ export default {
             } finally {
                 this.loading = false;
             }
+        },
+        async save() {
+            this.dialog = BEDITA.confirm(
+                t`Related items order will be changed.`,
+                t`OK`,
+                async () => {
+                    this.dialog?.hide();
+                    await this.changeOrder();
+                }
+            );
         },
     },
 };

--- a/resources/js/app/components/sort-related/sort-related.vue
+++ b/resources/js/app/components/sort-related/sort-related.vue
@@ -1,11 +1,12 @@
 <template>
     <div class="mb-05">
+        <span class="mr-05">{{ msgSortBy }}</span>
         <select v-model="field">
             <option v-for="item in sortFields" :value="item.value" :key="item.value">{{ item.label }}</option>
         </select>
         <select v-model="direction">
-            <option value="asc">↑</option>
-            <option value="desc">↓</option>
+            <option value="asc">{{ msgAsc }}</option>
+            <option value="desc">{{ msgDesc }}</option>
         </select>
         <span v-if="loading" class="is-loading-spinner"></span>
         <button
@@ -14,7 +15,7 @@
             v-else
         >
             <app-icon icon="carbon:save"></app-icon>
-            <span class="ml-05">{{ msgChangeOrder }}</span>
+            <span class="ml-05">{{ msgSave }}</span>
         </button>
     </div>
 </template>
@@ -50,7 +51,10 @@ export default {
             direction: 'asc',
             field: '',
             loading: false,
-            msgChangeOrder: t`Sort`,
+            msgAsc: t`Ascending`,
+            msgSave: t`Save`,
+            msgDesc: t`Descending`,
+            msgSortBy: t`Sort by`,
         };
     },
     mounted() {

--- a/resources/js/app/components/sort-related/sort-related.vue
+++ b/resources/js/app/components/sort-related/sort-related.vue
@@ -36,6 +36,10 @@ export default {
             type: String,
             required: true,
         },
+        defaultField: {
+            type: String,
+            default: 'title',
+        },
         sortFields: {
             type: Array,
             default: () => [{label: t`Title`, value: 'title'}],
@@ -44,10 +48,15 @@ export default {
     data() {
         return {
             direction: 'asc',
-            field: 'title',
+            field: '',
             loading: false,
             msgChangeOrder: t`Sort`,
         };
+    },
+    mounted() {
+        this.$nextTick(() => {
+            this.field = this.defaultField;
+        });
     },
     methods: {
         async changeOrder() {

--- a/src/View/Helper/SystemHelper.php
+++ b/src/View/Helper/SystemHelper.php
@@ -135,6 +135,20 @@ class SystemHelper extends Helper
     }
 
     /**
+     * Check if BEdita API version is greater or equal to required version.
+     *
+     * @param string $requiredApiVersion Required API version
+     * @return bool
+     */
+    public function isBEditaApiVersionGte(string $requiredApiVersion): bool
+    {
+        $project = (array)$this->getView()->get('project');
+        $apiVersion = Hash::get($project, 'version');
+
+        return empty($apiVersion) ? false : version_compare($apiVersion, $requiredApiVersion) >= 0;
+    }
+
+    /**
      * Placeholders config
      *
      * @return array

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -67,6 +67,17 @@
                 {% else %}
                     {{ Form.hidden('children_order', {'id': 'children-order'})|raw }}
                 {% endif %}
+            {% else %}
+                {% if System.isBEditaApiVersionGte('5.31.0') and Perms.canSave() and not readonly %}
+                <sort-related
+                    :object-id="{{ mainObject.id|json_encode }}"
+                    :object-type="{{ mainObject.type|json_encode }}"
+                    :relation-name="{{ relationName|json_encode }}"
+                    @reload-related="reloadObjects"
+                    v-if="objects?.length > 1"
+                >
+                </sort-related>
+                {% endif %}
             {% endif %}
 
             {% set dragAndDrop = relationName != 'children' or (relationName == 'children' and mainObject.attributes.children_order in [null, 'position', '-position']) %}

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -68,7 +68,7 @@
                     {{ Form.hidden('children_order', {'id': 'children-order'})|raw }}
                 {% endif %}
             {% else %}
-                {% if System.isBEditaApiVersionGte('5.30.0') and Perms.canSave() and not readonly %}
+                {% if System.isBEditaApiVersionGte('5.31.0') and Perms.canSave() and not readonly %}
                 <sort-related
                     :object-id="{{ mainObject.id|json_encode }}"
                     :object-type="{{ mainObject.type|json_encode }}"

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -68,7 +68,7 @@
                     {{ Form.hidden('children_order', {'id': 'children-order'})|raw }}
                 {% endif %}
             {% else %}
-                {% if Perms.canSave() and not readonly %}
+                {% if System.isBEditaApiVersionGte('5.31.0') and Perms.canSave() and not readonly %}
                 <sort-related
                     :object-id="{{ mainObject.id|json_encode }}"
                     :object-type="{{ mainObject.type|json_encode }}"

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -74,7 +74,7 @@
                     :object-type="{{ mainObject.type|json_encode }}"
                     :relation-name="{{ relationName|json_encode }}"
                     :default-field="{{ config('RelationsSortFields.' ~ relationName ~ '_default')|default('title')|json_encode }}"
-                    :sort-fields="{{ config('RelationsSortFields.' ~ relationName)|default([{'label':'Title','value':'title'}])|json_encode }}"
+                    :sort-fields="{{ config('RelationsSortFields.' ~ relationName)|default([{'label':__('Title'),'value':'title'}])|json_encode }}"
                     @reload-related="reloadObjects"
                     v-if="objects?.length > 1"
                 >

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -68,7 +68,7 @@
                     {{ Form.hidden('children_order', {'id': 'children-order'})|raw }}
                 {% endif %}
             {% else %}
-                {% if System.isBEditaApiVersionGte('5.31.0') and Perms.canSave() and not readonly %}
+                {% if System.isBEditaApiVersionGte('5.30.0') and Perms.canSave() and not readonly %}
                 <sort-related
                     :object-id="{{ mainObject.id|json_encode }}"
                     :object-type="{{ mainObject.type|json_encode }}"

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -68,7 +68,7 @@
                     {{ Form.hidden('children_order', {'id': 'children-order'})|raw }}
                 {% endif %}
             {% else %}
-                {% if System.isBEditaApiVersionGte('5.30.0') and Perms.canSave() and not readonly %}
+                {% if Perms.canSave() and not readonly %}
                 <sort-related
                     :object-id="{{ mainObject.id|json_encode }}"
                     :object-type="{{ mainObject.type|json_encode }}"

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -73,6 +73,8 @@
                     :object-id="{{ mainObject.id|json_encode }}"
                     :object-type="{{ mainObject.type|json_encode }}"
                     :relation-name="{{ relationName|json_encode }}"
+                    :default-field="{{ config('RelationsSortFields.' ~ relationName ~ '_default')|default('title')|json_encode }}"
+                    :sort-fields="{{ config('RelationsSortFields.' ~ relationName)|default([{'label':'Title','value':'title'}])|json_encode }}"
                     @reload-related="reloadObjects"
                     v-if="objects?.length > 1"
                 >

--- a/tests/TestCase/View/Helper/SystemHelperTest.php
+++ b/tests/TestCase/View/Helper/SystemHelperTest.php
@@ -101,6 +101,36 @@ class SystemHelperTest extends TestCase
     }
 
     /**
+     * Test `isBEditaApiVersionGte`
+     *
+     * @return void
+     * @covers ::isBEditaApiVersionGte()
+     */
+    public function testIsBEditaApiVersionGte(): void
+    {
+        // no project
+        static::assertFalse($this->System->isBEditaApiVersionGte('4.7.1'));
+
+        // project version 4.5.0
+        $this->System->getView()->set('project', ['version' => '4.5.0']);
+        static::assertTrue($this->System->isBEditaApiVersionGte('4.1.2'));
+        static::assertTrue($this->System->isBEditaApiVersionGte('4.5.0'));
+        static::assertFalse($this->System->isBEditaApiVersionGte('4.5.1'));
+        static::assertFalse($this->System->isBEditaApiVersionGte('4.7.1'));
+        static::assertFalse($this->System->isBEditaApiVersionGte('4.13.0'));
+        static::assertFalse($this->System->isBEditaApiVersionGte('5.12.3'));
+
+        // project version 5.12.4
+        $this->System->getView()->set('project', ['version' => '5.12.4']);
+        static::assertTrue($this->System->isBEditaApiVersionGte('4.7.1'));
+        static::assertTrue($this->System->isBEditaApiVersionGte('4.13.0'));
+        static::assertTrue($this->System->isBEditaApiVersionGte('5.12.3'));
+        static::assertTrue($this->System->isBEditaApiVersionGte('5.12.4'));
+        static::assertFalse($this->System->isBEditaApiVersionGte('5.12.5'));
+        static::assertFalse($this->System->isBEditaApiVersionGte('5.21.1'));
+    }
+
+    /**
      * Test `placeholdersConfig`
      *
      * @return void


### PR DESCRIPTION
This introduces a "sort" section to sort by title (asc or desc) related contents for a specific object and relation.

![image](https://github.com/user-attachments/assets/2430c68c-867e-4f0d-bcb2-ccc5d8ee49bc)

Feature is available if BEdita API is at least 5.31.0 (waiting for https://github.com/bedita/bedita/pull/2102 to be merged, to have release 5.31.0).

Sort fields can be configured per relation by `RelationsSortFields` config. An example follows:
```php
    /**
     * Relations sort fields.
     * Define sortable fields per relation.
     */
    'RelationsSortFields' => [
        'composed_by' => [
            ['label' => 'Short title', 'value' => 'short_title'],
            ['label' => 'Title', 'value' => 'title'],
        ],
        'composed_by_default' => 'short_title',
        'part_of' => [
            ['label' => 'Short title', 'value' => 'short_title'],
            ['label' => 'Title', 'value' => 'title'],
        ],
        'part_of_default' => 'short_title',
    ],
```

On "save" click, a modal confirm pops up: you can decide if continue or skip.

![image](https://github.com/user-attachments/assets/2908b456-0d20-4acc-8867-4f0b166a9195)
