### PR TITLE
Minimum date for date range

### DIFF
--- a/resources/js/app/components/date-range/date-range.vue
+++ b/resources/js/app/components/date-range/date-range.vue
@@ -26,7 +26,7 @@
                         type="text"
                         date="true"
                         :time="!all_day"
-                        :data-min-date="start_date"
+                        :data-min-date="minDateStart(start_date)"
                         daterange="true"
                         v-model="end_date"
                         v-datepicker="true"
@@ -249,6 +249,15 @@ export default {
             const diff = moment.duration(ed.diff(sd)).asDays();
 
             return diff >= 1;
+        },
+        minDateStart(startDate) {
+            if (!startDate) {
+                return '';
+            }
+            const date = moment(startDate);
+            date.set({ hour: 0, minute: 0, second: 0, millisecond: 0 });
+
+            return date.toISOString();
         },
         msdiff(dateRange) {
             const input = dateRange || this.range;


### PR DESCRIPTION
This fixes an unexpected behaviour when adding multiple dates.
The unexpected behaviour: the second date of the range is empty.
It's a side effect of https://github.com/bedita/manager/pull/1307
