### PR TITLE
Related objects filter in filter box

### DIFF
--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2025-06-03 07:31:05 \n"
+"POT-Creation-Date: 2025-06-16 08:08:55 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1589,6 +1589,21 @@ msgid "Missing required data \"${ required }\". Retry"
 msgstr ""
 
 msgid "Error while creating new object."
+msgstr ""
+
+msgid "Edit related objects"
+msgstr ""
+
+msgid "Choose object type"
+msgstr ""
+
+msgid "Choose relation"
+msgstr ""
+
+msgid "Filter to apply"
+msgstr ""
+
+msgid "Search related objects"
 msgstr ""
 
 msgid "Action"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2025-06-03 07:31:05 \n"
+"POT-Creation-Date: 2025-06-16 08:08:55 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1592,6 +1592,21 @@ msgid "Missing required data \"${ required }\". Retry"
 msgstr ""
 
 msgid "Error while creating new object."
+msgstr ""
+
+msgid "Edit related objects"
+msgstr ""
+
+msgid "Choose object type"
+msgstr ""
+
+msgid "Choose relation"
+msgstr ""
+
+msgid "Filter to apply"
+msgstr ""
+
+msgid "Search related objects"
 msgstr ""
 
 msgid "Action"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2025-06-03 07:31:05 \n"
+"POT-Creation-Date: 2025-06-16 08:08:55 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1612,6 +1612,21 @@ msgstr "Dato obbligatorio mancante \"${ required }\". Riprovare"
 
 msgid "Error while creating new object."
 msgstr "Si è verificato un errore durante la creazione del nuovo oggetto."
+
+msgid "Edit related objects"
+msgstr "Modifica oggetti correlati"
+
+msgid "Choose object type"
+msgstr "Scegli il tipo di oggetto"
+
+msgid "Choose relation"
+msgstr "Scegli la relazione"
+
+msgid "Filter to apply"
+msgstr "Filtro da applicare"
+
+msgid "Search related objects"
+msgstr "Cerca oggetti correlati"
 
 msgid "Action"
 msgstr "Azione"

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -623,6 +623,7 @@ window._vueInstance = _vueInstance;
 
 // use component everywhere in Manager
 Vue.component('AppIcon', AppIcon);
+Vue.component('ClipboardItem', _vueInstance.$options.components.ClipboardItem);
 Vue.component('DateRangesView', _vueInstance.$options.components.DateRangesView);
 Vue.component('FieldCheckbox', _vueInstance.$options.components.FieldCheckbox);
 Vue.component('FieldGeoCoordinates', _vueInstance.$options.components.FieldGeoCoordinates);
@@ -643,3 +644,4 @@ Vue.component('ObjectCategories', _vueInstance.$options.components.ObjectCategor
 Vue.component('ObjectCaptions', _vueInstance.$options.components.ObjectCaptions);
 Vue.component('ObjectInfo', _vueInstance.$options.components.ObjectInfo);
 Vue.component('RelatedObjectsFilter', _vueInstance.$options.components.RelatedObjectsFilter);
+Vue.component('Thumbnail', _vueInstance.$options.components.Thumbnail);

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -109,6 +109,7 @@ const _vueInstance = new Vue({
         FieldTextarea: () => import(/* webpackChunkName: "field-textarea" */'app/components/form/field-textarea'),
         FieldTitle: () => import(/* webpackChunkName: "field-title" */'app/components/form/field-title'),
         ObjectInfo: () => import(/* webpackChunkName: "object-info" */'app/components/object-info/object-info'),
+        RelatedObjectsFilter: () => import(/* webpackChunkName: "related-objects-filter" */'app/components/related-objects-filter/related-objects-filter'),
         AppIcon,
     },
 
@@ -633,3 +634,4 @@ Vue.component('FileUpload', _vueInstance.$options.components.FileUpload);
 Vue.component('ObjectCategories', _vueInstance.$options.components.ObjectCategories);
 Vue.component('ObjectCaptions', _vueInstance.$options.components.ObjectCaptions);
 Vue.component('ObjectInfo', _vueInstance.$options.components.ObjectInfo);
+Vue.component('RelatedObjectsFilter', _vueInstance.$options.components.RelatedObjectsFilter);

--- a/resources/js/app/components/filter-box.vue
+++ b/resources/js/app/components/filter-box.vue
@@ -83,6 +83,7 @@ export default {
              */
             editFilterRelations: false,
             filterByDescendants: false,
+            filterRelations: {},
             folder: null,
             moreFilters: this.filterActive,
             pageSize: this.pagination.page_size,
@@ -365,6 +366,10 @@ export default {
 
             const filter = this.prepareFilters();
             const filterObject = { ...this.queryFilter, filter };
+            filterObject.filter = {
+                ...filterObject.filter,
+                ...this.filterRelations,
+            };
             this.availableFilters = this.filtersByType?.[filterObject?.filter?.type] || [];
             this.$emit('filter-objects', filterObject);
         },
@@ -465,6 +470,16 @@ export default {
 
         toggleFilterRelations() {
             this.editFilterRelations = !this.editFilterRelations;
+        },
+
+        updateFilterRelations(filter) {
+            this.filterRelations = {};
+            for (const [key, value] of Object.entries(filter)) {
+                this.filterRelations[key] = [];
+                for (const v of value) {
+                    this.filterRelations[key].push(v);
+                }
+            }
         },
     }
 };

--- a/resources/js/app/components/filter-box.vue
+++ b/resources/js/app/components/filter-box.vue
@@ -81,7 +81,7 @@ export default {
              * When disabled, only direct children are fetched.
              * This will switch the API filter between `parent` and `ancestor`.
              */
-            editFilterRelations: false,
+            editFilterRelations: this.filterActive,
             filterByDescendants: false,
             filterRelations: {},
             folder: null,

--- a/resources/js/app/components/filter-box.vue
+++ b/resources/js/app/components/filter-box.vue
@@ -38,6 +38,10 @@ export default {
             default: '[10]'
         },
         filterActive: Boolean,
+        filterRelationsActive: {
+            type: Boolean,
+            default: false
+        },
         filterList: {
             type: Array,
             default: () => [],
@@ -81,7 +85,7 @@ export default {
              * When disabled, only direct children are fetched.
              * This will switch the API filter between `parent` and `ancestor`.
              */
-            editFilterRelations: this.filterActive,
+            editFilterRelations: this.filterRelationsActive,
             filterByDescendants: false,
             filterRelations: {},
             folder: null,

--- a/resources/js/app/components/filter-box.vue
+++ b/resources/js/app/components/filter-box.vue
@@ -81,6 +81,7 @@ export default {
              * When disabled, only direct children are fetched.
              * This will switch the API filter between `parent` and `ancestor`.
              */
+            editFilterRelations: false,
             filterByDescendants: false,
             folder: null,
             moreFilters: this.filterActive,
@@ -460,6 +461,10 @@ export default {
             const oldFilter = newFilter === 'ancestor' ? 'parent' : 'ancestor';
             delete this.queryFilter.filter[oldFilter];
             this.queryFilter.filter[newFilter] = this.folder?.id || null;
+        },
+
+        toggleFilterRelations() {
+            this.editFilterRelations = !this.editFilterRelations;
         },
     }
 };

--- a/resources/js/app/components/object-info/object-info.vue
+++ b/resources/js/app/components/object-info/object-info.vue
@@ -57,7 +57,7 @@ export default {
         fillData() {
             const source = BEDITA?.indexLists?.[this.reloadedData?.type] || {};
             this.fields = source || ['title', 'description'];
-            this.fields = this.fields.filter((value, index, array) => {
+            this.fields = this.fields?.filter((value, index, array) => {
                 return array.indexOf(value) === index;
             });
             for (const field of this.fields) {

--- a/resources/js/app/components/related-objects-filter/related-objects-filter.vue
+++ b/resources/js/app/components/related-objects-filter/related-objects-filter.vue
@@ -1,0 +1,275 @@
+<template>
+    <div class="related-objects-filter">
+        <div class="filter-to-apply">
+            <div
+                v-for="relationName in Object.keys(filter)"
+                :key="relationName"
+            >
+                <template v-if="filter?.[relationName]?.length">
+                    <span class="tag relation">{{ tr(relationName) }}</span>
+                    <template v-for="relatedId in filter[relationName]">
+                        <div
+                            class="tag"
+                            :class="moduleClass(relatedId)"
+                        >
+                            [{{ relatedId }}] {{ objectsMap?.[relatedId]?.title }}
+                            <a
+                                class="unpick"
+                                @click.prevent="pickout(relationName, relatedId)"
+                            >
+                                <app-icon
+                                    icon="carbon:close"
+                                    width="18"
+                                    height="18"
+                                />
+                            </a>
+                        </div>
+                    </template>
+                </template>
+            </div>
+        </div>
+        <div class="selection-container">
+            <div>
+                <select
+                    v-model="relation"
+                    @change="changeRelation"
+                >
+                    <option
+                        v-for="item in relations"
+                        :key="item.name"
+                        :value="item.name"
+                    >
+                        {{ tr(item.label) }}
+                    </option>
+                </select>
+            </div>
+            <div
+                class="ml-05"
+                v-if="relation"
+            >
+                <select v-model="objectType">
+                    <option
+                        v-for="item in objectTypes"
+                        :key="item"
+                        :value="item"
+                    >
+                        {{ tr(item) }}
+                    </option>
+                </select>
+            </div>
+            <div
+                class="ml-05"
+                v-if="relation && objectType != msgChooseObjectType"
+            >
+                <input
+                    type="text"
+                    v-model="searchText"
+                >
+                <button
+                    :class="{ 'is-loading-spinner': loading }"
+                    :disabled="loading || !searchText || searchText?.length < 3"
+                    @click.prevent="search"
+                >
+                    <app-icon icon="carbon:search" />
+                    <span class="ml-05">{{ msgSearch }}</span>
+                </button>
+            </div>
+        </div>
+        <div
+            class="search-results"
+            v-if="!loading && searchResults?.length"
+        >
+            <div
+                v-for="item in searchResults"
+                :key="item.id"
+            >
+                <button
+                    class="picker button button-outlined is-width-auto"
+                    @click.prevent="pickin(item)"
+                    v-if="!filter?.[relation]?.includes(item?.id)"
+                >
+                    <app-icon icon="carbon:add" />
+                    <span class="ml-05">
+                        [{{ item.id }}] {{ item?.attributes?.title }}
+                    </span>
+                </button>
+            </div>
+        </div>
+    </div>
+</template>
+<script>
+import { t } from 'ttag';
+
+export default {
+    name: 'RelatedObjectsFilter',
+    props: {
+        relationsSchema: {
+            type: Object,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            filter: {},
+            loading: false,
+            msgChooseObjectType: t`Choose object type`,
+            msgChooseRelation: t`Choose relation`,
+            msgFilterToApply: t`Filter to apply`,
+            msgSearch: t`Search`,
+            objectsMap: {},
+            objectType: null,
+            objectTypes: [],
+            relation: null,
+            relations: [],
+            searchResults: [],
+            searchText: null,
+        };
+    },
+    mounted() {
+        this.$nextTick(() => {
+            for (const [key, value] of Object.entries(this.relationsSchema)) {
+                this.relations.push({
+                    label: value?.label || key,
+                    name: key,
+                    types: value?.types || [],
+                });
+            }
+            this.relations.sort((a, b) => {
+                if (a.label < b.label) return -1;
+                if (a.label > b.label) return 1;
+                return 0;
+            });
+            this.relations.unshift({
+                label: this.msgChooseRelation,
+                name: null,
+                types: [],
+            });
+            this.relation = this.relations[0].name;
+        });
+    },
+    methods: {
+        changeRelation() {
+            this.searchResults = [];
+            this.objectTypes = this.relations.find((item) => item.name === this.relation)?.types || [];
+            this.objectTypes.sort((a, b) => {
+                if (a < b) return -1;
+                if (a > b) return 1;
+                return 0;
+            });
+            if (!this.objectTypes.includes(this.msgChooseObjectType)) {
+                this.objectTypes.unshift(this.msgChooseObjectType);
+            }
+            this.objectType = this.msgChooseObjectType;
+        },
+        moduleClass(item) {
+            const objectType = this.objectsMap?.[item]?.type || null;
+            if (!objectType) {
+                return '';
+            }
+
+            return `has-background-module-${objectType}`;
+        },
+        pickin(item) {
+            if (!this.filter[this.relation]) {
+                this.filter[this.relation] = [];
+            }
+            if (this.filter?.[this.relation]?.includes(item?.id)) {
+                return;
+            }
+            this.filter[this.relation].push(item.id);
+            this.updateFilter();
+        },
+        pickout(relationName, relatedId) {
+            if (this.filter?.[relationName]) {
+                this.filter[relationName] = this.filter[relationName].filter((id) => id !== relatedId);
+                this.updateFilter();
+            }
+        },
+        async search() {
+            try {
+                this.loading = true;
+                const headers = new Headers({
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': BEDITA.csrfToken,
+                });
+                const options = {
+                    credentials: 'same-origin',
+                    headers,
+                    method: 'GET',
+                };
+                const url = `/api/${this.objectType}?q=${this.searchText}&page=1&page_size=10`;
+                const response = await fetch(url, options);
+                const responseJson = await response.json();
+                if (responseJson?.error) {
+                    throw new Error(responseJson.error);
+                }
+                if (responseJson?.data) {
+                    this.searchResults = responseJson.data;
+                } else {
+                    this.searchResults = [];
+                }
+                for (const item of this.searchResults) {
+                    if (!this.objectsMap[item.id]) {
+                        this.objectsMap[item.id] = {'type': item?.type || '', 'title': item?.attributes?.title || ''};
+                    }
+                }
+            } catch (e) {
+                console.error(e);
+            } finally {
+                this.loading = false;
+            }
+        },
+        tr(item) {
+            return BEDITA_I18N?.[item] || this.t(item) || item;
+        },
+        updateFilter() {
+            this.$forceUpdate();
+            this.$emit('update-filter-related', this.filter);
+        },
+    },
+}
+</script>
+<style scoped>
+div.related-objects-filter {
+    display: flex;
+    flex-direction: column;
+    grid-gap: 0.5em;
+    justify-content: space-between;
+}
+div.related-objects-filter div.selection-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr 50%;
+    grid-gap: 0.5em;
+    width: 100%;
+}
+div.related-objects-filter div.search-results {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-gap: 0.5em;
+    width: 100%;
+}
+div.related-objects-filter button.picker {
+    height: 20px;
+    background-color: transparent;
+    border: none;
+    color: var(--color-text);
+    cursor: pointer;
+}
+div.related-objects-filter div.filter-to-apply {
+    display: block;
+    width: 100%;
+}
+div.related-objects-filter .unpick {
+    cursor: pointer;
+    height: 100%;
+}
+div.related-objects-filter .unpick > svg {
+    margin-left: 0.5rem;
+    height: 100%;
+}
+div.related-objects-filter .relation {
+    background-color: darkslategrey;
+    color: white;
+}
+</style>

--- a/resources/js/app/components/related-objects-filter/related-objects-filter.vue
+++ b/resources/js/app/components/related-objects-filter/related-objects-filter.vue
@@ -22,6 +22,7 @@
                             <div
                                 class="tag"
                                 :class="moduleClass(relatedId)"
+                                :key="relatedId"
                             >
                                 [{{ relatedId }}] {{ objectsMap?.[relatedId]?.title }}
                                 <a

--- a/resources/js/app/components/related-objects-filter/related-objects-filter.vue
+++ b/resources/js/app/components/related-objects-filter/related-objects-filter.vue
@@ -1,100 +1,53 @@
 <template>
     <div class="related-objects-filter">
-        <div class="filter-to-apply">
-            <div
-                v-for="relationName in Object.keys(filter)"
-                :key="relationName"
-            >
-                <template v-if="filter?.[relationName]?.length">
-                    <span class="tag relation">{{ tr(relationName) }}</span>
-                    <template v-for="relatedId in filter[relationName]">
-                        <div
-                            class="tag"
-                            :class="moduleClass(relatedId)"
-                        >
-                            [{{ relatedId }}] {{ objectsMap?.[relatedId]?.title }}
-                            <a
-                                class="unpick"
-                                @click.prevent="pickout(relationName, relatedId)"
+        <template v-if="openPanel">
+            <related-objects-panel
+                :initial-filter="initialFilter"
+                :relations-schema="relationsSchema"
+                :show-panel="openPanel"
+                @update:filter="updateData('filter', $event)"
+                @update:objectsMap="updateData('objectsMap', $event)"
+                @update:showPanel="updateData('openPanel', $event)"
+            />
+        </template>
+        <template v-if="filter">
+            <div class="filter-to-apply">
+                <div
+                    v-for="relationName in Object.keys(filter)"
+                    :key="relationName"
+                >
+                    <template v-if="filter?.[relationName]?.length">
+                        <span class="tag relation">{{ tr(relationName) }}</span>
+                        <template v-for="relatedId in filter[relationName]">
+                            <div
+                                class="tag"
+                                :class="moduleClass(relatedId)"
                             >
-                                <app-icon
-                                    icon="carbon:close"
-                                    width="18"
-                                    height="18"
-                                />
-                            </a>
-                        </div>
+                                [{{ relatedId }}] {{ objectsMap?.[relatedId]?.title }}
+                                <a
+                                    class="unpick"
+                                    @click.prevent="pickout(relationName, relatedId)"
+                                >
+                                    <app-icon
+                                        icon="carbon:close"
+                                        width="18"
+                                        height="18"
+                                    />
+                                </a>
+                            </div>
+                        </template>
                     </template>
-                </template>
-            </div>
-        </div>
-        <div class="selection-container">
-            <div>
-                <select
-                    v-model="relation"
-                    @change="changeRelation"
-                >
-                    <option
-                        v-for="item in relations"
-                        :key="item.name"
-                        :value="item.name"
-                    >
-                        {{ tr(item.label) }}
-                    </option>
-                </select>
-            </div>
-            <div
-                class="ml-05"
-                v-if="relation"
-            >
-                <select v-model="objectType">
-                    <option
-                        v-for="item in objectTypes"
-                        :key="item"
-                        :value="item"
-                    >
-                        {{ tr(item) }}
-                    </option>
-                </select>
-            </div>
-            <div
-                class="ml-05"
-                v-if="relation && objectType != msgChooseObjectType"
-            >
-                <input
-                    type="text"
-                    v-model="searchText"
-                >
+                </div>
+
                 <button
-                    :class="{ 'is-loading-spinner': loading }"
-                    :disabled="loading || !searchText || searchText?.length < 3"
-                    @click.prevent="search"
+                    class="mt-1 button button-outlined is-small"
+                    @click.prevent="openPanel = true"
                 >
-                    <app-icon icon="carbon:search" />
-                    <span class="ml-05">{{ msgSearch }}</span>
+                    <app-icon icon="carbon:edit" />
+                    <span class="ml-05">{{ msgEdit }}</span>
                 </button>
             </div>
-        </div>
-        <div
-            class="search-results"
-            v-if="!loading && searchResults?.length"
-        >
-            <div
-                v-for="item in searchResults"
-                :key="item.id"
-            >
-                <button
-                    class="picker button button-outlined is-width-auto"
-                    @click.prevent="pickin(item)"
-                    v-if="!filter?.[relation]?.includes(item?.id)"
-                >
-                    <app-icon icon="carbon:add" />
-                    <span class="ml-05">
-                        [{{ item.id }}] {{ item?.attributes?.title }}
-                    </span>
-                </button>
-            </div>
-        </div>
+        </template>
     </div>
 </template>
 <script>
@@ -102,6 +55,9 @@ import { t } from 'ttag';
 
 export default {
     name: 'RelatedObjectsFilter',
+    components: {
+        'related-objects-panel': () => import('./related-objects-panel.vue'),
+    },
     props: {
         initialFilter: {
             type: Object,
@@ -114,44 +70,14 @@ export default {
     },
     data() {
         return {
-            filter: {},
-            loading: false,
-            msgChooseObjectType: t`Choose object type`,
-            msgChooseRelation: t`Choose relation`,
-            msgFilterToApply: t`Filter to apply`,
-            msgSearch: t`Search`,
-            objectsMap: {},
-            objectType: null,
-            objectTypes: [],
-            relation: null,
-            relations: [],
-            searchResults: [],
-            searchText: null,
+            filter: null,
+            msgEdit: t`Edit related objects`,
+            objectsMap: null,
+            openPanel: false,
         };
     },
     mounted() {
         this.$nextTick(() => {
-            if (Object.keys(this.filter).length) {
-                this.$emit('edit-filter-relations', true);
-            }
-            for (const [key, value] of Object.entries(this.relationsSchema)) {
-                this.relations.push({
-                    label: value?.label || key,
-                    name: key,
-                    types: value?.types || [],
-                });
-            }
-            this.relations.sort((a, b) => {
-                if (a.label < b.label) return -1;
-                if (a.label > b.label) return 1;
-                return 0;
-            });
-            this.relations.unshift({
-                label: this.msgChooseRelation,
-                name: null,
-                types: [],
-            });
-            this.relation = this.relations[0].name;
             if (this.initialFilter) {
                 const relationNames = Object.keys(this.relationsSchema);
                 const relationKeys = Object.keys(this.initialFilter).filter((key) => relationNames.includes(key));
@@ -163,19 +89,6 @@ export default {
         });
     },
     methods: {
-        changeRelation() {
-            this.searchResults = [];
-            this.objectTypes = this.relations.find((item) => item.name === this.relation)?.types || [];
-            this.objectTypes.sort((a, b) => {
-                if (a < b) return -1;
-                if (a > b) return 1;
-                return 0;
-            });
-            if (!this.objectTypes.includes(this.msgChooseObjectType)) {
-                this.objectTypes.unshift(this.msgChooseObjectType);
-            }
-            this.objectType = this.msgChooseObjectType;
-        },
         moduleClass(item) {
             const objectType = this.objectsMap?.[item]?.type || null;
             if (!objectType) {
@@ -184,59 +97,21 @@ export default {
 
             return `has-background-module-${objectType}`;
         },
-        pickin(item) {
-            if (!this.filter[this.relation]) {
-                this.filter[this.relation] = [];
-            }
-            if (this.filter?.[this.relation]?.includes(item?.id)) {
-                return;
-            }
-            this.filter[this.relation].push(item.id);
-            this.updateFilter();
-        },
         pickout(relationName, relatedId) {
             if (this.filter?.[relationName]) {
                 this.filter[relationName] = this.filter[relationName].filter((id) => id !== relatedId);
                 this.updateFilter();
             }
         },
-        async search() {
-            try {
-                this.loading = true;
-                const headers = new Headers({
-                    'Accept': 'application/json',
-                    'Content-Type': 'application/json',
-                    'X-CSRF-Token': BEDITA.csrfToken,
-                });
-                const options = {
-                    credentials: 'same-origin',
-                    headers,
-                    method: 'GET',
-                };
-                const url = `/api/${this.objectType}?q=${this.searchText}&page=1&page_size=10`;
-                const response = await fetch(url, options);
-                const responseJson = await response.json();
-                if (responseJson?.error) {
-                    throw new Error(responseJson.error);
-                }
-                if (responseJson?.data) {
-                    this.searchResults = responseJson.data;
-                } else {
-                    this.searchResults = [];
-                }
-                for (const item of this.searchResults) {
-                    if (!this.objectsMap[item.id]) {
-                        this.objectsMap[item.id] = {'type': item?.type || '', 'title': item?.attributes?.title || ''};
-                    }
-                }
-            } catch (e) {
-                console.error(e);
-            } finally {
-                this.loading = false;
-            }
-        },
         tr(item) {
             return BEDITA_I18N?.[item] || this.t(item) || item;
+        },
+        updateData(key, value) {
+            this.$emit('edit-filter-relations', true);
+            this[key] = value;
+            if (key === 'filter') {
+                this.updateFilter();
+            }
         },
         updateFilter() {
             this.$forceUpdate();
@@ -251,40 +126,5 @@ div.related-objects-filter {
     flex-direction: column;
     grid-gap: 0.5em;
     justify-content: space-between;
-}
-div.related-objects-filter div.selection-container {
-    display: grid;
-    grid-template-columns: 1fr 1fr 50%;
-    grid-gap: 0.5em;
-    width: 100%;
-}
-div.related-objects-filter div.search-results {
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-gap: 0.5em;
-    width: 100%;
-}
-div.related-objects-filter button.picker {
-    height: 20px;
-    background-color: transparent;
-    border: none;
-    color: var(--color-text);
-    cursor: pointer;
-}
-div.related-objects-filter div.filter-to-apply {
-    display: block;
-    width: 100%;
-}
-div.related-objects-filter .unpick {
-    cursor: pointer;
-    height: 100%;
-}
-div.related-objects-filter .unpick > svg {
-    margin-left: 0.5rem;
-    height: 100%;
-}
-div.related-objects-filter .relation {
-    background-color: darkslategrey;
-    color: white;
 }
 </style>

--- a/resources/js/app/components/related-objects-filter/related-objects-filter.vue
+++ b/resources/js/app/components/related-objects-filter/related-objects-filter.vue
@@ -131,12 +131,6 @@ export default {
     },
     mounted() {
         this.$nextTick(() => {
-            const relationNames = Object.keys(this.relationsSchema);
-            const relationKeys = Object.keys(this.initialFilter).filter((key) => relationNames.includes(key));
-            this.filter = relationKeys.reduce((acc, key) => {
-                acc[key] = this.initialFilter[key];
-                return acc;
-            }, {});
             if (Object.keys(this.filter).length) {
                 this.$emit('edit-filter-relations', true);
             }
@@ -158,6 +152,14 @@ export default {
                 types: [],
             });
             this.relation = this.relations[0].name;
+            if (this.initialFilter) {
+                const relationNames = Object.keys(this.relationsSchema);
+                const relationKeys = Object.keys(this.initialFilter).filter((key) => relationNames.includes(key));
+                this.filter = relationKeys.reduce((acc, key) => {
+                    acc[key] = this.initialFilter[key];
+                    return acc;
+                }, {});
+            }
         });
     },
     methods: {

--- a/resources/js/app/components/related-objects-filter/related-objects-filter.vue
+++ b/resources/js/app/components/related-objects-filter/related-objects-filter.vue
@@ -103,6 +103,10 @@ import { t } from 'ttag';
 export default {
     name: 'RelatedObjectsFilter',
     props: {
+        initialFilter: {
+            type: Object,
+            default: () => ({}),
+        },
         relationsSchema: {
             type: Object,
             required: true,
@@ -127,6 +131,15 @@ export default {
     },
     mounted() {
         this.$nextTick(() => {
+            const relationNames = Object.keys(this.relationsSchema);
+            const relationKeys = Object.keys(this.initialFilter).filter((key) => relationNames.includes(key));
+            this.filter = relationKeys.reduce((acc, key) => {
+                acc[key] = this.initialFilter[key];
+                return acc;
+            }, {});
+            if (Object.keys(this.filter).length) {
+                this.$emit('edit-filter-relations', true);
+            }
             for (const [key, value] of Object.entries(this.relationsSchema)) {
                 this.relations.push({
                     label: value?.label || key,

--- a/resources/js/app/components/related-objects-filter/related-objects-filter.vue
+++ b/resources/js/app/components/related-objects-filter/related-objects-filter.vue
@@ -85,6 +85,8 @@ export default {
                     acc[key] = this.initialFilter[key];
                     return acc;
                 }, {});
+            } else {
+                this.openPanel = true;
             }
         });
     },

--- a/resources/js/app/components/related-objects-filter/related-objects-panel.vue
+++ b/resources/js/app/components/related-objects-filter/related-objects-panel.vue
@@ -135,21 +135,6 @@
                                     @discard="discard"
                                 />
                             </div>
-                            <!-- <div
-                                v-for="item in searchResults"
-                                :key="item.id"
-                            >
-                                <button
-                                    class="picker button button-outlined is-width-auto"
-                                    @click.prevent="pickin(item)"
-                                    v-if="!filter?.[relation]?.includes(item?.id)"
-                                >
-                                    <app-icon icon="carbon:add" />
-                                    <span class="ml-05">
-                                        [{{ item.id }}] {{ item?.attributes?.title }}
-                                    </span>
-                                </button>
-                            </div> -->
                         </div>
                         <div class="buttons">
                             <button
@@ -223,7 +208,7 @@ export default {
         this.$nextTick(() => {
             for (const [key, value] of Object.entries(this.relationsSchema)) {
                 this.relations.push({
-                    label: value?.label || key,
+                    label: this.$helpers.humanize(value?.label || key),
                     name: key,
                     types: value?.types || [],
                 });

--- a/resources/js/app/components/related-objects-filter/related-objects-panel.vue
+++ b/resources/js/app/components/related-objects-filter/related-objects-panel.vue
@@ -1,0 +1,363 @@
+<template>
+    <div class="related-objects-panel">
+        <template v-if="showPanel">
+            <div
+                class="backdrop"
+                style="display: block; z-index: 9998;"
+                @click="closePanel()"
+            />
+            <aside
+                class="main-panel-container on"
+                custom-footer="true"
+                custom-header="true"
+            >
+                <div class="main-panel fieldset">
+                    <header class="mx-1 mt-1 tab tab-static unselectable">
+                        <h2>{{ msgSearchRelated }}</h2>
+                        <button
+                            class="button button-outlined close"
+                            v-title="msgClose"
+                            @click.prevent.stop="closePanel()"
+                        >
+                            <app-icon icon="carbon:close" />
+                        </button>
+                    </header>
+                    <div class="pcontainer">
+                        <div class="filter-to-apply">
+                            <div
+                                v-for="relationName in Object.keys(filter)"
+                                :key="relationName"
+                            >
+                                <template v-if="filter?.[relationName]?.length">
+                                    <span class="tag relation">{{ tr(relationName) }}</span>
+                                    <template v-for="relatedId in filter[relationName]">
+                                        <div
+                                            class="tag"
+                                            :class="moduleClass(relatedId)"
+                                        >
+                                            [{{ relatedId }}] {{ objectsMap?.[relatedId]?.title }}
+                                            <a
+                                                class="unpick"
+                                                @click.prevent="pickout(relationName, relatedId)"
+                                            >
+                                                <app-icon
+                                                    icon="carbon:close"
+                                                    width="18"
+                                                    height="18"
+                                                />
+                                            </a>
+                                        </div>
+                                    </template>
+                                </template>
+                            </div>
+                        </div>
+                        <div class="selection-container">
+                            <div>
+                                <select
+                                    class="is-width-full"
+                                    v-model="relation"
+                                    @change="changeRelation"
+                                >
+                                    <option
+                                        v-for="item in relations"
+                                        :key="item.name"
+                                        :value="item.name"
+                                    >
+                                        {{ tr(item.label) }}
+                                    </option>
+                                </select>
+                            </div>
+                            <div
+                                class="ml-05"
+                                v-if="relation"
+                            >
+                                <select
+                                    class="is-width-full"
+                                    v-model="objectType"
+                                >
+                                    <option
+                                        v-for="item in objectTypes"
+                                        :key="item"
+                                        :value="item"
+                                    >
+                                        {{ tr(item) }}
+                                    </option>
+                                </select>
+                            </div>
+                            <div
+                                class="ml-05"
+                                v-if="relation && objectType != msgChooseObjectType"
+                            >
+                                <input
+                                    type="text"
+                                    v-model="searchText"
+                                >
+                                <button
+                                    :class="{ 'is-loading-spinner': loading }"
+                                    :disabled="loading || !searchText || searchText?.length < 3"
+                                    @click.prevent="search"
+                                >
+                                    <app-icon icon="carbon:search" />
+                                    <span class="ml-05">{{ msgSearch }}</span>
+                                </button>
+                            </div>
+                        </div>
+                        <div
+                            class="search-results"
+                            v-if="!loading && searchResults?.length"
+                        >
+                            <div
+                                v-for="item in searchResults"
+                                :key="item.id"
+                            >
+                                <button
+                                    class="picker button button-outlined is-width-auto"
+                                    @click.prevent="pickin(item)"
+                                    v-if="!filter?.[relation]?.includes(item?.id)"
+                                >
+                                    <app-icon icon="carbon:add" />
+                                    <span class="ml-05">
+                                        [{{ item.id }}] {{ item?.attributes?.title }}
+                                    </span>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="buttons">
+                            <button
+                                class="button button-primary"
+                                @click.prevent.stop="closePanel()"
+                            >
+                                <app-icon icon="carbon:close" />
+                                <span class="ml-05">
+                                    {{ msgClose }}
+                                </span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </aside>
+        </template>
+    </div>
+</template>
+<script>
+import { t } from 'ttag';
+export default {
+    name: 'RelatedObjectsPanel',
+    props: {
+        initialFilter: {
+            type: Object,
+            default: () => ({}),
+        },
+        relationsSchema: {
+            type: Object,
+            required: true,
+        },
+        showPanel: {
+            type: Boolean,
+            default: false
+        },
+    },
+    data() {
+        return {
+            filter: {},
+            loading: false,
+            msgChooseObjectType: t`Choose object type`,
+            msgChooseRelation: t`Choose relation`,
+            msgClose: t`Close`,
+            msgFilterToApply: t`Filter to apply`,
+            msgSearch: t`Search`,
+            msgSearchRelated: t`Search related objects`,
+            objectsMap: {},
+            objectType: null,
+            objectTypes: [],
+            openPanel: false,
+            relation: null,
+            relations: [],
+            searchResults: [],
+            searchText: null,
+        }
+    },
+
+    mounted() {
+        this.$nextTick(() => {
+            for (const [key, value] of Object.entries(this.relationsSchema)) {
+                this.relations.push({
+                    label: value?.label || key,
+                    name: key,
+                    types: value?.types || [],
+                });
+            }
+            this.relations.sort((a, b) => {
+                if (a.label < b.label) return -1;
+                if (a.label > b.label) return 1;
+                return 0;
+            });
+            this.relations.unshift({
+                label: this.msgChooseRelation,
+                name: null,
+                types: [],
+            });
+            this.relation = this.relations[0].name;
+            if (this.initialFilter) {
+                const relationNames = Object.keys(this.relationsSchema);
+                const relationKeys = Object.keys(this.initialFilter).filter((key) => relationNames.includes(key));
+                this.filter = relationKeys.reduce((acc, key) => {
+                    acc[key] = this.initialFilter[key];
+                    return acc;
+                }, {});
+            }
+        });
+    },
+    methods: {
+        changeRelation() {
+            this.searchResults = [];
+            this.objectTypes = this.relations.find((item) => item.name === this.relation)?.types || [];
+            this.objectTypes.sort((a, b) => {
+                if (a < b) return -1;
+                if (a > b) return 1;
+                return 0;
+            });
+            if (!this.objectTypes.includes(this.msgChooseObjectType)) {
+                this.objectTypes.unshift(this.msgChooseObjectType);
+            }
+            this.objectType = this.msgChooseObjectType;
+        },
+        closePanel() {
+            this.$emit('update:filter', this.filter);
+            this.$emit('update:objectsMap', this.objectsMap);
+            this.$emit('update:showPanel', false);
+        },
+        moduleClass(item) {
+            const objectType = this.objectsMap?.[item]?.type || null;
+            if (!objectType) {
+                return '';
+            }
+
+            return `has-background-module-${objectType}`;
+        },
+        pickin(item) {
+            if (!this.filter[this.relation]) {
+                this.filter[this.relation] = [];
+            }
+            if (this.filter?.[this.relation]?.includes(item?.id)) {
+                return;
+            }
+            this.filter[this.relation].push(item.id);
+            this.updateFilter();
+        },
+        pickout(relationName, relatedId) {
+            if (this.filter?.[relationName]) {
+                this.filter[relationName] = this.filter[relationName].filter((id) => id !== relatedId);
+                this.updateFilter();
+            }
+        },
+        async search() {
+            try {
+                this.loading = true;
+                const headers = new Headers({
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': BEDITA.csrfToken,
+                });
+                const options = {
+                    credentials: 'same-origin',
+                    headers,
+                    method: 'GET',
+                };
+                const url = `/api/${this.objectType}?q=${this.searchText}&page=1&page_size=10`;
+                const response = await fetch(url, options);
+                const responseJson = await response.json();
+                if (responseJson?.error) {
+                    throw new Error(responseJson.error);
+                }
+                if (responseJson?.data) {
+                    this.searchResults = responseJson.data;
+                } else {
+                    this.searchResults = [];
+                }
+                for (const item of this.searchResults) {
+                    if (!this.objectsMap[item.id]) {
+                        this.objectsMap[item.id] = {'type': item?.type || '', 'title': item?.attributes?.title || ''};
+                    }
+                }
+            } catch (e) {
+                console.error(e);
+            } finally {
+                this.loading = false;
+            }
+        },
+        tr(item) {
+            return BEDITA_I18N?.[item] || this.t(item) || item;
+        },
+        updateFilter() {
+            this.$forceUpdate();
+            this.$emit('update-filter-related', this.filter);
+        },
+    },
+}
+</script>
+<style scoped>
+div.related-objects-panel aside.main-panel-container {
+    z-index: 9999;
+}
+div.related-objects-panel aside.main-panel {
+    margin: 1rem;
+    padding: 1rem;
+}
+div.related-objects-panel button.close {
+    border: solid transparent 0px;
+    min-width: 36px;
+    max-width: 36px;
+}
+div.related-objects-panel .pcontainer {
+    padding: 1rem;
+    margin: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+div.related-objects-panel .pcontainer > div {
+    display: flex;
+    flex-direction: column;
+}
+div.related-objects-panel div.buttons {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+}
+div.related-objects-panel div.selection-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr 50%;
+    grid-gap: 0.5em;
+    width: 100%;
+}
+div.related-objects-panel div.search-results {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-gap: 0.5em;
+    width: 100%;
+}
+div.related-objects-panel button.picker {
+    height: 20px;
+    background-color: transparent;
+    border: none;
+    color: var(--color-text);
+    cursor: pointer;
+}
+div.related-objects-panel div.filter-to-apply {
+    display: block;
+    width: 100%;
+}
+div.related-objects-panel .unpick {
+    cursor: pointer;
+    height: 100%;
+}
+div.related-objects-panel .unpick > svg {
+    margin-left: 0.5rem;
+    height: 100%;
+}
+div.related-objects-panel .relation {
+    background-color: darkslategrey;
+    color: white;
+}
+</style>

--- a/resources/js/app/components/related-objects-filter/related-objects-panel.vue
+++ b/resources/js/app/components/related-objects-filter/related-objects-panel.vue
@@ -115,6 +115,7 @@
                             <results-pagination
                                 :count="paginationCount"
                                 :filter="paginationFilter"
+                                :object-type="objectType"
                                 :options="paginationOptions"
                                 @update="updatePagination"
                             />

--- a/resources/js/app/components/related-objects-filter/results-pagination.vue
+++ b/resources/js/app/components/related-objects-filter/results-pagination.vue
@@ -1,0 +1,89 @@
+<template>
+    <div class="pagination">
+        <div>
+            <nav class="pagination has-text-size-smallest">
+                <div class="count-items">
+                    <span class="has-font-weight-bold">{{ count }}</span>
+                    <span>Items</span>
+                </div>
+                <div class="page-size">
+                    <span>Size</span>
+                    <select
+                        class="page-size-selector has-background-gray-700 has-border-gray-700 has-font-weight-light has-text-gray-200 has-text-size-smallest"
+                        v-model="changeSize"
+                        @change="update"
+                    >
+                        <option
+                            v-for="size in options.sizes"
+                            :key="size"
+                            :value="size"
+                        >
+                            {{ size }}
+                        </option>
+                    </select>
+                </div>
+                <div
+                    class="pagination-buttons"
+                    v-if="pages > 1"
+                >
+                    <div>
+                        <button
+                            v-for="page in pages"
+                            :key="page"
+                            class="button is-width-auto has-text-size-smallest"
+                            :class="{ 'current-page': page === (filter?.page || 1), 'button-outlined': page !== (filter?.page || 1) }"
+                            @click.prevent="updatePage(page)"
+                        >
+                            {{ page }}
+                        </button>
+                    </div>
+                </div>
+            </nav>
+        </div>
+    </div>
+</template>
+<script>
+export default {
+    name: 'ResultsPagination',
+    props: {
+        count: {
+            type: Number,
+            default: 0,
+        },
+        filter: {
+            type: Object,
+            default: null,
+        },
+        options: {
+            type: Object,
+            default: () => ({ page: 1, pageSize: 10, sizes: [10, 20, 50, 100] }),
+        },
+    },
+    data() {
+        return {
+            changePage: null,
+            changeSize: null,
+            pages: 1,
+        };
+    },
+    mounted() {
+        this.$nextTick(() => {
+            this.changePage = this.filter?.page || this.options.page || 1,
+            this.changeSize = this.filter?.pageSize || this.options.pageSize || 10,
+            this.pages = Math.ceil(this.count / this.changeSize);
+        });
+    },
+    methods: {
+        update() {
+            this.$emit('update', {
+                page: this.changePage,
+                pageSize: this.changeSize,
+            });
+        },
+        updatePage(page) {
+            this.changePage = page;
+            this.update();
+        },
+    },
+}
+</script>

--- a/resources/js/app/components/related-objects-filter/results-pagination.vue
+++ b/resources/js/app/components/related-objects-filter/results-pagination.vue
@@ -27,15 +27,35 @@
                     v-if="pages > 1"
                 >
                     <div>
-                        <button
-                            v-for="page in pages"
-                            :key="page"
-                            class="button is-width-auto has-text-size-smallest"
-                            :class="{ 'current-page': page === (filter?.page || 1), 'button-outlined': page !== (filter?.page || 1) }"
-                            @click.prevent="updatePage(page)"
-                        >
-                            {{ page }}
-                        </button>
+                        <template v-for="page in pages">
+                            <input
+                                size="2"
+                                class="ml-05 mr-05"
+                                type="number"
+                                min="1"
+                                :max="pages"
+                                :key="`input-${page}`"
+                                v-model="changePage"
+                                @keyup.enter="updatePage(changePage)"
+                                @change="updatePage(changePage)"
+                                v-if="page == changePage"
+                            >
+                            <button
+                                :key="page"
+                                class="button is-width-auto has-text-size-smallest"
+                                :class="{ 'current-page': page === (filter?.page || 1), 'button-outlined': page !== (filter?.page || 1) }"
+                                @click.prevent="updatePage(page)"
+                                v-if="visiblePages.includes(page) && page !== changePage"
+                            >
+                                {{ page }}
+                            </button>
+                            <template v-if="!visiblePages.includes(page) && (page === changePage - 2 || page === changePage + 2)">
+                                <span
+                                    :key="page"
+                                    class="pages-delimiter"
+                                />
+                            </template>
+                        </template>
                     </div>
                 </div>
             </nav>
@@ -64,6 +84,7 @@ export default {
             changePage: null,
             changeSize: null,
             pages: 1,
+            visiblePages: [],
         };
     },
     mounted() {
@@ -71,6 +92,25 @@ export default {
             this.changePage = this.filter?.page || this.options.page || 1,
             this.changeSize = this.filter?.pageSize || this.options.pageSize || 10,
             this.pages = Math.ceil(this.count / this.changeSize);
+            let visiblePages = [];
+            if (this.pages <= 5) {
+                visiblePages = Array.from({ length: this.pages }, (_, i) => i + 1);
+                visiblePages = [...new Set(visiblePages)];
+                visiblePages.sort();
+                this.visiblePages = visiblePages;
+                return;
+            }
+            // visible pages should be the first, the last, current, the previous and the next page
+            visiblePages = [
+                1,
+                this.pages,
+                this.changePage - 1,
+                this.changePage,
+                this.changePage + 1
+            ].filter(page => page > 0 && page <= this.pages);
+            visiblePages = [...new Set(visiblePages)];
+            visiblePages.sort();
+            this.visiblePages = visiblePages;
         });
     },
     methods: {
@@ -81,7 +121,7 @@ export default {
             });
         },
         updatePage(page) {
-            this.changePage = page;
+            this.changePage = parseInt(page);
             this.update();
         },
     },

--- a/resources/js/app/components/related-objects-filter/results-pagination.vue
+++ b/resources/js/app/components/related-objects-filter/results-pagination.vue
@@ -4,10 +4,10 @@
             <nav class="pagination has-text-size-smallest">
                 <div class="count-items">
                     <span class="has-font-weight-bold">{{ count }}</span>
-                    <span>Items</span>
+                    <span>{{ msgItems }}</span>
                 </div>
                 <div class="page-size">
-                    <span>Size</span>
+                    <span>{{ msgSize }}</span>
                     <select
                         class="page-size-selector has-background-gray-700 has-border-gray-700 has-font-weight-light has-text-gray-200 has-text-size-smallest"
                         v-model="changeSize"
@@ -63,6 +63,8 @@
     </div>
 </template>
 <script>
+import { t } from 'ttag';
+
 export default {
     name: 'ResultsPagination',
     props: {
@@ -74,6 +76,10 @@ export default {
             type: Object,
             default: null,
         },
+        objectType: {
+            type: String,
+            default: null,
+        },
         options: {
             type: Object,
             default: () => ({ page: 1, pageSize: 10, sizes: [10, 20, 50, 100] }),
@@ -83,6 +89,8 @@ export default {
         return {
             changePage: null,
             changeSize: null,
+            msgItems: BEDITA_I18N?.[this.objectType] || t`Items`,
+            msgSize: t`Size`,
             pages: 1,
             visiblePages: [],
         };

--- a/resources/js/app/components/related-objects-filter/search-result.vue
+++ b/resources/js/app/components/related-objects-filter/search-result.vue
@@ -1,0 +1,133 @@
+<template>
+    <article class="search-result box">
+        <thumbnail :related="item" />
+        <div class="box-body p-05">
+            <div class="is-flex space-between align-center">
+                <span :class="`tag has-background-module-${objectType}`">{{ objectType }}</span>
+                <span
+                    class="icon-calendar-check-o"
+                    v-title="datesInfo(item)"
+                />
+                <span class="status is-uppercase has-text-size-smallest on">{{ item.attributes.status }}</span>
+            </div>
+            <div class="is-flex space-between align-center">
+                <clipboard-item
+                    label="ID"
+                    :text="item.id"
+                />
+                <clipboard-item
+                    label="uname"
+                    :text="item.attributes.uname"
+                />
+            </div>
+            <header class="is-flex space-between mt-05">
+                <div>
+                    <h3
+                        class="title m-0 has-text-size-small"
+                        style="padding-bottom: 7px;"
+                    >
+                        <span :title="item.attributes.title">{{ item.attributes.title }}</span>
+                    </h3>
+                </div>
+            </header>
+        </div>
+        <footer class="is-flex space-between mt-05 p-05">
+            <button
+                class="is-small has-font-weight-bold mr-1"
+                :class="selected ? 'button-secondary icon-check' : 'button-outlined-white button-text icon-check-empty'"
+                @click.prevent="toggle()"
+            >
+                <template v-if="selected">
+                    {{ msgDiscard }}
+                </template>
+                <template v-else>
+                    {{ msgPick }}
+                </template>
+            </button>
+            <object-info :object-data="item" />
+            <a
+                :href="`/view/${item.id}`"
+                target="_blank"
+                class="button button-outlined-white is-small"
+            >
+                <app-icon icon="carbon:launch" />
+                <span class="ml-05">{{ msgOpen }}</span>
+            </a>
+        </footer>
+    </article>
+</template>
+<script>
+import { t } from 'ttag';
+
+export default {
+    name: 'SearchResult',
+    props: {
+        item: {
+            type: Object,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            msgDiscard: t`Discard`,
+            msgOpen: t`Open`,
+            msgPick: t`Pick`,
+            objectType: this.item?.type || 'unknown',
+            selected: false,
+        };
+    },
+    methods: {
+        datesInfo(obj) {
+            if (obj?.meta?.created === undefined || obj?.meta?.modified === undefined) {
+                return '';
+            }
+            const created = new Date(obj.meta.created).toLocaleDateString() + ' ' + new Date(obj.meta.created).toLocaleTimeString();
+            const modified = new Date(obj.meta.modified).toLocaleDateString() + ' ' + new Date(obj.meta.modified).toLocaleTimeString();
+            if (!obj?.attributes?.publish_start) {
+                return t`Created on ${created}.` + ' ' + t`Modified on ${modified}.`;
+            }
+            const published = new Date(obj.meta.publish_start).toLocaleDateString() + ' ' + new Date(obj.attributes.publish_start).toLocaleTimeString();
+
+            return t`Created on ${created}.` + ' ' + t`Modified on ${modified}.` + ' ' + t`Publish start on ${published}.`;
+        },
+        toggle() {
+            this.selected = !this.selected;
+            const event = this.selected ? 'select' : 'discard';
+            this.$emit(event, this.item.id);
+        },
+    },
+};
+</script>
+<style scoped>
+article.search-result {
+    flex: 1;
+    border: 1px solid #eee;
+    border-radius: 4px;
+    padding: 12px;
+    margin-bottom: 12px;
+    background-color: #fff;
+}
+article.search-result .thumbnail {
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: 63%;
+    background-color: #f8f9fa;
+    pointer-events: none;
+}
+article.search-result .thumbnail figure {
+    font-size: 2.5rem;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0 !important;
+}
+article.search-result .thumbnail figure img {
+    display: block;
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
+}
+</style>

--- a/src/View/Helper/ArrayHelper.php
+++ b/src/View/Helper/ArrayHelper.php
@@ -81,4 +81,16 @@ class ArrayHelper extends Helper
     {
         return (array)Hash::extract($data, $path);
     }
+
+    /**
+     * Return intersection of two arrays reindexing values.
+     *
+     * @param array $arr1 First array.
+     * @param array $arr2 Second array.
+     * @return array The intersection of two arrays.
+     */
+    public function intersect(array $arr1, array $arr2): array
+    {
+        return array_values(array_intersect($arr1, $arr2));
+    }
 }

--- a/templates/Element/FilterBox/filter_box.twig
+++ b/templates/Element/FilterBox/filter_box.twig
@@ -1,7 +1,7 @@
 <div class="filter-box">
     {% if not hideFilter %}
     <div>
-        {{ element('FilterBox/filter_box_common', { showFilterSearchByType }) }}
+        {{ element('FilterBox/filter_box_common', { showFilterSearchByType, hideFilterRelations }) }}
     </div>
     {% endif %}
 

--- a/templates/Element/FilterBox/filter_box_common.twig
+++ b/templates/Element/FilterBox/filter_box_common.twig
@@ -58,12 +58,31 @@
                 <span class="ml-05">{{ __('Reset') }}</span>
             </button>
 
+            {% if hideFilterRelations == '' %}
+            <button class="toggle-filters button button-outlined is-width-auto" type="button" @click.prevent="toggleFilterRelations()">
+                <app-icon icon="carbon:filter-edit" v-show="!editFilterRelations"></app-icon><span class="ml-05" v-show="!editFilterRelations">{{ __('Relations') }}</span>
+                <app-icon icon="carbon:filter" v-show="editFilterRelations"></app-icon><span class="ml-05" v-show="editFilterRelations">{{ __('Relations') }}</span>
+            </button>
+            {% endif %}
+
             <button class="toggle-filters button button-outlined is-width-auto" type="button" @click="moreFilters = !moreFilters" v-if="canShowAdvanced">
                 <app-icon icon="carbon:filter-edit" v-if="!moreFilters"></app-icon><span class="ml-05" v-show="!moreFilters">{{ __('More') }}</span>
                 <app-icon icon="carbon:filter" v-if="moreFilters"></app-icon><span class="ml-05" v-show="moreFilters">{{ __('Less') }}</span>
             </button>
+
         </div>
     </div>
+
+    {% if hideFilterRelations == '' %}
+    <div class="more-filters" v-show="editFilterRelations">
+        <div class="filter-container">
+            <related-objects-filter
+                :relations-schema="{{ schema['relations']|json_encode }}"
+            >
+            </related-objects-filter>
+        </div>
+    </div>
+    {% endif %}
 
     <div class="more-filters" v-show="moreFilters">
         {# object type filter #}

--- a/templates/Element/FilterBox/filter_box_common.twig
+++ b/templates/Element/FilterBox/filter_box_common.twig
@@ -77,7 +77,10 @@
     <div class="more-filters" v-show="editFilterRelations">
         <div class="filter-container">
             <related-objects-filter
+                :initial-filter="{{ _view.request.getQuery('filter')|json_encode }}"
                 :relations-schema="{{ schema['relations']|json_encode }}"
+                @edit-filter-relations="editFilterRelations = 1"
+                @update-filter-related="updateFilterRelations"
             >
             </related-objects-filter>
         </div>

--- a/templates/Element/Form/relation.twig
+++ b/templates/Element/Form/relation.twig
@@ -55,7 +55,7 @@
                     @filter-reset="reloadObjects"
                     inline-template
                 >
-                    {{ element('FilterBox/filter_box') }}
+                    {{ element('FilterBox/filter_box', {'hideFilterRelations': true}) }}
                 </filter-box-view>
             </div>
 

--- a/templates/Element/Modules/index_header.twig
+++ b/templates/Element/Modules/index_header.twig
@@ -1,12 +1,14 @@
 <div class="module-header">
     {% set filterActive = (_view.request.getQuery('filter') or _view.request.getQuery('q')) %}
     {% set list = Schema.filterList(filter | default([]), schema.properties) %}
+    {% set relationsFilter = Array.intersect(_view.request.getQuery('filter')|keys|default([]), schema.relations|keys|default([])) %}
     <filter-box-view
         :pagination="{{ meta.pagination|json_encode|escape('html_attr') }}"
         :init-filter="urlFilterQuery"
         :selected-types='selectedTypes'
         :filter-list="{{ list|json_encode|escape('html_attr') }}"
         :filter-active="{{ filterActive|json_encode|escape('html_attr') }}"
+        :filter-relations-active="{{ relationsFilter|length > 0 ? 'true' : 'false' }}"
 
         config-paginate-sizes="{{ config('Pagination.sizeAvailable')|json_encode|escape('html_attr') }}"
         placeholder="{{ __('Search') }}"

--- a/templates/Element/Panel/relations_add.twig
+++ b/templates/Element/Panel/relations_add.twig
@@ -25,7 +25,7 @@
 
                 inline-template
             >
-                {{ element('FilterBox/filter_box', { 'showFilterSearchByType': true }) }}
+                {{ element('FilterBox/filter_box', { 'showFilterSearchByType': true, 'hideFilterRelations': true }) }}
             </filter-box-view>
         </div>
 

--- a/tests/TestCase/View/Helper/ArrayHelperTest.php
+++ b/tests/TestCase/View/Helper/ArrayHelperTest.php
@@ -199,4 +199,19 @@ class ArrayHelperTest extends TestCase
         $actual = $this->Array->extract($data, $pattern);
         static::assertSame($expected, $actual);
     }
+
+    /**
+     * Test `intersect()` method.
+     *
+     * @return void
+     * @covers ::intersect()
+     */
+    public function testIntersect(): void
+    {
+        $a = ['a', 'b', 'c', 'd'];
+        $b = ['c', 'd', 'e', 'f'];
+        $expected = ['c', 'd'];
+        $actual = $this->Array->intersect($a, $b);
+        static::assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
This introduces a new filter per relations in index of modules.

The user can select a relation, search a related object and filter the index data by those relation(s) and object(s).

![image](https://github.com/user-attachments/assets/501044b8-15f7-470f-a916-9956a19332f0)

![image](https://github.com/user-attachments/assets/2522bdf4-5776-4dc5-a3c2-08667ac6aad3)
