### PR TITLE
Avoid sorting custom props from model

### DIFF
--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -365,6 +365,41 @@ class SchemaComponent extends Component
     }
 
     /**
+     * Retrieve list of custom properties for a given object type.
+     *
+     * @param string $type Object type name.
+     * @return array
+     */
+    public function customProps(string $type): array
+    {
+        return (array)Cache::remember(
+            CacheTools::cacheKey(sprintf('custom_props_%s', $type)),
+            function () use ($type) {
+                return $this->fetchCustomProps($type);
+            },
+            self::CACHE_CONFIG
+        );
+    }
+
+    /**
+     * Fetch custom properties for a given object type.
+     *
+     * @param string $type Object type name.
+     * @return array
+     */
+    protected function fetchCustomProps(string $type): array
+    {
+        $query = [
+            'fields' => 'name',
+            'filter' => ['object_type' => $type, 'type' => 'dynamic'],
+            'page_size' => 100,
+        ];
+        $response = ApiClientProvider::getApiClient()->get('/model/properties', $query);
+
+        return (array)Hash::extract($response, 'data.{n}.attributes.name');
+    }
+
+    /**
      * Read object types features from API
      *
      * @return array

--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -389,6 +389,9 @@ class SchemaComponent extends Component
      */
     protected function fetchCustomProps(string $type): array
     {
+        if ($this->getConfig('internalSchema')) {
+            return []; // internal resources don't have custom properties
+        }
         $query = [
             'fields' => 'name',
             'filter' => ['object_type' => $type, 'type' => 'dynamic'],

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -135,6 +135,8 @@ class ModulesController extends AppController
 
         // objectTypes schema
         $this->set('schema', $this->getSchemaForIndex($this->objectType));
+        // custom properties
+        $this->set('customProps', $this->Schema->customProps($this->objectType));
 
         // set prevNext for views navigations
         $this->setObjectNav($objects);

--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -43,6 +43,7 @@ class TranslationsController extends ModulesController
         $this->setRequest($this->getRequest()->withParam('object_type', 'translations'));
         parent::initialize();
         $this->Query->setConfig('include', 'object');
+        $this->Schema->setConfig(['internalSchema' => true]);
     }
 
     /**

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -317,9 +317,10 @@ class SchemaHelper extends Helper
             return true;
         }
         $schema = (array)$this->_View->get('schema');
+        $customProps = (array)$this->_View->get('customProps');
         $schema = Hash::get($schema, sprintf('properties.%s', $field), []);
-        // empty schema, then not sortable
-        if (empty($schema)) {
+        // empty schema or field is a custom prop, then not sortable
+        if (empty($schema) || in_array($field, $customProps)) {
             return false;
         }
         $type = self::typeFromSchema($schema);

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -322,12 +322,12 @@ class SchemaHelper extends Helper
         if (empty($schema)) {
             return false;
         }
+        $type = self::typeFromSchema($schema);
 
-        // check from configuration Properties.%s.sortable
-        $name = Hash::get((array)$this->_View->get('currentModule'), 'name');
-        $sortable = (array)Configure::read(sprintf('Properties.%s.sortable', $name));
+        // not sortable: 'array', 'object'
+        // other types are sortable: 'string', 'number', 'integer', 'boolean', 'date-time', 'date'
 
-        return in_array($field, $sortable);
+        return !in_array($type, ['array', 'object']);
     }
 
     /**

--- a/templates/Element/Modules/index_table_header.twig
+++ b/templates/Element/Modules/index_table_header.twig
@@ -8,7 +8,7 @@
     {% set emptyQuerySearch = (_view.getRequest().getSession().read(currentModule.name ~ '.filter.q')|length == 0) %}
     {% for prop in properties %}
         <div class="{{ Link.sortClass(prop) }}">
-            {% if emptyQuerySearch and Schema.sortable(prop) and not in_array(prop, customProps) %}
+            {% if emptyQuerySearch and Schema.sortable(prop) %}
                 <a href="{{ Link.sortUrl(prop) }}">{{ Property.fieldLabel(prop) }}</a>
             {% else %}
                 {{ Property.fieldLabel(prop) }}

--- a/templates/Element/Modules/index_table_header.twig
+++ b/templates/Element/Modules/index_table_header.twig
@@ -8,7 +8,7 @@
     {% set emptyQuerySearch = (_view.getRequest().getSession().read(currentModule.name ~ '.filter.q')|length == 0) %}
     {% for prop in properties %}
         <div class="{{ Link.sortClass(prop) }}">
-            {% if emptyQuerySearch and Schema.sortable(prop) %}
+            {% if emptyQuerySearch and Schema.sortable(prop) and not in_array(prop, customProps) %}
                 <a href="{{ Link.sortUrl(prop) }}">{{ Property.fieldLabel(prop) }}</a>
             {% else %}
                 {{ Property.fieldLabel(prop) }}

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -740,6 +740,54 @@ class SchemaComponentTest extends TestCase
     }
 
     /**
+     * Test `customProps` method.
+     *
+     * @return void
+     * @covers ::customProps()
+     * @covers ::fetchCustomProps()
+     */
+    public function testCustomProps(): void
+    {
+        $props = [
+            'data' => [
+                [
+                    'id' => '1',
+                    'attributes' => [
+                        'name' => 'custom_prop1',
+                    ],
+                ],
+                [
+                    'id' => '2',
+                    'attributes' => [
+                        'name' => 'custom_prop2',
+                    ],
+                ],
+            ],
+        ];
+
+        // Setup mock API client.
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://api.example.org'])
+            ->getMock();
+        $apiClient->method('get')
+            ->willReturn($props);
+        ApiClientProvider::setApiClient($apiClient);
+
+        Cache::clearAll();
+
+        $this->Schema->setConfig(['internalSchema' => true]);
+        $result = $this->Schema->customProps('translations');
+        static::assertIsArray($result);
+        static::assertEmpty($result);
+
+        $this->Schema->setConfig(['internalSchema' => false]);
+        $result = $this->Schema->customProps('documents');
+        static::assertIsArray($result);
+        static::assertNotEmpty($result);
+        static::assertEquals($result, ['custom_prop1', 'custom_prop2']);
+    }
+
+    /**
      * Test `abstractTypes`
      *
      * @return void

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -770,47 +770,96 @@ class SchemaHelperTest extends TestCase
                 [],
                 false,
             ],
+            'string: sortable' => [
+                'dummy_string',
+                ['type' => 'string'],
+                true,
+            ],
+            'number: sortable' => [
+                'dummy_number',
+                ['type' => 'number'],
+                true,
+            ],
+            'integer: sortable' => [
+                'dummy_integer',
+                ['type' => 'integer'],
+                true,
+            ],
+            'boolean: sortable' => [
+                'dummy_boolean',
+                ['type' => 'boolean'],
+                true,
+            ],
+            'date-time: sortable' => [
+                'dummy_date-time',
+                ['type' => 'date-time'],
+                true,
+            ],
+            'date: sortable' => [
+                'dummy_date',
+                ['type' => 'date'],
+                true,
+            ],
+            'array: not sortable' => [
+                'dummy_array',
+                ['type' => 'array'],
+                false,
+            ],
+            'object: not sortable' => [
+                'dummy_object',
+                ['type' => 'object'],
+                false,
+            ],
+            'oneOf, string: sortable' => [
+                'dummy_oneof_string',
+                ['oneOf' => [['type' => 'null'], ['type' => 'string']]],
+                true,
+            ],
+            'oneOf, number: sortable' => [
+                'dummy_oneof_number',
+                ['oneOf' => [['type' => 'null'], ['type' => 'number']]],
+                true,
+            ],
+            'oneOf, integer: sortable' => [
+                'dummy_oneof_integer',
+                ['oneOf' => [['type' => 'null'], ['type' => 'integer']]],
+                true,
+            ],
+            'oneOf, boolean: sortable' => [
+                'dummy_oneof_boolean',
+                ['oneOf' => [['type' => 'null'], ['type' => 'boolean']]],
+                true,
+            ],
+            'oneOf, date-time: sortable' => [
+                'dummy_oneof_date-time',
+                ['oneOf' => [['type' => 'null'], ['type' => 'date-time']]],
+                true,
+            ],
+            'oneOf, date: sortable' => [
+                'dummy_oneof_date',
+                ['oneOf' => [['type' => 'null'], ['type' => 'date']]],
+                true,
+            ],
+            'oneOf, array: not sortable' => [
+                'dummy_oneof_array',
+                ['oneOf' => [['type' => 'null'], ['type' => 'array']]],
+                false,
+            ],
+            'oneOf, object: not sortable' => [
+                'dummy_oneof_object',
+                ['oneOf' => [['type' => 'null'], ['type' => 'object']]],
+                false,
+            ],
             'date_ranges' => [
                 'date_ranges',
                 [],
                 true,
             ],
-            'modified' => [
-                'modified',
-                [
-                    'type' => 'string',
-                    'format' => 'date-time',
-                ],
-                true,
-            ],
-            'id' => [
-                'id',
-                [
-                    'type' => 'integer',
-                ],
-                true,
-            ],
-            'title' => [
-                'title',
-                [
-                    'type' => 'string',
-                ],
-                true,
-            ],
-            'sortable from conf' => [
-                'dummy',
-                [
-                    'type' => 'string',
-                ],
-                true,
-            ],
-            'not sortable from conf' => [
-                'dummy2',
-                [
-                    'type' => 'string',
-                ],
+            'custom_prop' => [
+                'custom_prop',
+                [],
                 false,
-            ],
+            ]
         ];
     }
 
@@ -826,14 +875,13 @@ class SchemaHelperTest extends TestCase
      */
     public function testSortable(string $field, array $schema, bool $expected): void
     {
-        Configure::write('Properties.dummies.sortable', ['dummy']);
         $view = $this->Schema->getView();
-        $view->set('currentModule', ['name' => 'dummies']);
         $view->set('schema', [
             'properties' => [
                 $field => $schema,
             ],
         ]);
+        $view->set('custom_props', ['custom_prop']);
         $actual = $this->Schema->sortable($field);
         static::assertSame($expected, $actual);
     }

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -859,7 +859,7 @@ class SchemaHelperTest extends TestCase
                 'custom_prop',
                 [],
                 false,
-            ]
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR introduces a fix on how `sortable` properties in modules index are handled. 
Instead of relaying on a configuration we check if the property type is sortable (property must be scalar, not a vector or an object) and if it's not a custom property since those properties are not sortable in BEdita API right now.