### PR TITLE
Timeout in upload config

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -740,6 +740,7 @@ return [
     // ],
     // 'uploadMaxResolution' => '1920x1080',
     // 'uploadMaxSize' => -1, // -1 means no limit, otherwise set a limit in bytes
+    // 'uploadTimeout' => 30000, // in milliseconds
 
     /**
      * Configuration for "Children" association parameters.

--- a/resources/js/app/mixins/fetch.js
+++ b/resources/js/app/mixins/fetch.js
@@ -31,7 +31,7 @@ export const FetchMixin = {
         createCustomAxios() {
             return axios.create({
                 baseURL: BEDITA.base,
-                timeout: 30000,
+                timeout: BEDITA?.uploadConfig?.timeout || 30000,
                 credentials: 'same-origin',
                 headers: {
                     'accept': 'application/json',

--- a/src/View/Helper/SystemHelper.php
+++ b/src/View/Helper/SystemHelper.php
@@ -87,6 +87,20 @@ class SystemHelper extends Helper
     ];
 
     /**
+     * Maximum size for uploaded files, in bytes
+     *
+     * @var int
+     */
+    protected int $defaultUploadMaxSize = -1;
+
+    /**
+     * Timeout for upload operations, in milliseconds
+     *
+     * @var int
+     */
+    protected int $defaultUploadTimeout = 30000; // in milliseconds
+
+    /**
      * Maximum resolution for images
      *
      * @var string
@@ -166,8 +180,10 @@ class SystemHelper extends Helper
         $accepted = (array)Configure::read('uploadAccepted', $this->defaultUploadAccepted);
         $forbidden = (array)Configure::read('uploadForbidden', $this->defaultUploadForbidden);
         $maxResolution = (string)Configure::read('uploadMaxResolution', $this->defaultUploadMaxResolution);
+        $maxSize = (int)Configure::read('uploadMaxSize', $this->defaultUploadMaxSize);
+        $timeout = (int)Configure::read('uploadTimeout', $this->defaultUploadTimeout);
 
-        return compact('accepted', 'forbidden', 'maxResolution');
+        return compact('accepted', 'forbidden', 'maxResolution', 'maxSize', 'timeout');
     }
 
     /**

--- a/tests/TestCase/View/Helper/SystemHelperTest.php
+++ b/tests/TestCase/View/Helper/SystemHelperTest.php
@@ -182,7 +182,13 @@ class SystemHelperTest extends TestCase
         $property = $reflectionClass->getProperty('defaultUploadMaxResolution');
         $property->setAccessible(true);
         $maxResolution = $property->getValue($this->System);
-        $expected = compact('accepted', 'forbidden', 'maxResolution');
+        $property = $reflectionClass->getProperty('defaultUploadMaxSize');
+        $property->setAccessible(true);
+        $maxSize = $property->getValue($this->System);
+        $property = $reflectionClass->getProperty('defaultUploadTimeout');
+        $property->setAccessible(true);
+        $timeout = $property->getValue($this->System);
+        $expected = compact('accepted', 'forbidden', 'maxResolution', 'maxSize', 'timeout');
         $actual = $this->System->uploadConfig();
         static::assertSame($expected, $actual);
     }


### PR DESCRIPTION
You can set "timeout" in upload configuration, if you want to customize it, default "30000" milliseconds.

Example:
```php
// config/app_local.php
<?php

return [
    // ...
    'uploadTimeout' => 30000, // in milliseconds
    // ...
];
```