### PR TITLE
Rename `asciiToBinaryUtf8` and `binaryToAsciiUtf8`

### DIFF
--- a/resources/js/app/components/placeholder-list/placeholder-list.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-list.vue
@@ -129,7 +129,7 @@ export default {
                     id: m[1],
                     obj: o,
                     params_raw: m[2],
-                    params: this.$helpers.binaryToAsciiUtf8(m[2]),
+                    params: this.$helpers.base64ToUtf8(m[2]),
                 });
             }
         },

--- a/resources/js/app/components/placeholder-list/placeholder-params.vue
+++ b/resources/js/app/components/placeholder-list/placeholder-params.vue
@@ -88,9 +88,9 @@ export default {
     mounted() {
         this.$nextTick(() => {
             this.parameters = BEDITA?.placeholdersConfig?.[this.type] || {};
-            const decoded = this.$helpers.binaryToAsciiUtf8(this.value);
+            const decoded = this.$helpers.base64ToUtf8(this.value);
             if (decoded === 'undefined') {
-                this.newValue = this.$helpers.asciiToBinaryUtf8('undefined');
+                this.newValue = this.$helpers.utf8ToBase64('undefined');
 
                 return;
             }
@@ -104,7 +104,7 @@ export default {
     methods: {
         changeParams() {
             this.oldValue = this.newValue || this.value;
-            this.newValue = this.$helpers.asciiToBinaryUtf8(JSON.stringify(this.decodedValue));
+            this.newValue = this.$helpers.utf8ToBase64(JSON.stringify(this.decodedValue));
             EventBus.send('replace-placeholder', {
                 id: this.id,
                 field: this.field,

--- a/resources/js/app/components/relation-view/relations-add.js
+++ b/resources/js/app/components/relation-view/relations-add.js
@@ -106,7 +106,7 @@ export default {
 
             // alreadyInView doesn't get out of pagination objects. We need to "re-add" all objects
             try {
-                if (this.$attrs.object.type && this.$attrs.object.id) {
+                if (this.$attrs.object?.type && this.$attrs.object?.id) {
                     const related = await this.fetchRelated(this.$attrs.object.type, this.$attrs.object.id);
                     for (const obj of related) {
                         if (this.alreadyInView.indexOf(obj.id) === -1) {

--- a/resources/js/app/helpers/text-helper.js
+++ b/resources/js/app/helpers/text-helper.js
@@ -26,7 +26,7 @@ export function upperCaseFirst(input) {
  * @param {string|undefined} value
  * @returns {string} base64 encoded string
  */
-export function asciiToBinaryUtf8(value = 'undefined') {
+export function utf8ToBase64(value = 'undefined') {
     const utf8Bytes = new TextEncoder().encode(value);
 
     return btoa(String.fromCharCode(...utf8Bytes));
@@ -37,7 +37,7 @@ export function asciiToBinaryUtf8(value = 'undefined') {
  * @param {string| undefined} value
  * @returns {string} decoded string
  */
-export function binaryToAsciiUtf8(value) {
+export function base64ToUtf8(value) {
     const binaryString = atob(value);
     const bytes = Uint8Array.from(binaryString, c => c.charCodeAt(0));
 

--- a/resources/js/app/helpers/view.js
+++ b/resources/js/app/helpers/view.js
@@ -1,6 +1,6 @@
 import { t } from 'ttag';
 import { warning } from 'app/components/dialog/dialog';
-import { humanizeString, asciiToBinaryUtf8, binaryToAsciiUtf8 } from 'app/helpers/text-helper.js';
+import { humanizeString, utf8ToBase64, base64ToUtf8 } from 'app/helpers/text-helper.js';
 
 export default {
     install (Vue) {
@@ -307,12 +307,12 @@ export default {
                 return humanizeString(str);
             },
 
-            asciiToBinaryUtf8(str) {
-                return asciiToBinaryUtf8(str);
+            utf8ToBase64(str) {
+                return utf8ToBase64(str);
             },
 
-            binaryToAsciiUtf8(str) {
-                return binaryToAsciiUtf8(str);
+            base64ToUtf8(str) {
+                return base64ToUtf8(str);
             },
 
             stripHtml(str) {

--- a/resources/js/app/plugins/tinymce/placeholders.js
+++ b/resources/js/app/plugins/tinymce/placeholders.js
@@ -45,7 +45,7 @@ function loadPreview(editor, node, id) {
                         content = `<img src="${data.meta.media_url}" alt="${data.attributes.title}" />`;
                         break;
                     default:
-                        if (data.meta.media_url) {
+                        if (data.meta?.media_url) {
                             content = `<iframe src="${data.meta.media_url}" sandbox=""></iframe>`;
                         } else {
                             content = `<div class="embed-card">

--- a/resources/js/app/plugins/tinymce/placeholders.js
+++ b/resources/js/app/plugins/tinymce/placeholders.js
@@ -3,7 +3,7 @@ import 'tinymce/tinymce';
 import { EventBus } from 'app/components/event-bus';
 import { PanelEvents } from 'app/components/panel-view';
 import tinymce from 'tinymce/tinymce';
-import { asciiToBinaryUtf8, binaryToAsciiUtf8 } from 'app/helpers/text-helper';
+import { utf8ToBase64, base64ToUtf8 } from 'app/helpers/text-helper';
 
 const cache = {};
 const regex = /BE-PLACEHOLDER\.(\d+)(?:\.([a-zA-Z0-9+/]+={0,2}))?/;
@@ -73,7 +73,7 @@ tinymce.util.Tools.resolve('tinymce.PluginManager').add('placeholders', function
                     return;
                 }
                 let [, id, params] = match;
-                node.attr('data-params', params ? binaryToAsciiUtf8(params) : '');
+                node.attr('data-params', params ? base64ToUtf8(params) : '');
                 node.attr('contenteditable', 'false');
                 loadPreview(editor, node, id);
             });
@@ -84,7 +84,7 @@ tinymce.util.Tools.resolve('tinymce.PluginManager').add('placeholders', function
                 let params = node.attributes.map['data-params'];
                 node.empty();
                 let comment = tinymce.html.Node.create('#comment');
-                comment.value = `BE-PLACEHOLDER.${id}.${asciiToBinaryUtf8(params)}`;
+                comment.value = `BE-PLACEHOLDER.${id}.${utf8ToBase64(params)}`;
                 node.append(comment);
             });
         });
@@ -114,7 +114,7 @@ tinymce.util.Tools.resolve('tinymce.PluginManager').add('placeholders', function
                     let view = editor.dom.create(isEmptyBlock ? 'div' : 'span', {
                         'data-placeholder': data.id,
                         'data-params': data.params,
-                    }, `<!-- BE-PLACEHOLDER.${data.id}.${asciiToBinaryUtf8(data.params)} -->`);
+                    }, `<!-- BE-PLACEHOLDER.${data.id}.${utf8ToBase64(data.params)} -->`);
                     editor.insertContent(view.outerHTML);
                     if (isEmptyBlock) {
                         tinymce.dom.DOMUtils.DOM.remove(node);


### PR DESCRIPTION
After https://github.com/bedita/manager/pull/1257 we introduced `asciiToBinaryUtf8`  and `binaryToAsciiUtf8` functions (replacing `atob` and `btoa`).

This renames the functions to `utf8ToBase64` and `base64ToUtf8`.