### PR TITLE
User profile page enhancements

### DIFF
--- a/config/i18n_strings.php
+++ b/config/i18n_strings.php
@@ -55,6 +55,7 @@
 //  __('completed');
 //  __('uname');
 //  __('Subtitle');
+//  __('Locked');
 
 // Admin
 // __('Auth Providers');
@@ -95,6 +96,9 @@
 //  __('Zipcode');
 //  __('Country');
 //  __('State Name');
+//  __('Old Password');
+//  __('Password');
+//  __('Confirm-password');
 
 // Users
 //  __('username');

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2025-04-01 12:09:55 \n"
+"POT-Creation-Date: 2025-05-15 10:01:27 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -38,6 +38,9 @@ msgid "Advanced"
 msgstr ""
 
 msgid "Advanced Data"
+msgstr ""
+
+msgid "Age"
 msgstr ""
 
 msgid "Alert Message"
@@ -167,6 +170,9 @@ msgid "Config"
 msgstr ""
 
 msgid "Confirm new password"
+msgstr ""
+
+msgid "Confirm-password"
 msgstr ""
 
 msgid "Conflict"
@@ -436,6 +442,12 @@ msgstr ""
 msgid "Language and translations"
 msgstr ""
 
+msgid "Last login"
+msgstr ""
+
+msgid "Last login error"
+msgstr ""
+
 msgid "Left types"
 msgstr ""
 
@@ -457,6 +469,9 @@ msgstr ""
 msgid "Lock"
 msgstr ""
 
+msgid "Locked"
+msgstr ""
+
 msgid "Locked_until"
 msgstr ""
 
@@ -464,6 +479,9 @@ msgid "Log out"
 msgstr ""
 
 msgid "Login"
+msgstr ""
+
+msgid "Login informations"
 msgstr ""
 
 msgid "Login required"
@@ -570,6 +588,9 @@ msgstr ""
 msgid "Number of created objects"
 msgstr ""
 
+msgid "Number of login errors"
+msgstr ""
+
 msgid "Number of updated objects"
 msgstr ""
 
@@ -603,6 +624,9 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
+msgid "Old Password"
+msgstr ""
+
 msgid "On"
 msgstr ""
 
@@ -633,7 +657,13 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
+msgid "Password"
+msgstr ""
+
 msgid "Password Modified"
+msgstr ""
+
+msgid "Password informations"
 msgstr ""
 
 msgid "Password reset"
@@ -798,6 +828,9 @@ msgstr ""
 msgid "Select a project"
 msgstr ""
 
+msgid "Setup module"
+msgstr ""
+
 msgid "Show active positions"
 msgstr ""
 
@@ -951,6 +984,9 @@ msgstr ""
 msgid "Vat Number"
 msgstr ""
 
+msgid "Verified"
+msgstr ""
+
 msgid "Version"
 msgstr ""
 
@@ -970,6 +1006,9 @@ msgid "Write"
 msgstr ""
 
 msgid "Yes"
+msgstr ""
+
+msgid "You are not authorized to access here"
 msgstr ""
 
 msgid "You are not authorized to access that location."
@@ -1014,6 +1053,9 @@ msgstr ""
 msgid "bearing"
 msgstr ""
 
+msgid "by"
+msgstr ""
+
 msgid "cancel"
 msgstr ""
 
@@ -1036,6 +1078,9 @@ msgid "created"
 msgstr ""
 
 msgid "current password"
+msgstr ""
+
+msgid "day(s)"
 msgstr ""
 
 msgid "description"
@@ -1658,6 +1703,9 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
+msgid "Module"
+msgstr ""
+
 msgid ""
 "Sorry, your browser does not support embedded <code>audio</code> element"
 msgstr ""
@@ -1679,9 +1727,6 @@ msgid ""
 msgstr ""
 
 msgid "View original"
-msgstr ""
-
-msgid "Password"
 msgstr ""
 
 msgid "Address"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2025-04-01 12:09:55 \n"
+"POT-Creation-Date: 2025-05-15 10:01:27 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -41,6 +41,9 @@ msgid "Advanced"
 msgstr ""
 
 msgid "Advanced Data"
+msgstr ""
+
+msgid "Age"
 msgstr ""
 
 msgid "Alert Message"
@@ -170,6 +173,9 @@ msgid "Config"
 msgstr ""
 
 msgid "Confirm new password"
+msgstr ""
+
+msgid "Confirm-password"
 msgstr ""
 
 msgid "Conflict"
@@ -439,6 +445,12 @@ msgstr ""
 msgid "Language and translations"
 msgstr ""
 
+msgid "Last login"
+msgstr ""
+
+msgid "Last login error"
+msgstr ""
+
 msgid "Left types"
 msgstr ""
 
@@ -460,6 +472,9 @@ msgstr ""
 msgid "Lock"
 msgstr ""
 
+msgid "Locked"
+msgstr ""
+
 msgid "Locked_until"
 msgstr ""
 
@@ -467,6 +482,9 @@ msgid "Log out"
 msgstr ""
 
 msgid "Login"
+msgstr ""
+
+msgid "Login informations"
 msgstr ""
 
 msgid "Login required"
@@ -573,6 +591,9 @@ msgstr ""
 msgid "Number of created objects"
 msgstr ""
 
+msgid "Number of login errors"
+msgstr ""
+
 msgid "Number of updated objects"
 msgstr ""
 
@@ -606,6 +627,9 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
+msgid "Old Password"
+msgstr ""
+
 msgid "On"
 msgstr ""
 
@@ -636,7 +660,13 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
+msgid "Password"
+msgstr ""
+
 msgid "Password Modified"
+msgstr ""
+
+msgid "Password informations"
 msgstr ""
 
 msgid "Password reset"
@@ -801,6 +831,9 @@ msgstr ""
 msgid "Select a project"
 msgstr ""
 
+msgid "Setup module"
+msgstr ""
+
 msgid "Show active positions"
 msgstr ""
 
@@ -954,6 +987,9 @@ msgstr ""
 msgid "Vat Number"
 msgstr ""
 
+msgid "Verified"
+msgstr ""
+
 msgid "Version"
 msgstr ""
 
@@ -973,6 +1009,9 @@ msgid "Write"
 msgstr ""
 
 msgid "Yes"
+msgstr ""
+
+msgid "You are not authorized to access here"
 msgstr ""
 
 msgid "You are not authorized to access that location."
@@ -1017,6 +1056,9 @@ msgstr ""
 msgid "bearing"
 msgstr ""
 
+msgid "by"
+msgstr ""
+
 msgid "cancel"
 msgstr ""
 
@@ -1039,6 +1081,9 @@ msgid "created"
 msgstr ""
 
 msgid "current password"
+msgstr ""
+
+msgid "day(s)"
 msgstr ""
 
 msgid "description"
@@ -1661,6 +1706,9 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
+msgid "Module"
+msgstr ""
+
 msgid ""
 "Sorry, your browser does not support embedded <code>audio</code> element"
 msgstr ""
@@ -1682,9 +1730,6 @@ msgid ""
 msgstr ""
 
 msgid "View original"
-msgstr ""
-
-msgid "Password"
 msgstr ""
 
 msgid "Address"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2025-04-01 12:09:55 \n"
+"POT-Creation-Date: 2025-05-15 10:01:27 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -44,6 +44,9 @@ msgstr "Avanzate"
 
 msgid "Advanced Data"
 msgstr "Dati Avanzati"
+
+msgid "Age"
+msgstr "Età"
 
 msgid "Alert Message"
 msgstr "Messaggio di Attenzione"
@@ -173,6 +176,9 @@ msgstr "Configurazioni"
 
 msgid "Confirm new password"
 msgstr "Conferma nuova password"
+
+msgid "Confirm-password"
+msgstr "Conferma password"
 
 msgid "Conflict"
 msgstr "Conflitto"
@@ -442,6 +448,12 @@ msgstr "Lingua"
 msgid "Language and translations"
 msgstr "Lingua e traduzioni"
 
+msgid "Last login"
+msgstr "Ultimo accesso"
+
+msgid "Last login error"
+msgstr "Ultimo errore di accesso"
+
 msgid "Left types"
 msgstr "Tipi di sinistra"
 
@@ -463,6 +475,9 @@ msgstr "Posizioni"
 msgid "Lock"
 msgstr "Blocca"
 
+msgid "Locked"
+msgstr "Bloccato"
+
 msgid "Locked_until"
 msgstr "Termine blocco"
 
@@ -471,6 +486,9 @@ msgstr "Esci"
 
 msgid "Login"
 msgstr "Accedi"
+
+msgid "Login informations"
+msgstr "Informazioni di accesso"
 
 msgid "Login required"
 msgstr "È richiesto il login"
@@ -578,6 +596,9 @@ msgstr "Non trovato"
 msgid "Number of created objects"
 msgstr "Numero di oggetti creati"
 
+msgid "Number of login errors"
+msgstr "Numero di errori di accesso"
+
 msgid "Number of updated objects"
 msgstr "Numero di oggetti aggiornati"
 
@@ -609,7 +630,10 @@ msgid "Off"
 msgstr ""
 
 msgid "Ok"
-msgstr ""
+msgstr "Ok"
+
+msgid "Old Password"
+msgstr "Vecchia Password"
 
 msgid "On"
 msgstr ""
@@ -641,8 +665,14 @@ msgstr "Paginazione"
 msgid "Parent"
 msgstr "Genitore"
 
+msgid "Password"
+msgstr "Password"
+
 msgid "Password Modified"
 msgstr "Password modificata il"
+
+msgid "Password informations"
+msgstr "Informazioni password"
 
 msgid "Password reset"
 msgstr "Reimposta password"
@@ -808,6 +838,9 @@ msgstr "Cerca"
 msgid "Select a project"
 msgstr "Seleziona un progetto"
 
+msgid "Setup module"
+msgstr "Configura modulo"
+
 msgid "Show active positions"
 msgstr "Mostra posizioni attive"
 
@@ -962,6 +995,9 @@ msgstr "Utenti"
 msgid "Vat Number"
 msgstr "Partita Iva"
 
+msgid "Verified"
+msgstr "Verificato"
+
 msgid "Version"
 msgstr "Versione"
 
@@ -982,6 +1018,8 @@ msgstr "Scrittura"
 
 msgid "Yes"
 msgstr "Sì"
+msgid "You are not authorized to access here"
+msgstr "Non sei autorizzato ad accedere qui."
 
 msgid "You are not authorized to access that location."
 msgstr "Non sei autorizzato ad accedere a quest'area."
@@ -1025,6 +1063,9 @@ msgstr ""
 msgid "bearing"
 msgstr ""
 
+msgid "by"
+msgstr "da"
+
 msgid "cancel"
 msgstr "annulla"
 
@@ -1048,6 +1089,9 @@ msgstr "creato"
 
 msgid "current password"
 msgstr "password corrente"
+
+msgid "day(s)"
+msgstr "giorno/i"
 
 msgid "description"
 msgstr "descrizione"
@@ -1680,6 +1724,9 @@ msgstr "Parametri"
 msgid "Valid"
 msgstr "Valido"
 
+msgid "Module"
+msgstr ""
+
 msgid ""
 "Sorry, your browser does not support embedded <code>audio</code> element"
 msgstr ""
@@ -1706,9 +1753,6 @@ msgstr ""
 
 msgid "View original"
 msgstr "Vedi originale"
-
-msgid "Password"
-msgstr "Password"
 
 msgid "Address"
 msgstr "Indirizzo"

--- a/resources/js/app/components/property-view/property-view.js
+++ b/resources/js/app/components/property-view/property-view.js
@@ -203,11 +203,21 @@ export default {
 
                     // using == because user.id String and creatorById Number
                     if(user.id == creatorId && userInfo!= undefined) {
-                        document.querySelector('td[name=\'created_by\']').innerHTML = `<a href="${href}">${userInfo}</a>`;
+                        if (document.querySelector('span[name=\'created_by\']')) {
+                            document.querySelector('span[name=\'created_by\']').innerHTML = `<a href="${href}">${userInfo}</a>`;
+                        }
+                        if (document.querySelector('td[name=\'created_by\']')) {
+                            document.querySelector('td[name=\'created_by\']').innerHTML = `<a href="${href}">${userInfo}</a>`;
+                        }
                     }
-
+                    // using == because user.id String and modifierId Number
                     if (user.id == modifierId && userInfo!= undefined) {
-                        document.querySelector('td[name=\'modified_by\']').innerHTML = `<a href="${href}">${userInfo}</a>`;
+                        if (document.querySelector('span[name=\'modified_by\']')) {
+                            document.querySelector('span[name=\'modified_by\']').innerHTML = `<a href="${href}">${userInfo}</a>`;
+                        }
+                        if (document.querySelector('td[name=\'modified_by\']')) {
+                            document.querySelector('td[name=\'modified_by\']').innerHTML = `<a href="${href}">${userInfo}</a>`;
+                        }
                     }
                 });
             }

--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -21,6 +21,7 @@ use Cake\Utility\Hash;
  *
  * @property \App\View\Helper\AdminHelper $Admin
  * @property \App\View\Helper\CalendarHelper $Calendar
+ * @property \App\View\Helper\DatesHelper $Dates
  * @property \App\View\Helper\EditorsHelper $Editors
  * @property \App\View\Helper\LayoutHelper $Layout
  * @property \App\View\Helper\ArrayHelper $Array
@@ -65,6 +66,7 @@ class AppView extends TwigView
         ]);
         $this->addHelper('Admin');
         $this->addHelper('Calendar');
+        $this->addHelper('Dates');
         $this->addHelper('Editors');
         $this->addHelper('Element');
         $this->addHelper('Layout');

--- a/src/View/Helper/DatesHelper.php
+++ b/src/View/Helper/DatesHelper.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace App\View\Helper;
+
+use Cake\View\Helper;
+use DateTime;
+
+/**
+ * Dates helper
+ */
+class DatesHelper extends Helper
+{
+    /**
+     * Get the number of days between the current date and the given date.
+     *
+     * @param string $then The date to compare with the current date.
+     * @return int The number of days between the two dates.
+     */
+    public function daysAgo(string $then): int
+    {
+        $now = new DateTime();
+        $diff = $now->diff(new DateTime($then));
+
+        return $diff->days;
+    }
+}

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -172,7 +172,7 @@ class SchemaHelper extends Helper
      * @param mixed $value Property value.
      * @return string
      */
-    protected function formatByte($value): string
+    public function formatByte($value): string
     {
         return Number::toReadableSize((int)$value);
     }
@@ -183,7 +183,7 @@ class SchemaHelper extends Helper
      * @param mixed $value Property value.
      * @return string
      */
-    protected function formatBoolean($value): string
+    public function formatBoolean($value): string
     {
         $res = filter_var($value, FILTER_VALIDATE_BOOLEAN);
 
@@ -196,7 +196,7 @@ class SchemaHelper extends Helper
      * @param mixed $value Property value.
      * @return string
      */
-    protected function formatDate($value): string
+    public function formatDate($value): string
     {
         if (empty($value)) {
             return '';
@@ -211,7 +211,7 @@ class SchemaHelper extends Helper
      * @param mixed $value Property value.
      * @return string
      */
-    protected function formatDateTime($value): string
+    public function formatDateTime($value): string
     {
         return $this->formatDate($value);
     }

--- a/templates/Pages/Dashboard/index.twig
+++ b/templates/Pages/Dashboard/index.twig
@@ -31,7 +31,7 @@
                     <a href="{{ Url.build({'_name': 'modules:list', 'object_type': 'users'}) }}" title="{{ __('System users') }}" class="dashboard-item has-background-black">
                         <span>{{ __('System users') }}</span>
                         {% if Layout.showCounter('users') %}{{ Layout.moduleCount('users', 'has-background-black')|raw }}{% endif %}
-                        <app-icon icon="carbon:user-admin" :style="{ width: '28px', height: '28px' }"></app-icon>
+                        <app-icon icon="carbon:events-alt" :style="{ width: '28px', height: '28px' }"></app-icon>
                     </a>
                 {% endif %}
 

--- a/templates/Pages/UserProfile/view.twig
+++ b/templates/Pages/UserProfile/view.twig
@@ -101,7 +101,8 @@
                                     </div>
                                 </section>
                             </property-view>
-                        {% else %}
+                        {% endif %}
+                        {% if object.meta.password_modified %}
                             <property-view inline-template :tab-open="tabsOpen" tab-name="password-info">
                                 <section class="fieldset">
                                     <header @click.prevent="toggleVisibility()" class="tab unselectable" :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">

--- a/templates/Pages/UserProfile/view.twig
+++ b/templates/Pages/UserProfile/view.twig
@@ -1,6 +1,7 @@
 {% do _view.assign('bodyViewClass', 'userprofiles-view') %}
 {% do _view.assign('title', 'User Profile') %}
 
+<modules-view inline-template ref="moduleView" :user-roles="{{ user.roles|json_encode }}"  :object="{{ object|json_encode }}">
 <div class="modules-view">
 
     <div class="module-form">
@@ -16,60 +17,154 @@
                 {% set jsonKeys = [] %}
                 {% for group, attributes in properties %}
                     {% if group != 'other' and group != 'password_change' and attributes %}
-                        <section class="fieldset">
-                            <header>
-                                {% if group|trim  %}
-                                    <h2>{{ __(group|humanize) }}</h2>
-                                {% else %}
-                                    <h2>{{ __('General') }}</h2>
-                                {% endif %}
-                            </header>
-                            <div class="tab-container">
-                                {% for key, value in attributes %}
-                                    {% set options = {} %}
-                                    {% if key == 'email' or key == 'username' %}
-                                        {% set options = options|merge({'readonly': 'true'}) %}
+                        <property-view inline-template :tab-open="tabsOpen" tab-name="{{ __(group|default('general')) }}">
+                            <section class="fieldset">
+                                <header @click.prevent="toggleVisibility()" class="tab unselectable" :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                                    {% if group|trim  %}
+                                        <h2>{{ __(group|humanize) }}</h2>
+                                    {% else %}
+                                        <h2>{{ __('General') }}</h2>
                                     {% endif %}
-                                    {% if key != 'title' %}
-                                        {{ Property.control(key, value, options)|raw }}
-                                    {% endif %}
-                                {% endfor %}
-                            </div>
-                        </section>
+                                </header>
+                                <div v-show="isOpen" class="tab-container">
+                                    {% for key, value in attributes %}
+                                        {% set options = {} %}
+                                        {% if key == 'email' or key == 'username' %}
+                                            {% set options = options|merge({'readonly': 'true'}) %}
+                                        {% endif %}
+                                        {% if key != 'title' %}
+                                            {{ Property.control(key, value, options)|raw }}
+                                        {% endif %}
+                                    {% endfor %}
+                                </div>
+                            </section>
+                        </property-view>
                     {% endif %}
                 {% endfor %}
-                <section class="fieldset">
-                    <header>
-                        <h2>{{ __('Roles') }}</h2>
-                    </header>
-                    <div class="tab-container">
-                        <div>
-                            {% for role in user.roles %}
-                            <span class="tag is-black mx-05">
-                                {{ role }}
-                            </span>
-                            {% endfor %}
+                <property-view inline-template :tab-open="tabsOpen" tab-name="roles">
+                    <section class="fieldset">
+                        <header @click.prevent="toggleVisibility()" class="tab unselectable" :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                            <h2>{{ __('Roles') }}</h2>
+                        </header>
+                        <div v-show="isOpen" class="tab-container">
+                            <div>
+                                {% for role in user.roles %}
+                                <span class="tag is-black mx-05">
+                                    {{ role }}
+                                </span>
+                                {% endfor %}
+                            </div>
                         </div>
-                    </div>
-                </section>
+                    </section>
+                </property-view>
             </div>
 
             <div class="side-view-column">
                 {% for group, attributes in properties %}
                     {% if group == 'password_change' and attributes %}
-                        <section class="fieldset">
-                            <header>
-                                <h2>{{ __('Change password') }}</h2>
-                            </header>
+                        <property-view inline-template :tab-open="tabsOpen" tab-name="login-info">
+                            <section class="fieldset">
+                                <header @click.prevent="toggleVisibility()" class="tab unselectable" :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                                    <h2>{{ __('Login informations') }}</h2>
+                                </header>
+                                <div v-show="isOpen" class="tab-container">
+                                    <div class="input text">
+                                        <label>{{ __('Last login') }}</label>
+                                        <span>{{ Schema.formatDateTime(object.meta.last_login)|default('-') }}</span>
+                                    </div>
+                                    <div class="input text">
+                                        <label>{{ __('Last login error') }}</label>
+                                        <span>{{ Schema.formatDateTime(object.meta.last_login_err)|default('-') }}</span>
+                                    </div>
+                                    <div class="input text">
+                                        <label>{{ __('Number of login errors') }}</label>
+                                        <span>{{ object.meta.num_login_err }}</span>
+                                    </div>
+                                </div>
+                            </section>
+                        </property-view>
 
-                            <div class="tab-container">
-                                {% for key, value in attributes %}
-                                    {{ Property.control(key, value)|raw }}
-                                {% endfor %}
-                            </div>
-                        </section>
+
+                        {% if object.meta.external_auth|length > 0 %}
+                            <property-view inline-template :tab-open="tabsOpen" tab-name="external-auth">
+                                <section class="fieldset">
+                                    <header @click.prevent="toggleVisibility()" class="tab unselectable" :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                                        <h2>{{ __('External Auth') }}</h2>
+                                    </header>
+                                    <div v-show="isOpen" class="tab-container">
+                                        {% for auth in object.meta.external_auth %}
+                                            <div class="input text">
+                                                <label>{{ __('Username') }} {{ auth.provider }}</label>
+                                                <span>{{ auth.username }}</span>
+                                            </div>
+                                        {% endfor %}
+                                    </div>
+                                </section>
+                            </property-view>
+                        {% else %}
+                            <property-view inline-template :tab-open="tabsOpen" tab-name="password-info">
+                                <section class="fieldset">
+                                    <header @click.prevent="toggleVisibility()" class="tab unselectable" :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                                        <h2>{{ __('Password informations') }}</h2>
+                                    </header>
+                                    <div v-show="isOpen" class="tab-container">
+                                        <div class="input text">
+                                            <label>{{ __('Age') }}</label>
+                                            <span>{{ Dates.daysAgo(object.meta.password_modified) }} {{ __('day(s)') }}</span>
+                                        </div>
+                                        <div class="input text">
+                                            <label>{{ __('Modified') }}</label>
+                                            <span>{{ Schema.formatDateTime(object.meta.password_modified) }}</span>
+                                        </div>
+                                        <div class="input text">
+                                            <label>{{ __('Verified') }}</label>
+                                            <span>{{ Schema.formatDateTime(object.meta.verified) }}</span>
+                                        </div>
+                                    </div>
+                                </section>
+                            </property-view>
+                            <property-view inline-template :tab-open="tabsOpen" tab-name="password-info">
+                                <section class="fieldset">
+                                    <header @click.prevent="toggleVisibility()" class="tab unselectable" :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                                        <h2>{{ __('Change password') }}</h2>
+                                    </header>
+                                    <div v-show="isOpen" class="tab-container">
+                                        {% for key, value in attributes %}
+                                            {{ Property.control(key, value)|raw }}
+                                        {% endfor %}
+                                    </div>
+                                </section>
+                            </property-view>
+                        {% endif %}
                     {% endif %}
                 {% endfor %}
+                <property-view inline-template :tab-open="tabsOpen" tab-name="meta" :object="object">
+                    <section class="fieldset">
+                        <header @click.prevent="toggleVisibility()" class="tab unselectable" :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+                            <h2>{{ __('Metadata') }}</h2>
+                        </header>
+                        <div v-show="isOpen" class="tab-container">
+                            <div class="input text">
+                                <label>{{ __('Created') }}</label>
+                                <span>
+                                    {{ Schema.formatDateTime(object.meta.created) }}
+                                </span>
+                                {{ __('by') }}
+                                <span name="created_by">{{ Schema.format(object.meta.created_by, schema.properties.created_by) }}</span>
+                            </div>
+                            <div class="input text">
+                                <label>{{ __('Modified') }}</label>
+                                <span>{{ Schema.formatDateTime(object.meta.modified) }}</span>
+                                {{ __('by') }}
+                                <span name="modified_by">{{ Schema.format(object.meta.modified_by, schema.properties.modified_by) }}</span>
+                            </div>
+                            <div class="input text">
+                                <label>{{ __('Locked') }}</label>
+                                <span>{{ object.meta.locked == 1 ? __('Yes') : __('No') }}</span>
+                            </div>
+                        </div>
+                    </section>
+                </property-view>
             </div>
 
             {% if jsonKeys %}
@@ -86,3 +181,4 @@
     </div>
 
 </div>
+</modules-view>

--- a/tests/TestCase/View/Helper/DatesHelperTest.php
+++ b/tests/TestCase/View/Helper/DatesHelperTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\View\Helper;
+
+use App\View\Helper\DatesHelper;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+/**
+ * App\View\Helper\DatesHelper Test Case
+ *
+ * @coversDefaultClass \App\View\Helper\DatesHelper
+ */
+class DatesHelperTest extends TestCase
+{
+    /**
+     * Test `daysAgo` method.
+     *
+     * @return void
+     * @covers ::daysAgo()
+     */
+    public function testDaysAgo(): void
+    {
+        $view = new View();
+        $helper = new DatesHelper($view);
+
+        // Test with a date 5 days ago
+        $date = (new \DateTime())->modify('-5 days')->format('Y-m-d');
+        $result = $helper->daysAgo($date);
+        $this->assertEquals(5, $result);
+
+        // Test with a date 10 days ago
+        $date = (new \DateTime())->modify('-10 days')->format('Y-m-d');
+        $result = $helper->daysAgo($date);
+        $this->assertEquals(10, $result);
+
+        // Test with today's date
+        $date = (new \DateTime())->format('Y-m-d');
+        $result = $helper->daysAgo($date);
+        $this->assertEquals(0, $result);
+    }
+}


### PR DESCRIPTION
This applies a refactor in "User Profile" page:

 - each section is expandable/collapsable
 - if user has "external_auth", do not show "change password" section, and show external auth info: provider and username
 - show login info: last login, last login error, number of login errors
 - show password info: modification date, verification date, password's age
 - show metadata: created date and user, last modification date and user, locked

![image](https://github.com/user-attachments/assets/c284d98f-41e8-4a6b-b2cc-58aa9f7ab06e)

Bonus: in dashboard, use a different icon for users, `carbon:events-alt` instead of `carbon:user-admin`.
