### PR TITLE
Date range min-date

### DIFF
--- a/resources/js/app/components/date-range/date-range.vue
+++ b/resources/js/app/components/date-range/date-range.vue
@@ -26,7 +26,7 @@
                         type="text"
                         date="true"
                         :time="!all_day"
-                        :data-min-date="end_date ? false : start_date"
+                        :data-min-date="start_date"
                         daterange="true"
                         v-model="end_date"
                         v-datepicker="true"


### PR DESCRIPTION
This provides an enhancement: when editing a date range, the second date calendar should allow dates after the first date of the date range interval, even when date range has already been saved.

<img width="803" height="513" alt="image" src="https://github.com/user-attachments/assets/e305896e-a0e5-4325-80e9-6fe5c7029dbe" />
