### PR TITLE
Module setup for admins

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -331,6 +331,11 @@ $routes->scope('/', function (RouteBuilder $routes) {
         ['_name' => 'modules:create']
     );
     $routes->connect(
+        '/{object_type}/setup',
+        ['controller' => 'Modules', 'action' => 'setup'],
+        ['_name' => 'modules:setup']
+    );
+    $routes->connect(
         '/{object_type}/multiupload',
         ['controller' => 'Multiupload', 'action' => 'index'],
         ['_name' => 'modules:multiupload']

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -111,6 +111,8 @@ const _vueInstance = new Vue({
         FieldTextarea: () => import(/* webpackChunkName: "field-textarea" */'app/components/form/field-textarea'),
         FieldTitle: () => import(/* webpackChunkName: "field-title" */'app/components/form/field-title'),
         ObjectInfo: () => import(/* webpackChunkName: "object-info" */'app/components/object-info/object-info'),
+        ModuleProperties: () => import(/* webpackChunkName: "module-properties" */'app/components/module/module-properties'),
+        ModuleSetup: () => import(/* webpackChunkName: "module-setup" */'app/components/module/module-setup'),
         AppIcon,
     },
 
@@ -633,6 +635,8 @@ Vue.component('FieldString', _vueInstance.$options.components.FieldString);
 Vue.component('FieldTextarea', _vueInstance.$options.components.FieldTextarea);
 Vue.component('FieldTitle', _vueInstance.$options.components.FieldTitle);
 Vue.component('FileUpload', _vueInstance.$options.components.FileUpload);
+Vue.component('ModuleProperties', _vueInstance.$options.components.ModuleProperties);
+Vue.component('ModuleSetup', _vueInstance.$options.components.ModuleSetup);
 Vue.component('ObjectCategories', _vueInstance.$options.components.ObjectCategories);
 Vue.component('ObjectCaptions', _vueInstance.$options.components.ObjectCaptions);
 Vue.component('ObjectInfo', _vueInstance.$options.components.ObjectInfo);

--- a/resources/js/app/components/json-editor/json-editor.vue
+++ b/resources/js/app/components/json-editor/json-editor.vue
@@ -8,6 +8,10 @@ export default {
     name: 'JsonEditor',
 
     props: {
+        name: {
+            type: String,
+            default: '',
+        },
         target: {
             type: String,
             default: '',
@@ -35,11 +39,20 @@ export default {
             readOnly: true,
             ...this.options
         };
+        if (!options?.onChange) {
+            options.onChange = this.handleChange;
+        }
         this.editor = new JSONEditor({
             target: element,
             props: options
         });
         element.jsonEditor = this.editor;
+    },
+
+    methods: {
+        handleChange(updatedContent, previousContent, { contentErrors, patchResult }) {
+            this.$emit('change', this.name, updatedContent, previousContent, contentErrors, patchResult);
+        }
     },
 }
 </script>

--- a/resources/js/app/components/module/module-properties.vue
+++ b/resources/js/app/components/module/module-properties.vue
@@ -1,0 +1,242 @@
+<template>
+    <div class="module-properties">
+        <header
+            class="tab"
+            :class="{'open': open}"
+            :open="open"
+            @click="toggle"
+        >
+            <h2><span v-if="open">-</span><span v-else>+</span> <span>{{ msgProperties }}</span></h2>
+        </header>
+        <template v-if="open">
+            <div
+                class="input field"
+                v-for="field in fields"
+                :key="field"
+            >
+                <label :for="field">
+                    {{ field }}
+                    <span
+                        class="sample"
+                        v-html="samples[field]"
+                    />
+                </label>
+                <div>
+                    <div
+                        :id="`container-${field}`"
+                        class="jsoneditor-container"
+                    />
+                    <json-editor
+                        :name="field"
+                        :options="jsonEditorOptions"
+                        :target="`container-${field}`"
+                        :text="map[field] ? JSON.stringify(map[field], null, 2) : ''"
+                        @change="change"
+                    />
+                </div>
+            </div>
+            <div>
+                <template v-if="success">
+                    <button @click.prevent="skip">
+                        <app-icon
+                            icon="carbon:checkmark"
+                            color="green"
+                        />
+                        <span class="ml-05">
+                            {{ msgSuccess }}
+                        </span>
+                    </button>
+                </template>
+                <template v-else>
+                    <button
+                        :class="{'is-loading-spinner': loading}"
+                        :disabled="jsonVal === originalVal"
+                        @click.prevent="save"
+                    >
+                        <app-icon icon="carbon:save" />
+                        <span class="ml-05">
+                            {{ msgSave }}
+                        </span>
+                    </button>
+                </template>
+            </div>
+        </template>
+    </div>
+</template>
+<script>
+import { t } from 'ttag';
+
+export default {
+    name: 'ModuleProperties',
+    components: {
+        JsonEditor: () => import(/* webpackChunkName: "json-editor" */'app/components/json-editor/json-editor'),
+    },
+    inject: ['getCSFRToken'],
+    props: {
+        module: {
+            type: Object,
+            required: true,
+        },
+        objectType: {
+            type: String,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            fields: [
+                'bulk',
+                'fastCreate',
+                'filter',
+                'index',
+                'options',
+                'relations',
+                'view',
+            ],
+            jsonEditorOptions: {
+                mainMenuBar: true,
+                mode: 'text',
+                navigationBar: false,
+                statusBar: false,
+                readOnly: false,
+            },
+            loading: false,
+            map: {
+                bulk: '',
+                fastCreate: '',
+                filter: '',
+                index: '',
+                options: '',
+                relations: '',
+                view: '',
+            },
+            samples: {
+                bulk: 'look at <a href="https://github.com/bedita/manager/wiki/Setup:-Properties-display#bulk" target="_new">wikidoc</a>',
+                fastCreate: 'look at <a href="https://github.com/bedita/manager/wiki/Setup:-Properties-display#fastcreate" target="_new">wikidoc</a>',
+                filter: 'look at <a href="https://github.com/bedita/manager/wiki/Setup:-Properties-display#filter" target="_new">wikidoc</a>',
+                index: 'look at <a href="https://github.com/bedita/manager/wiki/Setup:-Properties-display#index" target="_new">wikidoc</a>',
+                options: 'look at <a href="https://github.com/bedita/manager/wiki/Setup:-Properties-display#options" target="_new">wikidoc</a>',
+                relations: 'look at <a href="https://github.com/bedita/manager/wiki/Setup:-Properties-display#relations" target="_new">wikidoc</a>',
+                view: 'look at <a href="https://github.com/bedita/manager/wiki/Setup:-Properties-display#view" target="_new">wikidoc</a>',
+            },
+            msgProperties: t`Properties`,
+            msgSave: t`Save`,
+            msgSuccess: t`Done`,
+            open: false,
+            originalVal: null,
+            success: false,
+        };
+    },
+    computed: {
+        jsonVal() {
+            const val = {};
+            const keys = Object.keys(this.map);
+            keys.forEach((key) => {
+                if (this.map[key] === '') {
+                    val[key] = null;
+                } else {
+                    if (typeof this.map[key] === 'string') {
+                        val[key] = JSON.parse(this.map[key]);
+                    } else {
+                        val[key] = JSON.parse(JSON.stringify(this.map[key]));
+                    }
+                }
+            });
+
+            return JSON.stringify(val);
+        },
+    },
+    mounted() {
+        this.$nextTick(() => {
+            this.originalVal = JSON.stringify(this.module);
+            this.fields.forEach((field) => {
+                this.map[field] = this.module[field] || '';
+            });
+        });
+    },
+    methods: {
+        change(field, val, prevVal, validation) {
+            if (validation?.validationErrors?.length === 0) {
+                this.map[field] = val?.text;
+            }
+        },
+        async save() {
+            try {
+                this.loading = true;
+                const payload = {
+                    configurationKey: `Properties.${this.objectType}`,
+                };
+                const keys = Object.keys(this.map);
+                keys.forEach((key) => {
+                    if (this.map[key] === '') {
+                        payload[key] = null;
+                    } else {
+                        if (typeof this.map[key] === 'string') {
+                            payload[key] = JSON.parse(this.map[key]);
+                        } else {
+                            payload[key] = JSON.parse(JSON.stringify(this.map[key]));
+                        }
+                    }
+                });
+                const url = `/${this.objectType}/setup`;
+                const body = JSON.stringify(payload);
+                const options = {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {
+                        'Accept': 'application/json',
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': this.getCSFRToken(),
+                    },
+                    body,
+                };
+                const response = await fetch(url, options);
+                const responseJson = await response.json();
+                if (responseJson?.error) {
+                    throw new Error(responseJson.error);
+                }
+                this.success = true;
+                delete payload.configurationKey;
+                this.originalVal = JSON.stringify(payload);
+                setTimeout(() => {
+                    this.$nextTick(() => {
+                        this.success = false;
+                    });
+                }, 2000);
+            } catch (e) {
+                BEDITA.error(e);
+            } finally {
+                this.loading = false;
+            }
+        },
+        skip() {
+            // do nothing
+        },
+        toggle() {
+            this.open = !this.open;
+        },
+    },
+};
+</script>
+<style scoped>
+div.module-properties {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 800px;
+    margin-top: 1rem;
+    padding-top: 1rem;
+}
+div.module-properties .input {
+    display: flex;
+    flex-direction: column;
+}
+div.module-properties .sample {
+    font-size: 0.8rem;
+    color: #999;
+}
+div.module-properties .tab {
+    cursor: pointer;
+    border-bottom: solid #FFF 1px;
+}
+</style>

--- a/resources/js/app/components/module/module-setup.vue
+++ b/resources/js/app/components/module/module-setup.vue
@@ -1,0 +1,264 @@
+
+<template>
+    <div class="module-setup">
+        <header
+            class="tab"
+            :class="{'open': open}"
+            :open="open"
+            @click="toggle"
+        >
+            <h2><span v-if="open">-</span><span v-else>+</span> <span>{{ msgModule }}</span></h2>
+        </header>
+        <template v-if="open">
+            <div class="grid">
+                <div
+                    v-for="field in otherFields"
+                    :key="field"
+                >
+                    <label :for="field">
+                        {{ field }}
+                        <span
+                            class="sample"
+                            v-html="samples[field]"
+                        />
+                    </label>
+                    <input
+                        :id="field"
+                        :name="field"
+                        type="text"
+                        v-model="map[field]"
+                    >
+                </div>
+            </div>
+            <div
+                class="input field"
+                v-for="field in jsonFields"
+                :key="field"
+            >
+                <label :for="field">
+                    {{ field }}
+                    <span
+                        class="sample"
+                        v-html="samples[field]"
+                    />
+                </label>
+                <div
+                    :id="`container-${field}`"
+                    class="jsoneditor-container"
+                />
+                <json-editor
+                    :name="field"
+                    :options="jsonEditorOptions"
+                    :target="`container-${field}`"
+                    :text="map[field] ? JSON.stringify(map[field], null, 2) : ''"
+                    @change="change"
+                />
+            </div>
+            <div>
+                <template v-if="success">
+                    <button @click.prevent="skip">
+                        <app-icon
+                            icon="carbon:checkmark"
+                            color="green"
+                        />
+                        <span class="ml-05">
+                            {{ msgSuccess }}
+                        </span>
+                    </button>
+                </template>
+                <template v-else>
+                    <button
+                        :class="{'is-loading-spinner': loading}"
+                        :disabled="jsonVal === originalVal"
+                        @click.prevent="save"
+                    >
+                        <app-icon icon="carbon:save" />
+                        <span class="ml-05">
+                            {{ msgSave }}
+                        </span>
+                    </button>
+                </template>
+            </div>
+        </template>
+    </div>
+</template>
+<script>
+import { t } from 'ttag';
+
+export default {
+    name: 'ModuleSetup',
+    components: {
+        JsonEditor: () => import(/* webpackChunkName: "json-editor" */'app/components/json-editor/json-editor'),
+    },
+    inject: ['getCSFRToken'],
+    props: {
+        module: {
+            type: Object,
+            required: true,
+        },
+        objectType: {
+            type: String,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            fields: [
+                'color',
+                'icon',
+                'shortLabel',
+                'sort',
+                'route',
+                'sidebar',
+            ],
+            jsonEditorOptions: {
+                mainMenuBar: true,
+                mode: 'text',
+                navigationBar: false,
+                statusBar: false,
+                readOnly: false,
+            },
+            jsonFields: ['route', 'sidebar'],
+            loading: false,
+            otherFields: ['color', 'icon', 'shortLabel', 'sort'],
+            map: {
+                color: '',
+                shortLabel: '',
+                sort: '',
+                icon: '',
+                sidebar: '',
+                route: '',
+            },
+            samples: {
+                color: 'i.e. #FF0000',
+                shortLabel: 'i.e. Usr',
+                sort: 'i.e. -modified',
+                icon: 'look at <a href="https://icon-sets.iconify.design" targer="_new">icon sets</a>',
+                route: 'i.e. {"_name": "users:organizer"}',
+                sidebar: 'i.e. {"index":[{"label":"Organizer","url":{"_name":"users:organizer"},"icon":"carbon:add"}]}',
+            },
+            msgModule: t`Module`,
+            msgSave: t`Save`,
+            msgSuccess: t`Done`,
+            open: false,
+            originalVal: null,
+            success: false,
+        };
+    },
+    computed: {
+        jsonVal() {
+            const val = {};
+            const keys = Object.keys(this.map);
+            keys.forEach((key) => {
+                if (this.map[key] !== '') {
+                    val[key] = this.map[key];
+                }
+            });
+
+            return JSON.stringify(val);
+        },
+    },
+    mounted() {
+        this.$nextTick(() => {
+            this.originalVal = JSON.stringify(this.module);
+            this.fields.forEach((field) => {
+                this.map[field] = this.module[field] || '';
+            });
+        });
+    },
+    methods: {
+        change(field, val, prevVal, validation) {
+            if (validation?.validationErrors?.length === 0) {
+                this.map[field] = val?.text;
+            }
+        },
+        async save() {
+            try {
+                this.loading = true;
+                const payload = {
+                    configurationKey: `Modules.${this.objectType}`,
+                };
+                const keys = Object.keys(this.map);
+                keys.forEach((key) => {
+                    if (this.map[key] === '') {
+                        payload[key] = null;
+                    } else if (this.jsonFields.includes(key)) {
+                        if (typeof this.map[key] === 'string') {
+                            payload[key] = JSON.parse(this.map[key]);
+                        } else {
+                            payload[key] = JSON.parse(JSON.stringify(this.map[key]));
+                        }
+                    } else {
+                        payload[key] = this.map[key];
+                    }
+                });
+                const url = `/${this.objectType}/setup`;
+                const body = JSON.stringify(payload);
+                const options = {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {
+                        'Accept': 'application/json',
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': this.getCSFRToken(),
+                    },
+                    body,
+                };
+                const response = await fetch(url, options);
+                const responseJson = await response.json();
+                if (responseJson?.error) {
+                    throw new Error(responseJson.error);
+                }
+                this.success = true;
+                delete payload.configurationKey;
+                this.originalVal = JSON.stringify(payload);
+                setTimeout(() => {
+                    this.$nextTick(() => {
+                        this.success = false;
+                    });
+                }, 2000);
+            } catch (e) {
+                BEDITA.error(e);
+            } finally {
+                this.loading = false;
+            }
+        },
+        skip() {
+            // do nothing
+        },
+        toggle() {
+            this.open = !this.open;
+        },
+    },
+};
+</script>
+<style scoped>
+div.module-setup {
+    display: flex;
+    flex-direction: column;
+    width: 800px;
+}
+div.module-setup .grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    grid-gap: 1rem;
+}
+div.module-setup > div {
+    margin-top: 1rem;
+}
+div.module-setup .input {
+    display: flex;
+    flex-direction: column;
+}
+div.module-setup .sample {
+    font-size: 0.8rem;
+    color: #999;
+}
+div.module-setup input {
+    width: 150px;
+}
+div.module-setup .tab {
+    cursor: pointer;
+    border-bottom: solid #FFF 1px;
+}
+</style>

--- a/templates/Element/Menu/menu.twig
+++ b/templates/Element/Menu/menu.twig
@@ -7,7 +7,7 @@
                 {% if name != 'trash' %}
                     {% set label = Layout.tr(module.label|default(name)) %}
                     {% set shortLabel = module.shortLabel|default(label[0:5]) %}
-                    {% if label|length > 5 %}
+                    {% if module.shortLabel or label|length > 5 %}
                         {% set label = shortLabel %}
                     {% endif %}
 

--- a/templates/Element/Modules/sidebar.twig
+++ b/templates/Element/Modules/sidebar.twig
@@ -50,3 +50,10 @@
         {% endif %}
     {% endfor %}
 {% endif %}
+
+{% if in_array('admin', user.roles) %}
+    {% do _view.append(
+        'app-module-buttons',
+        '<a href="' ~ Url.build({'_name': 'modules:setup', 'object_type': objectType}) ~ '" class="button button-outlined button-outlined-module-' ~ currentModule.name ~ '"><app-icon icon="carbon:settings"></app-icon><span class="ml-05">' ~ __('Setup module') ~ '</span></a>'
+    ) %}
+{% endif %}

--- a/templates/Pages/Modules/setup.twig
+++ b/templates/Pages/Modules/setup.twig
@@ -1,0 +1,19 @@
+{% do _view.assign('bodyViewClass', 'view-module view-model') %}
+
+<div class="module-header">
+	<header>
+		<h1>{{ __('Setup module') }}</h1>
+	</header>
+</div>
+
+<module-setup
+    :module="{{ config('Modules.' ~ objectType)|json_encode }}"
+    :object-type="{{ objectType|json_encode }}"
+>
+</module-setup>
+
+<module-properties
+    :module="{{ config('Properties.' ~ objectType)|json_encode }}"
+    :object-type="{{ objectType|json_encode }}"
+>
+</module-properties>


### PR DESCRIPTION
This introduces a new page "Module setup" in Modules, for admins.

Module setup page lets you edit configurations `Modules` and `Properties` for the current module.

As admin you can still edit the full configurations in Administration->Appearance, but this new page lets you focus on the module configuration data, that is much more compact.

![image](https://github.com/user-attachments/assets/5b6943ba-7ee6-444d-84a1-e634299dbde4)

![image](https://github.com/user-attachments/assets/0f0fe510-cbbb-48e5-85ae-848927e38277)
