### PR TITLE
Update dependabot conf, group "bedita"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     groups:
       gh-actions:
         patterns: ['actions/*']
+      bedita:
+        patterns: ['bedita/*']
       docker:
         patterns: ['docker/*']
-      codecov:
-        patterns: ['codecov/*']


### PR DESCRIPTION
This updates dependabot conf to deal with "bedita/*" workflows.