### PR TITLE
Readonly json fields

### DIFF
--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -82,7 +82,7 @@ class PropertyHelper extends Helper
         if ($readonly === true && array_key_exists('v-datepicker', $controlOptions)) {
             unset($controlOptions['v-datepicker']);
         }
-        if (Hash::get($controlOptions, 'class') === 'json' || Hash::get($controlOptions, 'type') === 'json') {
+        if (!$readonly && Hash::get($controlOptions, 'class') === 'json' || Hash::get($controlOptions, 'type') === 'json') {
             $jsonKeys = (array)Configure::read('_jsonKeys');
             Configure::write('_jsonKeys', array_merge($jsonKeys, [$name]));
         }


### PR DESCRIPTION
This fixes a buggy behavior when saving a json field that has been set as `readonly` by `Properties.<type>.options.<field>` configuration.