### PR TITLE
Folder Permissions, readonly roles

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -32,6 +32,17 @@ return [
     // ],
 
     /**
+     * Permissions per roles: force configuration.
+     * This is used to define which roles cannot edit permissions, even though they are allowed to modify the folder and its descendants.
+     */
+    // 'Permissions' => [
+    //     'readonly' => [
+    //         'publisher',
+    //         'editor',
+    //     ],
+    // ],
+
+    /**
      * Display an alert message in a top bar.
      * Useful to announce mainteinance or to specify a non-production environment
      *

--- a/config/routes.php
+++ b/config/routes.php
@@ -472,6 +472,11 @@ $routes->scope('/', function (RouteBuilder $routes) {
         ['controller' => 'Modules', 'action' => 'get'],
         ['pass' => ['id'], '_name' => 'resource:get'],
     );
+    $routes->get(
+        '/roles/list',
+        ['controller' => 'Roles', 'action' => 'list'],
+        'roles:list',
+    );
 
     // Download stream
     $routes->get(

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2025-05-19 09:08:13 \n"
+"POT-Creation-Date: 2025-05-27 06:53:32 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1613,6 +1613,9 @@ msgid "(deleted)"
 msgstr ""
 
 msgid "placeholders"
+msgstr ""
+
+msgid "Roles that cannot modify permissions"
 msgstr ""
 
 msgid "You can modify the permissions"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2025-05-19 09:08:13 \n"
+"POT-Creation-Date: 2025-05-27 06:53:32 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1616,6 +1616,9 @@ msgid "(deleted)"
 msgstr ""
 
 msgid "placeholders"
+msgstr ""
+
+msgid "Roles that cannot modify permissions"
 msgstr ""
 
 msgid "You can modify the permissions"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2025-05-19 09:08:13 \n"
+"POT-Creation-Date: 2025-05-27 06:53:32 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -1636,6 +1636,9 @@ msgstr "(eliminato)"
 
 msgid "placeholders"
 msgstr "segnaposto"
+
+msgid "Roles that cannot modify permissions"
+msgstr "Ruoli che non possono modificare i permessi"
 
 msgid "You can modify the permissions"
 msgstr "Puoi modificare i permessi"

--- a/resources/js/app/components/permissions/permissions.vue
+++ b/resources/js/app/components/permissions/permissions.vue
@@ -24,7 +24,7 @@
             <span class="ml-05 has-text-danger">
                 {{ msgYouCannotModify }}.
                 {{ msgYourRoles }}: {{ userRoles.join(',') }}.
-                <template v-if="readonlyRoles">{{ msgReadonlyRoles }}: {{ readonlyRoles.join(',') }}.</template>
+                <template v-if="readonlyRoles">{{ msgReadonlyRoles }}: {{ readonlyRoles.join(', ') }}.</template>
             </span>
         </div>
         <template v-for="role in roles">

--- a/resources/js/app/components/permissions/permissions.vue
+++ b/resources/js/app/components/permissions/permissions.vue
@@ -66,7 +66,7 @@ export default {
             headers,
             method: 'GET',
         };
-        const response = await fetch(`${BEDITA.base}/api/roles`, options);
+        const response = await fetch(`${BEDITA.base}/roles/list`, options);
         const responseJson = await response.json();
         this.roles = responseJson.data || [];
         this.canModify = this.userRoles.includes('admin') || this.roles?.length === 0 || this.objectRoles?.length === 0 || this.objectRoles.some(item => this.userRoles.includes(item));

--- a/resources/js/app/components/permissions/permissions.vue
+++ b/resources/js/app/components/permissions/permissions.vue
@@ -1,23 +1,53 @@
 <template>
-    <div>
-        <div v-if="canModify" class="mb-05">
-            <app-icon icon="carbon:information" class="has-text-info"></app-icon>
-            <span class="ml-05 has-text-info">{{ msgYouCanModify }}. {{ msgYourRoles }}: {{ userRoles.join(',') }}</span>
+    <div class="permissions">
+        <div
+            class="mb-05"
+            v-if="canModify"
+        >
+            <app-icon
+                icon="carbon:information"
+                class="has-text-info"
+            />
+            <span class="ml-05 has-text-info">
+                {{ msgYouCanModify }}.
+                {{ msgYourRoles }}: {{ userRoles.join(',') }}.
+            </span>
         </div>
-        <div v-else class="mb-05">
-            <app-icon icon="carbon:warning" class="has-text-danger"></app-icon>
-            <span class="ml-05 has-text-danger">{{ msgYouCannotModify }}. {{ msgYourRoles }}: {{ userRoles.join(',') }}</span>
+        <div
+            class="mb-05"
+            v-else
+        >
+            <app-icon
+                icon="carbon:warning"
+                class="has-text-danger"
+            />
+            <span class="ml-05 has-text-danger">
+                {{ msgYouCannotModify }}.
+                {{ msgYourRoles }}: {{ userRoles.join(',') }}.
+                <template v-if="readonlyRoles">{{ msgReadonlyRoles }}: {{ readonlyRoles.join(',') }}.</template>
+            </span>
         </div>
-        <label v-for="role in roles" v-if="role.attributes.name != 'admin'">
-            <input type="checkbox" name="permissions[]" :value="role.id" :checked="objectRoles.includes(role.attributes.name)" :disabled="!canModify" />
-            {{ role.attributes.name }}
-            <permission
-                :inherited="objectPerms?.inherited || false"
-                :role="role.attributes.name"
-                :object-roles="objectRoles"
-                :user-roles="userRoles">
-            </permission>
-        </label>
+        <template v-for="role in roles">
+            <label
+                :key="role.id"
+                v-if="role.attributes.name != 'admin'"
+            >
+                <input
+                    type="checkbox"
+                    name="permissions[]"
+                    :value="role.id"
+                    :checked="objectRoles.includes(role.attributes.name)"
+                    :disabled="!canModify"
+                >
+                {{ role.attributes.name }}
+                <permission
+                    :inherited="objectPerms?.inherited || false"
+                    :role="role.attributes.name"
+                    :object-roles="objectRoles"
+                    :user-roles="userRoles"
+                />
+            </label>
+        </template>
     </div>
 </template>
 
@@ -25,17 +55,18 @@
 import { t } from 'ttag';
 
 export default {
-
-    name: 'permissions',
-
+    name: 'Permissions',
     components: {
         Permission:() => import(/* webpackChunkName: "permission" */'app/components/permission/permission'),
     },
-
     props: {
         objectPerms: {
             type: Object,
             default: () => ({}),
+        },
+        readonlyRoles: {
+            type: Array,
+            default: () => ([]),
         },
         userRoles: {
             type: Array,
@@ -48,6 +79,7 @@ export default {
             canModify: false,
             objectRoles: [],
             roles: [],
+            msgReadonlyRoles: t`Roles that cannot modify permissions`,
             msgYouCanModify: t`You can modify the permissions`,
             msgYouCannotModify: t`You cannot modify the permissions`,
             msgYourRoles: t`Your roles`,
@@ -69,7 +101,11 @@ export default {
         const response = await fetch(`${BEDITA.base}/roles/list`, options);
         const responseJson = await response.json();
         this.roles = responseJson.data || [];
-        this.canModify = this.userRoles.includes('admin') || this.roles?.length === 0 || this.objectRoles?.length === 0 || this.objectRoles.some(item => this.userRoles.includes(item));
+        if (this.userRoles.includes('admin') || this.roles?.length === 0 || this.objectRoles?.length === 0) {
+            this.canModify = true;
+            return;
+        }
+        this.canModify = this.objectRoles.some(item => !this.readonlyRoles.includes(item) && this.userRoles.includes(item));
     },
 }
 </script>

--- a/resources/js/app/components/permissions/permissions.vue
+++ b/resources/js/app/components/permissions/permissions.vue
@@ -32,20 +32,32 @@
                 :key="role.id"
                 v-if="role.attributes.name != 'admin'"
             >
-                <input
-                    type="checkbox"
-                    name="permissions[]"
-                    :value="role.id"
-                    :checked="objectRoles.includes(role.attributes.name)"
-                    :disabled="!canModify"
-                >
-                {{ role.attributes.name }}
-                <permission
-                    :inherited="objectPerms?.inherited || false"
-                    :role="role.attributes.name"
-                    :object-roles="objectRoles"
-                    :user-roles="userRoles"
-                />
+                <template v-if="!canModify">
+                    <input
+                        type="hidden"
+                        name="permissions[]"
+                        :value="role.id"
+                        v-if="objectRoles.includes(role.attributes.name)"
+                    >
+                    <app-icon icon="carbon:checkmark" v-if="objectRoles.includes(role.attributes.name)" />
+                    <app-icon icon="carbon:close" v-else />
+                    {{ role.attributes.name }}
+                </template>
+                <template v-else>
+                    <input
+                        type="checkbox"
+                        name="permissions[]"
+                        :value="role.id"
+                        :checked="objectRoles.includes(role.attributes.name)"
+                    >
+                    {{ role.attributes.name }}
+                    <permission
+                        :inherited="objectPerms?.inherited || false"
+                        :role="role.attributes.name"
+                        :object-roles="objectRoles"
+                        :user-roles="userRoles"
+                    />
+                </template>
             </label>
         </template>
     </div>

--- a/src/Controller/RolesController.php
+++ b/src/Controller/RolesController.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2025 Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Controller;
+
+use BEdita\SDK\BEditaClientException;
+use Cake\Event\EventInterface;
+use Cake\Http\Exception\UnauthorizedException;
+use Cake\Http\Response;
+use Cake\Utility\Hash;
+use Psr\Log\LogLevel;
+
+/**
+ * Roles Controller: list
+ */
+class RolesController extends AppController
+{
+    /**
+     * @inheritDoc
+     */
+    public function beforeFilter(EventInterface $event): ?Response
+    {
+        parent::beforeFilter($event);
+        if (!$this->allowed()) {
+            throw new UnauthorizedException(__('You are not authorized to access this resource'));
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if the request is allowed.
+     *
+     * @return bool
+     */
+    protected function allowed(): bool
+    {
+        // block requests from browser address bar
+        $sameOrigin = (string)Hash::get((array)$this->request->getHeader('Sec-Fetch-Site'), 0) === 'same-origin';
+        $noReferer = empty((array)$this->request->getHeader('Referer'));
+        $isNavigate = in_array('navigate', (array)$this->request->getHeader('Sec-Fetch-Mode'));
+        if (!$sameOrigin || $noReferer || $isNavigate) {
+            return false;
+        }
+        /** @var \Authentication\Identity|null $user */
+        $user = $this->Authentication->getIdentity();
+        $roles = empty($user) ? [] : (array)$user->get('roles');
+        if (empty($roles)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * List all roles.
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function list(): ?Response
+    {
+        $this->viewBuilder()->setClassName('Json');
+        $this->getRequest()->allowMethod(['get']);
+        try {
+            $response = $this->apiClient->get('roles', []);
+        } catch (BEditaClientException $error) {
+            $this->log($error->getMessage(), LogLevel::ERROR);
+            $this->set(compact('error'));
+            $this->setSerialize(['error']);
+
+            return null;
+        }
+        $this->set((array)$response);
+        $this->setSerialize(array_keys($response));
+
+        return null;
+    }
+}

--- a/templates/Element/Form/permissions.twig
+++ b/templates/Element/Form/permissions.twig
@@ -10,9 +10,12 @@
         {% set objectPerms = object.meta.perms|default({})|json_encode %}
         {% if objectPerms == '[]' %}{% set objectPerms = '{}' %}{% endif %}
 
+        {% set readonlyRoles = config('Permissions.readonly')|default([]) %}
+
         <div v-show="isOpen" class="tab-container">
             <permissions
                 :object-perms="{{ objectPerms }}"
+                :readonly-roles="{{ readonlyRoles|json_encode }}"
                 :user-roles="{{ user.roles|default([])|json_encode }}">
             </permissions>
         </div>

--- a/tests/TestCase/Controller/RolesControllerTest.php
+++ b/tests/TestCase/Controller/RolesControllerTest.php
@@ -25,7 +25,6 @@ use Cake\Http\Exception\UnauthorizedException;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
-use ComuneBo\Provider\Bedita;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 

--- a/tests/TestCase/Controller/RolesControllerTest.php
+++ b/tests/TestCase/Controller/RolesControllerTest.php
@@ -1,0 +1,254 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2025 Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Test\TestCase\Controller;
+
+use App\Controller\RolesController;
+use Authentication\AuthenticationServiceInterface;
+use Authentication\Identity;
+use Authentication\IdentityInterface;
+use Cake\Http\Exception\UnauthorizedException;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * {@see \App\Controller\RolesController} Test Case
+ *
+ * @coversDefaultClass \App\Controller\RolesController
+ * @uses \App\Controller\RolesController
+ */
+class RolesControllerTest extends TestCase
+{
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->loadRoutes();
+    }
+
+    /**
+     * Test subject
+     *
+     * @var \App\Controller\RolesController
+     */
+    protected $RolesController;
+
+    /**
+     * Setup controller to test with request config
+     *
+     * @param array $config configuration for controller setup
+     * @return void
+     */
+    protected function setupController($config = null): void
+    {
+        $request = null;
+        if ($config != null) {
+            $headers = (array)Hash::get($config, 'headers', []);
+            unset($config['headers']);
+            $request = new ServerRequest($config);
+            foreach ($headers as $name => $value) {
+                $request = $request->withHeader($name, $value);
+            }
+        }
+        $this->RolesController = new RolesController($request);
+    }
+
+    /**
+     * Data provider for `testUnauthorizedException` test case.
+     *
+     * @return array
+     */
+    public function unauthorizedExceptionProvider(): array
+    {
+        return [
+            'no same origin' => [
+                [
+                    'headers' => [
+                        'Referer' => 'http://example.com',
+                    ],
+                ],
+            ],
+            'no referer' => [
+                [
+                    'headers' => [
+                        'Sec-Fetch-Site' => 'same-origin',
+                    ],
+                ],
+            ],
+            'navigate' => [
+                [
+                    'headers' => [
+                        'Sec-Fetch-Site' => 'same-origin',
+                        'Referer' => 'http://example.com',
+                        'Sec-Fetch-Mode' => 'navigate',
+                    ],
+                ],
+            ],
+            'user empty roles' => [
+                [
+                    'headers' => [
+                        'Sec-Fetch-Site' => 'same-origin',
+                        'Referer' => 'http://example.com',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test for unauthorized exception
+     *
+     * @param array $config Request configuration.
+     * @return void
+     * @dataProvider unauthorizedExceptionProvider
+     * @covers ::beforeFilter()
+     * @covers ::allowed()
+     */
+    public function testUnauthorizedException(array $config): void
+    {
+        $expected = new UnauthorizedException(__('You are not authorized to access this resource'));
+        $this->expectException(get_class($expected));
+        $this->expectExceptionCode($expected->getCode());
+        $this->expectExceptionMessage($expected->getMessage());
+        $this->setupController($config);
+        $this->RolesController->setRequest($this->RolesController->getRequest()->withAttribute('authentication', $this->getAuthenticationServiceMock()));
+        $this->RolesController->dispatchEvent('Controller.initialize');
+    }
+
+    /**
+     * Test unauthorized role
+     *
+     * @return void
+     * @covers ::beforeFilter()
+     * @covers ::allowed()
+     */
+    public function testUnauthorizedRole(): void
+    {
+        $expected = new UnauthorizedException(__('You are not authorized to access this resource'));
+        $this->expectException(get_class($expected));
+        $this->expectExceptionCode($expected->getCode());
+        $this->expectExceptionMessage($expected->getMessage());
+        $this->setupController([
+            'headers' => [
+                'Sec-Fetch-Site' => 'same-origin',
+                'Referer' => 'http://example.com',
+            ],
+        ]);
+        $user = new Identity([
+            'id' => 1,
+            'username' => 'dummy',
+            'roles' => [],
+        ]);
+        $this->RolesController->setRequest($this->RolesController->getRequest()->withAttribute('authentication', $this->getAuthenticationServiceMock()));
+        $this->RolesController->Authentication->setIdentity($user);
+        $this->RolesController->dispatchEvent('Controller.initialize');
+    }
+
+    /**
+     * Test for authorized admin
+     *
+     * @return void
+     * @covers ::beforeFilter()
+     * @covers ::allowed()
+     * @covers ::list()
+     */
+    public function testAuthorizeAdmin(): void
+    {
+        $this->setupController([
+            'headers' => [
+                'Sec-Fetch-Site' => 'same-origin',
+                'Referer' => 'http://example.com',
+            ],
+        ]);
+        $user = new Identity([
+            'id' => 1,
+            'username' => 'admin',
+            'roles' => ['admin'],
+        ]);
+        $this->RolesController->setRequest($this->RolesController->getRequest()->withAttribute('authentication', $this->getAuthenticationServiceMock()));
+        $this->RolesController->Authentication->setIdentity($user);
+        $this->RolesController->dispatchEvent('Controller.initialize');
+        $actual = $this->RolesController->Security->getConfig('unlockedActions');
+        $expected = [];
+        static::assertEquals($expected, $actual);
+        $response = $this->RolesController->list();
+        static::assertNull($response);
+        $data = $this->RolesController->viewBuilder()->getVars('roles');
+        $roles = (array)Hash::extract($data, 'data.{n}.attributes.name');
+        static::assertNotEmpty($roles);
+        static::assertTrue(in_array('admin', $roles), 'Admin role should be present in the list of roles');
+    }
+
+    /**
+     * Test for authorized user
+     *
+     * @return void
+     * @covers ::beforeFilter()
+     * @covers ::allowed()
+     */
+    public function testUserAllowed(): void
+    {
+        $this->setupController([
+            'params' => ['pass' => ['events']],
+            'headers' => [
+                'Sec-Fetch-Site' => 'same-origin',
+                'Referer' => 'http://example.com',
+            ],
+        ]);
+        $user = new Identity([
+            'id' => 1,
+            'username' => 'dummy',
+            'roles' => ['manager'],
+        ]);
+        $this->RolesController->setRequest($this->RolesController->getRequest()->withAttribute('authentication', $this->getAuthenticationServiceMock()));
+        $this->RolesController->Authentication->setIdentity($user);
+        $this->RolesController->dispatchEvent('Controller.initialize');
+        $actual = $this->RolesController->Security->getConfig('unlockedActions');
+        $expected = [];
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Get mocked AuthenticationService.
+     *
+     * @return AuthenticationServiceInterface
+     */
+    protected function getAuthenticationServiceMock(): AuthenticationServiceInterface
+    {
+        $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)
+            ->getMock();
+        $authenticationService->method('clearIdentity')
+            ->willReturnCallback(function (ServerRequestInterface $request, ResponseInterface $response): array {
+                return [
+                    'request' => $request->withoutAttribute('identity'),
+                    'response' => $response,
+                ];
+            });
+        $authenticationService->method('persistIdentity')
+            ->willReturnCallback(function (ServerRequestInterface $request, ResponseInterface $response, IdentityInterface $identity): array {
+                return [
+                    'request' => $request->withAttribute('identity', $identity),
+                    'response' => $response,
+                ];
+            });
+
+        return $authenticationService;
+    }
+}

--- a/tests/TestCase/Controller/RolesControllerTest.php
+++ b/tests/TestCase/Controller/RolesControllerTest.php
@@ -190,7 +190,7 @@ class RolesControllerTest extends TestCase
         static::assertEquals($expected, $actual);
         $response = $this->RolesController->list();
         static::assertNull($response);
-        $data = $this->RolesController->viewBuilder()->getVars('roles');
+        $data = $this->RolesController->viewBuilder()->getVars();
         $roles = (array)Hash::extract($data, 'data.{n}.attributes.name');
         static::assertNotEmpty($roles);
         static::assertTrue(in_array('admin', $roles), 'Admin role should be present in the list of roles');


### PR DESCRIPTION
This fixes a buggy behaviour in getting roles, in permissions module, and provides a way to force "readonly" of Permission section, per specific roles, using a configuration.

Example:
```php
'Permissions' => [
    'readonly' => [
        'publisher',
    ],
],
```

In the example above, role "publisher" will be forced to see Permission section in readonly mode.