### PR TITLE
ApiProxy allowed configuration

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -84,9 +84,13 @@ return [
      *
      * ## Options
      *
+     * - `allowed` - Array of allowed methods per endpoint.
      * - `blocked` - Array of blocked methods per endpoint.
      */
     // 'ApiProxy' => [
+    //     'allowed' => [
+    //         'products' => ['GET', 'POST', 'PATCH', 'DELETE'],
+    //     ],
     //     'blocked' => [
     //         'objects' => ['GET', 'POST', 'PATCH', 'DELETE'],
     //         'users' => ['GET', 'POST', 'PATCH', 'DELETE'],

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -79,19 +79,13 @@ class ApiController extends AppController
         $blocked = in_array($method, $blockedMethods[$action] ?? []);
         $modules = $this->viewBuilder()->getVar('modules');
         $modules = array_values($modules);
-        $modules = (array)Hash::combine($modules, '{n}.name', '{n}.hints.allow');
         $modules = array_merge(
-            $modules,
-            [
-                'history' => ['GET'],
-                'model' => ['GET'],
-            ],
+            (array)Hash::combine($modules, '{n}.name', '{n}.hints.allow'),
+            ['history' => ['GET'], 'model' => ['GET']],
         );
-        $allowedMethods = (array)Hash::get($modules, $action, []);
-        $allowedConfig = (array)Configure::read('ApiProxy.allowed', []);
         $allowedMethods = array_merge(
-            $allowedMethods,
-            (array)Hash::get($allowedConfig, $action, [])
+            (array)Hash::get($modules, $action, []),
+            (array)Hash::get((array)Configure::read('ApiProxy.allowed'), $action, []),
         );
         $allowed = in_array($method, $allowedMethods);
 

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -88,6 +88,11 @@ class ApiController extends AppController
             ],
         );
         $allowedMethods = (array)Hash::get($modules, $action, []);
+        $allowedConfig = (array)Configure::read('ApiProxy.allowed', []);
+        $allowedMethods = array_merge(
+            $allowedMethods,
+            (array)Hash::get($allowedConfig, $action, [])
+        );
         $allowed = in_array($method, $allowedMethods);
 
         return $allowed && !$blocked;


### PR DESCRIPTION
This provides a new configuration for `ApiProxy` to allow specific methods per custom endpoints.

This is useful when you want to use a `/api/:custom-endpoint` that is available in API, but not listed in `/api/home` response.