### PR TITLE
New object, search available for relation

### DIFF
--- a/resources/js/app/mixins/paginated-content.js
+++ b/resources/js/app/mixins/paginated-content.js
@@ -70,6 +70,9 @@ export const PaginatedContentMixin = {
 
                     return Promise.resolve();
                 }
+                if (requestUrl.indexOf('view/relationships') >= 0) {
+                    requestUrl = requestUrl.replace('view/relationships', 'view/0/relationships');
+                }
 
                 // if requestQueue is populated then abort all fetch request and start over
                 if (this.requestsQueue.length > 0) {

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -150,6 +150,7 @@
                 </button>
 
                 <template v-else>
+                    {% if object.id %}
                     <button
                         class="button button-primary button-primary-hover-module-{{ currentModule.name }} is-width-auto"
                         :class="{'is-loading-spinner': resettingRelated}"
@@ -176,6 +177,7 @@
                         <app-icon icon="carbon:save"></app-icon>
                         <span class="ml-05">{{ __('Save') }}</span>
                     </button>
+                    {% endif %}
 
                     <button
                         class="button button-primary button-primary-hover-module-{{ currentModule.name }} is-width-auto"


### PR DESCRIPTION
This fixes a buggy behavior on create new object: searching for "available" related objects always return no data.

This provides a fix: you can search available and add related, in the form, and then save.