### PR TITLE
Expandable related items in index cell

### DIFF
--- a/resources/js/app/components/index-cell/index-cell.vue
+++ b/resources/js/app/components/index-cell/index-cell.vue
@@ -7,7 +7,7 @@
     >
         <div
             v-html="truncated"
-            v-if="!msg"
+            v-if="!msg && truncated"
         />
 
         <div
@@ -22,9 +22,64 @@
             class="msg"
             v-if="msg"
         >
-            <app-icon icon="carbon:checkmark" color="green" />
+            <app-icon
+                icon="carbon:checkmark"
+                color="green"
+            />
             <span>{{ msg }}</span>
         </div>
+        <template v-if="related?.length > 0">
+            <div class="related-container">
+                <div class="related-item">
+                    <span
+                        v-for="f in relatedFields"
+                        :key="f"
+                    >
+                        {{ related?.[0]?.attributes?.[f] }}
+                    </span>
+                </div>
+                <div
+                    class="related-toggle"
+                    v-if="related?.length > 1"
+                >
+                    <button
+                        class="show-toggle icon icon-only-icon"
+                        :title="msgMore"
+                        @click.stop.prevent="relatedOpen = !relatedOpen"
+                        v-if="relatedOpen"
+                    >
+                        <app-icon icon="carbon:subtract" />
+                        <span class="is-sr-only">{{ msgMore }}</span>
+                    </button>
+                    <button
+                        class="show-toggle icon icon-only-icon"
+                        :title="msgMore"
+                        @click.stop.prevent="relatedOpen = !relatedOpen"
+                        v-else
+                    >
+                        <app-icon icon="carbon:add" />
+                        <span class="is-sr-only">{{ msgMore }}</span>
+                    </button>
+                </div>
+            </div>
+            <template v-if="relatedOpen">
+                <template v-for="(relatedItem, index) in related">
+                    <div
+                        class="related-item"
+                        @click.stop.prevent="relatedOpen = !relatedOpen"
+                        :key="index"
+                        v-if="index > 0"
+                    >
+                        <span
+                            v-for="f in relatedFields"
+                            :key="f"
+                        >
+                            {{ relatedItem?.attributes?.[f] }}
+                        </span>
+                    </div>
+                </template>
+            </template>
+        </template>
     </div>
 </template>
 <script>
@@ -44,6 +99,14 @@ export default {
             type: String,
             default: '',
         },
+        related: {
+            type: Array,
+            default: () => [],
+        },
+        relatedFields: {
+            type: Array,
+            default: () => [],
+        },
         untitledlabel: {
             type: String,
             default: '',
@@ -52,16 +115,20 @@ export default {
     data() {
         return {
             msg: '',
+            msgMore: t`More`,
+            relatedOpen: false,
             showCopy: false,
             truncated: '',
         };
     },
     async mounted() {
-        this.truncated = this.text.length <= 100 ? this.text : this.text.substring(0, 100);
+        this.$nextTick(() => {
+            this.truncated = this.text?.length <= 100 ? this.text : this.text?.substring(0, 100);
+        });
     },
     methods: {
         className() {
-            return `index-cell ${this.prop}-cell`;
+            return this.related?.length ? 'index-cell related-cell' : `index-cell ${this.prop}-cell`;
         },
         copy() {
             navigator.clipboard.writeText(this.text.replace(/<[^>]*>/g, ''));
@@ -100,5 +167,20 @@ div.index-cell > div.msg {
     color: forestgreen;
     font-family: monospace;
     font-style: italic;
+}
+div.index-cell div.related-container {
+    display: flex;
+}
+div.index-cell div.related-item {
+    display: flex;
+}
+div.index-cell div.related-toggle {
+    display: flex;
+}
+div.index-cell div.related-toggle > button {
+    margin-left: 16px;
+    line-height: 1;
+    height: 20px;
+    cursor: cell;
 }
 </style>

--- a/resources/js/app/components/index-cell/index-cell.vue
+++ b/resources/js/app/components/index-cell/index-cell.vue
@@ -32,6 +32,7 @@
             <div class="related-container">
                 <div class="related-item">
                     <span
+                        class="ml-05"
                         v-for="f in relatedFields"
                         :key="f"
                     >
@@ -71,6 +72,7 @@
                         v-if="index > 0"
                     >
                         <span
+                            class="ml-05"
                             v-for="f in relatedFields"
                             :key="f"
                         >

--- a/templates/Element/Modules/index_table_row.twig
+++ b/templates/Element/Modules/index_table_row.twig
@@ -23,13 +23,11 @@
                 </div>
             {% elseif (prop is iterable) %}
                 {% for relationName,relationFields in prop %}
-                    <div>
-                        {% if object.relationships[relationName]['data'][0] %}
-                            {% for f in relationFields %}
-                                {{ object.relationships[relationName]['data'][0]['attributes'][f] }}
-                            {% endfor %}
-                        {% endif %}
-                    </div>
+                    <index-cell
+                        :prop="{{ relationName|json_encode }}"
+                        :related="{{ object.relationships[relationName]['data']|json_encode }}"
+                        :related-fields="{{ relationFields|json_encode }}">
+                    </index-cell>
                 {% endfor %}
             {% else %}
                 <index-cell


### PR DESCRIPTION
With https://github.com/bedita/manager/pull/1262 we introduced the possibility to have "relation(s)" column(s) in module index, showing the first related item.

This enhances this part by providing a way to view all related item, clicking on an "expandable/collapsable" cell.

![image](https://github.com/user-attachments/assets/c5b48424-4fa6-4771-a8ef-4e5c1bb0cc21)

![image](https://github.com/user-attachments/assets/b173c5c4-f255-486f-9ca2-aebbd8c7ba15)
