### PR TITLE
User roles on creation

### DIFF
--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -97,6 +97,7 @@ class PropertiesComponent extends Component
         'lang',
         'children_order',
         'captions',
+        'roles',
     ];
 
     /**

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -189,15 +189,26 @@ class AppControllerTest extends TestCase
      */
     public function testCorrectTokens(): void
     {
-        $expectedtokens = [];
+        // no auth
+        $this->setupControllerAndLogin();
+        $expected = ['jwt', 'renew'];
+        $emptyUser = new Identity([]);
+        $this->AppController->Authentication->setIdentity($emptyUser);
+        $this->AppController->dispatchEvent('Controller.initialize');
+        $apiClient = $this->accessProperty($this->AppController, 'apiClient');
+        $apiClientTokens = $apiClient->getTokens();
+        $actual = array_keys($apiClientTokens);
+        static::assertEquals($expected, $actual);
+
+        // auth
         $this->setupControllerAndLogin();
         /** @var \Authentication\Identity|null $user */
         $user = $this->AppController->Authentication->getIdentity();
         $expectedtokens = $user->get('tokens');
         $this->AppController->initialize();
+        $this->AppController->dispatchEvent('Controller.initialize');
         $apiClient = $this->accessProperty($this->AppController, 'apiClient');
         $apiClientTokens = $apiClient->getTokens();
-
         static::assertEquals($expectedtokens, $apiClientTokens);
     }
 


### PR DESCRIPTION
In the view of a single user, the property `roles` is shown in the right sidebar. When creating a new object it's shown twice, also inside the group `Other`; this fixes it, to show `Roles` just once, as it is supposed to be.