### PR TITLE
Allow meta keys in group properties

### DIFF
--- a/src/Controller/Component/PropertiesComponent.php
+++ b/src/Controller/Component/PropertiesComponent.php
@@ -165,6 +165,7 @@ class PropertiesComponent extends Component
         $keep = (array)$this->getConfig(sprintf('Properties.%s.view._keep', $type), []);
         $hide = (array)$this->getConfig(sprintf('Properties.%s.view._hide', $type), []);
         $attributes = array_merge(array_fill_keys($keep, ''), (array)Hash::get($object, 'attributes'));
+        $attributes = array_merge($attributes, (array)Hash::get($object, 'meta', []));
         $attributes = array_diff_key($attributes, array_flip($this->excluded));
         $attributes = array_diff_key($attributes, array_flip($hide));
         $defaults = array_merge($this->getConfig(sprintf('Properties.%s.view', $type), []), $this->defaultGroups['view']);

--- a/templates/Element/Form/group_properties.twig
+++ b/templates/Element/Form/group_properties.twig
@@ -9,6 +9,8 @@
         {% elseif locked and key == 'status' %}
             {{ Property.control(key, value, {'disabled': 'disabled'})|raw }}
             <input type="hidden" name="status" id="status" value="{{ value }}" />
+        {% elseif key in object.meta|keys %}
+            {{ Property.control(key, value, {'disabled': true, 'readonly': true})|raw }}
         {% else %}
             {{ Property.control(key, value)|raw }}
             {% if schema.properties[key].placeholders %}


### PR DESCRIPTION
This provides an enhancement in group properties views, allowing object keys from `meta`.

Example: in your module "view" configuration you have something like the following
```json
{
  "my_data": [
    "title",
    "modified"
  ]
}
```

In the object view you will see "title" as an input text and "modified" as a readonly input field.