### PR TITLE
Fix header `Authorization` in api calls

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -68,6 +68,12 @@ class AppController extends Controller
         ]);
         $this->loadComponent('Schema');
         $this->loadComponent('Categories');
+
+        /** @var \Authentication\Identity|null $identity */
+        $identity = $this->Authentication->getIdentity();
+        if ($identity && $identity->get('tokens')) {
+            $this->apiClient->setupTokens($identity->get('tokens'));
+        }
     }
 
     /**
@@ -77,9 +83,7 @@ class AppController extends Controller
     {
         /** @var \Authentication\Identity|null $identity */
         $identity = $this->Authentication->getIdentity();
-        if ($identity && $identity->get('tokens')) {
-            $this->apiClient->setupTokens($identity->get('tokens'));
-        } elseif (!in_array(rtrim($this->getRequest()->getPath(), '/'), ['/login'])) {
+        if (!($identity && $identity->get('tokens')) && !in_array(rtrim($this->getRequest()->getPath(), '/'), ['/login'])) {
             $route = $this->loginRedirectRoute();
             $this->Flash->error(__('Login required'));
 

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -147,7 +147,7 @@ class AppControllerTest extends TestCase
      */
     public function testInitialize(): void
     {
-        $this->setupController();
+        $this->setupControllerAndLogin();
 
         static::assertNotEmpty($this->AppController->{'RequestHandler'});
         static::assertNotEmpty($this->AppController->{'Flash'});

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -142,12 +142,12 @@ class AppControllerTest extends TestCase
     /**
      * test `initialize` function
      *
-     * @covers ::initialize()
      * @return void
+     * @covers ::initialize()
      */
     public function testInitialize(): void
     {
-        $this->setupControllerAndLogin();
+        $this->setupController();
 
         static::assertNotEmpty($this->AppController->{'RequestHandler'});
         static::assertNotEmpty($this->AppController->{'Flash'});
@@ -181,21 +181,20 @@ class AppControllerTest extends TestCase
     }
 
     /**
-     * test 'beforeFilter' for correct apiClient token setup
+     * test 'initialize' and 'beforeFilter' for correct apiClient token setup
      *
-     * @covers ::beforeFilter()
      * @return void
+     * @covers ::beforeFilter()
+     * @covers ::initialize()
      */
-    public function testBeforeFilterCorrectTokens(): void
+    public function testCorrectTokens(): void
     {
         $expectedtokens = [];
-
         $this->setupControllerAndLogin();
-
         /** @var \Authentication\Identity|null $user */
         $user = $this->AppController->Authentication->getIdentity();
         $expectedtokens = $user->get('tokens');
-        $this->AppController->dispatchEvent('Controller.initialize');
+        $this->AppController->initialize();
         $apiClient = $this->accessProperty($this->AppController, 'apiClient');
         $apiClientTokens = $apiClient->getTokens();
 


### PR DESCRIPTION
This avoids an unexpected behaviour from components apiclient calls, that don't use header `Authorization`.

This refactorizes `AppController.php` and moves some logic from `beforeFilter` to `initialize`, so that api client setup tokens is done before the component beforeFilter... This way the component apiClient inherits the header `Authorization` propertly.