### PR TITLE
Fix translation view translatable fields

### DIFF
--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -126,6 +126,7 @@ class TranslationsController extends ModulesController
         }
         $this->ProjectConfiguration->read();
 
+        $this->Schema->setConfig(['internalSchema' => false]);
         $this->set('schema', $this->Schema->getSchema($this->objectType));
 
         $object = Hash::extract($response, 'data');


### PR DESCRIPTION
This fixes a bug in translation view, by loading schema with internal schema false to fetch all translatable fields properly.