### PR TITLE
Fix modules access control: use BEM roles only

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -186,8 +186,7 @@ class ModulesComponent extends Component
         if (empty($user) || empty($user->getOriginalData())) {
             return;
         }
-
-        $roles = (array)$user->get('roles');
+        $roles = array_intersect(array_keys($accessControl), (array)$user->get('roles'));
         $modules = (array)array_keys($this->modules);
         $hidden = [];
         $readonly = [];


### PR DESCRIPTION
When an user has multiple roles and one of them is a role for another application (not BEM), the user now inherits that role privileges, and this way the AccessControl configuration can be bypassed.
This fixes it by considering BEM roles only when checking AccessControl per module and authenticated user.