### PR TITLE
Rich text placeholder params

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -614,10 +614,12 @@ return [
     //         'bearing' => 'integer',
     //         'pitch' => 'integer',
     //         'zoom' => 'integer',
+    //         'caption' => 'richtext'
     //     ],
     //     'videos' => [
     //         'controls' => 'boolean',
     //         'autoplay' => 'boolean',
+    //         'caption' => 'richtext',
     //     ],
     // ],
 

--- a/resources/js/app/components/placeholder-list/placeholder-list.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-list.vue
@@ -11,19 +11,54 @@
             v-for="item in items"
             :key="itemKey(item)"
         >
-            <app-icon v-if="item.obj?.type === 'audio'" icon="carbon:document-audio" height="24" />
-            <app-icon v-if="item.obj?.type === 'documents'" icon="carbon:document" height="24" />
-            <app-icon v-if="item.obj?.type === 'events'" icon="carbon:event" height="24" />
-            <app-icon v-if="item.obj?.type === 'files'" icon="carbon:document-blank" height="24" />
-            <app-icon v-if="item.obj?.type === 'images'" icon="carbon:image" height="24" />
-            <app-icon v-if="item.obj?.type === 'links'" icon="carbon:link" height="24" />
-            <app-icon v-if="item.obj?.type === 'locations'" icon="carbon:location" height="24" />
-            <app-icon v-if="item.obj?.type === 'news'" icon="carbon:calendar" height="24" />
-            <app-icon v-if="item.obj?.type === 'profiles'" icon="carbon:person" height="24" />
-            <app-icon v-if="item.obj?.type === 'publications'" icon="carbon:wikis" height="24" />
-            <app-icon v-if="item.obj?.type === 'videos'" icon="carbon:video" height="24" />
+            <div class="placeholder-item-name">
+                <app-icon icon="carbon:document-audio"
+                          height="24"
+                          v-if="item.obj?.type === 'audio'"
+                />
+                <app-icon icon="carbon:document"
+                          height="24"
+                          v-if="item.obj?.type === 'documents'"
+                />
+                <app-icon icon="carbon:event"
+                          height="24"
+                          v-if="item.obj?.type === 'events'"
+                />
+                <app-icon icon="carbon:document-blank"
+                          height="24"
+                          v-if="item.obj?.type === 'files'"
+                />
+                <app-icon icon="carbon:image"
+                          height="24"
+                          v-if="item.obj?.type === 'images'"
+                />
+                <app-icon icon="carbon:link"
+                          height="24"
+                          v-if="item.obj?.type === 'links'"
+                />
+                <app-icon icon="carbon:location"
+                          height="24"
+                          v-if="item.obj?.type === 'locations'"
+                />
+                <app-icon icon="carbon:calendar"
+                          height="24"
+                          v-if="item.obj?.type === 'news'"
+                />
+                <app-icon icon="carbon:person"
+                          height="24"
+                          v-if="item.obj?.type === 'profiles'"
+                />
+                <app-icon icon="carbon:wikis"
+                          height="24"
+                          v-if="item.obj?.type === 'publications'"
+                />
+                <app-icon icon="carbon:video"
+                          height="24"
+                          v-if="item.obj?.type === 'videos'"
+                />
 
-            <span>{{ item.obj?.title }}</span>
+                <span>{{ item.obj?.title }}</span>
+            </div>
             <placeholder-params
                 :id="item.id"
                 :field="field"
@@ -163,11 +198,19 @@ div.placeholdersList > div.header {
 }
 div.placeholdersList > div.placeholder-item {
     display: grid;
-    grid-template-columns: 5% 60% 1fr;
+    grid-template-columns: 35% 60% 1fr;
     text-align: left;
     align-items: center;
     gap: 8px;
+    padding: 4px 0;
     margin: 4px 0;
     border-top: dotted 1px #ccc;
+}
+div.placeholdersList > div.placeholder-item > div.placeholder-item-name {
+    display: flex;
+    align-items: start;
+    align-self: flex-start;
+    gap: 8px;
+    margin: 4px 0;
 }
 </style>

--- a/resources/js/app/components/placeholder-list/placeholder-params.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-params.vue
@@ -96,7 +96,6 @@ export default {
             }
             try {
                 this.decodedValue = JSON.parse(decoded);
-                console.log(this.decodedValue);
             } catch(e) {
                 console.error(e, decoded, this.value);
             }

--- a/resources/js/app/components/placeholder-list/placeholder-params.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-params.vue
@@ -1,20 +1,51 @@
 <template>
     <div class="placeholderParams">
-        <div v-for="column in Object.keys(parameters)">
-            <span>{{ t(column) }}</span>
+        <div v-for="column in Object.keys(parameters)"
+             :key="column"
+        >
+            <span class="paramName">{{ t(column) }}</span>
             <template v-if="parameters[column] === 'integer'">
-                <input type="number" :placeholder="column" v-model="decodedValue[column]" @change="changeParams" />
+                <input type="number"
+                       :placeholder="column"
+                       v-model="decodedValue[column]"
+                       @change="changeParams"
+                >
             </template>
             <template v-if="parameters[column] === 'string'">
-                <input type="text" :placeholder="column" v-model="decodedValue[column]" @change="changeParams" />
+                <input type="text"
+                       :placeholder="column"
+                       v-model="decodedValue[column]"
+                       @change="changeParams"
+                >
             </template>
             <template v-if="parameters[column] === 'boolean'">
-                <input type="checkbox" v-model="decodedValue[column]" @click="changeParams" />
+                <input type="checkbox"
+                       v-model="decodedValue[column]"
+                       @click="changeParams"
+                >
+            </template>
+            <template v-if="parameters[column] === 'richtext'">
+                <field-textarea
+                    :id="`${column}-${Math.random().toString(36)}`"
+                    :name="column"
+                    :field="column"
+                    :value="decodedValue[column]"
+                    @change="(value) => changeRichText(value, column)"
+                />
             </template>
             <template v-if="typeof parameters[column] === 'object' ">
-                <select v-model="decodedValue[column]" @change="changeParams">
-                    <option v-for="option in parameters[column]" :value="option">{{ t(option) }}</option>
-                </select>
+                <div>
+                    <select v-model="decodedValue[column]"
+                            @change="changeParams"
+                    >
+                        <option v-for="option in parameters[column]"
+                                :key="option"
+                                :value="option"
+                        >
+                            {{ t(option) }}
+                        </option>
+                    </select>
+                </div>
             </template>
         </div>
     </div>
@@ -82,6 +113,10 @@ export default {
             });
             this.oldValue = this.newValue;
         },
+        changeRichText(value, column) {
+            this.decodedValue[column] = value;
+            this.changeParams();
+        },
         decoded(item) {
             return atob(item);
         },
@@ -91,10 +126,12 @@ export default {
 <style>
 div.placeholderParams {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    text-align: center;
     align-items: center;
     gap: 8px;
     margin: 4px 0;
+
+    .paramName {
+        text-transform: capitalize;
+    }
 }
 </style>

--- a/resources/js/app/components/placeholder-list/placeholder-params.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-params.vue
@@ -21,7 +21,7 @@
             <template v-if="parameters[column] === 'boolean'">
                 <input type="checkbox"
                        v-model="decodedValue[column]"
-                       @click="changeParams"
+                       @change="changeParams"
                 >
             </template>
             <template v-if="parameters[column] === 'richtext'">
@@ -96,6 +96,7 @@ export default {
             }
             try {
                 this.decodedValue = JSON.parse(decoded);
+                console.log(this.decodedValue);
             } catch(e) {
                 console.error(e, decoded, this.value);
             }
@@ -113,6 +114,10 @@ export default {
             });
             this.oldValue = this.newValue;
         },
+        changeParamsBoolean(value, column) {
+            this.decodedValue[column] = value;
+            this.changeParams();
+        },
         changeRichText(value, column) {
             this.decodedValue[column] = value;
             this.changeParams();
@@ -125,13 +130,15 @@ export default {
 </script>
 <style>
 div.placeholderParams {
-    display: grid;
-    align-items: center;
+    display: flex;
+    flex-direction: column;
     gap: 8px;
     margin: 4px 0;
+}
 
-    .paramName {
-        text-transform: capitalize;
-    }
+.paramName {
+    display: block;
+    margin-bottom: 4px;
+    text-transform: capitalize;
 }
 </style>


### PR DESCRIPTION
This PR introduce a richtext type for placeholders params, showing tiny editor like this:
To use richtext type rember to add a configuration of tiny inside `UI.richeditor.$nameOfParam`.        

<img width="827" alt="Screenshot 2025-03-11 alle 01 04 11" src="https://github.com/user-attachments/assets/54ec0aca-4bd2-481b-ad34-ca52f9bcfb48" />
