### PR TITLE
Fix dependency slevomat coding standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,5 +99,8 @@
             "merge-extra-deep": false,
             "merge-scripts": false
         }
+    },
+    "conflict": {
+        "slevomat/coding-standard": ">8.18.0"
     }
 }


### PR DESCRIPTION
This fixes a dependency conflict, to avoid an error `.........PHP Fatal error:  Uncaught Error: Access to undeclared static property SlevomatCodingStandard\Helpers\TokenHelper::$typeKeywordTokenCodes in /home/vendor/cakephp/cakephp-codesniffer/CakePHP/Sniffs/Classes/ReturnTypeHintSniff.php:233` when launching phpcs in pipelines.

The cause of the error is a wrong version of dependency `slevomat/coding-standard` installed via composer.

This fixes by forcing `"slevomat/coding-standard": ">8.18.0"` in composer conflict.