### PR TITLE
Use more reasonable default upload MIME types

### DIFF
--- a/src/View/Helper/SystemHelper.php
+++ b/src/View/Helper/SystemHelper.php
@@ -45,6 +45,24 @@ class SystemHelper extends Helper
         'audio' => [
             'audio/*',
         ],
+        'files' => [
+            'application/msword', // .doc, .dot
+            'application/pdf', // .pdf
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // .docx
+            'application/vnd.ms-excel', // .xls, .xlt, .xla
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // .xlsx
+            'application/vnd.ms-powerpoint', // .ppt, .pot, .pps, .ppa
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx
+            'application/x-mpegURL',
+            'audio/*',
+            'text/csv',
+            'text/html',
+            'text/plain',
+            'text/rtf',
+            'text/xml',
+            'image/*',
+            'video/*',
+        ],
         'images' => [
             'image/*',
         ],
@@ -53,9 +71,21 @@ class SystemHelper extends Helper
             'video/*',
         ],
         'media' => [
+            'application/msword', // .doc, .dot
+            'application/pdf', // .pdf
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // .docx
+            'application/vnd.ms-excel', // .xls, .xlt, .xla
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // .xlsx
+            'application/vnd.ms-powerpoint', // .ppt, .pot, .pps, .ppa
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx
             'application/x-mpegURL',
             'audio/*',
             'image/*',
+            'text/csv',
+            'text/html',
+            'text/plain',
+            'text/rtf',
+            'text/xml',
             'video/*',
         ],
     ];


### PR DESCRIPTION
Add more common and non-dangerous MIME types to `SystemHelper::$defaultUploadAccepted` array and avoid to add a custom configuration when not necessary.
