### PR TITLE
Fix side panel search filter

### DIFF
--- a/resources/js/app/components/filter-box.vue
+++ b/resources/js/app/components/filter-box.vue
@@ -261,6 +261,7 @@ export default {
             this.availableFilters = this.filterList;
         } else if (this.rightTypes.length == 1 && this.filtersByType) {
             this.availableFilters = this.filtersByType[this.rightTypes[0]];
+            this.queryFilter.filter.type = this.rightTypes[0];
         } else {
             this.availableFilters = this.filtersByType?.[this.queryFilter.filter.type] || [];
         }
@@ -383,6 +384,10 @@ export default {
             this.folder = null;
             this.selectedSearchType = 'q';
             this.queryFilter = this.getCleanQuery();
+            if (this.rightTypes.length == 1 && this.filtersByType) {
+                this.availableFilters = this.filtersByType[this.rightTypes[0]];
+                this.queryFilter.filter.type = this.rightTypes[0];
+            }
             this.$emit('filter-reset');
         },
 

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -481,7 +481,7 @@ class ModulesController extends AppController
     }
 
     /**
-     * Relation data load callig api `GET /:object_type/:id/relationships/:relation`
+     * Relation data load calling api `GET /:object_type/:id/relationships/:relation`
      * Json response
      *
      * @param string|int $id The object ID.
@@ -532,7 +532,7 @@ class ModulesController extends AppController
         $relationsSchema = $this->Schema->getRelationsSchema();
         $types = $this->Modules->relatedTypes($relationsSchema, $relation);
 
-        return '/objects?filter[type][]=' . implode('&filter[type][]=', $types);
+        return count($types) === 1 ? sprintf('/%s', $types[0]) : '/objects?filter[type][]=' . implode('&filter[type][]=', $types);
     }
 
     /**

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -368,6 +368,7 @@ class SchemaHelper extends Helper
         foreach ($filtersByType as $type => $filters) {
             $noSchema = empty($schemasByType) || !array_key_exists($type, $schemasByType);
             $schemaProperties = $noSchema ? null : Hash::get($schemasByType, $type);
+            $schemaProperties = array_key_exists('properties', $schemaProperties) ? $schemaProperties['properties'] : $schemaProperties;
             $schemaProperties = $schemaProperties !== false ? $schemaProperties : null;
             $list[$type] = self::filterList($filters, $schemaProperties);
         }

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -368,7 +368,7 @@ class SchemaHelper extends Helper
         foreach ($filtersByType as $type => $filters) {
             $noSchema = empty($schemasByType) || !array_key_exists($type, $schemasByType);
             $schemaProperties = $noSchema ? null : Hash::get($schemasByType, $type);
-            $schemaProperties = array_key_exists('properties', $schemaProperties) ? $schemaProperties['properties'] : $schemaProperties;
+            $schemaProperties = array_key_exists('properties', (array)$schemaProperties) ? $schemaProperties['properties'] : $schemaProperties;
             $schemaProperties = $schemaProperties !== false ? $schemaProperties : null;
             $list[$type] = self::filterList($filters, $schemaProperties);
         }

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -1021,7 +1021,7 @@ class ModulesControllerTest extends BaseControllerTest
             ->willReturn(['documents']);
 
         $url = $this->controller->availableRelationshipsUrl('test_relation');
-        static::assertEquals('/objects?filter[type][]=documents', $url);
+        static::assertEquals('/documents', $url);
 
         $this->controller->Modules = $this->createMock(ModulesComponent::class);
         $this->controller->Modules->method('relatedTypes')


### PR DESCRIPTION
This fixes search from side panel with advanced filters by adjusting properly the schema and using, if available, a `/:type` instead of `/objects?filter[type][]=:type`, when there is only one related type for relation.

This fixes the form, by using proper schema; in the following example, the custom field "booking status" is an enum, and it is shown as a combo; without this fix, it is shown as an input text field.

![image](https://github.com/user-attachments/assets/b1b9d33f-4cc0-4981-9356-a842cc0558be)
