### PR TITLE
Remove unnecessary failed save form data session handling

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -291,9 +291,6 @@ class ModulesController extends AppController
                 $this->set(['error' => __('Invalid numeric uname. Change it to a valid string')]);
                 $this->setSerialize(['error']);
 
-                // set session data to recover form
-                $this->Modules->setDataFromFailedSave($this->objectType, $requestData);
-
                 return;
             }
             $id = Hash::get($requestData, 'id');
@@ -328,16 +325,12 @@ class ModulesController extends AppController
             ];
             $event = new Event('Controller.afterSave', $this, $options);
             $this->getEventManager()->dispatch($event);
-            $this->getRequest()->getSession()->delete(sprintf('failedSave.%s.%s', $this->objectType, $id));
         } catch (BEditaClientException $error) {
             $message = new Message($error);
             $this->log($message->get(), LogLevel::ERROR);
             $this->Flash->error($message->get(), ['params' => $error]);
             $this->set(['error' => $message->get()]);
             $this->setSerialize(['error']);
-
-            // set session data to recover form
-            $this->Modules->setDataFromFailedSave($this->objectType, $requestData);
 
             return;
         }

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1074,65 +1074,6 @@ class ModulesComponentTest extends TestCase
     }
 
     /**
-     * Test `setDataFromFailedSave`.
-     *
-     * @covers ::setDataFromFailedSave()
-     * @return void
-     */
-    public function testSetDataFromFailedSave(): void
-    {
-        // empty case
-        $this->Modules->setDataFromFailedSave('', ['id' => 123]);
-        $actual = $this->Modules->getController()->getRequest()->getSession()->read('failedSave.123');
-        static::assertEmpty($actual);
-
-        // data and expected
-        $expected = [ 'id' => 999, 'name' => 'gustavo' ];
-        $type = 'documents';
-
-        $this->Modules->setDataFromFailedSave($type, $expected);
-
-        // verify data
-        $key = sprintf('failedSave.%s.%s', $type, $expected['id']);
-        $actual = $this->Modules->getController()->getRequest()->getSession()->read($key);
-        unset($expected['id']);
-        static::assertEquals($expected, $actual);
-    }
-
-    /**
-     * Test `updateFromFailedSave` method.
-     *
-     * @return void
-     * @covers ::setupAttributes()
-     * @covers ::updateFromFailedSave()
-     */
-    public function testUpdateFromFailedSave(): void
-    {
-        // empty case
-        $this->Modules->setDataFromFailedSave('', ['id' => 123]); // wrong data, missing type
-        $object = ['id' => 123, 'type' => 'documents'];
-        $this->Modules->setupAttributes($object);
-        static::assertArrayNotHasKey('attributes', $object);
-
-        // write to session data, to simulate recover from session.
-        $object = [
-            'id' => 999,
-            'type' => 'documents',
-            'attributes' => [
-                'name' => 'john doe',
-            ],
-        ];
-        $recover = [ 'name' => 'gustavo' ];
-        $this->Modules->setDataFromFailedSave('documents', $recover + ['id' => 999]);
-
-        // verify data
-        $this->Modules->setupAttributes($object);
-        $expected = $object;
-        $expected['attributes'] = array_merge($object['attributes'], $recover);
-        static::assertEquals($expected, $object);
-    }
-
-    /**
      * Data provider for `testSetupRelationsMeta`
      *
      * @return array


### PR DESCRIPTION
This PR removes the in-session handling of form data that previously caused server-side errors.

The issue was as follows: when a server-side error occurred while saving an object, the problematic form was displayed after showing the error message. However, upon reloading the object detail page, the form still displayed the erroneous data rather than the current data from the database, as expected. A second reload was required to display the correct data.

Since saving errors are now managed via AJAX, it’s no longer necessary to retain the erroneous data on reload. The in-session handling has therefore been removed.