### PR TITLE
Associations from config

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -762,4 +762,15 @@ return [
     //         'value' => 'draft',
     //     ],
     // ],
+
+    /**
+     * Configuration for "Schema" associations provided by the API instance.
+     *
+     *  An example follows. Note: "author", "summary" etc. are examples, you can define your own parameters. They will be saved in `meta.relation.params`.
+     */
+    // 'Schema' => [
+    //     'associations' => [
+    //         'Captions',
+    //     ],
+    // ],
 ];

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -313,6 +313,8 @@ class PropertiesComponent extends Component
             'Tags',
             'Permissions',
         ];
+        $config = (array)Configure::read('Schema.associations');
+        $fields = array_unique(array_merge($fields, $config));
         $fields = array_unique(array_merge($fields, $value));
         foreach ($fields as $text) {
             $value = $text;


### PR DESCRIPTION
This provides a way to extend the associations from a `Schema` configuration.

Example:
```
// in config/app_local.php
'Schema' => [
    'associations' => [
        'Captions',
    ],
],
```
In a model type form:

![image](https://github.com/user-attachments/assets/e89e8bf2-2649-4695-99c9-c8fc7c92b756)