### PR TITLE
Index columns for relations related (first object related)

### DIFF
--- a/resources/js/app/components/object-info/object-info.vue
+++ b/resources/js/app/components/object-info/object-info.vue
@@ -39,6 +39,9 @@ export default {
             });
 
             for (const field of this.fields) {
+                if (typeof field !== 'string') {
+                    continue;
+                }
                 this.labelsMap.set(field, BEDITA_I18N?.[field] || field);
                 this.values[field] = this.objectData?.relationships?.streams?.data?.[0]?.attributes?.[field]
                     || this.objectData?.relationships?.streams?.data?.[0]?.meta?.[field]
@@ -141,6 +144,9 @@ export default {
         showInfo() {
             let content = this.contentTitle();
             for (const field of this.fields) {
+                if (typeof field !== 'string') {
+                    continue;
+                }
                 content += this.content(field);
             }
             content += this.contentMeta();

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -196,9 +196,12 @@ class PropertiesComponent extends Component
      */
     public function indexList(string $type): array
     {
-        $list = $this->getConfig(sprintf('Properties.%s.index', $type), $this->defaultGroups['index']);
-
-        return array_diff($list, ['id', 'status', 'modified']);
+        return array_filter(
+            $this->getConfig(sprintf('Properties.%s.index', $type), $this->defaultGroups['index']),
+            function ($item) {
+                return !in_array($item, ['id', 'status', 'modified']);
+            }
+        );
     }
 
     /**

--- a/templates/Element/Modules/index_table_header.twig
+++ b/templates/Element/Modules/index_table_header.twig
@@ -7,6 +7,13 @@
 
     {% set emptyQuerySearch = (_view.getRequest().getSession().read(currentModule.name ~ '.filter.q')|length == 0) %}
     {% for prop in properties %}
+        {% if prop is iterable %}
+            {% for relationName,relationFields in prop %}
+                <div>
+                    {{ Layout.tr(relationName) }}
+                </div>
+            {% endfor %}
+        {% else %}
         <div class="{{ Link.sortClass(prop) }}">
             {% if emptyQuerySearch and Schema.sortable(prop) %}
                 <a href="{{ Link.sortUrl(prop) }}">{{ Property.fieldLabel(prop) }}</a>
@@ -14,6 +21,7 @@
                 {{ Property.fieldLabel(prop) }}
             {% endif %}
         </div>
+        {% endif %}
     {% endfor %}
 
     {% if currentModule.hints.multiple_types %}

--- a/templates/Element/Modules/index_table_row.twig
+++ b/templates/Element/Modules/index_table_row.twig
@@ -21,8 +21,22 @@
                 <div class="{{ prop }}-cell">
                     {{ element('Modules/index_properties_date_ranges', { dateRanges: object.attributes[prop] }) }}
                 </div>
+            {% elseif (prop is iterable) %}
+                {% for relationName,relationFields in prop %}
+                    <div>
+                        {% if object.relationships[relationName]['data'][0] %}
+                            {% for f in relationFields %}
+                                {{ object.relationships[relationName]['data'][0]['attributes'][f] }}
+                            {% endfor %}
+                        {% endif %}
+                    </div>
+                {% endfor %}
             {% else %}
-                <index-cell :settings="{{ config('UI.index')|default({'copy2clipboard': false})|json_encode }}" :prop="{{ prop|json_encode }}" :text="{{ Property.value(object, prop)|json_encode }}">
+                <index-cell
+                    :settings="{{ config('UI.index')|default({'copy2clipboard': false})|json_encode }}"
+                    :prop="{{ prop|json_encode }}"
+                    :text="{{ Property.value(object, prop)|json_encode }}"
+                >
                 </index-cell>
             {% endif %}
         {% endfor %}

--- a/tests/TestCase/Controller/Component/QueryComponentTest.php
+++ b/tests/TestCase/Controller/Component/QueryComponentTest.php
@@ -117,10 +117,10 @@ class QueryComponentTest extends TestCase
     }
 
     /**
-     * Test `handleSort` method.
+     * Test `handleInclude` method.
      *
      * @return void
-     * @covers ::handleSort()
+     * @covers ::handleInclude()
      */
     public function testHandleInclude(): void
     {

--- a/tests/TestCase/Controller/Component/QueryComponentTest.php
+++ b/tests/TestCase/Controller/Component/QueryComponentTest.php
@@ -115,29 +115,6 @@ class QueryComponentTest extends TestCase
         static::assertEquals($expected, $actual);
     }
 
-    public function testHandleInclude(): void
-    {
-        $query = [
-            'filter' => [
-                'type' => 'documents',
-            ],
-        ];
-        $expected = [
-            'filter' => [
-                'type' => 'documents',
-                'b' => null,
-            ],
-        ];
-        $component = new class () extends QueryComponent {
-            public function handleInclude(array $query): array
-            {
-                return parent::handleInclude($query);
-            }
-        };
-        $actual = $component->handleInclude($query);
-        static::assertEquals($expected, $actual);
-    }
-
     /**
      * Data provider for `testPrepare`
      *

--- a/tests/TestCase/Controller/Component/QueryComponentTest.php
+++ b/tests/TestCase/Controller/Component/QueryComponentTest.php
@@ -90,6 +90,7 @@ class QueryComponentTest extends TestCase
      * @return void
      * @covers ::index()
      * @covers ::handleSort()
+     * @covers ::handleInclude()
      * @dataProvider indexProvider()
      */
     public function testIndex(array $queryParams, array $config, array $expected): void
@@ -111,6 +112,29 @@ class QueryComponentTest extends TestCase
             $Query->setConfig($key, $val);
         }
         $actual = $Query->index();
+        static::assertEquals($expected, $actual);
+    }
+
+    public function testHandleInclude(): void
+    {
+        $query = [
+            'filter' => [
+                'type' => 'documents',
+            ],
+        ];
+        $expected = [
+            'filter' => [
+                'type' => 'documents',
+                'b' => null,
+            ],
+        ];
+        $component = new class () extends QueryComponent {
+            public function handleInclude(array $query): array
+            {
+                return parent::handleInclude($query);
+            }
+        };
+        $actual = $component->handleInclude($query);
         static::assertEquals($expected, $actual);
     }
 

--- a/tests/TestCase/Controller/Component/QueryComponentTest.php
+++ b/tests/TestCase/Controller/Component/QueryComponentTest.php
@@ -3,6 +3,7 @@ namespace App\Test\TestCase\Controller\Component;
 
 use App\Controller\Component\QueryComponent;
 use Cake\Controller\Controller;
+use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 
@@ -112,6 +113,50 @@ class QueryComponentTest extends TestCase
             $Query->setConfig($key, $val);
         }
         $actual = $Query->index();
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `handleSort` method.
+     *
+     * @return void
+     * @covers ::handleSort()
+     */
+    public function testHandleInclude(): void
+    {
+        $controller = new Controller(
+            new ServerRequest(
+                [
+                    'query' => [],
+                    'environment' => [
+                        'REQUEST_METHOD' => 'GET',
+                    ],
+                    'params' => [
+                        'object_type' => 'test',
+                    ],
+                ]
+            )
+        );
+        $registry = $controller->components();
+        $component = new class ($registry) extends QueryComponent {
+            public function handleInclude(array $query): array
+            {
+                return parent::handleInclude($query);
+            }
+        };
+        $component->setConfig('include', 'c,d,e');
+        $query = [];
+        Configure::write('Properties.test.index', [
+            'title',
+            'description',
+            [
+                'a' => ['title'],
+                'b' => ['title'],
+                'c' => ['title'],
+            ],
+        ]);
+        $actual = $component->handleInclude($query);
+        $expected = ['include' => 'a,b,c,d,e'];
         static::assertEquals($expected, $actual);
     }
 


### PR DESCRIPTION
This introduces the possibility to have in index list "relations" relatated data first, in separate columns.

The relations to show can be set up in the configuration `Properties.<type>.index` like:

```
"index": [
      "title",
      "date_ranges",
      "booking_status",
      "rol_case_number",
      {
          "organized_by": [
              "name",
              "surname"
          ],
          "venues_booked": [
              "title"
          ]
      }
],
```

In this example, "organized_by" and "venues_booked" relations columns are available in index, and related data will show respectively "`related.name` `related.surname`" and "`related.title"`.

![image](https://github.com/user-attachments/assets/99c75557-74ec-429f-8a90-0f1d620f71da)
