### PR TITLE
Customize history + make the component extensible

### DIFF
--- a/resources/js/app/components/history/history-changes.vue
+++ b/resources/js/app/components/history/history-changes.vue
@@ -6,8 +6,9 @@
             <ul class="history-items">
                 <li class="history-item is-expanded py-05 has-border-gray-600" v-for="item in history[date]">
                     <div class="change-time">{{ getFormattedTime(item.meta.created) }} </div>
-                    <div class="is-flex">
+                    <div class="is-flex wrap">
                         {{ getAuthor(item.meta) }}
+                        <slot name="info" :item="item" />
                     </div>
                     <div class="is-flex">
                         <button class="button button-text-white is-width-auto" @click.stop.prevent="showChanges(item, canSave)">info</button>

--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -168,6 +168,7 @@ class PropertiesComponent extends Component
         $attributes = array_diff_key($attributes, array_flip($this->excluded));
         $attributes = array_diff_key($attributes, array_flip($hide));
         $defaults = array_merge($this->getConfig(sprintf('Properties.%s.view', $type), []), $this->defaultGroups['view']);
+        $defaults = array_filter($defaults, fn($group) => $group !== 'history', ARRAY_FILTER_USE_KEY);
         unset($defaults['_keep']);
 
         foreach ($defaults as $group => $items) {

--- a/templates/Element/Form/history.twig
+++ b/templates/Element/Form/history.twig
@@ -8,7 +8,13 @@
                 </span>
             </header>
             <div v-show="isOpen" class="tab-container">
-                <keep-alive><history-changes v-if="isOpen" :object="{{ object|json_encode }}" @count="onCount" :cansave="{{ Perms.canSave()|json_encode }}"></history-changes></keep-alive>
+                <keep-alive>
+                    <history-changes v-if="isOpen" :object="{{ object|json_encode }}" @count="onCount" :cansave="{{ Perms.canSave()|json_encode }}">
+                        <template v-slot:info="{ item }">
+                            {% block info %}{% endblock %}
+                        </template>
+                    </history-changes>
+                </keep-alive>
             </div>
         </section>
     </section>

--- a/templates/Pages/Modules/view.twig
+++ b/templates/Pages/Modules/view.twig
@@ -99,7 +99,8 @@
             {{ element('Form/relations', {'relations': objectRelations.main, 'mainObject': object}) }}
 
             {% if object.id %}
-                {{ element('Form/history') }}
+                {% set historyPath = config('Properties.' ~ objectType ~ '.view.history._element', 'Form/history') %}
+                {{ element(historyPath) }}
             {% endif %}
 
             {# Set `_jsonKeys` hidden input from config #}


### PR DESCRIPTION
This provides the possibility to customize history template per object type using a proper configuration, i.e.:
```
'Properties' => [
    'documents' => [
        'view' => [
            'history' => [
                '_element' => 'MyPlugin.Form/history',
            ],
        ],
    ],
],
```
This also makes the component extensible (thanks to @edoardocavazza ).