### PR TITLE
Remove api call in trash delete

### DIFF
--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -228,7 +228,6 @@ class TrashController extends AppController
     public function deleteMulti(array $ids): bool
     {
         try {
-            $response = $this->apiClient->get('/streams', ['filter' => ['object_id' => $ids]]);
             $this->apiClient->removeObjects($ids);
         } catch (BEditaClientException $e) {
             // Error! Back to object view.


### PR DESCRIPTION
This removes a `GET` call, that is not useful, from trash delete multi.