### PR TITLE
Calendar in readonly mode

### DIFF
--- a/resources/js/app/components/date-range/date-range.vue
+++ b/resources/js/app/components/date-range/date-range.vue
@@ -62,7 +62,7 @@
                 {{ msgEveryDay }}
             </label>
         </div>
-        <div>
+        <div v-if="!readonly">
             <button
                 class="button button-primary"
                 @click.prevent="remove($event)"
@@ -158,6 +158,10 @@ export default {
         options: {
             type: Object,
             default: () => ({}),
+        },
+        readonly: {
+            type: Boolean,
+            default: false,
         },
         source: {
             type: Object,
@@ -370,10 +374,8 @@ export default {
             const input = dateRange || this.range;
             const button = document.querySelector('button[form=form-main]');
             const valid = skip || input?.start_date ? true : this.msdiff(input) > 0;
-            if (input?.start_date && !valid) {
-                button.disabled = 'disabled';
-            } else {
-                button.disabled = false;
+            if (button) {
+                button.disabled = input?.start_date && !valid ? 'disabled' : false;
             }
 
             return valid;

--- a/resources/js/app/components/date-ranges-view/date-ranges-view.vue
+++ b/resources/js/app/components/date-ranges-view/date-ranges-view.vue
@@ -5,6 +5,7 @@
                 v-for="(dateRange, index) in dateRanges"
                 :key="index"
                 :options="options"
+                :readonly="readonly"
                 :source="dateRanges[index]"
                 @remove="remove"
                 @undoRemove="undoRemove"
@@ -14,6 +15,7 @@
         <button
             class="button button-primary"
             @click.prevent="add"
+            v-if="!readonly"
         >
             <app-icon icon="carbon:add" />
             <span class="ml-05">{{ msgAdd }}</span>
@@ -43,6 +45,10 @@ export default {
         options: {
             type: Object,
             default: () => ({}),
+        },
+        readonly: {
+            type: Boolean,
+            default: false,
         },
     },
 

--- a/templates/Element/Form/calendar.twig
+++ b/templates/Element/Form/calendar.twig
@@ -15,8 +15,11 @@
         </header>
 
         <div v-show="isOpen" class="tab-container">
-            <date-ranges-view ranges={{ object.attributes.date_ranges|json_encode }}
-                :options={{ options|json_encode }}>
+            <date-ranges-view
+                ranges={{ object.attributes.date_ranges|json_encode }}
+                :options={{ options|json_encode }}
+                :readonly="{{ Perms.canCreate() ? 'false' : 'true' }}"
+            >
             </date-ranges-view>
             {% do Form.unlockField('date_ranges') %}
         </div>


### PR DESCRIPTION
When an user doesn't have the permission to write in a module, the object view doesn't show remove and save buttons.

This applies the same logic to "calendar" form data.