### PR TITLE
Tune tinymce conf

### DIFF
--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -4,7 +4,6 @@ import 'tinymce/tinymce';
 import 'tinymce/icons/default';
 import 'tinymce/themes/silver';
 import 'tinymce/plugins/paste';
-import 'tinymce/plugins/autoresize';
 import 'tinymce/plugins/charmap';
 import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
@@ -85,7 +84,15 @@ export default {
                 if (!binding.modifiers?.placeholders) {
                     items = items.replace(/\bplaceholders\b/, '');
                 }
-
+                const sizes = {};
+                if (BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.height) {
+                    sizes.height = BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.height;
+                }
+                sizes.min_height = BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.min_height || sizes.height || 300;
+                if (BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.max_height) {
+                    sizes.max_height = BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.max_height;
+                }
+                sizes.max_height = sizes.min_height > 500 ? sizes.min_height + 500 : 500;
                 const { default: contentCSS } = await import('../../../richeditor.lazy.scss');
                 const [editor] = await tinymce.init({
                     target: element,
@@ -93,14 +100,13 @@ export default {
                     content_css: contentCSS,
                     menubar: false,
                     branding: true,
-                    max_height: 500,
+                    ... sizes,
                     toolbar: items,
                     toolbar_mode: 'wrap',
                     block_formats: 'Paragraph=p; Header 1=h1; Header 2=h2; Header 3=h3',
                     entity_encoding: 'raw',
                     plugins: [
                         'paste',
-                        'autoresize',
                         'code',
                         'charmap',
                         'link',
@@ -113,7 +119,6 @@ export default {
                         'visualblocks',
                     ].join(' '),
                     resize: true,
-                    autoresize_bottom_margin: 50,
                     convert_urls: false,
                     relative_urls: false,
                     paste_block_drop: true,
@@ -124,22 +129,6 @@ export default {
                     setup: (editor) => {
                         editor.on('change', () => {
                             EventBus.send('refresh-placeholders', {id: editor.id, content: editor.getContent()});
-                            // force height from config
-                            const height = BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.height;
-                            if (height) {
-                                const id = editor.id;
-                                const elem = document.getElementById(id + '_ifr').parentNode.parentNode.parentNode.parentNode;
-                                elem.style.height = `${height}px`;
-                            }
-                        });
-                        editor.on('init', () => {
-                            // force height from config
-                            const height = BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.height;
-                            if (height) {
-                                const id = editor.id;
-                                const elem = document.getElementById(id + '_ifr').parentNode.parentNode.parentNode.parentNode;
-                                elem.style.height = `${height}px`;
-                            }
                         });
                     }
                 });

--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -112,6 +112,7 @@ export default {
                         'typos',
                         'visualblocks',
                     ].join(' '),
+                    resize: true,
                     autoresize_bottom_margin: 50,
                     convert_urls: false,
                     relative_urls: false,
@@ -128,7 +129,7 @@ export default {
                             if (height) {
                                 const id = editor.id;
                                 const elem = document.getElementById(id + '_ifr').parentNode.parentNode.parentNode.parentNode;
-                                elem.style.height = height;
+                                elem.style.height = `${height}px`;
                             }
                         });
                         editor.on('init', () => {
@@ -137,7 +138,7 @@ export default {
                             if (height) {
                                 const id = editor.id;
                                 const elem = document.getElementById(id + '_ifr').parentNode.parentNode.parentNode.parentNode;
-                                elem.style.height = height;
+                                elem.style.height = `${height}px`;
                             }
                         });
                     }

--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -123,6 +123,13 @@ export default {
                     setup: (editor) => {
                         editor.on('change', () => {
                             EventBus.send('refresh-placeholders', {id: editor.id, content: editor.getContent()});
+                            // force height from config
+                            const height = BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.height;
+                            if (height) {
+                                const id = editor.id;
+                                const elem = document.getElementById(id + '_ifr').parentNode.parentNode.parentNode.parentNode;
+                                elem.style.height = height;
+                            }
                         });
                         editor.on('init', () => {
                             // force height from config

--- a/templates/Element/Form/related_item.twig
+++ b/templates/Element/Form/related_item.twig
@@ -82,12 +82,10 @@
 
                 <h3 class="title m-0 has-text-size-small" style="padding-bottom: 7px;">
                     {% if translation %}
-                        <span :title="related.attributes.translated_fields.title" v-if="related.attributes.translated_fields && related.attributes.translated_fields.title ">
-                            <: truncate(related.attributes.translated_fields.title, 50) :>
+                        <span v-html="truncate(related.attributes.translated_fields.title, 50)" :title=" related.attributes.translated_fields.title" v-if=" related.attributes.translated_fields && related.attributes.translated_fields.title ">
                         </span>
                     {% else %}
-                        <span :title="related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-'">
-                            <: truncate(related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-', 50) :>
+                        <span v-html="truncate(related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-', 50)" :title=" related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-' ">
                         </span>
                     {% endif %}
                 </h3>

--- a/templates/Pages/Translations/index.twig
+++ b/templates/Pages/Translations/index.twig
@@ -47,7 +47,7 @@
                             <input type="checkbox" name="oneItem" value="{{ object.id }}" v-model="selectedRows" {% if not Perms.canRead(object.type) %}disabled="disabled"{% endif %}>
                         </div>
                         <div class="narrow">
-                            {{ object.attributes.translated_fields.title|truncate(80)|default('no title') }}
+                            {{ object.attributes.translated_fields.title|striptags|truncate(80)|default('no title') }}
                         </div>
                         <div class="narrow">
                             {% if translated.attributes.lang %}


### PR DESCRIPTION
This fixes minor issues in richtext customization:

 - height, min_height, max_height from config, if set
 - manual resize: remove autoresize plugin / preserve custom height, when textarea content changes
 - striptags for title in translations index
 - striptags for title in relation item box