### PR TITLE
Default sort order in admin pages

### DIFF
--- a/src/Controller/Admin/AdministrationBaseController.php
+++ b/src/Controller/Admin/AdministrationBaseController.php
@@ -244,16 +244,15 @@ abstract class AdministrationBaseController extends AppController
         if ($this->sortBy != null && !empty($resultResponse['data'])) {
             $attributesKeys = array_keys($resultResponse['data'][0]['attributes'] ?? []);
             $metaKeys = array_keys($resultResponse['data'][0]['meta'] ?? []);
-            if (!in_array($this->sortBy, $attributesKeys) && !in_array($this->sortBy, $metaKeys)) {
-                return $resultResponse;
+            if (in_array($this->sortBy, $attributesKeys) || in_array($this->sortBy, $metaKeys)) {
+                $key = in_array($this->sortBy, $attributesKeys) ? 'attributes' : 'meta';
+                usort($resultResponse['data'], function ($a, $b) use ($key) {
+                    return strcmp(
+                        (string)Hash::get($a, sprintf('%s.%s', $key, $this->sortBy)),
+                        (string)Hash::get($b, sprintf('%s.%s', $key, $this->sortBy))
+                    );
+                });
             }
-            $key = in_array($this->sortBy, $attributesKeys) ? 'attributes' : 'meta';
-            usort($resultResponse['data'], function ($a, $b) use ($key) {
-                return strcmp(
-                    (string)Hash::get($a, sprintf('%s.%s', $key, $this->sortBy)),
-                    (string)Hash::get($b, sprintf('%s.%s', $key, $this->sortBy))
-                );
-            });
         }
 
         return $resultResponse;

--- a/src/Controller/Admin/AdministrationBaseController.php
+++ b/src/Controller/Admin/AdministrationBaseController.php
@@ -82,6 +82,13 @@ abstract class AdministrationBaseController extends AppController
     protected $meta = ['created', 'modified'];
 
     /**
+     * Sort field
+     *
+     * @var string
+     */
+    protected $sortBy = null;
+
+    /**
      * @inheritDoc
      */
     public function initialize(): void
@@ -233,6 +240,20 @@ abstract class AdministrationBaseController extends AppController
             $count = (int)Hash::get($response, 'meta.pagination.page_items');
             $total += $count;
             $page++;
+        }
+        if ($this->sortBy != null && !empty($resultResponse['data'])) {
+            $attributesKeys = array_keys($resultResponse['data'][0]['attributes'] ?? []);
+            $metaKeys = array_keys($resultResponse['data'][0]['meta'] ?? []);
+            if (!in_array($this->sortBy, $attributesKeys) && !in_array($this->sortBy, $metaKeys)) {
+                return $resultResponse;
+            }
+            $key = in_array($this->sortBy, $attributesKeys) ? 'attributes' : 'meta';
+            usort($resultResponse['data'], function ($a, $b) use ($key) {
+                return strcmp(
+                    (string)Hash::get($a, sprintf('%s.%s', $key, $this->sortBy)),
+                    (string)Hash::get($b, sprintf('%s.%s', $key, $this->sortBy))
+                );
+            });
         }
 
         return $resultResponse;

--- a/src/Controller/Admin/ApplicationsController.php
+++ b/src/Controller/Admin/ApplicationsController.php
@@ -42,4 +42,9 @@ class ApplicationsController extends AdministrationBaseController
      * @inheritDoc
      */
     protected $propertiesSecrets = ['api_key', 'client_secret'];
+
+    /**
+     * @inheritDoc
+     */
+    protected $sortBy = 'name';
 }

--- a/src/Controller/Admin/AuthProvidersController.php
+++ b/src/Controller/Admin/AuthProvidersController.php
@@ -51,4 +51,9 @@ class AuthProvidersController extends AdministrationBaseController
      * @inheritDoc
      */
     protected $meta = [];
+
+    /**
+     * @inheritDoc
+     */
+    protected $sortBy = 'name';
 }

--- a/src/Controller/Admin/ConfigController.php
+++ b/src/Controller/Admin/ConfigController.php
@@ -48,6 +48,11 @@ class ConfigController extends AdministrationBaseController
     /**
      * @inheritDoc
      */
+    protected $sortBy = 'name';
+
+    /**
+     * @inheritDoc
+     */
     public function beforeFilter(EventInterface $event): ?Response
     {
         parent::beforeFilter($event);

--- a/src/Controller/Admin/EndpointsController.php
+++ b/src/Controller/Admin/EndpointsController.php
@@ -38,4 +38,9 @@ class EndpointsController extends AdministrationBaseController
         'name' => 'string',
         'description' => 'text',
     ];
+
+    /**
+     * @inheritDoc
+     */
+    protected $sortBy = 'name';
 }

--- a/src/Controller/Admin/ExternalAuthController.php
+++ b/src/Controller/Admin/ExternalAuthController.php
@@ -50,6 +50,11 @@ class ExternalAuthController extends AdministrationBaseController
     ];
 
     /**
+     * @inheritDoc
+     */
+    protected $sortBy = 'auth_provider_id';
+
+    /**
      * Index method
      *
      * @return \Cake\Http\Response|null

--- a/src/Controller/Admin/RolesController.php
+++ b/src/Controller/Admin/RolesController.php
@@ -50,6 +50,11 @@ class RolesController extends AdministrationBaseController
     /**
      * @inheritDoc
      */
+    protected $sortBy = 'name';
+
+    /**
+     * @inheritDoc
+     */
     public function save(): ?Response
     {
         Cache::delete(self::CACHE_KEY_ROLES);


### PR DESCRIPTION
This introduces a default sort order of data in admin pages: applications, auth providers, endpoints, external auths, roles and configurations.

