### PR TITLE
Set lang en in tests bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,9 @@
  * unit tests in this file.
  */
 
+use Cake\Core\Configure;
+use Cake\I18n\I18n;
+
 // set `APP_NAME` env to avoid config/.env load
 putenv('APP_NAME=TESTAPP');
 
@@ -34,3 +37,8 @@ if (empty(\Cake\Core\Configure::read('API'))) {
 }
 
 $_SERVER['PHP_SELF'] = '/';
+
+// ensure default locale is set to English
+Configure::write('I18n.default', 'en');
+Configure::write('I18n.lang', 'en');
+I18n::setLocale('en_US');


### PR DESCRIPTION
This can be useful in local unit test sessions. Bootstrap sets to `en` `I18n.default` and `I18n.lang`.

