### PR TITLE
No MAX_UPLOAD_SIZE in form if -1

### DIFF
--- a/templates/Element/Form/upload.twig
+++ b/templates/Element/Form/upload.twig
@@ -26,7 +26,9 @@
 
                 <div class="h-tabs-contents">
                     <div class="h-tab" v-show="activeIndex == 0">
-                        {{ Form.hidden('MAX_FILE_SIZE', {'value': System.getMaxFileSize()})|raw }}
+                        {% if System.getMaxFileSize() > 0 %}
+                            {{ Form.hidden('MAX_FILE_SIZE', {'value': System.getMaxFileSize()})|raw }}
+                        {% endif %}
                         {{ element('Form/form_file_upload') }}
                         {{ Form.control('model-type', { 'type': 'hidden', 'value': object.type}) | raw }}
                     </div>


### PR DESCRIPTION
This fixes a bug introduced by https://github.com/bedita/manager/pull/1250

If `Upload.uploadMaxSize` is "-1", this remove `MAX_UPLOAD_SIZE` from form, avoiding a `Laminas\Diactoros\UploadedFile` error `The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form`.