### PR TITLE
Richeditor configuration for fields from fast create form

### DIFF
--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -77,6 +77,12 @@ export default {
              * @param {Object} element DOM object
              */
             async inserted(element, binding) {
+                let elementName = element?.name || '';
+                if (elementName.indexOf('fast-') === 0) {
+                    const lastPos = elementName.lastIndexOf('-');
+                    elementName = elementName.substring(lastPos + 1);
+                }
+
                 let changing = false;
                 let toolbar = DEFAULT_TOOLBAR;
                 if (binding?.value?.toolbar) {
@@ -102,12 +108,12 @@ export default {
                         sizes.min_height = c.min_height;
                     }
                 }
-                if (BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.height) {
-                    sizes.height = BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.height;
+                if (BEDITA?.richeditorByPropertyConfig?.[elementName]?.config?.height) {
+                    sizes.height = BEDITA?.richeditorByPropertyConfig?.[elementName]?.config?.height;
                 }
-                sizes.min_height = BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.min_height || sizes.height || 300;
-                if (BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.max_height) {
-                    sizes.max_height = BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config?.max_height;
+                sizes.min_height = BEDITA?.richeditorByPropertyConfig?.[elementName]?.config?.min_height || sizes.height || 300;
+                if (BEDITA?.richeditorByPropertyConfig?.[elementName]?.config?.max_height) {
+                    sizes.max_height = BEDITA?.richeditorByPropertyConfig?.[elementName]?.config?.max_height;
                 }
                 sizes.max_height = sizes.min_height > 500 ? sizes.min_height + 500 : 500;
                 const { default: contentCSS } = await import('../../../richeditor.lazy.scss');
@@ -142,7 +148,7 @@ export default {
                     add_unload_trigger: false, // fix populating textarea elements with garbage when the user initiates a navigation with unsaved changes, but cancels it when the alert is shown
                     readonly: element.getAttribute('readonly') === 'readonly' ? 1 : 0,
                     ... BEDITA?.richeditorConfig,
-                    ... BEDITA?.richeditorByPropertyConfig?.[element?.name]?.config || {},
+                    ... BEDITA?.richeditorByPropertyConfig?.[elementName]?.config || {},
                     setup: (editor) => {
                         editor.on('change', () => {
                             EventBus.send('refresh-placeholders', {id: editor.id, content: editor.getContent()});


### PR DESCRIPTION
This fixes the richeditor configuration for fields that belong to fast create form