### PR TITLE
Sortable columns in module index, avoid `[400] Unsupported sorting field`

### DIFF
--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -312,23 +312,22 @@ class SchemaHelper extends Helper
      */
     public function sortable(string $field): bool
     {
-        // exception 'date_ranges' default sortable
-        if ($field === 'date_ranges') {
+        // default sortable fields
+        if (in_array($field, ['date_ranges', 'modified', 'id', 'title'])) {
             return true;
         }
         $schema = (array)$this->_View->get('schema');
         $schema = Hash::get($schema, sprintf('properties.%s', $field), []);
-
         // empty schema, then not sortable
         if (empty($schema)) {
             return false;
         }
-        $type = self::typeFromSchema($schema);
 
-        // not sortable: 'array', 'object'
-        // other types are sortable: 'string', 'number', 'integer', 'boolean', 'date-time', 'date'
+        // check from configuration Properties.%s.sortable
+        $name = Hash::get((array)$this->_View->get('currentModule'), 'name');
+        $sortable = (array)Configure::read(sprintf('Properties.%s.sortable', $name));
 
-        return !in_array($type, ['array', 'object']);
+        return in_array($field, $sortable);
     }
 
     /**

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -770,90 +770,46 @@ class SchemaHelperTest extends TestCase
                 [],
                 false,
             ],
-            'string: sortable' => [
-                'dummy_string',
-                ['type' => 'string'],
-                true,
-            ],
-            'number: sortable' => [
-                'dummy_number',
-                ['type' => 'number'],
-                true,
-            ],
-            'integer: sortable' => [
-                'dummy_integer',
-                ['type' => 'integer'],
-                true,
-            ],
-            'boolean: sortable' => [
-                'dummy_boolean',
-                ['type' => 'boolean'],
-                true,
-            ],
-            'date-time: sortable' => [
-                'dummy_date-time',
-                ['type' => 'date-time'],
-                true,
-            ],
-            'date: sortable' => [
-                'dummy_date',
-                ['type' => 'date'],
-                true,
-            ],
-            'array: not sortable' => [
-                'dummy_array',
-                ['type' => 'array'],
-                false,
-            ],
-            'object: not sortable' => [
-                'dummy_object',
-                ['type' => 'object'],
-                false,
-            ],
-            'oneOf, string: sortable' => [
-                'dummy_oneof_string',
-                ['oneOf' => [['type' => 'null'], ['type' => 'string']]],
-                true,
-            ],
-            'oneOf, number: sortable' => [
-                'dummy_oneof_number',
-                ['oneOf' => [['type' => 'null'], ['type' => 'number']]],
-                true,
-            ],
-            'oneOf, integer: sortable' => [
-                'dummy_oneof_integer',
-                ['oneOf' => [['type' => 'null'], ['type' => 'integer']]],
-                true,
-            ],
-            'oneOf, boolean: sortable' => [
-                'dummy_oneof_boolean',
-                ['oneOf' => [['type' => 'null'], ['type' => 'boolean']]],
-                true,
-            ],
-            'oneOf, date-time: sortable' => [
-                'dummy_oneof_date-time',
-                ['oneOf' => [['type' => 'null'], ['type' => 'date-time']]],
-                true,
-            ],
-            'oneOf, date: sortable' => [
-                'dummy_oneof_date',
-                ['oneOf' => [['type' => 'null'], ['type' => 'date']]],
-                true,
-            ],
-            'oneOf, array: not sortable' => [
-                'dummy_oneof_array',
-                ['oneOf' => [['type' => 'null'], ['type' => 'array']]],
-                false,
-            ],
-            'oneOf, object: not sortable' => [
-                'dummy_oneof_object',
-                ['oneOf' => [['type' => 'null'], ['type' => 'object']]],
-                false,
-            ],
             'date_ranges' => [
                 'date_ranges',
                 [],
                 true,
+            ],
+            'modified' => [
+                'modified',
+                [
+                    'type' => 'string',
+                    'format' => 'date-time',
+                ],
+                true,
+            ],
+            'id' => [
+                'id',
+                [
+                    'type' => 'integer',
+                ],
+                true,
+            ],
+            'title' => [
+                'title',
+                [
+                    'type' => 'string',
+                ],
+                true,
+            ],
+            'sortable from conf' => [
+                'dummy',
+                [
+                    'type' => 'string',
+                ],
+                true,
+            ],
+            'not sortable from conf' => [
+                'dummy2',
+                [
+                    'type' => 'string',
+                ],
+                false,
             ],
         ];
     }
@@ -870,7 +826,9 @@ class SchemaHelperTest extends TestCase
      */
     public function testSortable(string $field, array $schema, bool $expected): void
     {
+        Configure::write('Properties.dummies.sortable', ['dummy']);
         $view = $this->Schema->getView();
+        $view->set('currentModule', ['name' => 'dummies']);
         $view->set('schema', [
             'properties' => [
                 $field => $schema,


### PR DESCRIPTION
Sometimes in modules index page, the columns are considered sortable, even though they are not: a GET on BEdita APIs, with a sort by a non-sortable field, returns an error `[400] Unsupported sorting field`. This avoids that kind of error.

BEdita API don't provide in objects schema that information, whether a property can be used in `?sort=<prop>` or not. So, the approach used is: some fields are considered always sortable (`id`, `title`, `modified`, `date_ranges`); all the other fields are considered not sortable, if they are not set in `Properties.<objectType>.sortable` configuration. An example follows:
```json
{
  "bookings": {
    "sortable": ["booking_status"]
  }
}
```

Ref: https://github.com/bedita/manager/wiki/Setup:-Properties-display#sortable
