### PR TITLE
Enhance system info page and project api info in colophon

### DIFF
--- a/resources/js/app/components/system-info/system-info.vue
+++ b/resources/js/app/components/system-info/system-info.vue
@@ -50,7 +50,7 @@ export default {
                 mode: 'text',
                 navigationBar: false,
                 statusBar: false,
-                readOnly: false,
+                readOnly: true,
             },
             jsonKeys: [
                 'Extensions',

--- a/resources/js/app/components/system-info/system-info.vue
+++ b/resources/js/app/components/system-info/system-info.vue
@@ -1,8 +1,28 @@
 <template>
-    <div>
-        <p v-for="item,key of infos">
-            <span class="key">{{ key }}</span>:
-            <span class="version">{{ item }}</span>
+    <div class="system-info">
+        <p
+            v-for="item,key of infos"
+            :key="key"
+        >
+            <template v-if="jsonKeys.includes(key)">
+                <details>
+                    <summary>{{ key }}</summary>
+                    <div
+                        :id="`container-${hash}-${key}`"
+                        class="jsoneditor-container"
+                    />
+                    <json-editor
+                        :name="`${hash}-${key}`"
+                        :options="jsonEditorOptions"
+                        :target="`container-${hash}-${key}`"
+                        :text="JSON.stringify(item, null, 2)"
+                    />
+                </details>
+            </template>
+            <template v-else>
+                <span class="key">{{ key }}</span>:
+                <span class="version">{{ item }}</span>
+            </template>
         </p>
     </div>
 </template>
@@ -11,6 +31,9 @@ import Vue from 'vue';
 
 export default {
     name: 'SystemInfo',
+    components: {
+        JsonEditor: () => import(/* webpackChunkName: "json-editor" */'app/components/json-editor/json-editor'),
+    },
     props: {
         data: {
             type: String,
@@ -20,7 +43,20 @@ export default {
 
     data() {
         return {
+            hash: '',
             infos: {},
+            jsonEditorOptions: {
+                mainMenuBar: true,
+                mode: 'text',
+                navigationBar: false,
+                statusBar: false,
+                readOnly: false,
+            },
+            jsonKeys: [
+                'Extensions',
+                'Extensions info',
+                'GET /home',
+            ],
         }
     },
 
@@ -30,6 +66,7 @@ export default {
             if (this.infos['Vuejs'] !== undefined) {
                 this.infos['Vuejs'] = Vue.version;
             }
+            this.hash = Math.random().toString(36).substring(2, 15);
         });
     },
 }

--- a/src/Controller/Admin/SystemInfoController.php
+++ b/src/Controller/Admin/SystemInfoController.php
@@ -12,6 +12,7 @@
  */
 namespace App\Controller\Admin;
 
+use App\Utility\SchemaTrait;
 use BEdita\SDK\BEditaClientException;
 use Cake\Core\Configure;
 use Cake\Http\Response;
@@ -23,6 +24,8 @@ use Twig\Environment;
  */
 class SystemInfoController extends AdministrationBaseController
 {
+    use SchemaTrait;
+
     /**
      * @inheritDoc
      */
@@ -73,6 +76,10 @@ class SystemInfoController extends AdministrationBaseController
                 $this->apiClient->get('/admin/sysinfo'),
                 'meta.info'
             );
+            /** @var \Authentication\Identity $user */
+            $user = $this->Authentication->getIdentity();
+            $meta = $this->getMeta($user);
+            $info = array_merge($info, ['GET /home' => $meta]);
         } catch (BEditaClientException $e) {
             $this->log($e->getMessage(), 'error');
         }

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -252,11 +252,21 @@ class ModulesComponent extends Component
         /** @var \Authentication\Identity $user */
         $user = $this->Authentication->getIdentity();
         $api = $this->getMeta($user);
-        $project = (array)Configure::read('Project');
-        $name = (string)Hash::get($project, 'name', Hash::get($api, 'project.name'));
-        $version = Hash::get($api, 'version', '');
+        $apiName = (string)Hash::get($api, 'project.name');
+        $apiName = str_replace('API', '', $apiName);
+        $api['project']['name'] = $apiName;
 
-        return compact('api', 'name', 'version');
+        return [
+            'api' => (array)Hash::get($api, 'project'),
+            'beditaApi' => [
+                'name' => (string)Hash::get(
+                    (array)Configure::read('Project'),
+                    'name',
+                    (string)Hash::get($api, 'project.name')
+                ),
+                'version' => (string)Hash::get($api, 'version'),
+            ],
+        ];
     }
 
     /**

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -251,12 +251,12 @@ class ModulesComponent extends Component
     {
         /** @var \Authentication\Identity $user */
         $user = $this->Authentication->getIdentity();
-        $meta = $this->getMeta($user);
+        $api = $this->getMeta($user);
         $project = (array)Configure::read('Project');
-        $name = (string)Hash::get($project, 'name', Hash::get($meta, 'project.name'));
-        $version = Hash::get($meta, 'version', '');
+        $name = (string)Hash::get($project, 'name', Hash::get($api, 'project.name'));
+        $version = Hash::get($api, 'version', '');
 
-        return compact('name', 'version');
+        return compact('api', 'name', 'version');
     }
 
     /**

--- a/templates/Element/Menu/colophon.twig
+++ b/templates/Element/Menu/colophon.twig
@@ -8,11 +8,18 @@
         <app-icon icon="carbon:checkmark"></app-icon>
         {{ Html.link('Manager', 'https://github.com/bedita/manager', {'target': '_blank'})|raw }} {{ config('Manager.version') }}
     </span>
+    {% if project.api.project.name %}
+    <span class="{{ apiClass }}">
+        <app-icon icon="carbon:checkmark"></app-icon>
+        {{ project.api.project.name }} API
+        {% if project.api.project.version %}{{ project.api.project.version }}{% endif %}
+    </span>
+    {% endif %}
     {% if project.version %}
     <span class="{{ apiClass }}" title="{{ warn }}">
         {% if apiCheck == 1 %}<app-icon icon="carbon:checkmark"></app-icon>{% endif %}
         {% if apiCheck != 1 %}<app-icon icon="carbon:error"></app-icon>{% endif %}
-        {{ Html.link('API', 'https://github.com/bedita/bedita', {'target': '_blank'})|raw }} {{ project.version }}
+        {{ Html.link('BEdita API', 'https://github.com/bedita/bedita', {'target': '_blank'})|raw }} {{ project.version }}
     </span>
     {% endif %}
     <span>©{{ 'now'|date('Y') }} {{ authors|shuffle|toList(__('&'))|raw }}</span>

--- a/templates/Element/Menu/colophon.twig
+++ b/templates/Element/Menu/colophon.twig
@@ -25,5 +25,3 @@
     <span>©{{ 'now'|date('Y') }} {{ authors|shuffle|toList(__('&'))|raw }}</span>
     <span>LGPL {{ Html.link('www.bedita.com', 'https://www.bedita.com', {'title': __('BEdita Web site'), 'target': '_blank'})|raw }}</span>
 </div>
-
-{{ project.api|json_encode|raw }}

--- a/templates/Element/Menu/colophon.twig
+++ b/templates/Element/Menu/colophon.twig
@@ -8,20 +8,22 @@
         <app-icon icon="carbon:checkmark"></app-icon>
         {{ Html.link('Manager', 'https://github.com/bedita/manager', {'target': '_blank'})|raw }} {{ config('Manager.version') }}
     </span>
-    {% if project.api.project.name %}
+    {% if project.api.name %}
     <span class="{{ apiClass }}">
         <app-icon icon="carbon:checkmark"></app-icon>
-        {{ project.api.project.name }} API
-        {% if project.api.project.version %}{{ project.api.project.version }}{% endif %}
+        {{ project.api.name }} API
+        {% if project.api.version %}{{ project.api.version }}{% endif %}
     </span>
     {% endif %}
-    {% if project.version %}
+    {% if project.beditaApi.version %}
     <span class="{{ apiClass }}" title="{{ warn }}">
         {% if apiCheck == 1 %}<app-icon icon="carbon:checkmark"></app-icon>{% endif %}
         {% if apiCheck != 1 %}<app-icon icon="carbon:error"></app-icon>{% endif %}
-        {{ Html.link('BEdita API', 'https://github.com/bedita/bedita', {'target': '_blank'})|raw }} {{ project.version }}
+        {{ Html.link('BEdita API', 'https://github.com/bedita/bedita', {'target': '_blank'})|raw }} {{ project.beditaApi.version }}
     </span>
     {% endif %}
     <span>©{{ 'now'|date('Y') }} {{ authors|shuffle|toList(__('&'))|raw }}</span>
     <span>LGPL {{ Html.link('www.bedita.com', 'https://www.bedita.com', {'title': __('BEdita Web site'), 'target': '_blank'})|raw }}</span>
 </div>
+
+{{ project.api|json_encode|raw }}

--- a/tests/TestCase/Controller/Admin/SystemInfoControllerTest.php
+++ b/tests/TestCase/Controller/Admin/SystemInfoControllerTest.php
@@ -2,18 +2,19 @@
 namespace App\Test\TestCase\Controller\Admin;
 
 use App\Controller\Admin\SystemInfoController;
+use App\Test\TestCase\Controller\AppControllerTest;
+use Authentication\Identity;
 use BEdita\SDK\BEditaClient;
 use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Http\ServerRequest;
-use Cake\TestSuite\TestCase;
 
 /**
  * {@see \App\Controller\Admin\SystemInfoController} Test Case
  *
  * @coversDefaultClass \App\Controller\Admin\SystemInfoController
  */
-class SystemInfoControllerTest extends TestCase
+class SystemInfoControllerTest extends AppControllerTest
 {
     public $SystemInfoController;
 
@@ -63,6 +64,13 @@ class SystemInfoControllerTest extends TestCase
      */
     public function testIndex(): void
     {
+        $user = new Identity([
+            'id' => 1,
+            'username' => 'dummy',
+            'roles' => ['readers'],
+        ]);
+        $this->SystemInfoController->setRequest($this->SystemInfoController->getRequest()->withAttribute('authentication', $this->getAuthenticationServiceMock()));
+        $this->SystemInfoController->Authentication->setIdentity($user);
         $this->SystemInfoController->index();
         $keys = [
             'system_info',
@@ -113,7 +121,15 @@ class SystemInfoControllerTest extends TestCase
         $expectedKeys = [
             'Url',
             'Version',
+            'GET /home',
         ];
+        $user = new Identity([
+            'id' => 1,
+            'username' => 'dummy',
+            'roles' => ['readers'],
+        ]);
+        $this->SystemInfoController->setRequest($this->SystemInfoController->getRequest()->withAttribute('authentication', $this->getAuthenticationServiceMock()));
+        $this->SystemInfoController->Authentication->setIdentity($user);
         $actual = $this->SystemInfoController->getApiInfo();
         foreach ($expectedKeys as $expectedKey) {
             static::assertArrayHasKey($expectedKey, $actual);
@@ -144,6 +160,14 @@ class SystemInfoControllerTest extends TestCase
             }
         };
         $controller->setApiClient($apiClient);
+
+        $user = new Identity([
+            'id' => 1,
+            'username' => 'dummy',
+            'roles' => ['readers'],
+        ]);
+        $controller->setRequest($controller->getRequest()->withAttribute('authentication', $this->getAuthenticationServiceMock()));
+        $controller->Authentication->setIdentity($user);
         $actual = $controller->getApiInfo();
         static::assertEquals($expected, $actual);
     }

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -702,27 +702,12 @@ class ModulesComponentTest extends TestCase
                 ],
                 null,
                 [
-                    'name' => 'BEdita',
-                    'version' => 'v4.0.0-gustavo',
                     'api' => [
-                        'project' => [
-                            'name' => 'BEdita',
-                        ],
+                        'name' => 'BEdita',
+                    ],
+                    'beditaApi' => [
+                        'name' => 'BEdita',
                         'version' => 'v4.0.0-gustavo',
-                        'resources' => [
-                            [
-                                'name' => 'supporto',
-                                'hints' => [
-                                    'object_type' => true,
-                                ],
-                            ],
-                            [
-                                'name' => 'gustavo',
-                                'hints' => [
-                                    'object_type' => true,
-                                ],
-                            ],
-                        ],
                     ],
                 ],
                 [
@@ -757,27 +742,12 @@ class ModulesComponentTest extends TestCase
                 ],
                 'supporto',
                 [
-                    'name' => 'BEdita',
-                    'version' => 'v4.0.0-gustavo',
                     'api' => [
-                        'project' => [
-                            'name' => 'BEdita',
-                        ],
+                        'name' => 'BEdita',
+                    ],
+                    'beditaApi' => [
+                        'name' => 'BEdita',
                         'version' => 'v4.0.0-gustavo',
-                        'resources' => [
-                            [
-                                'name' => 'supporto',
-                                'hints' => [
-                                    'object_type' => true,
-                                ],
-                            ],
-                            [
-                                'name' => 'gustavo',
-                                'hints' => [
-                                    'object_type' => true,
-                                ],
-                            ],
-                        ],
                     ],
                 ],
                 [

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -151,6 +151,12 @@ class ModulesComponentTest extends TestCase
                 [
                     'name' => 'BEdita',
                     'version' => 'v4.0.0-gustavo',
+                    'api' => [
+                        'project' => [
+                            'name' => 'BEdita',
+                        ],
+                        'version' => 'v4.0.0-gustavo',
+                    ],
                 ],
                 [
                     'project' => [
@@ -163,6 +169,7 @@ class ModulesComponentTest extends TestCase
                 [
                     'name' => '',
                     'version' => '',
+                    'api' => [],
                 ],
                 [],
             ],
@@ -170,6 +177,7 @@ class ModulesComponentTest extends TestCase
                 [
                     'name' => '',
                     'version' => '',
+                    'api' => [],
                 ],
                 new BEditaClientException('I am a client exception'),
             ],
@@ -181,6 +189,9 @@ class ModulesComponentTest extends TestCase
                 [
                     'name' => 'Gustavo',
                     'version' => '4.1.2',
+                    'api' => [
+                        'version' => '4.1.2',
+                    ],
                 ],
                 [
                     'version' => '4.1.2',
@@ -684,6 +695,26 @@ class ModulesComponentTest extends TestCase
                 [
                     'name' => 'BEdita',
                     'version' => 'v4.0.0-gustavo',
+                    'api' => [
+                        'project' => [
+                            'name' => 'BEdita',
+                        ],
+                        'version' => 'v4.0.0-gustavo',
+                        'resources' => [
+                            [
+                                'name' => 'supporto',
+                                'hints' => [
+                                    'object_type' => true,
+                                ],
+                            ],
+                            [
+                                'name' => 'gustavo',
+                                'hints' => [
+                                    'object_type' => true,
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'resources' => [
@@ -719,6 +750,26 @@ class ModulesComponentTest extends TestCase
                 [
                     'name' => 'BEdita',
                     'version' => 'v4.0.0-gustavo',
+                    'api' => [
+                        'project' => [
+                            'name' => 'BEdita',
+                        ],
+                        'version' => 'v4.0.0-gustavo',
+                        'resources' => [
+                            [
+                                'name' => 'supporto',
+                                'hints' => [
+                                    'object_type' => true,
+                                ],
+                            ],
+                            [
+                                'name' => 'gustavo',
+                                'hints' => [
+                                    'object_type' => true,
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'resources' => [

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -149,12 +149,11 @@ class ModulesComponentTest extends TestCase
         return [
             'ok' => [
                 [
-                    'name' => 'BEdita',
-                    'version' => 'v4.0.0-gustavo',
                     'api' => [
-                        'project' => [
-                            'name' => 'BEdita',
-                        ],
+                        'name' => 'BEdita',
+                    ],
+                    'beditaApi' => [
+                        'name' => 'BEdita',
                         'version' => 'v4.0.0-gustavo',
                     ],
                 ],
@@ -167,17 +166,25 @@ class ModulesComponentTest extends TestCase
             ],
             'empty' => [
                 [
-                    'name' => '',
-                    'version' => '',
-                    'api' => [],
+                    'api' => [
+                        'name' => '',
+                    ],
+                    'beditaApi' => [
+                        'name' => '',
+                        'version' => '',
+                    ],
                 ],
                 [],
             ],
             'client exception' => [
                 [
-                    'name' => '',
-                    'version' => '',
-                    'api' => [],
+                    'api' => [
+                        'name' => '',
+                    ],
+                    'beditaApi' => [
+                        'name' => '',
+                        'version' => '',
+                    ],
                 ],
                 new BEditaClientException('I am a client exception'),
             ],
@@ -187,9 +194,11 @@ class ModulesComponentTest extends TestCase
             ],
             'config' => [
                 [
-                    'name' => 'Gustavo',
-                    'version' => '4.1.2',
                     'api' => [
+                        'name' => '',
+                    ],
+                    'beditaApi' => [
+                        'name' => 'Gustavo',
                         'version' => '4.1.2',
                     ],
                 ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2015,9 +2015,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001688:
-  version "1.0.30001699"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz#a102cf330d153bf8c92bfb5be3cd44c0a89c8c12"
-  integrity sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==
+  version "1.0.30001731"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz"
+  integrity sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==
 
 chalk@4.1.2, chalk@^4.0.0:
   version "4.1.2"


### PR DESCRIPTION
This provides an update in Administrator System Info page and colophon (all pages).

Administrator System Info includes API `GET /home` response. Json data is collapsed, and viewable in a json editor.

Colophon includes "project api name and version" from `GET /home`, if available.