### PR TITLE
Handle redirect on error when saving permissions or related items

### DIFF
--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -377,7 +377,9 @@ class ModulesController extends AppController
         $message = new Message($exception);
         $this->log($message->get(), LogLevel::ERROR);
         $this->Flash->error($message->get(), ['params' => $exception]);
-        $this->set(['error' => $message->get()]);
+        $error = $this->viewBuilder()->getVar('error') ?? [];
+        $error = is_array($error) ? array_merge($error, [$message->get()]) : [$error, $message->get()];
+        $this->set(['error' => $error]);
         $this->setSerialize(['error']);
     }
 

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -326,15 +326,23 @@ class ModulesController extends AppController
                 $response = $this->apiClient->getObject($id, $this->objectType);
             }
             if (!$skipSavePermissions) {
-                $this->savePermissions(
-                    (array)$response,
-                    $schema,
-                    $permissions
-                );
+                try {
+                    $this->savePermissions(
+                        (array)$response,
+                        $schema,
+                        $permissions
+                    );
+                } catch (BEditaClientException $error) {
+                    $this->handleError($error);
+                }
             }
             $id = (string)Hash::get($response, 'data.id');
             if (!$skipSaveRelated) {
-                $this->Modules->saveRelated($id, $this->objectType, $relatedData);
+                try {
+                    $this->Modules->saveRelated($id, $this->objectType, $relatedData);
+                } catch (BEditaClientException $error) {
+                    $this->handleError($error);
+                }
             }
             $options = [
                 'id' => Hash::get($response, 'data.id'),
@@ -344,11 +352,7 @@ class ModulesController extends AppController
             $event = new Event('Controller.afterSave', $this, $options);
             $this->getEventManager()->dispatch($event);
         } catch (BEditaClientException $error) {
-            $message = new Message($error);
-            $this->log($message->get(), LogLevel::ERROR);
-            $this->Flash->error($message->get(), ['params' => $error]);
-            $this->set(['error' => $message->get()]);
-            $this->setSerialize(['error']);
+            $this->handleError($error);
 
             return;
         }
@@ -360,6 +364,21 @@ class ModulesController extends AppController
 
         $this->set((array)$response);
         $this->setSerialize(array_keys($response));
+    }
+
+    /**
+     * Handle exception error: log, flash and set.
+     *
+     * @param \BEdita\SDK\BEditaClientException $exception The exception
+     * @return void
+     */
+    protected function handleError(BEditaClientException $exception): void
+    {
+        $message = new Message($exception);
+        $this->log($message->get(), LogLevel::ERROR);
+        $this->Flash->error($message->get(), ['params' => $exception]);
+        $this->set(['error' => $message->get()]);
+        $this->setSerialize(['error']);
     }
 
     /**
@@ -459,10 +478,7 @@ class ModulesController extends AppController
             $response = $this->apiClient->getRelated($id, $this->objectType, $relation, $query);
             $response = $this->ApiFormatter->embedIncluded((array)$response);
         } catch (BEditaClientException $error) {
-            $this->log($error->getMessage(), LogLevel::ERROR);
-
-            $this->set(compact('error'));
-            $this->setSerialize(['error']);
+            $this->handleError($error);
 
             return;
         }
@@ -488,10 +504,7 @@ class ModulesController extends AppController
         try {
             $response = $this->apiClient->get($type, $query);
         } catch (BEditaClientException $error) {
-            $this->log($error, LogLevel::ERROR);
-
-            $this->set(compact('error'));
-            $this->setSerialize(['error']);
+            $this->handleError($error);
 
             return;
         }


### PR DESCRIPTION
This provides a bugfix.
When you save a new object with permissions or related items in the form, BEM processes data save in different steps (it's not a transaction): first it saves the object, then permissions, then related items.

Buggy behaviour: if there is an exception in "saving permissions" or "saving related items", new object is saved but the page is still "new object page".

Fixed behaviour: if there is an exception in "saving permissions" or "saving related items", new object is saved, there's a redirect to the new object page with proper flash error(s).
