### PR TITLE
Fix tinymce richeditor unbind

### DIFF
--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -67,8 +67,8 @@ export default {
                 });
             },
 
-            unbind() {
-                tinymce.remove();
+            unbind(element) {
+                tinymce.remove(element.editor);
             },
 
             /**
@@ -82,8 +82,12 @@ export default {
                 if (binding?.value?.toolbar) {
                     toolbar = binding.value.toolbar.join(' ');
                 } else if (binding?.expression) {
-                    let exp = JSON.parse(binding.expression);
-                    toolbar = exp ? exp.join(' ') : toolbar;
+                    try {
+                        const exp = JSON.parse(binding.expression);
+                        toolbar = exp.join(' ');
+                    } catch (e) {
+                        // do nothing
+                    }
                 }
                 if (!binding.modifiers?.placeholders) {
                     toolbar = toolbar.replace(/\bplaceholders\b/, '');

--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -84,7 +84,7 @@ export default {
                 } else if (binding?.expression) {
                     try {
                         const exp = JSON.parse(binding.expression);
-                        toolbar = exp.join(' ');
+                        toolbar = exp ? exp.join(' ') : toolbar;
                     } catch (e) {
                         // do nothing
                     }


### PR DESCRIPTION
This fixes a glitch in richtext fields: when adding objects from "fast create form field", all richtext fields become simple textareas. This issue is caused by a global remove of all tinymce instances in the page.
The fix: on richeditor unbind, remove the element editor only, not all elements.