### PR TITLE
Avoid error 500 when using multiproject config for API

### DIFF
--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -457,6 +457,9 @@ class LayoutHelper extends Helper
      */
     public function indexLists(): array
     {
+        if (!Configure::check('API.apiBaseUrl')) {
+            return [];
+        }
         $cacheKey = CacheTools::cacheKey('properties.indexLists');
         $indexLists = Cache::read($cacheKey, 'default');
         if (!empty($indexLists)) {

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -948,6 +948,15 @@ class LayoutHelperTest extends TestCase
         static::assertArrayHasKey('users', $actual);
         static::assertArrayHasKey('user_profile', $actual);
         static::assertArrayHasKey('videos', $actual);
+
+        // remove API config, return empty array
+        $apiConfig = Configure::read('API');
+        Configure::write('API', []);
+        $actual = $layout->indexLists();
+        static::assertIsArray($actual);
+        static::assertEmpty($actual);
+        Configure::write('API', $apiConfig);
+
         Cache::disable();
     }
 }


### PR DESCRIPTION
This fixes an issue in `LayoutHelper::indexLists()`, when no `API` configuration is set.