### PR TITLE
Restore properties in model object types

### DIFF
--- a/src/Controller/Model/ObjectTypesController.php
+++ b/src/Controller/Model/ObjectTypesController.php
@@ -182,20 +182,24 @@ class ObjectTypesController extends ModelBaseController
      */
     protected function prepareProperties(array $data, string $name): array
     {
-        $map = [
-            'core' => [],
-            'inherited' => [],
-            'custom' => [],
-        ];
+        $inherited = $core = $custom = [];
         foreach ($data as $prop) {
-            $key = !is_numeric($prop['id']) ? ($prop['attributes']['object_type_name'] === $name ? 'core' : 'prop') : 'custom';
-            $map[$key][] = $prop;
+            if (!is_numeric($prop['id'])) {
+                $type = $prop['attributes']['object_type_name'];
+                if ($type == $name) {
+                    $core[] = $prop;
+                } else {
+                    $inherited[] = $prop;
+                }
+            } else {
+                $custom[] = $prop;
+            }
         }
 
         return [
-            'core' => Hash::sort($map['core'], '{n}.attributes.name'),
-            'inherited' => Hash::sort($map['inherited'], '{n}.attributes.name'),
-            'custom' => Hash::sort($map['custom'], '{n}.attributes.name'),
+            'core' => Hash::sort($core, '{n}.attributes.name'),
+            'inherited' => Hash::sort($inherited, '{n}.attributes.name'),
+            'custom' => Hash::sort($custom, '{n}.attributes.name'),
         ];
     }
 

--- a/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -180,6 +180,50 @@ class ObjectTypesControllerTest extends TestCase
     }
 
     /**
+     * Test `prepareProperties` method
+     *
+     * @return void
+     * @covers ::prepareProperties()
+     */
+    public function testPrepareCustomProperties(): void
+    {
+        $controller = new class (new ServerRequest()) extends ObjectTypesController {
+            public function prepareProperties(array $data, string $name): array
+            {
+                return parent::prepareProperties($data, $name);
+            }
+        };
+        $data = [
+            [
+                'id' => '123',
+                'name' => 'my_prop',
+                'type' => 'datetime',
+                'description' => 'My custom property',
+                'default' => null,
+                'required' => false,
+                'multiple' => false,
+            ],
+        ];
+        $expected = [
+            'core' => [],
+            'inherited' => [],
+            'custom' => [
+                [
+                    'id' => '123',
+                    'name' => 'my_prop',
+                    'type' => 'datetime',
+                    'description' => 'My custom property',
+                    'default' => null,
+                    'required' => false,
+                    'multiple' => false,
+                ],
+            ],
+        ];
+        $actual = $controller->prepareProperties($data, 'test');
+        static::assertSame($expected, $actual);
+    }
+
+    /**
      * Test `updateSchema`
      *
      * @return void


### PR DESCRIPTION
This fixes a buggy behaviour introduced by https://github.com/bedita/manager/pull/1233