### PR TITLE
Skip save when no data changed (advanced)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,5 +99,8 @@
             "merge-extra-deep": false,
             "merge-scripts": false
         }
+    },
+    "conflict": {
+        "slevomat/coding-standard": ">8.18.0"
     }
 }

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -473,10 +473,14 @@ class ModulesComponent extends Component
      *
      * @param string $id The object ID
      * @param array $requestPermissions The request permissions
+     * @param array $schema The object type schema
      * @return bool True if save permissions can be skipped, false otherwise
      */
-    public function skipSavePermissions(string $id, array $requestPermissions): bool
+    public function skipSavePermissions(string $id, array $requestPermissions, array $schema): bool
     {
+        if (!in_array('Permissions', (array)Hash::get($schema, 'associations'))) {
+            return true;
+        }
         $requestPermissions = array_map(
             function ($role) {
                 return (int)$role;

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -447,6 +447,43 @@ class ModulesComponent extends Component
     }
 
     /**
+     * Check if save can be skipped.
+     * This is used to avoid saving object with no changes.
+     *
+     * @param string $id The object ID
+     * @param array $requestData The request data
+     * @param array $relatedData The related data
+     * @return bool True if save can be skipped, false otherwise
+     */
+    public function skipSave(string $id, array $requestData, array $relatedData): bool
+    {
+        if (empty($id) || !empty($relatedData)) {
+            return false;
+        }
+        $data = $requestData;
+        unset($data['id']);
+        $requestPermissions = (array)Hash::get($data, 'permissions', []);
+        if (!empty($requestPermissions)) {
+            $requestPermissions = array_map(
+                function ($role) {
+                    return (int)$role;
+                },
+                $requestPermissions
+            );
+            sort($requestPermissions);
+            $query = ['filter' => ['object_id' => $id], 'page_size' => 100];
+            $objectPermissions = (array)ApiClientProvider::getApiClient()->getObjects('object_permissions', $query);
+            $actualPermissions = (array)Hash::extract($objectPermissions, 'data.{n}.attributes.role_id');
+            sort($actualPermissions);
+            if ($actualPermissions === $requestPermissions) {
+                unset($data['permissions']);
+            }
+        }
+
+        return empty($data);
+    }
+
+    /**
      * Set current attributes from loaded $object data in `currentAttributes`.
      *
      * @param array $object The object.

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -298,7 +298,7 @@ class ModulesController extends AppController
 
                 return;
             }
-            $id = Hash::get($requestData, 'id');
+            $id = (string)Hash::get($requestData, 'id');
             // skip save if no data changed
             if ($this->Modules->skipSave($id, $requestData, $relatedData)) {
                 $response = $this->apiClient->getObject($id, $this->objectType, ['count' => 'all']);

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -302,9 +302,10 @@ class ModulesController extends AppController
             // skip save if no data changed
             $schema = (array)$this->Schema->getSchema($this->objectType);
             $permissions = (array)Hash::get($requestData, 'permissions');
-            $skipSaveObject = $this->Modules->skipSaveObject($id, $requestData, $relatedData);
+            $skipSaveObject = $this->Modules->skipSaveObject($id, $requestData);
+            $skipSaveRelated = $this->Modules->skipSaveRelated($id, $relatedData);
             $skipSavePermissions = $this->Modules->skipSavePermissions($id, $permissions, $schema);
-            if ($skipSaveObject && $skipSavePermissions) {
+            if ($skipSaveObject && $skipSaveRelated && $skipSavePermissions) {
                 $response = $this->apiClient->getObject($id, $this->objectType, ['count' => 'all']);
                 $this->Thumbs->urls($response);
                 $this->set((array)$response);
@@ -332,7 +333,9 @@ class ModulesController extends AppController
                 );
             }
             $id = (string)Hash::get($response, 'data.id');
-            $this->Modules->saveRelated($id, $this->objectType, $relatedData);
+            if (!$skipSaveRelated) {
+                $this->Modules->saveRelated($id, $this->objectType, $relatedData);
+            }
             $options = [
                 'id' => Hash::get($response, 'data.id'),
                 'type' => $this->objectType,

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -301,7 +301,7 @@ class ModulesController extends AppController
             $id = (string)Hash::get($requestData, 'id');
             // skip save if no data changed
             $skipSaveObject = $this->Modules->skipSaveObject($id, $requestData, $relatedData);
-            $skipSavePermissions = $this->Modules->skipSavePermissions($id, $requestData);
+            $skipSavePermissions = $this->Modules->skipSavePermissions($id, (array)Hash::get($requestData, 'permissions'));
             if ($skipSaveObject && $skipSavePermissions) {
                 $response = $this->apiClient->getObject($id, $this->objectType, ['count' => 'all']);
                 $this->Thumbs->urls($response);

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -300,8 +300,10 @@ class ModulesController extends AppController
             }
             $id = (string)Hash::get($requestData, 'id');
             // skip save if no data changed
+            $schema = (array)$this->Schema->getSchema($this->objectType);
+            $permissions = (array)Hash::get($requestData, 'permissions');
             $skipSaveObject = $this->Modules->skipSaveObject($id, $requestData, $relatedData);
-            $skipSavePermissions = $this->Modules->skipSavePermissions($id, (array)Hash::get($requestData, 'permissions'));
+            $skipSavePermissions = $this->Modules->skipSavePermissions($id, $permissions, $schema);
             if ($skipSaveObject && $skipSavePermissions) {
                 $response = $this->apiClient->getObject($id, $this->objectType, ['count' => 'all']);
                 $this->Thumbs->urls($response);
@@ -325,8 +327,8 @@ class ModulesController extends AppController
             if (!$skipSavePermissions) {
                 $this->savePermissions(
                     (array)$response,
-                    (array)$this->Schema->getSchema($this->objectType),
-                    (array)Hash::get($requestData, 'permissions')
+                    $schema,
+                    $permissions
                 );
             }
             $id = (string)Hash::get($response, 'data.id');

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -300,7 +300,7 @@ class ModulesController extends AppController
             }
             $id = Hash::get($requestData, 'id');
             // skip save if no data changed
-            if (empty($relatedData) && count($requestData) === 1 && !empty($id)) {
+            if ($this->Modules->skipSave($id, $requestData, $relatedData)) {
                 $response = $this->apiClient->getObject($id, $this->objectType, ['count' => 'all']);
                 $this->Thumbs->urls($response);
                 $this->set((array)$response);

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -317,7 +317,11 @@ class ModulesController extends AppController
             // save data
             $lang = I18n::getLocale();
             $headers = ['Accept-Language' => $lang];
-            $response = $this->apiClient->save($this->objectType, $requestData, $headers);
+            if (!$skipSaveObject) {
+                $response = $this->apiClient->save($this->objectType, $requestData, $headers);
+            } else {
+                $response = $this->apiClient->getObject($id, $this->objectType);
+            }
             if (!$skipSavePermissions) {
                 $this->savePermissions(
                     (array)$response,

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -142,4 +142,29 @@ class DateRangesTools
 
         return empty($data) ? null : $data;
     }
+
+    /**
+     * Convert date ranges to string.
+     *
+     * @param array $dateRanges Date ranges to convert.
+     * @return string
+     */
+    public static function toString(array $dateRanges): string
+    {
+        $drs = [];
+        foreach ($dateRanges as $dateRange) {
+            $startDate = (string)Hash::get($dateRange, 'start_date');
+            $endDate = (string)Hash::get($dateRange, 'end_date');
+            $params = json_encode((array)Hash::get($dateRange, 'params', []));
+
+            $drs[] = sprintf(
+                '%s-%s-%s',
+                $startDate,
+                $endDate,
+                $params
+            );
+        }
+
+        return implode(',', $drs ?? []);
+    }
 }

--- a/src/Utility/DateRangesTools.php
+++ b/src/Utility/DateRangesTools.php
@@ -165,6 +165,6 @@ class DateRangesTools
             );
         }
 
-        return implode(',', $drs ?? []);
+        return implode(',', $drs);
     }
 }

--- a/src/Utility/RelationsTools.php
+++ b/src/Utility/RelationsTools.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace App\Utility;
+
+use Cake\Utility\Hash;
+
+/**
+ * Relations tools
+ */
+class RelationsTools
+{
+    /**
+     * Convert relations to string.
+     *
+     * @param array $relations Relations to convert.
+     * @return string
+     */
+    public static function toString(array $relations): string
+    {
+        $rrs = [];
+        foreach ($relations as $item) {
+            $id = (string)Hash::get($item, 'id');
+            $type = (string)Hash::get($item, 'type');
+            $meta = json_encode((array)Hash::get($item, 'meta.relation', []));
+            $rrs[] = sprintf(
+                '%s-%s-%s',
+                $id,
+                $type,
+                $meta
+            );
+        }
+
+        return implode(',', $rrs ?? []);
+    }
+}

--- a/src/Utility/RelationsTools.php
+++ b/src/Utility/RelationsTools.php
@@ -44,6 +44,6 @@ class RelationsTools
             );
         }
 
-        return implode(',', $rrs ?? []);
+        return implode(',', $rrs);
     }
 }

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1771,8 +1771,12 @@ class ModulesComponentTest extends TestCase
         /** @var \App\Controller\Component\ModulesComponent $modulesComponent */
         $modulesComponent = $registry->load(ModulesComponent::class);
         $this->Modules = $modulesComponent;
-        $actual = $this->Modules->skipSavePermissions('123', $requestData['permissions']);
-        ApiClientProvider::setApiClient($safeClient);
+        $schema = ['associations' => []];
+        $actual = $this->Modules->skipSavePermissions('123', $requestData['permissions'], $schema);
         static::assertTrue($actual);
+        $schema = ['associations' => ['Permissions']];
+        $actual = $this->Modules->skipSavePermissions('123', $requestData['permissions'], $schema);
+        static::assertTrue($actual);
+        ApiClientProvider::setApiClient($safeClient);
     }
 }

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1723,21 +1723,169 @@ class ModulesComponentTest extends TestCase
      */
     public function testSkipSaveObject(): void
     {
-        // empty id and empty related data
-        $actual = $this->Modules->skipSaveObject('', [], []);
+        // empty id
+        $requestData = [];
+        $actual = $this->Modules->skipSaveObject('', $requestData);
         static::assertFalse($actual);
 
-        // not empty id and not empty related data
-        $actual = $this->Modules->skipSaveObject('123', [], ['some' => 'thing']);
-        static::assertFalse($actual);
-
-        // not empty id and empty related data, not empty request data
-        $actual = $this->Modules->skipSaveObject('123', ['id' => '123', 'title' => 'test', 'permissions' => []], []);
-        static::assertFalse($actual);
-
-        // not empty id and empty related data, empty request data
-        $actual = $this->Modules->skipSaveObject('123', ['id' => '123', 'permissions' => []], []);
+        // not empty id, empty request data
+        $requestData = [];
+        $actual = $this->Modules->skipSaveObject('123', $requestData);
         static::assertTrue($actual);
+
+        // not empty id, not empty request data
+        $requestData = ['id' => '123', 'title' => 'test', 'permissions' => []];
+        $actual = $this->Modules->skipSaveObject('123', $requestData);
+        static::assertFalse($actual);
+
+        // not empty id, empty request data
+        $requestData = ['id' => '123', 'permissions' => []];
+        $actual = $this->Modules->skipSaveObject('123', $requestData);
+        static::assertTrue($actual);
+
+        // not empty id, date ranges unchanged
+        $request = $this->Modules->getController()->getRequest()->withParam('object_type', 'events');
+        $this->Modules->getController()->setRequest($request);
+        // mock apiClient getObject
+        $apiClient = new class ('https://api.example.com') extends BEditaClient {
+            public function getObject(string|int $id, string $type = 'objects', ?array $query = null, ?array $headers = null): ?array
+            {
+                return [
+                    'data' => [
+                        'id' => '123',
+                        'type' => 'events',
+                        'attributes' => [
+                            'date_ranges' => [],
+                        ],
+                    ],
+                ];
+            }
+        };
+        $safeClient = ApiClientProvider::getApiClient();
+        ApiClientProvider::setApiClient($apiClient);
+        $requestData = ['id' => '123', 'date_ranges' => []];
+        $actual = $this->Modules->skipSaveObject('123', $requestData);
+        static::assertTrue($actual);
+
+        // not empty id, date ranges changed
+        $request = $this->Modules->getController()->getRequest()->withParam('object_type', 'events');
+        $this->Modules->getController()->setRequest($request);
+        // mock apiClient getObject
+        $apiClient = new class ('https://api.example.com') extends BEditaClient {
+            public function getObject(string|int $id, string $type = 'objects', ?array $query = null, ?array $headers = null): ?array
+            {
+                return [
+                    'data' => [
+                        'id' => '123',
+                        'type' => 'events',
+                        'attributes' => [
+                            'date_ranges' => [
+                                [
+                                    'start' => '2023-01-01',
+                                    'end' => '2023-01-31',
+                                ],
+                            ],
+                        ],
+                    ],
+                ];
+            }
+        };
+        ApiClientProvider::setApiClient($apiClient);
+        $requestData = [
+            'id' => '123',
+            'date_ranges' => [
+                [
+                    'start' => '2023-01-01',
+                    'end' => '2023-01-31',
+                ],
+                [
+                    'start' => '2023-02-01',
+                    'end' => '2023-02-28',
+                ],
+            ],
+        ];
+        $actual = $this->Modules->skipSaveObject('123', $requestData);
+        static::assertFalse($actual);
+
+        ApiClientProvider::setApiClient($safeClient);
+    }
+
+    /**
+     * Test `skipSaveRelated` method
+     *
+     * @return void
+     * @covers ::skipSaveRelated()
+     */
+    public function testSkipSaveRelated(): void
+    {
+        $request = $this->Modules->getController()->getRequest()->withParam('object_type', 'dummies');
+        $this->Modules->getController()->setRequest($request);
+
+        // empty related data => true
+        $relatedData = [];
+        $actual = $this->Modules->skipSaveRelated('123', $relatedData);
+        static::assertTrue($actual);
+
+        // addRelated or removeRelated => false
+        $relatedData = [
+            [
+                'method' => 'addRelated',
+                'relation' => 'see_also',
+                'relatedIds' => [['id' => '456', 'type' => 'dummies']],
+            ],
+        ];
+        $actual = $this->Modules->skipSaveRelated('123', $relatedData);
+        static::assertFalse($actual);
+        $relatedData = [
+            [
+                'method' => 'removeRelated',
+                'relation' => 'see_also',
+                'relatedIds' => [['id' => '456', 'type' => 'dummies']],
+            ],
+        ];
+        $actual = $this->Modules->skipSaveRelated('123', $relatedData);
+        static::assertFalse($actual);
+
+        // replaceRelated with a change => false
+        $relatedData = [
+            [
+                'method' => 'replaceRelated',
+                'relation' => 'see_also',
+                'relatedIds' => [['id' => '1001', 'type' => 'dummies', 'meta' => ['relation' => ['priority' => 1]]]],
+            ],
+        ];
+        // mock apiClient getRelated
+        $apiClient = new class ('https://api.example.com') extends BEditaClient {
+            public function getRelated(string|int $id, string $type, string $relation, ?array $query = null, ?array $headers = null): ?array
+            {
+                return [
+                    'data' => [
+                        ['id' => '1001', 'type' => 'dummies', 'meta' => ['relation' => ['priority' => 1]]],
+                        ['id' => '1002', 'type' => 'dummies', 'meta' => ['relation' => ['priority' => 2]]],
+                    ],
+                ];
+            }
+        };
+        $safeClient = ApiClientProvider::getApiClient();
+        ApiClientProvider::setApiClient($apiClient);
+        $actual = $this->Modules->skipSaveRelated('123', $relatedData);
+        static::assertFalse($actual);
+
+        // replaceRelated without a change => true
+        $relatedData = [
+            [
+                'method' => 'replaceRelated',
+                'relation' => 'see_also',
+                'relatedIds' => [
+                    ['id' => '1001', 'type' => 'dummies', 'meta' => ['relation' => ['priority' => 1]]],
+                    ['id' => '1002', 'type' => 'dummies', 'meta' => ['relation' => ['priority' => 2]]],
+                ],
+            ],
+        ];
+        $actual = $this->Modules->skipSaveRelated('123', $relatedData);
+        static::assertTrue($actual);
+
+        ApiClientProvider::setApiClient($safeClient);
     }
 
     /**

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -1318,7 +1318,7 @@ class ModulesControllerTest extends BaseControllerTest
                 'permissions' => ['1','2','3'],
             ],
             'params' => [
-                'object_type' => 'dummies',
+                'object_type' => 'folders',
             ],
         ];
 
@@ -1365,6 +1365,17 @@ class ModulesControllerTest extends BaseControllerTest
             }
         };
         $this->controller->setApiClient($apiClient);
+
+        // mock schema getSchema to return ['associations' => ['Permissions']]
+        $registry = $this->controller->components();
+        $schemaComponent = new class ($registry) extends SchemaComponent
+        {
+            public function getSchema(?string $type = null, ?string $revision = null)
+            {
+                return ['associations' => ['Permissions']];
+            }
+        };
+        $this->controller->Schema = $schemaComponent;
 
         // do controller call
         $this->controller->save();

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -1417,6 +1417,12 @@ class ModulesControllerTest extends BaseControllerTest
         $component = new class ($registry) extends ModulesComponent
         {
             public bool $saveRelated = false;
+
+            public function getSaveRelated(): bool
+            {
+                return $this->saveRelated;
+            }
+
             public function saveRelated(string $id, string $type, array $relatedData): void
             {
                 $this->saveRelated = true;
@@ -1459,7 +1465,7 @@ class ModulesControllerTest extends BaseControllerTest
         // do controller call
         $this->controller->save();
 
-        static::assertTrue($this->controller->Modules->saveRelated, 'Component save related should be called');
+        static::assertTrue($component->getSaveRelated(), 'Component save related should be called');
         static::assertFalse($apiClient->getSave(), 'ApiClient save method should not be called when no post data is provided');
         static::assertTrue($apiClient->getLoad(), 'ApiClient load method should be called to load object');
     }

--- a/tests/TestCase/Controller/ModulesControllerTest.php
+++ b/tests/TestCase/Controller/ModulesControllerTest.php
@@ -1260,8 +1260,8 @@ class ModulesControllerTest extends BaseControllerTest
         $this->controller = new ModulesControllerSample($request);
 
         // mock api client save... and check it's not called
-        $apiClient = new class ('https://api.example.com') extends BEditaClient {
-
+        $apiClient = new class ('https://api.example.com') extends BEditaClient
+        {
             protected bool $load = false;
             protected bool $save = false;
 
@@ -1335,8 +1335,8 @@ class ModulesControllerTest extends BaseControllerTest
         };
 
         // mock api client save... and check it's not called
-        $apiClient = new class ('https://api.example.com') extends BEditaClient {
-
+        $apiClient = new class ('https://api.example.com') extends BEditaClient
+        {
             protected bool $load = false;
             protected bool $save = false;
 
@@ -1412,8 +1412,8 @@ class ModulesControllerTest extends BaseControllerTest
         };
 
         // mock api client save... and check it's not called
-        $apiClient = new class ('https://api.example.com') extends BEditaClient {
-
+        $apiClient = new class ('https://api.example.com') extends BEditaClient
+        {
             protected bool $load = false;
             protected bool $save = false;
 

--- a/tests/TestCase/Utility/DateRangesToolsTest.php
+++ b/tests/TestCase/Utility/DateRangesToolsTest.php
@@ -269,4 +269,24 @@ class DateRangesToolsTest extends TestCase
         $actual = DateRangesTools::prepare($dateRanges);
         static::assertEquals($expected, $actual);
     }
+
+    /**
+     * Test `toString` method.
+     *
+     * @return void
+     * @covers ::toString()
+     */
+    public function testToString(): void
+    {
+        $dateRanges = [
+            [
+                'start_date' => '2021-01-01 00:00:00',
+                'end_date' => '2021-01-02 00:00:00',
+                'params' => ['every_day' => true, 'all_day' => true],
+            ],
+        ];
+        $expected = '2021-01-01 00:00:00-2021-01-02 00:00:00-{"every_day":true,"all_day":true}';
+        $actual = DateRangesTools::toString($dateRanges);
+        static::assertEquals($expected, $actual);
+    }
 }

--- a/tests/TestCase/Utility/RelationsToolsTest.php
+++ b/tests/TestCase/Utility/RelationsToolsTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase;
+
+use App\Utility\RelationsTools;
+use Cake\TestSuite\TestCase;
+
+/**
+ * App\Utility\RelationsTools Test Case
+ *
+ * @coversDefaultClass App\Utility\RelationsTools
+ */
+class RelationsToolsTest extends TestCase
+{
+    /**
+     * Test `toString` method.
+     *
+     * @return void
+     * @covers ::toString()
+     */
+    public function testToString(): void
+    {
+        $relations = [
+            [
+                'id' => 1,
+                'type' => 'event',
+                'meta' => [
+                    'relation' => [
+                        'priority' => 1,
+                    ],
+                ],
+            ],
+            [
+                'id' => 2,
+                'type' => 'document',
+                'meta' => [
+                    'relation' => [
+                        'priority' => 2,
+                    ],
+                ],
+            ],
+        ];
+        $expected = '1-event-{"priority":1},2-document-{"priority":2}';
+        $actual = RelationsTools::toString($relations);
+        static::assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
This introduces a refactor to check form data before calling api save for specific parts (date ranges, permissions, relations): if no data changed, skip save and reload object. If data changed, save only the part that has changed (object data, related data, permissions).