### PR TITLE
Upload in a single api call `POST /:type/upload/:filename`

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -395,6 +395,7 @@ class ModulesComponent extends Component
      * @param string $defaultTitle The default title for media
      * @return string The media ID
      * @deprecated 5.15.4 This method is no longer used and will be removed in a future version.
+     * @codeCoverageIgnore
      */
     public function assocStreamToMedia(string $streamId, array &$requestData, string $defaultTitle): string
     {

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -344,17 +344,20 @@ class ModulesComponent extends Component
 
             /** @var \Laminas\Diactoros\UploadedFile $file */
             $file = $requestData['file'];
+            $filepath = $file->getStream()->getMetadata('uri');
+            $content = file_get_contents($filepath);
 
             // upload file
             $filename = basename($file->getClientFileName());
-            $filepath = $file->getStream()->getMetadata('uri');
             $headers = ['Content-Type' => $file->getClientMediaType()];
             $apiClient = ApiClientProvider::getApiClient();
-            $response = $apiClient->upload($filename, $filepath, $headers);
-
-            // assoc stream to media
-            $streamId = $response['data']['id'];
-            $requestData['id'] = $this->assocStreamToMedia($streamId, $requestData, $filename);
+            $type = $this->getController()->getRequest()->getParam('object_type');
+            $response = $apiClient->post(
+                sprintf('/%s/upload/%s', $type, $filename),
+                $content,
+                $headers
+            );
+            $requestData['id'] = Hash::get($response, 'data.id');
         }
         unset($requestData['file'], $requestData['remote_url']);
     }
@@ -391,6 +394,7 @@ class ModulesComponent extends Component
      * @param array $requestData The request data
      * @param string $defaultTitle The default title for media
      * @return string The media ID
+     * @deprecated 5.15.4 This method is no longer used and will be removed in a future version.
      */
     public function assocStreamToMedia(string $streamId, array &$requestData, string $defaultTitle): string
     {


### PR DESCRIPTION
This provides an optimization for upload by using a single api call `POST /:type/upload/:filename` instead of 3 calls (stream creation, add stream to media, get media).

The function `assocStreamToMedia` is deprecated, as unnecessary and it will be dropped in future version.