### PR TITLE
Bypass module access check when user has role admin

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -185,10 +185,11 @@ class ModulesComponent extends Component
         }
         /** @var \Authentication\Identity|null $user */
         $user = $this->Authentication->getIdentity();
-        if (empty($user) || empty($user->getOriginalData())) {
+        $userRoles = (array)$user->get('roles');
+        if (empty($user) || empty($user->getOriginalData()) || in_array('admin', $userRoles)) {
             return;
         }
-        $roles = array_intersect(array_keys($accessControl), (array)$user->get('roles'));
+        $roles = array_intersect(array_keys($accessControl), $userRoles);
         $modules = (array)array_keys($this->modules);
         $hidden = [];
         $readonly = [];


### PR DESCRIPTION
This provides a fix on checking roles to specify modules accesses per authenticated user.
When user has role "admin", he can access all modules.