### PR TITLE
Configuration `Upload.uploadMaxSize`

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -714,7 +714,7 @@ return [
     //     ],
     // ],
     // 'uploadMaxResolution' => '1920x1080',
-    // 'uploadMaxSize' => '-1', // -1 means no limit, otherwise set a limit in megabytes
+    // 'uploadMaxSize' => -1, // -1 means no limit, otherwise set a limit in megabytes
 
     /**
      * Configuration for "Children" association parameters.

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -714,6 +714,7 @@ return [
     //     ],
     // ],
     // 'uploadMaxResolution' => '1920x1080',
+    // 'uploadMaxSize' => '-1', // -1 means no limit, otherwise set a limit in megabytes
 
     /**
      * Configuration for "Children" association parameters.

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -714,7 +714,7 @@ return [
     //     ],
     // ],
     // 'uploadMaxResolution' => '1920x1080',
-    // 'uploadMaxSize' => -1, // -1 means no limit, otherwise set a limit in megabytes
+    // 'uploadMaxSize' => -1, // -1 means no limit, otherwise set a limit in bytes
 
     /**
      * Configuration for "Children" association parameters.

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -78,8 +78,11 @@ export default {
              * @returns {Boolean}
              */
             checkMaxFileSize(file) {
-                const fileSize = Math.round(file.size);
                 const maxFileSize = BEDITA.maxFileSize;
+                if (maxFileSize < 0) {// no limit
+                    return true;
+                }
+                const fileSize = Math.round(file.size);
                 if (fileSize >= maxFileSize) {
                     const filename = file.name;
                     const fileSizeMb = Math.round(fileSize / 1024 / 1024);

--- a/src/View/Helper/SystemHelper.php
+++ b/src/View/Helper/SystemHelper.php
@@ -100,6 +100,10 @@ class SystemHelper extends Helper
      */
     public function getMaxFileSize(): int
     {
+        $forcedMaxFileSize = Configure::read('Upload.uploadMaxSize');
+        if ($forcedMaxFileSize) {
+            return $forcedMaxFileSize;
+        }
         $postMaxSize = intVal(substr(ini_get('post_max_size'), 0, -1));
         $uploadMaxFilesize = intVal(substr(ini_get('upload_max_filesize'), 0, -1));
 

--- a/tests/TestCase/View/Helper/SystemHelperTest.php
+++ b/tests/TestCase/View/Helper/SystemHelperTest.php
@@ -70,6 +70,12 @@ class SystemHelperTest extends TestCase
         $expected = min($pms, $umf) * 1024 * 1024;
         $actual = $this->System->getMaxFileSize();
         static::assertSame($expected, $actual);
+        // test with forced max file size
+        $forcedMaxFileSize = -1;
+        Configure::write('Upload.uploadMaxSize', $forcedMaxFileSize);
+        $actual = $this->System->getMaxFileSize();
+        static::assertSame($forcedMaxFileSize, $actual);
+        Configure::delete('Upload.uploadMaxSize');
     }
 
     /**


### PR DESCRIPTION
This provides a way to force the "upload max size" from the configuration `Upload.uploadMaxSize`. If no configuration is set, BEM calculates the value considering the min value between `post_max_size` and `upload_max_filesize`.

Examples:
```
'Upload' => [
    'uploadMaxSize' => -1, // no limit
    //'uploadMaxSize' => 10 * 1024 * 1024, // 10Mb
],
```