### PR TITLE
Media and files upload: skip check mime type

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -666,52 +666,18 @@ return [
 
     /**
      * Upload configurations.
+     *
+     * 'files' and 'media' accept all mimes, so no configuration needed.
      */
     // 'uploadAccepted' => [
     //     'audio' => [
     //         'audio/*',
-    //     ],
-    //     'files' => [
-    //         'application/msword', // .doc, .dot
-    //         'application/pdf', // .pdf
-    //         'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // .docx
-    //         'application/vnd.ms-excel', // .xls, .xlt, .xla
-    //         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // .xlsx
-    //         'application/vnd.ms-powerpoint', // .ppt, .pot, .pps, .ppa
-    //         'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx
-    //         'application/x-mpegURL',
-    //         'audio/*',
-    //         'text/csv',
-    //         'text/html',
-    //         'text/plain',
-    //         'text/rtf',
-    //         'text/xml',
-    //         'image/*',
-    //         'video/*',
     //     ],
     //     'images' => [
     //         'image/*',
     //     ],
     //     'videos' => [
     //         'application/x-mpegURL',
-    //         'video/*',
-    //     ],
-    //     'media' => [
-    //         'application/msword', // .doc, .dot
-    //         'application/pdf', // .pdf
-    //         'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // .docx
-    //         'application/vnd.ms-excel', // .xls, .xlt, .xla
-    //         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // .xlsx
-    //         'application/vnd.ms-powerpoint', // .ppt, .pot, .pps, .ppa
-    //         'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx
-    //         'application/x-mpegURL',
-    //         'audio/*',
-    //         'image/*',
-    //         'text/csv',
-    //         'text/html',
-    //         'text/plain',
-    //         'text/rtf',
-    //         'text/xml',
     //         'video/*',
     //     ],
     // ],

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -198,8 +198,9 @@ export default {
 
                 /** accepted mime types check */
                 const mimes = BEDITA.uploadConfig?.accepted;
-                if (!['files', 'media'].includes(objectType) && mimes?.[objectType] && !this.checkAcceptedMime(mimes[objectType], fileType)) {
-                    const msg = t`File type not accepted` + `: "${fileType}". ` + t`Accepted types` + `: "${mimes[objectType].join('", "')}".`;
+                const ot = objectType === 'media' ? this.getObjectTypeFromMime(fileType) : objectType;
+                if (ot !== 'files' && mimes?.[ot] && !this.checkAcceptedMime(mimes[ot], fileType)) {
+                    const msg = t`File type not accepted` + `: "${fileType}". ` + t`Accepted types` + `: "${mimes[ot].join('", "')}".`;
                     BEDITA.warning(msg);
 
                     return false;

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -198,7 +198,7 @@ export default {
 
                 /** accepted mime types check */
                 const mimes = BEDITA.uploadConfig?.accepted;
-                if (['files', 'media'].includes(objectType) && mimes?.[objectType] && !this.checkAcceptedMime(mimes[objectType], fileType)) {
+                if (!['files', 'media'].includes(objectType) && mimes?.[objectType] && !this.checkAcceptedMime(mimes[objectType], fileType)) {
                     const msg = t`File type not accepted` + `: "${fileType}". ` + t`Accepted types` + `: "${mimes[objectType].join('", "')}".`;
                     BEDITA.warning(msg);
 

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -167,7 +167,7 @@ export default {
             },
 
             acceptMimeTypes(type) {
-                if (!BEDITA.uploadConfig?.accepted?.[type]) {
+                if (['files', 'media'].includes(type) || !BEDITA.uploadConfig?.accepted?.[type]) {
                     return '';
                 }
 
@@ -198,7 +198,7 @@ export default {
 
                 /** accepted mime types check */
                 const mimes = BEDITA.uploadConfig?.accepted;
-                if (mimes?.[objectType] && !this.checkAcceptedMime(mimes[objectType], fileType)) {
+                if (['files', 'media'].includes(objectType) && mimes?.[objectType] && !this.checkAcceptedMime(mimes[objectType], fileType)) {
                     const msg = t`File type not accepted` + `: "${fileType}". ` + t`Accepted types` + `: "${mimes[objectType].join('", "')}".`;
                     BEDITA.warning(msg);
 

--- a/src/View/Helper/SystemHelper.php
+++ b/src/View/Helper/SystemHelper.php
@@ -52,12 +52,6 @@ class SystemHelper extends Helper
             'application/x-mpegURL',
             'video/*',
         ],
-        'media' => [
-            'application/x-mpegURL',
-            'audio/*',
-            'image/*',
-            'video/*',
-        ],
     ];
 
     /**

--- a/templates/Element/Form/dropupload.twig
+++ b/templates/Element/Form/dropupload.twig
@@ -1,5 +1,7 @@
 {# :accepted-drop="[`.from-relation-${relationName}`,isRelationWithMedia && 'from-files']"> #}
+{% set ot = objectTypes|length == 1 ? objectTypes[0] : 'media' %}
 <drop-upload
+    :object-type="{{ ot|json_encode }}"
     placeholder="{{ __('Click or drop new files here') }}"
     @new-relations="appendRelations"
     v-if="isRelationWithMedia"

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -129,7 +129,9 @@
         </div>
         <div class="mt-5">
             {% if uploadableNum %}
-                {{ element(Element.dropupload(relationsSchema[relationName]['right'])) }}
+                {{ element(Element.dropupload(relationsSchema[relationName]['right']), {
+                    'objectTypes': relationsSchema[relationName]['right']
+                }) }}
             {% endif %}
             <div>
                 <button v-if="isPanelOpen({{object.id|json_encode}})" @click.prevent.stop="closePanel()">


### PR DESCRIPTION
This update the "check mime type". When the object type is "media" or "files", all mime types are accepted.