### PR TITLE
Richtext onchange regex per field + code in toolbar for admins

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -549,8 +549,8 @@ return [
     ],
 
     /**
-     * Configuration for thumbnails component.
-     */
+ * Configuration for thumbnails component.
+ */
     // 'Thumbs' => [
     //     // Query parameters used for calling API to generate the thumbnail
     //     'queryParams' => ['preset' => 'default'],
@@ -559,8 +559,8 @@ return [
     // ],
 
     /**
-     * Translators engine configuration
-     */
+ * Translators engine configuration
+ */
     // 'Translators' => [
     //     [
     //         'name' => 'AWS',
@@ -593,8 +593,8 @@ return [
     // ],
 
     /**
-     * Richeditor configuration.
-     */
+ * Richeditor configuration.
+ */
     // 'Richeditor' => [
     //     'style_formats' => [
     //         [
@@ -609,11 +609,18 @@ return [
     //     'cleanup_regex_pattern' => '\\sstyle="[^"]*"', // remove style attributes from tags
     //     'cleanup_regex_argument' => 'gs', // global and match new lines
     //     'cleanup_regex_replace' => '', // replace with empty string
+    //     'fields_regex_map' => [
+    //         'title' => [ // cleanup title field from unwanted tags
+    //             'cleanup_regex_pattern' => '<(?!/?(i|sub|sup)\\b)[^>]+>',
+    //             'cleanup_regex_argument' => 'gi',
+    //             'cleanup_regex_replacement' => '',
+    //         ],
+    //     ],
     // ],
 
     /**
-     * Placeholders configuration.
-     */
+ * Placeholders configuration.
+ */
     // 'Placeholders' => [
     //     'audio' => [
     //         'controls' => 'boolean',
@@ -638,12 +645,12 @@ return [
     // ],
 
     /**
-     * UI settings.
-     * - index: index settings. 'copy2clipboard' enables "onmouseover" of index general cells showing copy to clipboard button
-     * - modules: modules settings. 'counters' to show counters in modules; 'all', 'none', <list of modules> to show all, none or custom modules. Default is ['trash']
-     * - richeditor: richeditor settings per field: you can set 'config' and 'toolbar' per single field.
-     * - fast_create_form: custom element to use for fast create form
-     */
+ * UI settings.
+ * - index: index settings. 'copy2clipboard' enables "onmouseover" of index general cells showing copy to clipboard button
+ * - modules: modules settings. 'counters' to show counters in modules; 'all', 'none', <list of modules> to show all, none or custom modules. Default is ['trash']
+ * - richeditor: richeditor settings per field: you can set 'config' and 'toolbar' per single field.
+ * - fast_create_form: custom element to use for fast create form
+ */
     // 'UI' => [
     //     'index' => [
     //         'copy2clipboard' => true,
@@ -685,10 +692,10 @@ return [
     // ],
 
     /**
-     * Upload configurations.
-     *
-     * 'files' and 'media' accept all mimes, so no configuration needed.
-     */
+ * Upload configurations.
+ *
+ * 'files' and 'media' accept all mimes, so no configuration needed.
+ */
     // 'uploadAccepted' => [
     //     'audio' => [
     //         'audio/*',
@@ -731,20 +738,20 @@ return [
     // 'uploadMaxSize' => -1, // -1 means no limit, otherwise set a limit in bytes
 
     /**
-     * Configuration for "Children" association parameters.
-     *
-     * This allows to define a set of parameters that can be used in children association between a folder and an object.
-     * The configuration is an associative array where keys are the parameter names and values are
-     * arrays with the following keys:
-     *
-     * - `description` - The description of the parameter.
-     * - `type` - The type of the parameter. Supported types are: `string`, `text`, `date`, `date-time`, `integer`, `boolean`, `enum`.
-     * - `format` - The format of the parameter. Supported formats are: `date`, `date-time`.
-     * - `value` - The default value of the parameter.
-     * - `enum` - The list of possible values for the parameter. Required if the type is `enum`.
-     *
-     *  An example follows. Note: "author", "summary" etc. are examples, you can define your own parameters. They will be saved in `meta.relation.params`.
-     */
+ * Configuration for "Children" association parameters.
+ *
+ * This allows to define a set of parameters that can be used in children association between a folder and an object.
+ * The configuration is an associative array where keys are the parameter names and values are
+ * arrays with the following keys:
+ *
+ * - `description` - The description of the parameter.
+ * - `type` - The type of the parameter. Supported types are: `string`, `text`, `date`, `date-time`, `integer`, `boolean`, `enum`.
+ * - `format` - The format of the parameter. Supported formats are: `date`, `date-time`.
+ * - `value` - The default value of the parameter.
+ * - `enum` - The list of possible values for the parameter. Required if the type is `enum`.
+ *
+ *  An example follows. Note: "author", "summary" etc. are examples, you can define your own parameters. They will be saved in `meta.relation.params`.
+ */
     // 'ChildrenParams' => [
     //     'author' => [
     //         'description' => 'The author',
@@ -787,9 +794,9 @@ return [
     // ],
 
     /**
-     * Relations sort fields.
-     * Define sortable fields per relation.
-     */
+ * Relations sort fields.
+ * Define sortable fields per relation.
+ */
     // 'RelationsSortFields' => [
     //     'composed_by' => [
     //         ['label' => 'Short title', 'value' => 'short_title'],
@@ -803,10 +810,10 @@ return [
     //     'part_of_default' => 'short_title',
 
     /**
-     * Configuration for "Schema" associations provided by the API instance.
-     *
-     *  An example follows. Note: "author", "summary" etc. are examples, you can define your own parameters. They will be saved in `meta.relation.params`.
-     */
+ * Configuration for "Schema" associations provided by the API instance.
+ *
+ *  An example follows. Note: "author", "summary" etc. are examples, you can define your own parameters. They will be saved in `meta.relation.params`.
+ */
     // 'Schema' => [
     //     'associations' => [
     //         'Captions',
@@ -814,10 +821,10 @@ return [
     // ],
 
     /**
-     * Configuration for "Captions".
-     * - formats.allowed: allowed formats for captions
-     * - formats.default: default format for captions
-     */
+ * Configuration for "Captions".
+ * - formats.allowed: allowed formats for captions
+ * - formats.default: default format for captions
+ */
     // 'Captions' => [
     //     'formats' => [
     //         'allowed' => ['srt', 'sub', 'webvtt'],
@@ -826,12 +833,12 @@ return [
     // ],
 
     /**
-     * Configuration for "TreePreview", to enable anchors on specific positions on the tree.
-     * - '123' is the root id
-     * - 'title' is the title for the preview anchor
-     * - 'url' is the href for the preview anchor
-     * - 'color' is the color of the icon for the preview anchor (default is 'white')
-     */
+ * Configuration for "TreePreview", to enable anchors on specific positions on the tree.
+ * - '123' is the root id
+ * - 'title' is the title for the preview anchor
+ * - 'url' is the href for the preview anchor
+ * - 'color' is the color of the icon for the preview anchor (default is 'white')
+ */
     // 'TreePreview' => [
     //     '123' => [
     //         [

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -549,8 +549,8 @@ return [
     ],
 
     /**
- * Configuration for thumbnails component.
- */
+     * Configuration for thumbnails component.
+     */
     // 'Thumbs' => [
     //     // Query parameters used for calling API to generate the thumbnail
     //     'queryParams' => ['preset' => 'default'],
@@ -559,8 +559,8 @@ return [
     // ],
 
     /**
- * Translators engine configuration
- */
+     * Translators engine configuration
+     */
     // 'Translators' => [
     //     [
     //         'name' => 'AWS',
@@ -619,8 +619,8 @@ return [
     // ],
 
     /**
- * Placeholders configuration.
- */
+     * Placeholders configuration.
+     */
     // 'Placeholders' => [
     //     'audio' => [
     //         'controls' => 'boolean',
@@ -645,12 +645,12 @@ return [
     // ],
 
     /**
- * UI settings.
- * - index: index settings. 'copy2clipboard' enables "onmouseover" of index general cells showing copy to clipboard button
- * - modules: modules settings. 'counters' to show counters in modules; 'all', 'none', <list of modules> to show all, none or custom modules. Default is ['trash']
- * - richeditor: richeditor settings per field: you can set 'config' and 'toolbar' per single field.
- * - fast_create_form: custom element to use for fast create form
- */
+     * UI settings.
+     * - index: index settings. 'copy2clipboard' enables "onmouseover" of index general cells showing copy to clipboard button
+     * - modules: modules settings. 'counters' to show counters in modules; 'all', 'none', <list of modules> to show all, none or custom modules. Default is ['trash']
+     * - richeditor: richeditor settings per field: you can set 'config' and 'toolbar' per single field.
+     * - fast_create_form: custom element to use for fast create form
+     */
     // 'UI' => [
     //     'index' => [
     //         'copy2clipboard' => true,
@@ -692,10 +692,10 @@ return [
     // ],
 
     /**
- * Upload configurations.
- *
- * 'files' and 'media' accept all mimes, so no configuration needed.
- */
+     * Upload configurations.
+     *
+     * 'files' and 'media' accept all mimes, so no configuration needed.
+     */
     // 'uploadAccepted' => [
     //     'audio' => [
     //         'audio/*',
@@ -738,20 +738,20 @@ return [
     // 'uploadMaxSize' => -1, // -1 means no limit, otherwise set a limit in bytes
 
     /**
- * Configuration for "Children" association parameters.
- *
- * This allows to define a set of parameters that can be used in children association between a folder and an object.
- * The configuration is an associative array where keys are the parameter names and values are
- * arrays with the following keys:
- *
- * - `description` - The description of the parameter.
- * - `type` - The type of the parameter. Supported types are: `string`, `text`, `date`, `date-time`, `integer`, `boolean`, `enum`.
- * - `format` - The format of the parameter. Supported formats are: `date`, `date-time`.
- * - `value` - The default value of the parameter.
- * - `enum` - The list of possible values for the parameter. Required if the type is `enum`.
- *
- *  An example follows. Note: "author", "summary" etc. are examples, you can define your own parameters. They will be saved in `meta.relation.params`.
- */
+     * Configuration for "Children" association parameters.
+     *
+     * This allows to define a set of parameters that can be used in children association between a folder and an object.
+     * The configuration is an associative array where keys are the parameter names and values are
+     * arrays with the following keys:
+     *
+     * - `description` - The description of the parameter.
+     * - `type` - The type of the parameter. Supported types are: `string`, `text`, `date`, `date-time`, `integer`, `boolean`, `enum`.
+     * - `format` - The format of the parameter. Supported formats are: `date`, `date-time`.
+     * - `value` - The default value of the parameter.
+     * - `enum` - The list of possible values for the parameter. Required if the type is `enum`.
+     *
+     *  An example follows. Note: "author", "summary" etc. are examples, you can define your own parameters. They will be saved in `meta.relation.params`.
+     */
     // 'ChildrenParams' => [
     //     'author' => [
     //         'description' => 'The author',
@@ -794,9 +794,9 @@ return [
     // ],
 
     /**
- * Relations sort fields.
- * Define sortable fields per relation.
- */
+     * Relations sort fields.
+     * Define sortable fields per relation.
+     */
     // 'RelationsSortFields' => [
     //     'composed_by' => [
     //         ['label' => 'Short title', 'value' => 'short_title'],
@@ -810,10 +810,10 @@ return [
     //     'part_of_default' => 'short_title',
 
     /**
- * Configuration for "Schema" associations provided by the API instance.
- *
- *  An example follows. Note: "author", "summary" etc. are examples, you can define your own parameters. They will be saved in `meta.relation.params`.
- */
+     * Configuration for "Schema" associations provided by the API instance.
+     *
+     *  An example follows. Note: "author", "summary" etc. are examples, you can define your own parameters. They will be saved in `meta.relation.params`.
+     */
     // 'Schema' => [
     //     'associations' => [
     //         'Captions',
@@ -821,10 +821,10 @@ return [
     // ],
 
     /**
- * Configuration for "Captions".
- * - formats.allowed: allowed formats for captions
- * - formats.default: default format for captions
- */
+     * Configuration for "Captions".
+     * - formats.allowed: allowed formats for captions
+     * - formats.default: default format for captions
+     */
     // 'Captions' => [
     //     'formats' => [
     //         'allowed' => ['srt', 'sub', 'webvtt'],
@@ -833,12 +833,12 @@ return [
     // ],
 
     /**
- * Configuration for "TreePreview", to enable anchors on specific positions on the tree.
- * - '123' is the root id
- * - 'title' is the title for the preview anchor
- * - 'url' is the href for the preview anchor
- * - 'color' is the color of the icon for the preview anchor (default is 'white')
- */
+     * Configuration for "TreePreview", to enable anchors on specific positions on the tree.
+     * - '123' is the root id
+     * - 'title' is the title for the preview anchor
+     * - 'url' is the href for the preview anchor
+     * - 'color' is the color of the icon for the preview anchor (default is 'white')
+     */
     // 'TreePreview' => [
     //     '123' => [
     //         [

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -593,8 +593,8 @@ return [
     // ],
 
     /**
- * Richeditor configuration.
- */
+     * Richeditor configuration.
+     */
     // 'Richeditor' => [
     //     'style_formats' => [
     //         [

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -611,7 +611,7 @@ return [
     //     'cleanup_regex_replace' => '', // replace with empty string
     //     'fields_regex_map' => [
     //         'title' => [ // cleanup title field from unwanted tags
-    //             'cleanup_regex_pattern' => '<(?!/?(i|sub|sup)\\b)[^>]+>',
+    //             'cleanup_regex_pattern' => '<(?!/?(em|sub|sup)\\b)[^>]+>',
     //             'cleanup_regex_argument' => 'gi',
     //             'cleanup_regex_replacement' => '',
     //         ],

--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -78,12 +78,13 @@ export default {
                             event.target.editor.setContent(cleanContent);
                         }
                     }
-                    // if field is title, cleanup html content
-                    if (element.name === 'title' && element.editor) {
-                        const content = element.editor.getContent();
-                        const cleanContent = content.replace(/<[^>]+>/g, '');
+                    if (BEDITA?.richeditorConfig?.fields_regex_map?.[element?.name]) {
+                        const { cleanup_regex_pattern, cleanup_regex_argument, cleanup_regex_replacement } = BEDITA.richeditorConfig.fields_regex_map[element.name];
+                        const regex = new RegExp(cleanup_regex_pattern, cleanup_regex_argument || 'gs');
+                        const content = event?.target?.editor?.getContent() || '';
+                        const cleanContent = content.replace(regex, cleanup_regex_replacement || '');
                         if (cleanContent !== content) {
-                            element.editor.setContent(cleanContent);
+                            event.target.editor.setContent(cleanContent);
                         }
                     }
                 });
@@ -220,7 +221,6 @@ export default {
                 }
 
                 if (element.value !== editor.getContent()) {
-                    console.log('update', element.value);
                     editor.setContent(element.value);
                 }
             },

--- a/resources/js/app/directives/richeditor.js
+++ b/resources/js/app/directives/richeditor.js
@@ -78,6 +78,14 @@ export default {
                             event.target.editor.setContent(cleanContent);
                         }
                     }
+                    // if field is title, cleanup html content
+                    if (element.name === 'title' && element.editor) {
+                        const content = element.editor.getContent();
+                        const cleanContent = content.replace(/<[^>]+>/g, '');
+                        if (cleanContent !== content) {
+                            element.editor.setContent(cleanContent);
+                        }
+                    }
                 });
             },
 
@@ -212,6 +220,7 @@ export default {
                 }
 
                 if (element.value !== editor.getContent()) {
+                    console.log('update', element.value);
                     editor.setContent(element.value);
                 }
             },

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -392,11 +392,9 @@ class LayoutHelper extends Helper
         if (!$this->Perms->userIsAdmin()) {
             return $cfg;
         }
-        foreach ($cfg as $key => $value) {
-            foreach ($value as $subKey => $subValue) {
-                if ($subKey === 'toolbar' && is_array($subValue) && !in_array('code', $subValue)) {
-                    $cfg[$key][$subKey][] = 'code';
-                }
+        foreach ($cfg as &$value) {
+            if (isset($value['toolbar']) && is_array($value['toolbar']) && !in_array('code', $value['toolbar'], true)) {
+                $value['toolbar'][] = 'code';
             }
         }
 

--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -375,9 +375,32 @@ class LayoutHelper extends Helper
             'uploadConfig' => $this->System->uploadConfig(),
             'relationsSchema' => $this->getView()->get('relationsSchema', []),
             'richeditorConfig' => (array)Configure::read('Richeditor'),
-            'richeditorByPropertyConfig' => (array)Configure::read('UI.richeditor', []),
+            'richeditorByPropertyConfig' => $this->uiRicheditorConfig(),
             'indexLists' => (array)$this->indexLists(),
         ];
+    }
+
+    /**
+     * Return configuration for UI rich editor.
+     * For admin users, add 'code' to the toolbar if not present.
+     *
+     * @return array
+     */
+    public function uiRicheditorConfig(): array
+    {
+        $cfg = (array)Configure::read('UI.richeditor', []);
+        if (!$this->Perms->userIsAdmin()) {
+            return $cfg;
+        }
+        foreach ($cfg as $key => $value) {
+            foreach ($value as $subKey => $subValue) {
+                if ($subKey === 'toolbar' && is_array($subValue) && !in_array('code', $subValue)) {
+                    $cfg[$key][$subKey][] = 'code';
+                }
+            }
+        }
+
+        return $cfg;
     }
 
     /**

--- a/src/View/Helper/PermsHelper.php
+++ b/src/View/Helper/PermsHelper.php
@@ -228,7 +228,7 @@ class PermsHelper extends Helper
      */
     public function userRoles(): array
     {
-        /** @var \Authentication\Identity $identity */
+        /** @var \Authentication\Identity|null $identity */
         $identity = $this->_View->get('user');
 
         return empty($identity) ? [] : (array)$identity->get('roles');

--- a/src/View/Helper/PermsHelper.php
+++ b/src/View/Helper/PermsHelper.php
@@ -231,7 +231,7 @@ class PermsHelper extends Helper
         /** @var \Authentication\Identity $identity */
         $identity = $this->_View->get('user');
 
-        return (array)$identity->get('roles');
+        return empty($identity) ? [] : (array)$identity->get('roles');
     }
 
     /**

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -25,6 +25,7 @@ use Cake\View\Helper;
 /**
  * Schema helper
  *
+ * @property \App\View\Helper\PermsHelper $Perms
  * @property \Cake\View\Helper\TimeHelper $Time
  */
 class SchemaHelper extends Helper
@@ -34,7 +35,7 @@ class SchemaHelper extends Helper
      *
      * @var array
      */
-    public $helpers = ['Time'];
+    public $helpers = ['Perms', 'Time'];
 
     /**
      * Default translatable fields to be prepended in translations
@@ -118,6 +119,9 @@ class SchemaHelper extends Helper
         $uiRichtext = (array)Configure::read(sprintf('UI.richeditor.%s.toolbar', $name));
         if (empty($uiRichtext)) {
             return;
+        }
+        if ($this->Perms->userIsAdmin() && !in_array('code', $uiRichtext)) {
+            $uiRichtext[] = 'code';
         }
         $options['type'] = 'textarea';
         $richeditorKey = $placeholders ? 'v-richeditor.placeholders' : 'v-richeditor';

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -597,7 +597,7 @@ class LayoutHelperTest extends TestCase
             'uploadConfig' => $system->uploadConfig(),
             'relationsSchema' => ['whatever'],
             'richeditorConfig' => (array)Configure::read('Richeditor'),
-            'richeditorByPropertyConfig' => $layout->richeditorByPropertyConfig(),
+            'richeditorByPropertyConfig' => $layout->uiRicheditorConfig(),
             'indexLists' => (array)$layout->indexLists(),
         ];
         static::assertSame($expected, $conf);

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -597,7 +597,7 @@ class LayoutHelperTest extends TestCase
             'uploadConfig' => $system->uploadConfig(),
             'relationsSchema' => ['whatever'],
             'richeditorConfig' => (array)Configure::read('Richeditor'),
-            'richeditorByPropertyConfig' => (array)Configure::read('RicheditorByProperty'),
+            'richeditorByPropertyConfig' => $layout->richeditorByPropertyConfig(),
             'indexLists' => (array)$layout->indexLists(),
         ];
         static::assertSame($expected, $conf);

--- a/tests/TestCase/View/Helper/LayoutHelperTest.php
+++ b/tests/TestCase/View/Helper/LayoutHelperTest.php
@@ -959,4 +959,53 @@ class LayoutHelperTest extends TestCase
 
         Cache::disable();
     }
+
+    /**
+     * Test `uiRicheditorConfig` method.
+     *
+     * @return void
+     * @covers ::uiRicheditorConfig()
+     */
+    public function testUiRicheditorConfig(): void
+    {
+        // non admin user
+        $view = new View();
+        $layout = new LayoutHelper($view);
+        $actual = $layout->uiRicheditorConfig();
+        static::assertIsArray($actual);
+        static::assertEmpty($actual);
+
+        // admin user
+        $safe = Configure::read('UI.richeditor');
+        Configure::delete('UI.richeditor');
+        Configure::write('UI.richeditor', [
+            'title' => [
+                'config' => [
+                    'forced_root_block' => false,
+                    'height' => 132,
+                ],
+                'toolbar' => [
+                    'italic',
+                    'subscript',
+                    'superscript',
+                ],
+            ],
+        ]);
+        $perms = new class ($view) extends PermsHelper {
+            public function userIsAdmin(): bool
+            {
+                return true;
+            }
+        };
+        $layout->Perms = $perms;
+        $actual = $layout->uiRicheditorConfig();
+        static::assertIsArray($actual);
+        static::assertArrayHasKey('toolbar', $actual['title']);
+        static::assertCount(4, $actual['title']['toolbar']);
+        static::assertContains('italic', $actual['title']['toolbar']);
+        static::assertContains('subscript', $actual['title']['toolbar']);
+        static::assertContains('superscript', $actual['title']['toolbar']);
+        static::assertContains('code', $actual['title']['toolbar']);
+        Configure::write('UI.richeditor', $safe);
+    }
 }

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -13,6 +13,7 @@
 
 namespace App\Test\TestCase\View\Helper;
 
+use App\View\Helper\PermsHelper;
 use App\View\Helper\SchemaHelper;
 use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
@@ -496,6 +497,53 @@ class SchemaHelperTest extends TestCase
             }
         };
         $actual = $helper->updateREopts($name, $placeholders, $options);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `updateRicheditorOptions` method for admin users.
+     *
+     * @return void
+     * @covers ::updateRicheditorOptions()
+     */
+    public function testUpdateRicheditorOptionsAdmin(): void
+    {
+        Configure::write('UI.richeditor.title.toolbar', [
+            'italic',
+            'subscript',
+            'superscript',
+        ]);
+        $request = new ServerRequest([
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+            'params' => [
+                'object_type' => 'dummies',
+            ],
+        ]);
+        $view = new View($request, null, null, []);
+        $view->set('objectType', 'dummies');
+        $helper = new class ($view) extends SchemaHelper {
+            public function updateREopts(string $name, bool $placeholders, array &$options): array
+            {
+                $this->updateRicheditorOptions($name, $placeholders, $options);
+
+                return $options;
+            }
+        };
+        $perms = new class ($view) extends PermsHelper {
+            public function userIsAdmin(): bool
+            {
+                return true;
+            }
+        };
+        $helper->Perms = $perms;
+        $options = [];
+        $actual = $helper->updateREopts('title', false, $options);
+        $expected = [
+            'type' => 'textarea',
+            'v-richeditor' => '["italic","subscript","superscript","code"]',
+        ];
         static::assertEquals($expected, $actual);
     }
 


### PR DESCRIPTION
This provides a couple of enhancements in richeditor:

 - new configuration `Richeditor.fields_regex_map` to force a regular expression replacement per field on content change
 - richeditor when user is admin: add "code" to toolbar, if missing... so that admins can always adjust content

Example of `Richeditor.fields_regex_map`:
```php
[
    'title' => [ // cleanup title field from unwanted tags
        'cleanup_regex_pattern' => '<(?!/?(em|sub|sup)\\b)[^>]+>',
        'cleanup_regex_argument' => 'gi',
        'cleanup_regex_replacement' => '',
    ],
],
```

Added reference to wiki page: https://github.com/bedita/manager/wiki/Setup:-Richeditor