### PR TITLE
Preserve user given title for cloned object uname

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -364,6 +364,11 @@ class ModulesController extends AppController
                 'title' => $this->getRequest()->getQuery('title'),
                 'status' => 'draft',
             ];
+
+            if (!empty($modified['title'])) {
+                $modified['uname'] = $modified['title'];
+            }
+
             $reset = (array)Configure::read(sprintf('Clone.%s.reset', $this->objectType));
             foreach ($reset as $field) {
                 $modified[$field] = null;


### PR DESCRIPTION
Currently, the UI for cloning an object requests to the user to choose a title, otherwise `<current-title>-"copy"` is used.

However, the newly cloned object `uname`, even when the user chooses a new title, is still computed starting from the original title, instead of using the given one.

In this PR we modify the ModulesController behaviour only on this particular case, where the method handles the user title for the new object. If given, we "proposed" the new title as the new uname -- the later call to the clone API will take care of escaping and/or check for available unames and will manage it as before.