### PR TITLE
Fix translation add: view translatable fields

### DIFF
--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -78,7 +78,7 @@ class TranslationsController extends ModulesController
             return $this->redirect(['_name' => 'modules:view', 'object_type' => $this->objectType, 'id' => $id]);
         }
         $this->ProjectConfiguration->read();
-
+        $this->Schema->setConfig(['internalSchema' => false]);
         $this->set('schema', $this->Schema->getSchema($this->objectType));
 
         $object = Hash::extract($response, 'data');


### PR DESCRIPTION
This fixes a buggy behaviour in translation add: show fields by disabling "internal schema" (as done in #1217 ).