### PR TITLE
Fix Tinymce branding true

### DIFF
--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -94,7 +94,7 @@ export default {
                     skin: false,
                     content_css: contentCSS,
                     menubar: false,
-                    branding: false,
+                    branding: true,
                     max_height: 500,
                     toolbar: items,
                     toolbar_mode: 'wrap',


### PR DESCRIPTION
This restores "branding: true" for richeditor, as expected in tinymce requirements for open source projects (https://www.tiny.cloud/docs/tinymce/5/editor-appearance/#_branding)

![image](https://github.com/user-attachments/assets/657a7cb1-5025-4b48-ab17-79ae4388ec18)
