### PR TITLE
Json properties in module index, avoid truncating

### DIFF
--- a/src/View/Helper/PropertyHelper.php
+++ b/src/View/Helper/PropertyHelper.php
@@ -188,7 +188,7 @@ class PropertyHelper extends Helper
         $value = '';
         foreach ($paths as $path) {
             if (Hash::check($resource, $path)) {
-                $value = (string)Hash::get($resource, $path);
+                $value = Hash::get($resource, $path);
                 break;
             }
         }

--- a/templates/Element/Modules/index_table_row.twig
+++ b/templates/Element/Modules/index_table_row.twig
@@ -45,6 +45,7 @@
                     :settings="{{ config('UI.index')|default({'copy2clipboard': false})|json_encode }}"
                     :prop="{{ prop|json_encode }}"
                     :text="{{ Property.value(object, prop)|json_encode }}"
+                    :schema="{{ schema['properties'][prop]|default({})|json_encode }}"
                 >
                 </index-cell>
             {% endif %}


### PR DESCRIPTION
This provides a UI fix for json properties in modules indexes.

Before this fix, json data can be truncated and is shown in a line, as described in the following image.

![image](https://github.com/user-attachments/assets/423528ff-7cdf-4771-a086-597ff016ad0c)

With this fix, JSON properties are "prettified" strings. On overflow (horizontal and/or vertical), scrollbars help.

![image](https://github.com/user-attachments/assets/a14c389b-788f-48f9-b003-60547fb2ab51)
