### PR TITLE
Apply regular expression on richeditor to cleanup content

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -595,7 +595,9 @@ return [
     //     ],
     //     'style_formats_merge' => true,
     //     'content_style' => '.be-highlight { background-color: #F6F6F6; }',
-    //     'cleanup_regex' => '\s\w+="[^"]*"', // remove attributes from tags
+    //     'cleanup_regex_pattern' => '\\sstyle="[^"]*"', // remove style attributes from tags
+    //     'cleanup_regex_argument' => 'gs', // global and match new lines
+    //     'cleanup_regex_replace' => '', // replace with empty string
     // ],
 
     /**

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -595,6 +595,7 @@ return [
     //     ],
     //     'style_formats_merge' => true,
     //     'content_style' => '.be-highlight { background-color: #F6F6F6; }',
+    //     'cleanup_regex' => '\s\w+="[^"]*"', // remove attributes from tags
     // ],
 
     /**

--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -64,10 +64,14 @@ export default {
             bind(element, binding, vnode) {
                 element.addEventListener('change', (event) => {
                     emit(vnode, 'input', event);
-                    if (BEDITA?.richeditorConfig?.cleanup_regex) {
-                        const regex = new RegExp(BEDITA.richeditorConfig.cleanup_regex, 'g');
+                    if (BEDITA?.richeditorConfig?.cleanup_regex_pattern) {
+                        const regex = new RegExp(
+                            BEDITA.richeditorConfig.cleanup_regex_pattern,
+                            BEDITA.richeditorConfig.cleanup_regex_argument || 'gs'
+                        );
                         const content = event?.target?.editor?.getContent() || '';
-                        const cleanContent = content.replace(regex, '');
+                        const replacement = BEDITA.richeditorConfig.cleanup_regex_replacement || '';
+                        const cleanContent = content.replace(regex, replacement);
                         if (cleanContent !== content) {
                             event.target.editor.setContent(cleanContent);
                         }

--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -64,6 +64,14 @@ export default {
             bind(element, binding, vnode) {
                 element.addEventListener('change', (event) => {
                     emit(vnode, 'input', event);
+                    if (BEDITA?.richeditorConfig?.cleanup_regex) {
+                        const regex = new RegExp(BEDITA.richeditorConfig.cleanup_regex, 'g');
+                        const content = event?.target?.editor?.getContent() || '';
+                        const cleanContent = content.replace(regex, '');
+                        if (cleanContent !== content) {
+                            event.target.editor.setContent(cleanContent);
+                        }
+                    }
                 });
             },
 


### PR DESCRIPTION
This provides a way to apply a regular expression on richeditor change, if set in configuration.
Example:
```php
'Richeditor' => [
    'cleanup_regex_pattern' => '\\sstyle="[^"]*"', // remove style attributes from tags
    'cleanup_regex_argument' => 'gs', // global and match new lines
    'cleanup_regex_replace' => '', // replace with empty string
],
```