### PR TITLE
[5.x] Folders tree compact view

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,5 +99,8 @@
             "merge-extra-deep": false,
             "merge-scripts": false
         }
+    },
+    "conflict": {
+        "slevomat/coding-standard": ">8.18.0"
     }
 }

--- a/config/routes.php
+++ b/config/routes.php
@@ -127,6 +127,11 @@ $routes->scope('/', function (RouteBuilder $routes) {
         ['controller' => 'Tree', 'action' => 'slug'],
         ['_name' => 'tree:slug']
     );
+    $routes->connect(
+        '/tree/{id}/children',
+        ['controller' => 'Tree', 'action' => 'children'],
+        ['_name' => 'tree:children', 'pass' => ['id']]
+    );
 
     // Admin.
     $routes->prefix('admin', ['_namePrefix' => 'admin:'], function (RouteBuilder $routes) {

--- a/config/routes.php
+++ b/config/routes.php
@@ -102,6 +102,11 @@ $routes->scope('/', function (RouteBuilder $routes) {
         ['_name' => 'tree:get']
     );
     $routes->connect(
+        '/tree/loadAll',
+        ['controller' => 'Tree', 'action' => 'loadAll'],
+        ['_name' => 'tree:load:all']
+    );
+    $routes->connect(
         '/tree/node/{id}',
         ['controller' => 'Tree', 'action' => 'node'],
         ['_name' => 'tree:node', 'pass' => ['id']]

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2025-06-03 07:31:05 \n"
+"POT-Creation-Date: 2025-06-09 12:35:39 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -457,6 +457,9 @@ msgstr ""
 msgid "Less"
 msgstr ""
 
+msgid "Limit"
+msgstr ""
+
 msgid "List"
 msgstr ""
 
@@ -589,6 +592,9 @@ msgid "Not Found"
 msgstr ""
 
 msgid "Number of created objects"
+msgstr ""
+
+msgid "Number of folders"
 msgstr ""
 
 msgid "Number of login errors"
@@ -879,6 +885,9 @@ msgstr ""
 msgid "Temporary folder missing"
 msgstr ""
 
+msgid "The number of folders is too high to be displayed in tree-compact view"
+msgstr ""
+
 msgid "There were errors creating the thumbnail(s)"
 msgstr ""
 
@@ -928,6 +937,9 @@ msgid "Trashcan"
 msgstr ""
 
 msgid "Trashd"
+msgstr ""
+
+msgid "Tree compact"
 msgstr ""
 
 msgid "Tree view"
@@ -1018,6 +1030,9 @@ msgid "You are not authorized to access that location."
 msgstr ""
 
 msgid "You are not authorized to access this resource"
+msgstr ""
+
+msgid "You cannot see folders in tree-compact view"
 msgstr ""
 
 msgid "You do not have the required permissions to view this page."
@@ -1532,6 +1547,30 @@ msgstr ""
 msgid "View"
 msgstr ""
 
+msgid "New content"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "Open in new tab"
+msgstr ""
+
+msgid "Undo"
+msgstr ""
+
+msgid "Choose object type"
+msgstr ""
+
+msgid "Object type"
+msgstr ""
+
+msgid "Parent folder"
+msgstr ""
+
+msgid "/ (root)"
+msgstr ""
+
 msgid "Add new tag"
 msgstr ""
 
@@ -1863,9 +1902,6 @@ msgid "Every day"
 msgstr ""
 
 msgid "Invalid date range"
-msgstr ""
-
-msgid "Undo"
 msgstr ""
 
 msgid "Copied!"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2025-06-03 07:31:05 \n"
+"POT-Creation-Date: 2025-06-09 12:35:39 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -460,6 +460,9 @@ msgstr ""
 msgid "Less"
 msgstr ""
 
+msgid "Limit"
+msgstr ""
+
 msgid "List"
 msgstr ""
 
@@ -592,6 +595,9 @@ msgid "Not Found"
 msgstr ""
 
 msgid "Number of created objects"
+msgstr ""
+
+msgid "Number of folders"
 msgstr ""
 
 msgid "Number of login errors"
@@ -882,6 +888,9 @@ msgstr ""
 msgid "Temporary folder missing"
 msgstr ""
 
+msgid "The number of folders is too high to be displayed in tree-compact view"
+msgstr ""
+
 msgid "There were errors creating the thumbnail(s)"
 msgstr ""
 
@@ -932,6 +941,9 @@ msgstr ""
 
 msgid "Trashd"
 msgstr "Trashed"
+
+msgid "Tree compact"
+msgstr ""
 
 msgid "Tree view"
 msgstr ""
@@ -1021,6 +1033,9 @@ msgid "You are not authorized to access that location."
 msgstr ""
 
 msgid "You are not authorized to access this resource"
+msgstr ""
+
+msgid "You cannot see folders in tree-compact view"
 msgstr ""
 
 msgid "You do not have the required permissions to view this page."
@@ -1535,6 +1550,30 @@ msgstr ""
 msgid "View"
 msgstr ""
 
+msgid "New content"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "Open in new tab"
+msgstr ""
+
+msgid "Undo"
+msgstr ""
+
+msgid "Choose object type"
+msgstr ""
+
+msgid "Object type"
+msgstr ""
+
+msgid "Parent folder"
+msgstr ""
+
+msgid "/ (root)"
+msgstr ""
+
 msgid "Add new tag"
 msgstr ""
 
@@ -1866,9 +1905,6 @@ msgid "Every day"
 msgstr ""
 
 msgid "Invalid date range"
-msgstr ""
-
-msgid "Undo"
 msgstr ""
 
 msgid "Copied!"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2025-06-03 07:31:05 \n"
+"POT-Creation-Date: 2025-06-09 12:35:39 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -463,6 +463,9 @@ msgstr "Tipi di sinistra"
 msgid "Less"
 msgstr "Meno"
 
+msgid "Limit"
+msgstr "Limite"
+
 msgid "List"
 msgstr "Lista"
 
@@ -598,6 +601,9 @@ msgstr "Non trovato"
 
 msgid "Number of created objects"
 msgstr "Numero di oggetti creati"
+
+msgid "Number of folders"
+msgstr "Numero di cartelle"
 
 msgid "Number of login errors"
 msgstr "Numero di errori di accesso"
@@ -890,6 +896,9 @@ msgstr "Tag"
 msgid "Temporary folder missing"
 msgstr "Cartella temporanea mancante"
 
+msgid "The number of folders is too high to be displayed in tree-compact view"
+msgstr "Il numero di cartelle è troppo elevato per essere visualizzato nella vista compatta ad albero."
+
 msgid "There were errors creating the thumbnail(s)"
 msgstr "È avvenuto un errore nella creazione delle miniature"
 
@@ -940,6 +949,9 @@ msgstr "Cestino"
 
 msgid "Trashd"
 msgstr "Cancellato"
+
+msgid "Tree compact"
+msgstr "Vista compatta ad albero"
 
 msgid "Tree view"
 msgstr "Vista ad albero"
@@ -1030,6 +1042,9 @@ msgstr "Non sei autorizzato ad accedere a quest'area."
 
 msgid "You are not authorized to access this resource"
 msgstr "Non sei autorizzato ad accedere a questa risorsa"
+
+msgid "You cannot see folders in tree-compact view"
+msgstr "Non puoi vedere le cartelle nella vista compatta ad albero."
 
 msgid "You do not have the required permissions to view this page."
 msgstr "Non hai i permessi necessari per visualizzare questa pagina."
@@ -1554,6 +1569,30 @@ msgstr "pagina"
 msgid "View"
 msgstr "Vedi"
 
+msgid "New content"
+msgstr "Nuovo contenuto"
+
+msgid "New folder"
+msgstr "Nuova cartella"
+
+msgid "Open in new tab"
+msgstr "Apri in una nuova scheda"
+
+msgid "Undo"
+msgstr "Annulla"
+
+msgid "Choose object type"
+msgstr "Scegli il tipo di oggetto"
+
+msgid "Object type"
+msgstr "Tipo di oggetto"
+
+msgid "Parent folder"
+msgstr "Cartella padre"
+
+msgid "/ (root)"
+msgstr "/ (radice)"
+
 msgid "Add new tag"
 msgstr "Aggiungi un nuovo tag"
 
@@ -1892,9 +1931,6 @@ msgstr "Tutti i giorni"
 
 msgid "Invalid date range"
 msgstr "Intervallo date non valido"
-
-msgid "Undo"
-msgstr "Annulla"
 
 msgid "Copied!"
 msgstr "Copiato!"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -951,7 +951,7 @@ msgid "Trashd"
 msgstr "Cancellato"
 
 msgid "Tree compact"
-msgstr "Vista compatta ad albero"
+msgstr "Albero compatto"
 
 msgid "Tree view"
 msgstr "Vista ad albero"

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -49,6 +49,7 @@ const _vueInstance = new Vue({
         DateRangesList: () => import(/* webpackChunkName: "date-ranges-list" */'app/components/date-ranges-list/date-ranges-list'),
         TreeView: () => import(/* webpackChunkName: "tree-view" */'app/components/tree-view/tree-view'),
         TreeSlug: () => import(/* webpackChunkName: "tree-slug" */'app/components/tree-slug/tree-slug'),
+        TreeCompact: () => import(/* webpackChunkName: "tree-compact" */'app/components/tree-compact/tree-compact'),
         IndexCell: () => import(/* webpackChunkName: "index-cell" */'app/components/index-cell/index-cell'),
         ModulesIndex: () => import(/* webpackChunkName: "modules-index" */'app/pages/modules/index'),
         ModulesView: () => import(/* webpackChunkName: "modules-view" */'app/pages/modules/view'),

--- a/resources/js/app/components/folder-picker/folder-picker.js
+++ b/resources/js/app/components/folder-picker/folder-picker.js
@@ -63,7 +63,7 @@ export default {
 
     async created() {
         if (this.initialFolder) {
-            const response = await fetch(`${API_URL}api/folders/${this.initialFolder}`);
+            const response = await fetch(`${API_URL}tree/${this.initialFolder}/children`);
             const json = await response.json();
             const data = json.data;
             const folder = { id: data.id, label: data.attributes.title };

--- a/resources/js/app/components/module/module-properties.vue
+++ b/resources/js/app/components/module/module-properties.vue
@@ -75,7 +75,7 @@ export default {
     props: {
         module: {
             type: Object,
-            required: true,
+            default: () => ({}),
         },
         objectType: {
             type: String,
@@ -150,7 +150,7 @@ export default {
         this.$nextTick(() => {
             this.originalVal = JSON.stringify(this.module);
             this.fields.forEach((field) => {
-                this.map[field] = this.module[field] || '';
+                this.map[field] = this.module?.[field] || '';
             });
         });
     },

--- a/resources/js/app/components/object-info/object-info.vue
+++ b/resources/js/app/components/object-info/object-info.vue
@@ -45,9 +45,9 @@ export default {
     },
     mounted() {
         this.$nextTick(() => {
-            const source = BEDITA?.indexLists?.[this.objectData?.type] || {};
+            const source = BEDITA?.indexLists?.[this.objectData?.type] || [];
             this.fields = source || ['title', 'description'];
-            this.fields = this.fields.filter((value, index, array) => {
+            this.fields = this.fields?.filter((value, index, array) => {
                 return array.indexOf(value) === index;
             });
 

--- a/resources/js/app/components/object-info/object-info.vue
+++ b/resources/js/app/components/object-info/object-info.vue
@@ -6,6 +6,7 @@
         <a
             :title="msgShowObjectInfo"
             class="button button-outlined-white is-small show-info"
+            :style="styles"
         >
             <app-icon icon="carbon:information" />
         </a>
@@ -17,6 +18,14 @@ import { t } from 'ttag';
 export default {
     name: 'ObjectInfo',
     props: {
+        borderColor: {
+            type: String,
+            default: 'black',
+        },
+        color: {
+            type: String,
+            default: 'white',
+        },
         objectData: {
             type: Object,
             required: true
@@ -27,6 +36,10 @@ export default {
             fields: ['title', 'description'],
             labelsMap: new Map(),
             msgShowObjectInfo: t`Show object info`,
+            styles: {
+                borderColor: this.borderColor,
+                color: this.color,
+            },
             values: {},
         };
     },

--- a/resources/js/app/components/tree-compact/tree-compact.vue
+++ b/resources/js/app/components/tree-compact/tree-compact.vue
@@ -5,6 +5,7 @@
             :key="rootId"
         >
             <TreeFolder
+                :can-save-map="canSaveMap"
                 :folder="folders?.[rootId] || {}"
                 :folders="folders || {}"
                 :subfolders="tree[rootId]?.subfolders || {}"
@@ -29,8 +30,8 @@ export default {
         TreeFolder: () => import('./tree-folder.vue'),
     },
     props: {
-        objectType: {
-            type: String,
+        canSaveMap: {
+            type: Object,
             required: true
         },
     },
@@ -51,7 +52,7 @@ export default {
             try {
                 this.loading = true;
                 this.tree = [];
-                const response = await fetch(`${API_URL}tree/loadAll?objectType=${this.objectType}`, API_OPTIONS);
+                const response = await fetch(`${API_URL}tree/loadAll?objectType=folders`, API_OPTIONS);
                 const json = await response.json();
                 if (json.error) {
                     throw new Error(json.error);

--- a/resources/js/app/components/tree-compact/tree-compact.vue
+++ b/resources/js/app/components/tree-compact/tree-compact.vue
@@ -150,6 +150,7 @@ div.tree-compact {
 }
 div.tree-compact > div.buttons {
     margin-left: 0.5rem;
+    max-width: 1000px;
 }
 div.tree-compact > div.buttons {
     margin-bottom: 0.5rem;

--- a/resources/js/app/components/tree-compact/tree-compact.vue
+++ b/resources/js/app/components/tree-compact/tree-compact.vue
@@ -8,6 +8,8 @@
                 :can-save-map="canSaveMap"
                 :folder="folders?.[rootId] || {}"
                 :folders="folders || {}"
+                :languages="languages"
+                :schema="schema"
                 :subfolders="tree[rootId]?.subfolders || {}"
             />
         </div>
@@ -33,6 +35,14 @@ export default {
         canSaveMap: {
             type: Object,
             required: true
+        },
+        languages: {
+            type: Object,
+            default: () => {},
+        },
+        schema: {
+            type: Object,
+            default: () => ({}),
         },
     },
     data() {

--- a/resources/js/app/components/tree-compact/tree-compact.vue
+++ b/resources/js/app/components/tree-compact/tree-compact.vue
@@ -1,16 +1,38 @@
 <template>
     <div class="tree-compact">
+        <tree-panel
+            :folders="folders || {}"
+            :languages="languages"
+            :obj="{}"
+            :object-type="'folders'"
+            :schema="schema"
+            :show-panel="newFolder"
+            :tree="tree"
+            @update:showPanel="newFolder = $event"
+            @success="loadTree"
+        />
+        <div class="buttons">
+            <button
+                class="button button-outlined"
+                @click.prevent="newFolder = true"
+            >
+                <app-icon icon="carbon:folder-add" />
+                <span class="ml-05">{{ msgNewFolder }}</span>
+            </button>
+        </div>
         <div
             v-for="rootId in Object.keys(tree)"
             :key="rootId"
         >
-            <TreeFolder
+            <tree-folder
                 :can-save-map="canSaveMap"
                 :folder="folders?.[rootId] || {}"
                 :folders="folders || {}"
                 :languages="languages"
                 :schema="schema"
                 :subfolders="tree[rootId]?.subfolders || {}"
+                :tree="tree"
+                @force-reload="loadTree(1)"
             />
         </div>
     </div>
@@ -26,10 +48,12 @@ const API_OPTIONS = {
         'X-CSRF-Token': BEDITA.csrfToken,
     },
 };
+import { t } from 'ttag';
 export default {
     name: 'TreeCompact',
     components: {
         TreeFolder: () => import('./tree-folder.vue'),
+        TreePanel: () => import('./tree-panel.vue'),
     },
     props: {
         canSaveMap: {
@@ -49,6 +73,8 @@ export default {
         return {
             loading: false,
             folders: {},
+            msgNewFolder: t`New folder`,
+            newFolder: false,
             tree: {},
         }
     },
@@ -58,16 +84,17 @@ export default {
         });
     },
     methods: {
-        async loadTree() {
+        async loadTree(noCache) {
             try {
                 this.loading = true;
-                this.tree = [];
-                const response = await fetch(`${API_URL}tree/loadAll?objectType=folders`, API_OPTIONS);
+                this.tree = {};
+                const query = noCache ? 'no_cache=true&objectType=folders' : 'objectType=folders';
+                const response = await fetch(`${API_URL}tree/loadAll?${query}`, API_OPTIONS);
                 const json = await response.json();
                 if (json.error) {
                     throw new Error(json.error);
                 }
-                this.tree = json?.data?.tree || [];
+                this.tree = json?.data?.tree || {};
                 this.folders = json?.data?.folders || [];
             } catch (error) {
                 BEDITA.error(error);
@@ -78,3 +105,19 @@ export default {
     },
 }
 </script>
+<style scoped>
+.tree-compact {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+}
+.tree-compact > div.buttons {
+    margin-left: 0.5rem;
+}
+.tree-compact > div.buttons {
+    margin-bottom: 0.5rem;
+}
+.tree-compact > div.buttons > button > span {
+    font-size: 0.7rem;
+}
+</style>

--- a/resources/js/app/components/tree-compact/tree-compact.vue
+++ b/resources/js/app/components/tree-compact/tree-compact.vue
@@ -1,0 +1,69 @@
+<template>
+    <div class="tree-compact">
+        <div
+            v-for="rootId in Object.keys(tree)"
+            :key="rootId"
+        >
+            <TreeFolder
+                :folder="folders?.[rootId] || {}"
+                :folders="folders || {}"
+                :subfolders="tree[rootId]?.subfolders || {}"
+            />
+        </div>
+    </div>
+</template>
+<script>
+const API_URL = new URL(BEDITA.base).pathname;
+const API_OPTIONS = {
+    method: 'GET',
+    credentials: 'same-origin',
+    headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': BEDITA.csrfToken,
+    },
+};
+export default {
+    name: 'TreeCompact',
+    components: {
+        TreeFolder: () => import('./tree-folder.vue'),
+    },
+    props: {
+        objectType: {
+            type: String,
+            required: true
+        },
+    },
+    data() {
+        return {
+            loading: false,
+            folders: {},
+            tree: {},
+        }
+    },
+    mounted() {
+        this.$nextTick(() => {
+            this.loadTree();
+        });
+    },
+    methods: {
+        async loadTree() {
+            try {
+                this.loading = true;
+                this.tree = [];
+                const response = await fetch(`${API_URL}tree/loadAll?objectType=${this.objectType}`, API_OPTIONS);
+                const json = await response.json();
+                if (json.error) {
+                    throw new Error(json.error);
+                }
+                this.tree = json?.data?.tree || [];
+                this.folders = json?.data?.folders || [];
+            } catch (error) {
+                BEDITA.error(error);
+            } finally {
+                this.loading = false;
+            }
+        },
+    },
+}
+</script>

--- a/resources/js/app/components/tree-compact/tree-compact.vue
+++ b/resources/js/app/components/tree-compact/tree-compact.vue
@@ -1,8 +1,5 @@
 <template>
     <div class="tree-compact">
-        <header>
-            <h2>{{ msgTreeCompactView }}</h2>
-        </header>
         <tree-panel
             :can-save-map="canSaveMap"
             :folders="folders || {}"
@@ -108,7 +105,6 @@ export default {
             msgFolders: t`Folders`,
             msgNewContent: t`New content`,
             msgNewFolder: t`New folder`,
-            msgTreeCompactView: t`Tree compact view`,
             newContent: false,
             newFolder: false,
             tree: {},

--- a/resources/js/app/components/tree-compact/tree-compact.vue
+++ b/resources/js/app/components/tree-compact/tree-compact.vue
@@ -1,5 +1,8 @@
 <template>
     <div class="tree-compact">
+        <header>
+            <h2>{{ msgTreeCompactView }}</h2>
+        </header>
         <tree-panel
             :can-save-map="canSaveMap"
             :folders="folders || {}"
@@ -42,6 +45,7 @@
                     <app-icon icon="carbon:document-add" />
                     <span class="ml-05">{{ msgNewContent }}</span>
                 </button>
+                <span class="tag has-background-module-folders">{{ count }} {{ msgFolders }}</span>
             </div>
         </template>
         <div
@@ -84,6 +88,10 @@ export default {
             type: Object,
             required: true
         },
+        count: {
+            type: Number,
+            default: 0,
+        },
         languages: {
             type: Object,
             default: () => {},
@@ -95,10 +103,12 @@ export default {
     },
     data() {
         return {
-            loading: false,
             folders: {},
+            loading: false,
+            msgFolders: t`Folders`,
             msgNewContent: t`New content`,
             msgNewFolder: t`New folder`,
+            msgTreeCompactView: t`Tree compact view`,
             newContent: false,
             newFolder: false,
             tree: {},
@@ -137,18 +147,27 @@ export default {
 }
 </script>
 <style scoped>
-.tree-compact {
+div.tree-compact {
     display: flex;
     flex-direction: column;
     gap: 0.1rem;
 }
-.tree-compact > div.buttons {
+div.tree-compact > div.buttons {
     margin-left: 0.5rem;
 }
-.tree-compact > div.buttons {
+div.tree-compact > div.buttons {
     margin-bottom: 0.5rem;
+    display: flex;
+    flex-direction: row;
+    gap: 0.2rem;
+    align-items: center;
+    justify-content: start;
+    border-bottom: dotted 0.1px silver;
 }
-.tree-compact > div.buttons > button > span {
+div.tree-compact > div.buttons > button > span {
     font-size: 0.7rem;
+}
+div.tree-compact span.tag {
+    margin-left: auto;
 }
 </style>

--- a/resources/js/app/components/tree-compact/tree-content.vue
+++ b/resources/js/app/components/tree-compact/tree-content.vue
@@ -1,9 +1,49 @@
 <template>
     <div class="tree-content">
-        <span><app-icon icon="carbon:document" /></span>
-        <span class="tag is-smallest mx-05" :class="`has-background-module-${obj?.type}`">{{ obj?.type }}</span>
-        <span v-title="obj?.attributes?.title">{{ truncate(obj?.attributes?.title, 80) }}</span>
-        <span class="modified">{{ $helpers.formatDate(obj?.meta?.modified) }}</span>
+        <header>
+            <h2>
+                <span><app-icon icon="carbon:document" /></span>
+                <span class="tag is-smallest mx-05" :class="`has-background-module-${obj?.type}`">{{ obj?.type }}</span>
+                <span
+                    class="title-edit"
+                    v-title="title"
+                    v-if="editField === 'title'"
+                >
+                    <input
+                        type="text"
+                        v-model="title"
+                        @click.prevent.stop="editField = 'title'"
+                    >
+                    <button
+                        class="button button-primary"
+                        @click.prevent.stop="saveTitle()"
+                    >
+                        <app-icon icon="carbon:save" />
+                        <span class="ml-05">{{ msgSave }}</span>
+                    </button>
+                    <button
+                        class="button button-primary"
+                        @click.prevent.stop="undoTitle()"
+                    >
+                        <app-icon icon="carbon:reset" />
+                        <span class="ml-05">{{ msgUndo }}</span>
+                    </button>
+                </span>
+                <span
+                    class="editable"
+                    @click.prevent.stop="editField = 'title'"
+                    @mouseover="hoverTitle=true"
+                    @mouseleave="hoverTitle=false"
+                    v-else
+                >
+                    {{ truncate(title, 80) }}
+                    <template v-if="hoverTitle">
+                        <app-icon icon="ph:pencil-fill" color="#00aaff" />
+                    </template>
+                </span>
+                <span class="modified">{{ $helpers.formatDate(obj?.meta?.modified) }}</span>
+            </h2>
+        </header>
     </div>
 </template>
 <script>
@@ -17,9 +57,26 @@ export default {
             required: true
         },
     },
+    data() {
+        return {
+            editField: null,
+            hoverTitle: false,
+            title: this.obj?.attributes?.title || '',
+            msgSave: t`Save`,
+            msgUndo: t`Undo`,
+        }
+    },
     methods: {
+        saveTitle() {
+            console.log('Saving title:', this.title);
+            this.editField = null;
+        },
         truncate(str, len) {
             return this.$helpers.truncate(str, len);
+        },
+        undoTitle() {
+            console.log('Undoing title change');
+            this.editField = null;
         },
     },
 }
@@ -27,5 +84,27 @@ export default {
 <style scoped>
 div.tree-content {
     padding-left: 0.5rem;
+}
+div.tree-content > header > h2 {
+    display: flex;
+    flex-direction: row;
+    gap: 0.2rem;
+    align-items: center;
+    justify-content: start;
+    border-bottom: dotted 0.1px silver;
+}
+div.tree-content > header > h2 > span.editable {
+    font-size: 0.875rem;
+}
+div.tree-content > header > h2 > span.modified {
+    font-size: 0.7rem;
+}
+div.tree-content .editable:hover {
+    cursor: pointer;
+    color: #00aaff;
+    text-decoration: underline;
+}
+div.tree-content span.modified {
+    margin-left: auto;
 }
 </style>

--- a/resources/js/app/components/tree-compact/tree-content.vue
+++ b/resources/js/app/components/tree-compact/tree-content.vue
@@ -54,10 +54,16 @@
         <header>
             <h2>
                 <span><app-icon icon="carbon:document" /></span>
-                <span class="tag is-smallest mx-05" :class="`has-background-module-${obj?.type}`">{{ obj?.type }}</span>
+                <span
+                    class="tag is-smallest mx-05"
+                    :class="`has-background-module-${obj?.type}`"
+                >
+                    {{ obj?.type }}
+                </span>
                 <template v-if="canSave()">
                     <span
-                        class="editable"
+                        class="editable content"
+                        :class="obj?.attributes?.status"
                         @click.prevent.stop="editMode = true"
                         @mouseover="hoverTitle=true"
                         @mouseleave="hoverTitle=false"
@@ -72,7 +78,13 @@
                     </span>
                 </template>
                 <template v-else>
-                    <span class="not-editable">{{ truncate(obj?.attributes?.title, 80) }}</span>
+                    <span
+                        class="content"
+                        :class="obj?.attributes?.status"
+                        v-title="obj?.attributes?.title"
+                    >
+                        {{ truncate(obj?.attributes?.title, 80) }}
+                    </span>
                 </template>
                 <div class="object-info-container">
                     <object-info
@@ -180,7 +192,10 @@ div.tree-content > header > h2 {
     justify-content: start;
     border-bottom: dotted 0.1px silver;
 }
-div.tree-content > header > h2 > span.editable, div.tree-content > header > h2 > span.not-editable {
+div.tree-content > header > h2 > span.off, div.tree-content > header > h2 > span.draft {
+    color: #737c81;
+}
+div.tree-content > header > h2 > span.content {
     font-size: 0.875rem;
 }
 div.tree-content > header > h2 > span.modified, div.tree-content > header > h2 > a {

--- a/resources/js/app/components/tree-compact/tree-content.vue
+++ b/resources/js/app/components/tree-compact/tree-content.vue
@@ -1,0 +1,31 @@
+<template>
+    <div class="tree-content">
+        <span><app-icon icon="carbon:document" /></span>
+        <span class="tag is-smallest mx-05" :class="`has-background-module-${obj?.type}`">{{ obj?.type }}</span>
+        <span v-title="obj?.attributes?.title">{{ truncate(obj?.attributes?.title, 80) }}</span>
+        <span class="modified">{{ $helpers.formatDate(obj?.meta?.modified) }}</span>
+    </div>
+</template>
+<script>
+import { t } from 'ttag';
+
+export default {
+    name: 'TreeContent',
+    props: {
+        obj: {
+            type: Object,
+            required: true
+        },
+    },
+    methods: {
+        truncate(str, len) {
+            return this.$helpers.truncate(str, len);
+        },
+    },
+}
+</script>
+<style scoped>
+div.tree-content {
+    padding-left: 0.5rem;
+}
+</style>

--- a/resources/js/app/components/tree-compact/tree-folder.vue
+++ b/resources/js/app/components/tree-compact/tree-folder.vue
@@ -34,7 +34,7 @@
                             :languages="languages"
                             :object-type="objectType"
                             :required="fieldsRequired?.includes(fieldKey(field))"
-                            :val="schema?.[fieldKey(field)] || null"
+                            :val="folders?.attributes?.[fieldKey(field)] || schema?.[fieldKey(field)] || null"
                             v-model="formFieldProperties[objectType][fieldKey(field)]"
                             @error="fieldError"
                             @update="fieldUpdate"
@@ -60,7 +60,7 @@
                                 :languages="languages"
                                 :object-type="objectType"
                                 :required="fieldsRequired?.includes(fieldKey(field))"
-                                :val="schema?.[fieldKey(field)] || null"
+                                :val="folder?.attributes?.[fieldKey(field)] || schema?.[fieldKey(field)] || null"
                                 v-model="formFieldProperties[objectType][fieldKey(field)]"
                                 @error="fieldError"
                                 @update="fieldUpdate"
@@ -177,6 +177,8 @@
                         :key="index"
                         :folder="folders[childId]"
                         :folders="folders || {}"
+                        :languages="languages"
+                        :schema="schema"
                         :subfolders="subfolders[childId]?.subfolders || {}"
                     />
                 </template>
@@ -185,7 +187,9 @@
                         v-for="(child, index) in children"
                         :can-save-map="canSaveMap"
                         :key="index"
+                        :languages="languages"
                         :obj="child"
+                        :schema="schema"
                     />
                 </template>
             </div>
@@ -279,7 +283,7 @@ export default {
         this.$nextTick(async () => {
             this.formFieldProperties[this.objectType] = {};
             this.fieldsRequired = BEDITA?.fastCreateFields?.[this.objectType]?.required || [];
-            this.fieldsAll = BEDITA?.fastCreateFields?.[this.objectType]?.fields || ['id', 'title'];
+            this.fieldsAll = BEDITA?.fastCreateFields?.[this.objectType]?.fields || ['title'];
             this.fieldsAll = this.fieldsAll.map(field => {
                 if (typeof field === 'object') {
                     return Object.keys(field)[0];

--- a/resources/js/app/components/tree-compact/tree-folder.vue
+++ b/resources/js/app/components/tree-compact/tree-folder.vue
@@ -13,13 +13,29 @@
                 <span class="folder-closed" v-else>
                     <app-icon icon="material-symbols:folder" />
                 </span>
-                <span class="title-edit" v-if="editField === 'title'">
+                <span
+                    class="title-edit"
+                    v-if="editField === 'title'"
+                >
                     <input
                         type="text"
                         v-model="title"
                         @click.prevent.stop="editField = 'title'"
                     >
-                    <button @click.prevent.stop="saveTitle()">{{ msgSave }}</button>
+                    <button
+                        class="button button-primary"
+                        @click.prevent.stop="saveTitle()"
+                    >
+                        <app-icon icon="carbon:save" />
+                        <span class="ml-05">{{ msgSave }}</span>
+                    </button>
+                    <button
+                        class="button button-primary"
+                        @click.prevent.stop="undoTitle()"
+                    >
+                        <app-icon icon="carbon:reset" />
+                        <span class="ml-05">{{ msgUndo }}</span>
+                    </button>
                 </span>
                 <span
                     class="editable"
@@ -33,16 +49,22 @@
                         <app-icon icon="ph:pencil-fill" color="#00aaff" />
                     </template>
                 </span>
-                <span class="loader is-loading-spinner" v-if="loading"></span>
-                <span class="tag is-smallest is-black ml-2" v-if="!loading">
+                <span
+                    class="loader is-loading-spinner"
+                    v-if="loading"
+                />
+                <span
+                    class="tag is-smallest is-black ml-2"
+                    v-if="!loading"
+                >
                     {{ totalChildren }} {{ msgObjects }}
                 </span>
                 <span class="modified">{{ $helpers.formatDate(folder?.meta?.modified) }}</span>
             </h2>
         </header>
         <template v-if="open">
-            <template v-if="Object.keys(subfolders)?.length">
-                <div class="subfolders">
+            <div class="contents">
+                <template v-if="Object.keys(subfolders)?.length">
                     <tree-folder
                         v-for="(childId, index) in Object.keys(subfolders)"
                         :key="index"
@@ -50,17 +72,15 @@
                         :folders="folders || {}"
                         :subfolders="subfolders[childId]?.subfolders || {}"
                     />
-                </div>
-            </template>
-            <template v-if="children?.length">
-                <div class="children">
+                </template>
+                <template v-if="children?.length">
                     <tree-content
                         v-for="(child, index) in children"
                         :key="index"
                         :obj="child"
                     />
-                </div>
-            </template>
+                </template>
+            </div>
         </template>
     </div>
 </template>
@@ -109,6 +129,7 @@ export default {
             msgFolders: t`Folders`,
             msgObjects: t`objects`,
             msgSave: t`Save`,
+            msgUndo: t`Undo`,
             open: false,
             show: 'subfolders',
             title: '',
@@ -151,6 +172,11 @@ export default {
             this.hoverTitle = false;
             this.folder.attributes.title = this.title;
         },
+        async undoTitle() {
+            this.editField = null;
+            this.hoverTitle = false;
+            this.title = this.folder?.attributes?.title || '';
+        },
         toggle() {
             this.open = !this.open;
         },
@@ -179,20 +205,9 @@ div.tree-folder > header > h2 > span.editable {
 div.tree-folder > header > h2 > span.modified {
     font-size: 0.7rem;
 }
-div.tree-folder div.children, div.tree-folder div.subfolders {
-    background-color: #121c21;
-}
-div.tree-folder div.children {
-    border: solid blue 1px;
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    gap: 0.2rem;
-}
-div.tree-folder div.children > div {
-    padding: 0.2rem;
-    margin: 0.2rem;
-    border-bottom: dotted 1px orange;
+div.tree-folder div.contents {
+    border-bottom: dashed aqua 0.5px;
+    margin-bottom: 1rem;
 }
 div.tree-folder .editable:hover {
     cursor: pointer;

--- a/resources/js/app/components/tree-compact/tree-folder.vue
+++ b/resources/js/app/components/tree-compact/tree-folder.vue
@@ -391,7 +391,8 @@ div.tree-folder > header > h2 > span.modified, div.tree-folder > header > h2 > a
     font-size: 0.7rem;
 }
 div.tree-folder div.contents {
-    border-bottom: dashed aqua 0.5px;
+    border-left: dashed white 0.5px;
+    border-bottom: dashed white 0.5px;
     margin-bottom: 1rem;
 }
 div.tree-folder .editable:hover {

--- a/resources/js/app/components/tree-compact/tree-folder.vue
+++ b/resources/js/app/components/tree-compact/tree-folder.vue
@@ -1,0 +1,206 @@
+<template>
+    <div class="tree-folder">
+        <header
+            class="tab"
+            :class="{'open': open}"
+            :open="open"
+            @click.prevent.stop="toggle"
+        >
+            <h2 :class="{'is-loading-spinner': loading}">
+                <template v-if="open">
+                    <app-icon icon="carbon:folder-open" />
+                </template>
+                <template v-else>
+                    <app-icon icon="carbon:folder" />
+                </template>
+                <template v-if="editField === 'title'">
+                    <input
+                        type="text"
+                        v-model="title"
+                        @click.prevent.stop="editField = 'title'"
+                    />
+                    <button @click.prevent.stop="saveTitle()">Save</button>
+                </template>
+                <span
+                    class="editable"
+                    @click.prevent.stop="editField = 'title'"
+                    @mouseover="hoverTitle=true"
+                    @mouseleave="hoverTitle=false"
+                    v-else
+                >
+                    {{ folder?.attributes?.title }}
+                    <template v-if="hoverTitle">
+                        <app-icon icon="ph:pencil-fill" color="#00aaff" />
+                    </template>
+                </span>
+                <span class="tag is-smallest is-black ml-2" style="float:right">
+                    {{ totalChildren }}
+                </span>
+            </h2>
+        </header>
+        <template v-if="open">
+            <div>
+                <button
+                    class="button button-outlined"
+                    :disabled="show === 'subfolders'"
+                    @click="show='subfolders'"
+                >
+                    <app-icon icon="carbon:folder" />
+                    <span class="mx-05">Subfolders ({{ Object.keys(subfolders)?.length || 0 }})</span>
+                </button>
+                <button
+                    class="button button-outlined"
+                    :disabled="show === 'contents'"
+                    @click="show='contents'"
+                >
+                    <app-icon icon="carbon:document" />
+                    <span class="mx-05">Contents ({{ Object.keys(children)?.length || 0 }})</span>
+                </button>
+                <button
+                    class="button button-outlined ml-05"
+                    style="float:right;"
+                >
+                    <app-icon icon="carbon:add" />
+                    <span class="ml-05">Create content</span>
+                </button>
+                <button
+                    class="button button-outlined ml-05"
+                    style="float:right;"
+                >
+                    <app-icon icon="carbon:add" />
+                    <span class="ml-05">Create folder</span>
+                </button>
+            </div>
+            <template v-if="Object.keys(subfolders)?.length && show === 'subfolders'">
+                <div class="subfolders">
+                    <tree-folder
+                        v-for="(childId, index) in Object.keys(subfolders)"
+                        :key="index"
+                        :folder="folders[childId]"
+                        :folders="folders || {}"
+                        :subfolders="subfolders[childId]?.subfolders || {}"
+                    />
+                </div>
+            </template>
+            <template v-if="children?.length && show === 'contents'">
+                <div class="children">
+                    <div v-for="(child, index) in children" :key="index">
+                        <div>
+                            <app-icon icon="carbon:document" />
+                            <span class="tag is-smallest mx-05" :class="`has-background-module-${child?.type}`">{{ child?.type }}</span>
+                        </div>
+                        <div>
+                            <span v-title="child?.attributes?.title">{{ truncate(child?.attributes?.title, 80) }}</span>
+                        </div>
+                    </div>
+                </div>
+            </template>
+        </template>
+    </div>
+</template>
+<script>
+const API_URL = new URL(BEDITA.base).pathname;
+const API_OPTIONS = {
+    method: 'GET',
+    credentials: 'same-origin',
+    headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': BEDITA.csrfToken,
+    },
+};
+export default {
+    name: 'TreeFolder',
+    props: {
+        folder: {
+            type: Object,
+            required: true
+        },
+        folders: {
+            type: Object,
+            required: true
+        },
+        subfolders: {
+            type: Object,
+            default: () => ({})
+        }
+    },
+    data() {
+        return {
+            children: [],
+            editField: null,
+            hoverTitle: false,
+            loading: false,
+            open: false,
+            show: 'subfolders',
+            title: '',
+            totalChildren: 0,
+        }
+    },
+    mounted() {
+        this.$nextTick(async () => {
+            this.title = this.folder?.attributes?.title || '';
+            await this.loadChildren();
+        });
+    },
+    methods: {
+        async loadChildren() {
+            try {
+                this.loading = true;
+                this.children = [];
+                const response = await fetch(`${API_URL}api/folders/${this.folder.id}/children?page_size=100`, API_OPTIONS);
+                const json = await response.json();
+                if (json.error) {
+                    throw new Error(json.error);
+                }
+                this.children = json?.data?.filter(item => item?.type !== 'folders') || [];
+                this.totalChildren = json?.meta?.pagination?.count || 0;
+            } catch (error) {
+                BEDITA.error(error);
+            } finally {
+                this.loading = false;
+            }
+        },
+        async saveTitle() {
+            console.log('Saving title:', this.title);
+            this.editField = null;
+            this.hoverTitle = false;
+            this.folder.attributes.title = this.title;
+        },
+        toggle() {
+            this.open = !this.open;
+        },
+        truncate(str, len) {
+            return this.$helpers.truncate(str, len);
+        },
+    },
+}
+</script>
+<style scoped>
+div.tree-folder {
+    padding: 0.5rem;
+    border: dotted 0.1px silver;
+    max-width: 1000px;
+}
+div.tree-folder > header > h2 {
+}
+div.tree-folder div.children {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.2rem;
+}
+div.tree-folder div.children > div {
+    padding: 0.2rem;
+    margin: 0.5rem;
+    border: dotted 1px yellowgreen;
+    width: 125px;
+    height: 100px;
+    font-size: x-small;
+}
+div.tree-folder .editable:hover {
+    cursor: pointer;
+    color: #00aaff;
+    text-decoration: underline;
+}
+</style>

--- a/resources/js/app/components/tree-compact/tree-node.vue
+++ b/resources/js/app/components/tree-compact/tree-node.vue
@@ -1,0 +1,109 @@
+<template>
+    <div class="tree-node">
+        <label>
+            <span>
+                <input
+                    :type="inputType"
+                    name="position"
+                    :checked="parentFolderId === node.id"
+                    :disabled="branchDisabled || referenceObject?.id === node?.id"
+                    @click="setParent($event)"
+                >
+            </span>
+            <span class="ml-05">
+                {{ folders[node?.id]?.attributes?.title || node?.id }}
+            </span>
+        </label>
+        <div
+            class="tree-node-children"
+            v-if="children?.length > 0"
+        >
+            <tree-node
+                v-for="child in children"
+                :branch-disabled="branchDisabled || referenceObject?.id === node?.id"
+                :key="child.id"
+                :folders="folders"
+                :node="child"
+                :object-type="objectType"
+                :parent-folder-id="parentFolderId"
+                :reference-object="referenceObject"
+                @update-parent="updateParent"
+            />
+        </div>
+    </div>
+</template>
+<script>
+
+export default {
+    name: 'TreeNode',
+    components: {
+        TreeNode: () => import('./tree-node.vue'),
+    },
+    props: {
+        branchDisabled: {
+            type: Boolean,
+            default: false
+        },
+        folders: {
+            type: Object,
+            default: () => ({}),
+        },
+        node: {
+            type: Object,
+            required: true
+        },
+        objectType: {
+            type: String,
+            required: true
+        },
+        parentFolderId: {
+            type: String,
+            default: null
+        },
+        referenceObject: {
+            type: Object,
+            default: () => ({})
+        }
+    },
+    data() {
+        return {
+            children: [],
+            inputType: '',
+            parentId: null,
+        };
+    },
+    mounted() {
+        this.$nextTick(() => {
+            this.children = Object.keys(this.node?.subfolders || {}).map(key => this.node.subfolders[key]);
+            this.inputType = this.objectType === 'folders' ? 'radio' : 'checkbox';
+        });
+    },
+    methods: {
+        setParent(ev) {
+            if (ev?.target?.checked) {
+                this.$emit('update-parent', this.node.id);
+            }
+        },
+        updateParent(id) {
+            this.parentId = id;
+            this.$emit('update-parent', id);
+        }
+    },
+};
+</script>
+<style scoped>
+div.tree-node > label {
+    display:flex;
+    align-items:center;
+    direction:column;
+    cursor: pointer;
+}
+div.tree-node > label > span {
+    display: flex;
+    align-self: center;
+    cursor: pointer;
+}
+div.tree-node, div.tree-node div.tree-node-children {
+    margin-left: 1rem;
+}
+</style>

--- a/resources/js/app/components/tree-compact/tree-node.vue
+++ b/resources/js/app/components/tree-compact/tree-node.vue
@@ -116,6 +116,11 @@ export default {
 };
 </script>
 <style scoped>
+div.tree-node {
+    padding-left: 0.5rem;
+    border-left: dotted white 1px;
+    font-size: 0.7rem;
+}
 div.tree-node > label {
     display:flex;
     align-items:center;
@@ -127,7 +132,7 @@ div.tree-node > label > span {
     align-self: center;
     cursor: pointer;
 }
-div.tree-node, div.tree-node div.tree-node-children {
-    margin-left: 1rem;
+div.tree-node div.tree-node-children {
+    margin-left: 0.4rem;
 }
 </style>

--- a/resources/js/app/components/tree-compact/tree-node.vue
+++ b/resources/js/app/components/tree-compact/tree-node.vue
@@ -1,15 +1,28 @@
 <template>
     <div class="tree-node">
         <label>
-            <span>
-                <input
-                    :type="inputType"
-                    name="position"
-                    :checked="parentFolderId === node.id"
-                    :disabled="branchDisabled || referenceObject?.id === node?.id"
-                    @click="setParent($event)"
-                >
-            </span>
+            <template v-if="objectType === 'folders'">
+                <span>
+                    <input
+                        type="radio"
+                        name="position"
+                        :checked="parentFolderId === node.id"
+                        :disabled="branchDisabled || referenceObject?.id === node?.id"
+                        @click="setParent($event)"
+                    >
+                </span>
+            </template>
+            <template v-else>
+                <span>
+                    <input
+                        type="checkbox"
+                        name="position[]"
+                        :checked="originalParents.includes(node.id)"
+                        :disabled="branchDisabled || referenceObject?.id === node?.id"
+                        @click="setParent($event)"
+                    >
+                </span>
+            </template>
             <span class="ml-05">
                 {{ folders[node?.id]?.attributes?.title || node?.id }}
             </span>
@@ -25,8 +38,10 @@
                 :folders="folders"
                 :node="child"
                 :object-type="objectType"
+                :original-parents="originalParents"
                 :parent-folder-id="parentFolderId"
                 :reference-object="referenceObject"
+                @remove-parent="removeParent"
                 @update-parent="updateParent"
             />
         </div>
@@ -56,6 +71,10 @@ export default {
             type: String,
             required: true
         },
+        originalParents: {
+            type: Array,
+            default: () => []
+        },
         parentFolderId: {
             type: String,
             default: null
@@ -79,15 +98,20 @@ export default {
         });
     },
     methods: {
+        removeParent(id) {
+            this.$emit('remove-parent', id);
+        },
         setParent(ev) {
             if (ev?.target?.checked) {
                 this.$emit('update-parent', this.node.id);
+            } else {
+                this.$emit('remove-parent', this.node.id);
             }
         },
         updateParent(id) {
             this.parentId = id;
             this.$emit('update-parent', id);
-        }
+        },
     },
 };
 </script>

--- a/resources/js/app/components/tree-compact/tree-panel.vue
+++ b/resources/js/app/components/tree-compact/tree-panel.vue
@@ -13,7 +13,12 @@
             >
                 <div class="main-panel fieldset">
                     <header class="mx-1 mt-1 tab tab-static unselectable">
-                        <h2>{{ msgNew }} {{ objectType }}</h2>
+                        <template v-if="objectTypeForm">
+                            <h2>{{ msgNewObjectIn }} {{ objectTypeForm }}</h2>
+                        </template>
+                        <template v-else>
+                            <h2>{{ msgNewContent }}</h2>
+                        </template>
                         <button
                             class="button button-outlined close"
                             v-title="msgClose"
@@ -22,7 +27,30 @@
                             <app-icon icon="carbon:close" />
                         </button>
                     </header>
-                    <div class="container">
+                    <div
+                        class="container"
+                        v-show="!objectTypeForm"
+                    >
+                        <label>{{ msgObjectType }} <span class="required">*</span></label>
+                        <select
+                            v-model="objectTypeForm"
+                            @change="updateObjectType"
+                        >
+                            <option
+                                v-for="item in objectTypes"
+                                :key="item.value"
+                                :value="item.value"
+                            >
+                                <span class="tag" :class="`has-background-module-${item.value}`">
+                                    {{ item.label }}
+                                </span>
+                            </option>
+                        </select>
+                    </div>
+                    <div
+                        class="container"
+                        v-if="objectTypeForm"
+                    >
                         <form-field
                             v-for="field in fieldsRequired"
                             :key="field"
@@ -31,17 +59,25 @@
                             :json-schema="schema?.properties?.[fieldKey(field)] || {}"
                             :is-uploadable="false"
                             :languages="languages"
-                            :object-type="objectType"
+                            :object-type="objectTypeForm"
                             :required="fieldsRequired?.includes(fieldKey(field))"
                             :val="obj?.attributes?.[fieldKey(field)] || schema?.[fieldKey(field)] || null"
-                            v-model="formFieldProperties[objectType][fieldKey(field)]"
+                            v-model="formFieldProperties[objectTypeForm][fieldKey(field)]"
                             @error="fieldError"
                             @update="fieldUpdate"
                             @success="fieldSuccess"
                         />
                         <div>
-                            <label>{{ msgParentFolder }} <span class="required">*</span> {{ parentId }}</label>
-                            <div class="root">
+                            <template v-if="objectTypeForm === 'folders'">
+                                <label>{{ msgParentFolder }} <span class="required">*</span></label>
+                            </template>
+                            <template v-else>
+                                <label>{{ msgPosition }} <span class="required">*</span></label>
+                            </template>
+                            <div
+                                class="root"
+                                v-if="objectTypeForm === 'folders'"
+                            >
                                 <label>
                                     <span>
                                         <input
@@ -56,16 +92,30 @@
                                     </span>
                                 </label>
                             </div>
-                            <tree-node
-                                v-for="(node, id) in tree"
-                                :key="id"
-                                :folders="folders"
-                                :node="node"
-                                :object-type="objectType"
-                                :parent-folder-id="parentId"
-                                :reference-object="obj"
-                                @update-parent="updateParent"
-                            />
+                            <template v-if="objectTypeForm === 'folders'">
+                                <tree-node
+                                    v-for="(node, id) in tree"
+                                    :key="id"
+                                    :folders="folders"
+                                    :node="node"
+                                    :object-type="objectTypeForm"
+                                    :parent-folder-id="parentId"
+                                    :reference-object="obj"
+                                    @update-parent="updateParent"
+                                />
+                            </template>
+                            <template v-else>
+                                <tree-node
+                                    v-for="(node, id) in tree"
+                                    :key="id"
+                                    :folders="folders"
+                                    :node="node"
+                                    :object-type="objectTypeForm"
+                                    :parent-folder-id="parentId"
+                                    :reference-object="obj"
+                                    @update-parent="updateParents"
+                                />
+                            </template>
                         </div>
                         <template v-for="field in fieldsOther">
                             <form-field
@@ -75,10 +125,10 @@
                                 :json-schema="schema?.properties?.[fieldKey(field)] || {}"
                                 :is-uploadable="false"
                                 :languages="languages"
-                                :object-type="objectType"
+                                :object-type="objectTypeForm"
                                 :required="fieldsRequired?.includes(fieldKey(field))"
                                 :val="obj?.attributes?.[fieldKey(field)] || schema?.[fieldKey(field)] || null"
-                                v-model="formFieldProperties[objectType][fieldKey(field)]"
+                                v-model="formFieldProperties[objectTypeForm][fieldKey(field)]"
                                 @error="fieldError"
                                 @update="fieldUpdate"
                                 @success="fieldSuccess"
@@ -106,7 +156,7 @@
                                 </span>
                             </button>
                         </div>
-                        <div v-if="error && (error.length > 0 || Object.keys(error).length > 0)">
+                        <div v-if="error">
                             <p class="error">
                                 {{ error }}
                             </p>
@@ -128,6 +178,10 @@ export default {
     },
     inject: ['getCSFRToken'],
     props: {
+        canSaveMap: {
+            type: Object,
+            default: () => ({}),
+        },
         folders: {
             type: Object,
             default: () => ({}),
@@ -159,69 +213,74 @@ export default {
     },
     data() {
         return {
-            error: {},
+            error: null,
             fieldsMap: {},
             fieldsAll: [],
             fieldsInvalid: [],
             fieldsOther: [],
             fieldsRequired: [],
             formFieldProperties: {},
+            msgChooseObjectType: t`Choose object type`,
             msgClose: t`Close`,
-            msgNew: t`New object in`,
+            msgNewContent: t`New content`,
+            msgNewObjectIn: t`New object in`,
+            msgObjectType: t`Object type`,
             msgParentFolder: t`Parent folder`,
+            msgPosition: t`Position`,
             msgRoot: t`/ (root)`,
             msgSave: t`Save`,
+            objectTypeForm: null,
+            objectTypes: [],
             parentId: null,
+            parentIds: [],
             saving: false,
             success: {},
         }
     },
     computed: {
+        inputName() {
+            return this.objectTypeForm === 'folders' ? 'position' : 'position[]';
+        },
+        inputType() {
+            return this.objectTypeForm === 'folders' ? 'radio' : 'checkbox';
+        },
         saveDisabled() {
             return this.fieldsInvalid.length > 0 || this.saving;
         },
     },
     mounted() {
         this.$nextTick(async () => {
-            this.formFieldProperties[this.objectType] = {};
-            this.fieldsRequired = BEDITA?.fastCreateFields?.[this.objectType]?.required || [];
-            this.fieldsAll = BEDITA?.fastCreateFields?.[this.objectType]?.fields || ['title'];
-            this.fieldsAll = this.fieldsAll.map(field => {
-                if (typeof field === 'object') {
-                    return Object.keys(field)[0];
-                }
-                return field;
-            });
-            this.fieldsOther = this.fieldsAll.filter(field => !this.fieldsRequired.includes(field));
-            const fields = BEDITA?.fastCreateFields?.[this.objectType]?.fields || [];
-            let ff = fields;
-            if (fields.constructor === Object) {
-                ff = Object.keys(fields);
-                this.fieldsMap = fields;
+            this.objectTypeForm = this.objectType === 'choose' ? null : this.objectType;
+            if (!this.objectTypeForm) {
+                this.objectTypes = BEDITA?.concreteTypes || [];
+                this.objectTypes = this.objectTypes.filter(type => this.canSaveMap[type]);
+                // remove 'folders' from the list
+                this.objectTypes = this.objectTypes.filter(type => type !== 'folders');
+                this.objectTypes = this.objectTypes.map(type => {
+                    return {
+                        label: BEDITA_I18N?.[type] || this.$helpers.humanize(type),
+                        value: type,
+                    };
+                });
+                this.objectTypes = this.objectTypes.sort((a, b) => {
+                    return a.label.localeCompare(b.label);
+                });
+                return;
             }
-            for (const item of ff) {
-                if (item.constructor === Object) {
-                    const itemKey = Object.keys(item)[0];
-                    this.fieldsMap[itemKey] = item[itemKey];
-                }
-            }
-            this.fieldsInvalid = this.fieldsRequired.filter(f => !this.formFieldProperties[this.objectType][f]);
-            if (this.obj?.meta?.path) {
-                const tmp = this.obj.meta.path.split('/').reverse();
-                this.parentId = tmp[1] || null;
-            }
+            this.updateObjectType();
         });
     },
     methods: {
         closePanel() {
             this.$emit('update:showPanel', false);
+            this.objectTypeForm = null;
         },
         fieldError(field, val) {
             this.error[field] = val;
         },
         fieldUpdate(field, val) {
-            this.formFieldProperties[this.objectType][field] = val;
-            this.fieldsInvalid = this.fieldsRequired.filter(f => !this.formFieldProperties[this.objectType][f]);
+            this.formFieldProperties[this.objectTypeForm][field] = val;
+            this.fieldsInvalid = this.fieldsRequired.filter(f => !this.formFieldProperties[this.objectTypeForm][f]);
         },
         fieldSuccess(field, val) {
             this.success[field] = val;
@@ -238,15 +297,54 @@ export default {
             }
             return !isNaN(str) && !isNaN(parseFloat(str));
         },
+        ll(field) {
+            return BEDITA_I18N?.[field] || field;
+        },
+        updateObjectType() {
+            this.formFieldProperties[this.objectTypeForm] = {};
+            this.fieldsRequired = BEDITA?.fastCreateFields?.[this.objectTypeForm]?.required || [];
+            this.fieldsAll = BEDITA?.fastCreateFields?.[this.objectTypeForm]?.fields || ['title'];
+            this.fieldsAll = this.fieldsAll.map(field => {
+                if (typeof field === 'object') {
+                    return Object.keys(field)[0];
+                }
+                return field;
+            });
+            this.fieldsOther = this.fieldsAll.filter(field => !this.fieldsRequired.includes(field));
+            const fields = BEDITA?.fastCreateFields?.[this.objectTypeForm]?.fields || [];
+            let ff = fields;
+            if (fields.constructor === Object) {
+                ff = Object.keys(fields);
+                this.fieldsMap = fields;
+            }
+            for (const item of ff) {
+                if (item.constructor === Object) {
+                    const itemKey = Object.keys(item)[0];
+                    this.fieldsMap[itemKey] = item[itemKey];
+                }
+            }
+            this.fieldsInvalid = this.fieldsRequired.filter(f => !this.formFieldProperties[this.objectTypeForm][f]);
+            if (this.obj?.meta?.path) {
+                const tmp = this.obj.meta.path.split('/').reverse();
+                this.parentId = tmp[1] || null;
+            }
+        },
         updateParent(id) {
             this.parentId = id;
         },
+        updateParents(id) {
+            if (this.parentIds.includes(id)) {
+                this.parentIds = this.parentIds.filter(pid => pid !== id);
+            } else {
+                this.parentIds.push(id);
+            }
+        },
         async save() {
-            console.log('saving...');
             try {
+                this.error = null;
                 this.saving = true;
-                this.payload = Object.assign({}, this.formFieldProperties[this.objectType]);
-                this.payload.objectType = this.objectType;
+                this.payload = Object.assign({}, this.formFieldProperties[this.objectTypeForm]);
+                this.payload.objectType = this.objectTypeForm;
                 if (this.obj?.id) {
                     this.payload.id = this.obj.id;
                 }
@@ -255,23 +353,43 @@ export default {
                     const tmp = this.obj.meta.path.split('/').reverse();
                     this.payload._originalParents = tmp[1] || null;
                 }
-                this.payload.relations = {
-                    parent: {
-                        replaceRelated: [
-                            JSON.stringify({
-                                id: this.parentId,
-                                type: this.objectType,
-                                meta: {
-                                    relation: {
-                                        menu: false,
-                                        canonical: false
+                if (this.objectTypeForm === 'folders') {
+                    this.payload.relations = {
+                        parent: {
+                            replaceRelated: [
+                                JSON.stringify({
+                                    id: this.parentId,
+                                    type: 'folders',
+                                    meta: {
+                                        relation: {
+                                            menu: false,
+                                            canonical: false
+                                        }
                                     }
-                                }
-                            })
-                        ]
-                    }
-                };
-                const url = `/${this.objectType}/save`;
+                                })
+                            ]
+                        },
+                    };
+                } else {
+                    this.payload._changedParents = this.parentIds?.join(',') || null;
+                    this.payload.relations = {
+                        parents: {
+                            replaceRelated: this.parentIds.map(
+                                id => JSON.stringify({
+                                    id,
+                                    type: 'folders',
+                                    meta: {
+                                        relation: {
+                                            menu: false,
+                                            canonical: false
+                                        }
+                                    }
+                                })
+                            ),
+                        },
+                    };
+                }
+                const url = `/${this.objectTypeForm}/save`;
                 const options = {
                     method: 'POST',
                     credentials: 'same-origin',
@@ -330,7 +448,6 @@ div.tree-panel div.buttons {
 div.tree-panel span.required {
     color: red;
 }
-
 div.tree-panel div.root > label {
     display:flex;
     align-items:center;

--- a/resources/js/app/pages/modules/index.js
+++ b/resources/js/app/pages/modules/index.js
@@ -16,6 +16,7 @@ export default {
         FolderPicker: () => import(/* webpackChunkName: "folder-picker" */'app/components/folder-picker/folder-picker'),
         DateRangesList: () => import(/* webpackChunkName: "date-ranges-list" */'app/components/date-ranges-list/date-ranges-list'),
         TreeView: () => import(/* webpackChunkName: "tree-view" */'app/components/tree-view/tree-view'),
+        TreeCompact: () => import(/* webpackChunkName: "tree-compact" */'app/components/tree-compact/tree-compact'),
         FilterBoxView: () => import(/* webpackChunkName: "tree-view" */'app/components/filter-box'),
         IndexCell: () => import(/* webpackChunkName: "index-cell" */'app/components/index-cell/index-cell'),
         PermissionToggle: () => import(/* webpackChunkName: "permission-toggle" */'app/components/permission-toggle/permission-toggle'),

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -311,7 +311,7 @@ class AppController extends Controller
         if (!empty($data['relations'])) {
             $api = [];
             foreach ($data['relations'] as $relation => $relationData) {
-                $id = $data['id'];
+                $id = (string)Hash::get($data, 'id');
                 foreach ($relationData as $method => $ids) {
                     $relatedIds = $this->relatedIds($ids);
                     if ($method === 'replaceRelated' || !empty($relatedIds)) {

--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -523,6 +523,25 @@ class SchemaComponent extends Component
     }
 
     /**
+     * Get all concrete types, i.e. all descendants of abstract types.
+     *
+     * @return array
+     */
+    public function allConcreteTypes(): array
+    {
+        $features = $this->objectTypesFeatures();
+        $types = [];
+        foreach ($features['descendants'] as $descendants) {
+            if (!empty($descendants)) {
+                $types = array_unique(array_merge($types, $descendants));
+            }
+        }
+        sort($types);
+
+        return $types;
+    }
+
+    /**
      * Clear schema cache
      *
      * @return void

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -143,6 +143,9 @@ class ModulesController extends AppController
         // custom properties
         $this->set('customProps', $this->Schema->customProps($this->objectType));
 
+        // set all types (use cache)
+        $this->set('allConcreteTypes', $this->Schema->allConcreteTypes());
+
         // set prevNext for views navigations
         $this->setObjectNav($objects);
 

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -399,10 +399,9 @@ class TreeController extends AppController
 
             $parentPath = substr($path, 0, strrpos($path, '/'));
             $parentId = $paths[$parentPath];
-            if (empty($parentId)) {
-                continue;
+            if (!empty($parentId)) {
+                $this->pushIntoTree($tree, $parentId, $id, 'subfolders');
             }
-            $this->pushIntoTree($tree, $parentId, $id, 'subfolders');
         }
 
         return compact('tree', 'folders');

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -68,6 +68,27 @@ class TreeController extends AppController
         $this->setSerialize(['data']);
     }
 
+    public function children(string $id): void
+    {
+        $this->getRequest()->allowMethod(['get']);
+        $this->viewBuilder()->setClassName('Json');
+        $data = $meta = [];
+        try {
+            $query = $this->getRequest()->getQueryParams();
+            $response = $this->apiClient->get(sprintf('/folders/%s/children', $id), $query);
+            $data = (array)Hash::get($response, 'data');
+            foreach ($data as &$item) {
+                $item = $this->minimalDataWithMeta((array)$item);
+            }
+            $meta = (array)Hash::get($response, 'meta');
+        } catch (BEditaClientException $e) {
+            $this->log($e->getMessage(), LogLevel::ERROR);
+        }
+        $this->set('data', $data);
+        $this->set('meta', $meta);
+        $this->setSerialize(['data', 'meta']);
+    }
+
     /**
      * Get node by ID.
      * Use cache to store data.
@@ -456,6 +477,8 @@ class TreeController extends AppController
             'type' => (string)Hash::get($fullData, 'type'),
             'attributes' => [
                 'title' => (string)Hash::get($fullData, 'attributes.title'),
+                'uname' => (string)Hash::get($fullData, 'attributes.uname'),
+                'lang' => (string)Hash::get($fullData, 'attributes.lang'),
                 'status' => (string)Hash::get($fullData, 'attributes.status'),
             ],
             'meta' => [

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -68,6 +68,13 @@ class TreeController extends AppController
         $this->setSerialize(['data']);
     }
 
+    /**
+     * Get children of a folder by ID.
+     * Use cache to store data.
+     *
+     * @param string $id The ID.
+     * @return void
+     */
     public function children(string $id): void
     {
         $this->getRequest()->allowMethod(['get']);
@@ -181,6 +188,12 @@ class TreeController extends AppController
         return null;
     }
 
+    /**
+     * Get compact tree data.
+     * Use cache to store data.
+     *
+     * @return array
+     */
     public function compactTreeData(): array
     {
         $objectType = $this->getRequest()->getParam('object_type');

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -356,6 +356,14 @@ class TreeController extends AppController
         return $data;
     }
 
+    /**
+     * Fetch compact tree data from API.
+     * Retrieve minimal data for folders: id, status, title, meta.
+     * Return tree and folders.
+     * Return an array with 'tree' and 'folders' keys.
+     *
+     * @return array
+     */
     protected function fetchCompactTreeData(): array
     {
         $done = false;

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -459,6 +459,7 @@ class TreeController extends AppController
                 'status' => (string)Hash::get($fullData, 'attributes.status'),
             ],
             'meta' => [
+                'modified' => (string)Hash::get($fullData, 'meta.modified'),
                 'path' => (string)Hash::get($fullData, 'meta.path'),
                 'slug_path' => (array)Hash::get($fullData, 'meta.slug_path'),
                 'slug_path_compact' => $this->slugPathCompact((array)Hash::get($fullData, 'meta.slug_path')),

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -185,6 +185,10 @@ class TreeController extends AppController
     {
         $objectType = $this->getRequest()->getParam('object_type');
         $key = CacheTools::cacheKey(sprintf('compact-tree-%s', $objectType));
+        $noCache = (bool)$this->getRequest()->getQuery('no_cache');
+        if ($noCache === true) {
+            Cache::clearGroup('tree', TreeCacheEventHandler::CACHE_CONFIG);
+        }
         $data = [];
         try {
             $data = Cache::remember(

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -319,6 +319,9 @@ class LayoutHelper extends Helper
             $indexViewType = $this->moduleIndexViewType();
             foreach ($indexViewTypes as $t) {
                 if ($t !== $indexViewType) {
+                    $append = false;
+                    $icon = '';
+                    $label = '';
                     switch ($t) {
                         case 'tree':
                             $icon = 'carbon:tree-view';

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -435,6 +435,7 @@ class LayoutHelper extends Helper
             'richeditorByPropertyConfig' => (array)Configure::read('UI.richeditor', []),
             'indexLists' => (array)$this->indexLists(),
             'fastCreateFields' => (array)$this->Property->fastCreateFieldsMap(),
+            'concreteTypes' => (array)$this->getView()->get('allConcreteTypes', []),
         ];
     }
 

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -303,7 +303,60 @@ class LayoutHelper extends Helper
     {
         $defaultType = $this->moduleIndexDefaultViewType();
 
-        return $defaultType === 'tree' ? ['tree', 'list'] : ['list'];
+        return $defaultType === 'tree' ? ['tree', 'tree-compact', 'list'] : ['list'];
+    }
+
+    /**
+     * Append view type buttons to the sidebar
+     *
+     * @return void
+     */
+    public function appendViewTypeButtons(): void
+    {
+        $indexViewTypes = $this->moduleIndexViewTypes();
+        if (count($indexViewTypes) > 1) {
+            $indexViewType = $this->moduleIndexViewType();
+            foreach ($indexViewTypes as $t) {
+                if ($t !== $indexViewType) {
+                    switch ($t) {
+                        case 'tree':
+                            $icon = 'carbon:tree-view';
+                            $label = __('Tree view');
+                            $append = true;
+                            break;
+                        case 'tree-compact':
+                            $icon = 'carbon:tree-view';
+                            $label = __('Tree compact');
+                            $meta = $this->getView()->get('meta');
+                            $count = (int)Hash::get($meta, 'pagination.count');
+                            $append = $count <= Configure::read('UI.tree_compact_view_limit', 100);
+                            break;
+                        case 'list':
+                            $icon = 'carbon:list';
+                            $label = __('List view');
+                            $append = true;
+                            break;
+                    }
+                    if ($append) {
+                        $url = $this->Url->build(
+                            [
+                                '_name' => 'modules:list',
+                                'object_type' => $this->getView()->get('objectType'),
+                            ],
+                        );
+                        $url = sprintf('%s?view_type=%s', $url, $t);
+                        $anchor = sprintf(
+                            '<a href="%s" class="button button-outlined button-outlined-module-%s"><app-icon icon="%s"></app-icon><span class="ml-05">%s</span></a>',
+                            $url,
+                            $this->getView()->get('currentModule.name'),
+                            $icon,
+                            __($label)
+                        );
+                        $this->getView()->append('app-module-buttons', $anchor);
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -26,6 +26,7 @@ use Cake\View\Helper;
  * @property \Cake\View\Helper\HtmlHelper $Html
  * @property \App\View\Helper\LinkHelper $Link
  * @property \App\View\Helper\PermsHelper $Perms
+ * @property \App\View\Helper\PropertyHelper $Property
  * @property \App\View\Helper\SystemHelper $System
  * @property \Cake\View\Helper\UrlHelper $Url
  */
@@ -36,7 +37,7 @@ class LayoutHelper extends Helper
      *
      * @var array
      */
-    public $helpers = ['Editors', 'Html', 'Link', 'Perms', 'System', 'Url'];
+    public $helpers = ['Editors', 'Html', 'Link', 'Perms', 'Property', 'System', 'Url'];
 
     /**
      * Is Dashboard
@@ -430,6 +431,7 @@ class LayoutHelper extends Helper
             'richeditorConfig' => (array)Configure::read('Richeditor'),
             'richeditorByPropertyConfig' => (array)Configure::read('UI.richeditor', []),
             'indexLists' => (array)$this->indexLists(),
+            'fastCreateFields' => (array)$this->Property->fastCreateFieldsMap(),
         ];
     }
 

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -331,7 +331,7 @@ class LayoutHelper extends Helper
                         case 'tree-compact':
                             $icon = 'carbon:tree-view';
                             $label = __('Tree compact');
-                            $meta = $this->getView()->get('meta');
+                            $meta = (array)$this->getView()->get('meta');
                             $count = (int)Hash::get($meta, 'pagination.count');
                             $append = $count <= Configure::read('UI.tree_compact_view_limit', 100);
                             break;

--- a/src/View/Helper/PermsHelper.php
+++ b/src/View/Helper/PermsHelper.php
@@ -130,7 +130,23 @@ class PermsHelper extends Helper
      */
     public function canSave(?string $module = null): bool
     {
-        return $this->isAllowed('PATCH', $module) && $this->userIsAllowed($module);
+        return $this->userIsAdmin() || ($this->isAllowed('PATCH', $module) && $this->userIsAllowed($module));
+    }
+
+    /**
+     * Map of modules and their save permissions for the authenticated user.
+     *
+     * @return array
+     */
+    public function canSaveMap(): array
+    {
+        $modules = array_keys((array)$this->_View->get('modules'));
+        $map = [];
+        foreach ($modules as $module) {
+            $map[$module] = $this->canSave($module);
+        }
+
+        return $map;
     }
 
     /**
@@ -228,10 +244,10 @@ class PermsHelper extends Helper
      */
     public function userRoles(): array
     {
-        /** @var \Authentication\Identity $identity */
+        /** @var \Authentication\Identity|null $identity */
         $identity = $this->_View->get('user');
 
-        return (array)$identity->get('roles');
+        return empty($identity) ? [] : (array)$identity->get('roles');
     }
 
     /**

--- a/templates/Element/Modules/sidebar.twig
+++ b/templates/Element/Modules/sidebar.twig
@@ -36,20 +36,7 @@
 {% endfor %}
 {% endif %}
 
-{% set indexViewTypes = Layout.moduleIndexViewTypes() %}
-{% if indexViewTypes|length > 1 %}
-    {% set indexViewType = Layout.moduleIndexViewType() %}
-    {% for t in indexViewTypes %}
-        {% if t != indexViewType %}
-            {% set icon = t == 'tree' ? 'carbon:tree-view' : 'carbon:list' %}
-            {% set label = t == 'tree' ? __('Tree view') : __('List view') %}
-            {% do _view.append(
-                'app-module-buttons',
-                '<a href="' ~ url ~ '?view_type=' ~ t ~ '" class="button button-outlined button-outlined-module-' ~ currentModule.name ~ '"><app-icon icon="' ~ icon ~ '"></app-icon><span class="ml-05">' ~ __(label) ~ '</span></a>'
-            ) %}
-        {% endif %}
-    {% endfor %}
-{% endif %}
+{{ Layout.appendViewTypeButtons() }}
 
 {% if in_array('admin', user.roles) %}
     {% do _view.append(

--- a/templates/Element/Modules/tree-compact.twig
+++ b/templates/Element/Modules/tree-compact.twig
@@ -7,9 +7,9 @@
 	</header>
 	<div>
 		<p class="my-1">
-            {{ __('The number of folders is too high to be displayed in tree-compact view.') }}
-			{{ __('Number of folders:') }} {{ count }}.
-            {{ __('Limit:') }} {{ limit }}.
+            {{ __('The number of folders is too high to be displayed in tree-compact view') }}.
+			{{ __('Number of folders') }}: {{ count }}.
+            {{ __('Limit') }}: {{ limit }}.
 		</p>
     </div>
 </section>

--- a/templates/Element/Modules/tree-compact.twig
+++ b/templates/Element/Modules/tree-compact.twig
@@ -1,2 +1,4 @@
-<tree-compact :object-type="{{ objectType|json_encode }}">
+<tree-compact
+    :can-save-map="{{ Perms.canSaveMap()|json_encode }}"
+>
 </tree-compact>

--- a/templates/Element/Modules/tree-compact.twig
+++ b/templates/Element/Modules/tree-compact.twig
@@ -1,6 +1,24 @@
+{% set limit = config('UI.tree_compact_view_limit', 100) %}
+{% set count = meta.pagination.count %}
+{% if count > limit %}
+<section class="px-1">
+	<header>
+        <h1>{{ __('You cannot see folders in tree-compact view') }}</h1>
+	</header>
+	<div>
+		<p class="my-1">
+            {{ __('The number of folders is too high to be displayed in tree-compact view.') }}
+			{{ __('Number of folders:') }} {{ count }}.
+            {{ __('Limit:') }} {{ limit }}.
+		</p>
+    </div>
+</section>
+{% else %}
 <tree-compact
     :can-save-map="{{ Perms.canSaveMap()|json_encode }}"
+    :count="{{ count }}"
     :languages="{{ config('Project.config.I18n.languages')|default([])|json_encode|escape('html_attr') }}"
     :schema="{{ schema|json_encode }}"
 >
 </tree-compact>
+{% endif %}

--- a/templates/Element/Modules/tree-compact.twig
+++ b/templates/Element/Modules/tree-compact.twig
@@ -1,0 +1,2 @@
+<tree-compact :object-type="{{ objectType|json_encode }}">
+</tree-compact>

--- a/templates/Element/Modules/tree-compact.twig
+++ b/templates/Element/Modules/tree-compact.twig
@@ -1,4 +1,6 @@
 <tree-compact
     :can-save-map="{{ Perms.canSaveMap()|json_encode }}"
+    :languages="{{ config('Project.config.I18n.languages')|default([])|json_encode|escape('html_attr') }}"
+    :schema="{{ schema|json_encode }}"
 >
 </tree-compact>

--- a/templates/Pages/Modules/index.twig
+++ b/templates/Pages/Modules/index.twig
@@ -1,7 +1,9 @@
 {% do _view.assign('title', __(currentModule.name|humanize)) %}
 {% set indexViewType = Layout.moduleIndexViewType() %}
 
-{{ element('Modules/index_header', { 'meta': meta, 'filter': filter, 'Schema': Schema, 'hidePagination': indexViewType == 'tree'}) }}
+{% if indexViewType != 'tree-compact' %}
+    {{ element('Modules/index_header', { 'meta': meta, 'filter': filter, 'Schema': Schema, 'hidePagination': indexViewType == 'tree'}) }}
+{% endif %}
 
 {% set ids = Array.extract(objects, '{*}.id') %}
 <modules-index inline-template ids='{{ ids|json_encode }}'>

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -810,4 +810,22 @@ class SchemaComponentTest extends TestCase
         $actual = $this->Schema->tagsInUse();
         static::assertFalse($actual);
     }
+
+    /**
+     * Test `allConcreteTypes`
+     *
+     * @return void
+     * @covers ::allConcreteTypes()
+     */
+    public function testAllConcreteTypes(): void
+    {
+        $actual = $this->Schema->allConcreteTypes();
+        static::assertIsArray($actual);
+        // do not contain abstract types as objects or media
+        static::assertNotContains('objects', $actual);
+        static::assertNotContains('media', $actual);
+        // contain concrete types as documents, images, etc.
+        static::assertContains('documents', $actual);
+        static::assertContains('images', $actual);
+    }
 }

--- a/tests/TestCase/Controller/TreeControllerTest.php
+++ b/tests/TestCase/Controller/TreeControllerTest.php
@@ -132,6 +132,29 @@ class TreeControllerTest extends BaseControllerTest
     }
 
     /**
+     * Test `children` method on exception
+     *
+     * @return void
+     * @covers ::children()
+     */
+    public function testChildrenException(): void
+    {
+        $this->setupApi();
+        $config = [
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+            'get' => [],
+        ];
+        $request = new ServerRequest($config);
+        $tree = new TreeController($request);
+        $id = '99999999';
+        $tree->children($id);
+        $actual = $tree->viewBuilder()->getVar('data');
+        static::assertEmpty($actual);
+    }
+
+    /**
      * Test `compactTreeData` method with query parameter `no_cache` set to true
      *
      * @return void

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -384,7 +384,7 @@ class LayoutHelperTest extends TestCase
             ],
             'folders' => [
                 ['currentModule' => ['name' => 'folders']],
-                ['tree', 'list'],
+                ['tree', 'tree-compact', 'list'],
             ],
         ];
     }

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -415,6 +415,25 @@ class LayoutHelperTest extends TestCase
     }
 
     /**
+     * Test `appendViewTypeButtons` method.
+     *
+     * @return void
+     * @covers ::appendViewTypeButtons()
+     */
+    public function testAppendViewTypeButtons(): void
+    {
+        $response = $events = null;
+        $request = new ServerRequest(['query' => ['view_type' => 'other']]);
+        $view = new View($request, $response, $events);
+        $layout = new LayoutHelper($view);
+        $view->set('currentModule', ['name' => 'folders']);
+        $layout->appendViewTypeButtons();
+        $actual = $view->fetch('app-module-buttons');
+        $expected = '<a href="/?view_type=tree" class="button button-outlined button-outlined-module-"><app-icon icon="carbon:tree-view"></app-icon><span class="ml-05">Tree view</span></a><a href="/?view_type=tree-compact" class="button button-outlined button-outlined-module-"><app-icon icon="carbon:tree-view"></app-icon><span class="ml-05">Tree compact</span></a><a href="/?view_type=list" class="button button-outlined button-outlined-module-"><app-icon icon="carbon:list"></app-icon><span class="ml-05">List view</span></a>';
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
      * Data provider for `testTitle` test case.
      *
      * @return array

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -17,6 +17,7 @@ use App\Utility\CacheTools;
 use App\View\Helper\EditorsHelper;
 use App\View\Helper\LayoutHelper;
 use App\View\Helper\PermsHelper;
+use App\View\Helper\PropertyHelper;
 use App\View\Helper\SystemHelper;
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
@@ -578,6 +579,7 @@ class LayoutHelperTest extends TestCase
         ];
         $view = new View($request, null, null, compact('viewVars'));
         $layout = new LayoutHelper($view);
+        $property = new PropertyHelper($view);
         $system = new SystemHelper($view);
         $conf = $layout->metaConfig();
         $expected = [
@@ -599,6 +601,7 @@ class LayoutHelperTest extends TestCase
             'richeditorConfig' => (array)Configure::read('Richeditor'),
             'richeditorByPropertyConfig' => (array)Configure::read('RicheditorByProperty'),
             'indexLists' => (array)$layout->indexLists(),
+            'fastCreateFields' => (array)$property->fastCreateFieldsMap(),
         ];
         static::assertSame($expected, $conf);
         Cache::disable();

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -621,6 +621,7 @@ class LayoutHelperTest extends TestCase
             'richeditorByPropertyConfig' => (array)Configure::read('RicheditorByProperty'),
             'indexLists' => (array)$layout->indexLists(),
             'fastCreateFields' => (array)$property->fastCreateFieldsMap(),
+            'concreteTypes' => (array)$view->get('allConcreteTypes', []),
         ];
         static::assertSame($expected, $conf);
         Cache::disable();

--- a/tests/TestCase/View/Helper/PermsHelperTest.php
+++ b/tests/TestCase/View/Helper/PermsHelperTest.php
@@ -177,6 +177,22 @@ class PermsHelperTest extends TestCase
     }
 
     /**
+     * Test `canSaveMap` method
+     *
+     * @return void
+     * @covers ::canSaveMap()
+     */
+    public function testCanSaveMap(): void
+    {
+        $result = $this->Perms->canSaveMap();
+        static::assertIsArray($result);
+        static::assertArrayHasKey('documents', $result);
+        static::assertTrue($result['documents']);
+        static::assertArrayHasKey('profiles', $result);
+        static::assertFalse($result['profiles']);
+    }
+
+    /**
      * Test `canDelete` method
      *
      * @return void


### PR DESCRIPTION
This provides a new view type for module folders: "compact view".

It's available when folders tree elements are not more than `UI.tree_compact_view_limit` conf (100 as default). It means that if your database contains more than 100 (or `UI.tree_compact_view_limit`) folders, this view type is not available.

When available, you see a new button in `folders` sidebar (`tree compact` | `vista ad albero` [it]):

![image](https://github.com/user-attachments/assets/8f8da63f-00b1-4cdb-a206-aa732b7f8178)

The module view allows you to see all the folders tree loaded, and its non folders contents loaded when clicking on folders.

![image](https://github.com/user-attachments/assets/49aa7ea3-a1f8-4040-bafd-1468bfc0067b)

Edit of folders and contents is managed in side panel.

![image](https://github.com/user-attachments/assets/ee089394-f6d9-4c19-9d1a-500ba9b650c8)

![image](https://github.com/user-attachments/assets/5dc02508-8367-4fcf-9728-931f67d85839)

