### PR TITLE
Position tree: show active positions

### DIFF
--- a/locales/default.pot
+++ b/locales/default.pot
@@ -796,7 +796,7 @@ msgstr ""
 msgid "Select a project"
 msgstr ""
 
-msgid "Show actived positions"
+msgid "Show active positions"
 msgstr ""
 
 msgid "Sign in"

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2024-11-22 13:38:50 \n"
+"POT-Creation-Date: 2024-12-02 16:33:07 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -794,6 +794,9 @@ msgid "Search"
 msgstr ""
 
 msgid "Select a project"
+msgstr ""
+
+msgid "Show actived positions"
 msgstr ""
 
 msgid "Sign in"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -799,7 +799,7 @@ msgstr ""
 msgid "Select a project"
 msgstr ""
 
-msgid "Show actived positions"
+msgid "Show active positions"
 msgstr ""
 
 msgid "Sign in"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-11-22 13:38:50 \n"
+"POT-Creation-Date: 2024-12-02 16:33:07 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -797,6 +797,9 @@ msgid "Search"
 msgstr ""
 
 msgid "Select a project"
+msgstr ""
+
+msgid "Show actived positions"
 msgstr ""
 
 msgid "Sign in"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -805,7 +805,7 @@ msgid "Select a project"
 msgstr "Seleziona un progetto"
 
 msgid "Show active positions"
-msgstr "Mostra posizione attive"
+msgstr "Mostra posizioni attive"
 
 msgid "Sign in"
 msgstr "Accedi"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -804,7 +804,7 @@ msgstr "Cerca"
 msgid "Select a project"
 msgstr "Seleziona un progetto"
 
-msgid "Show actived positions"
+msgid "Show active positions"
 msgstr "Mostra posizione attive"
 
 msgid "Sign in"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2024-11-22 13:38:50 \n"
+"POT-Creation-Date: 2024-12-02 16:33:07 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -803,6 +803,9 @@ msgstr "Cerca"
 
 msgid "Select a project"
 msgstr "Seleziona un progetto"
+
+msgid "Show actived positions"
+msgstr "Mostra posizione attive"
 
 msgid "Sign in"
 msgstr "Accedi"

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -92,7 +92,7 @@ export default {
             userInfoLoaded: false,
             fileChanged: false,
             searchInPosition: '',
-            searchInPositionActived: false,
+            searchInPositionActive: false,
         }
     },
 
@@ -126,7 +126,7 @@ export default {
         toggleVisibility() {
             this.isOpen = !this.isOpen;
             this.searchInPosition = '';
-            this.searchInPositionActived = !this.searchInPositionActived;
+            this.searchInPositionActive = !this.searchInPositionActive;
             this.checkLoadRelated();
             this.updateStorage();
         },
@@ -252,8 +252,8 @@ export default {
             return debouncedSearchPosition(e.target.value);
         },
 
-        onSearchInPositionActived(e) {
-            this.searchInPositionActived = e.target.checked ? true : false;
+        onSearchInPositionActive(e) {
+            this.searchInPositionActive = e.target.checked ? true : false;
         },
     }
 }

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -126,7 +126,7 @@ export default {
         toggleVisibility() {
             this.isOpen = !this.isOpen;
             this.searchInPosition = '';
-            this.searchInPositionActive = !this.searchInPositionActive;
+            this.searchInPositionActive = this.searchInPositionActive ? true : false;
             this.checkLoadRelated();
             this.updateStorage();
         },

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -92,6 +92,7 @@ export default {
             userInfoLoaded: false,
             fileChanged: false,
             searchInPosition: '',
+            searchInPositionActived: false,
         }
     },
 
@@ -125,6 +126,7 @@ export default {
         toggleVisibility() {
             this.isOpen = !this.isOpen;
             this.searchInPosition = '';
+            this.searchInPositionActived = !this.searchInPositionActived;
             this.checkLoadRelated();
             this.updateStorage();
         },
@@ -248,6 +250,10 @@ export default {
             }
 
             return debouncedSearchPosition(e.target.value);
+        },
+
+        onSearchInPositionActived(e) {
+            this.searchInPositionActived = e.target.checked ? true : false;
         },
     }
 }

--- a/resources/js/app/components/tree-view/tree-view.vue
+++ b/resources/js/app/components/tree-view/tree-view.vue
@@ -334,7 +334,7 @@ export default {
                 return false;
             }
 
-            if (this.searchInPositionActive && !this.isParent && !!!this.node.children) {
+            if (this.searchInPositionActive && !this.isParent && !this.node.children) {
                 return false;
             }
 

--- a/resources/js/app/components/tree-view/tree-view.vue
+++ b/resources/js/app/components/tree-view/tree-view.vue
@@ -82,7 +82,8 @@
                 :user-roles="userRoles"
                 :has-permissions="hasPermissions"
                 :show-forbidden="showForbidden"
-                :search="search">
+                :search="search"
+                :search-in-position-actived="searchInPositionActived">
             </tree-view>
         </div>
     </div>
@@ -170,6 +171,10 @@ export default {
         search: {
             type: String,
             default: '',
+        },
+        searchInPositionActived: {
+            type: Boolean,
+            default: false,
         },
     },
 
@@ -327,6 +332,12 @@ export default {
         showNode() {
             if (this.search && !this.foundIn(this.node)) {
                 return false;
+            }
+
+            if (this.searchInPositionActived) {
+                if (!this.isParent && !!!this.node.children) {
+                    return false;
+                }
             }
 
             if (!this.hasPermissions) {

--- a/resources/js/app/components/tree-view/tree-view.vue
+++ b/resources/js/app/components/tree-view/tree-view.vue
@@ -83,7 +83,7 @@
                 :has-permissions="hasPermissions"
                 :show-forbidden="showForbidden"
                 :search="search"
-                :search-in-position-actived="searchInPositionActived">
+                :search-in-position-active="searchInPositionActive">
             </tree-view>
         </div>
     </div>
@@ -172,7 +172,7 @@ export default {
             type: String,
             default: '',
         },
-        searchInPositionActived: {
+        searchInPositionActive: {
             type: Boolean,
             default: false,
         },
@@ -334,10 +334,8 @@ export default {
                 return false;
             }
 
-            if (this.searchInPositionActived) {
-                if (!this.isParent && !!!this.node.children) {
-                    return false;
-                }
+            if (this.searchInPositionActive && !this.isParent && !!!this.node.children) {
+                return false;
             }
 
             if (!this.hasPermissions) {

--- a/templates/Element/Form/trees.twig
+++ b/templates/Element/Form/trees.twig
@@ -33,6 +33,13 @@
                     </button>
                 </div>
 
+                <div class="mt-1">
+                    <label>
+                        <input type="checkbox" @input="onSearchInPositionActived" />
+                        {{ __('Show actived positions') }}
+                    </label>
+                </div>
+
                 <p v-if="searchInPosition.length" class="is-expanded tag mt-1">
                     <app-icon icon="carbon:filter"></app-icon>
                     <span class="ml-05">{{ __('Data is filtered') }}</span>
@@ -46,7 +53,8 @@
                     :multiple-choice={{ options.multiple }}
                     :user-roles="{{ user.roles|json_encode }}"
                     :has-permissions="{{ hasPermissions|json_encode }}"
-                    :search="searchInPosition">
+                    :search="searchInPosition"
+                    :search-in-position-actived="searchInPositionActived">
                 </tree-view>
             </div>
             {% do Form.unlockField('relations.' ~ relationName ~ '.replaceRelated') %}

--- a/templates/Element/Form/trees.twig
+++ b/templates/Element/Form/trees.twig
@@ -35,8 +35,8 @@
 
                 <div class="mt-1">
                     <label>
-                        <input type="checkbox" @input="onSearchInPositionActived" />
-                        {{ __('Show actived positions') }}
+                        <input type="checkbox" @input="onSearchInPositionActive" />
+                        {{ __('Show active positions') }}
                     </label>
                 </div>
 
@@ -54,7 +54,7 @@
                     :user-roles="{{ user.roles|json_encode }}"
                     :has-permissions="{{ hasPermissions|json_encode }}"
                     :search="searchInPosition"
-                    :search-in-position-actived="searchInPositionActived">
+                    :search-in-position-active="searchInPositionActive">
                 </tree-view>
             </div>
             {% do Form.unlockField('relations.' ~ relationName ~ '.replaceRelated') %}


### PR DESCRIPTION
This pull request introduces a new feature that allows filtering by active positions in the property and tree view components. Specifically, it enables filtering the positions where an object is located (active positions), thereby hiding the positions where the object is not active.

New feature - filter by active positions:
* [`resources/js/app/components/property-view/property-view.js`](diffhunk://#diff-7013d997041f3a975c8b397a23029b49f47c93324bcaba168e989112e9e9080bR95): Added a new state property `searchInPositionActive` and methods to toggle and handle this state.
* [`resources/js/app/components/tree-view/tree-view.vue`](diffhunk://#diff-59e0679b2e1476731429f14d1310ead0ddff35cf47c90dec246f2d9f2a8657b0L85-R86): Added a new prop `searchInPositionActive` and logic to filter nodes based on this prop.
* [`templates/Element/Form/trees.twig`](diffhunk://#diff-145c77852aa4bcc6b83be3ecf0b72eeac678177a2877a693577fbb3a73acadaaR36-R42): Added a checkbox to toggle the "Show active positions" filter and bound it to the new state.

<img width="702" alt="Screenshot 2024-12-03 alle 08 31 01" src="https://github.com/user-attachments/assets/a18d9089-581c-428b-8df9-bca7d597795a">
