### PR TITLE
Bulk edit attributes with a single API call

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - name: Checkout current revision

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=8.3",
         "bedita/i18n": "^5.1.0",
-        "bedita/web-tools": "^5.3.3",
+        "bedita/web-tools": "^5.4.0",
         "cakephp/authentication": "^2.9",
         "cakephp/cakephp": "~4.5.0",
         "cakephp/plugin-installer": "^1.3",

--- a/resources/js/app/components/index-cell/index-cell.vue
+++ b/resources/js/app/components/index-cell/index-cell.vue
@@ -121,7 +121,7 @@ export default {
             default: () => [],
         },
         schema: {
-            type: Object,
+            type: [Object, Array],
             default: () => ({}),
         },
         settings: {

--- a/resources/js/app/pages/modules/index.js
+++ b/resources/js/app/pages/modules/index.js
@@ -32,6 +32,10 @@ export default {
             type: String,
             default: () => ([]),
         },
+        objects: {
+            type: String,
+            default: () => '[]',
+        },
     },
 
     /**
@@ -42,6 +46,8 @@ export default {
     data() {
         return {
             allIds: [],
+            objectsList: JSON.parse(this.objects),
+            selectedObjects: '[]',
             selectedRows: [],
             bulkField: null,
             bulkValue: null,
@@ -87,6 +93,8 @@ export default {
             } else {
                 this.$refs.checkAllCB.indeterminate = true;
             }
+            const selectedObjects = this.objectsList.filter((o) => val.includes(o.id));
+            this.selectedObjects = JSON.stringify(selectedObjects);
         },
     },
 
@@ -107,6 +115,9 @@ export default {
             }
         },
         checkAll() {
+            const oo = this.objectsList.map((o) => { return {id: o.id, type: o.type}; });
+            const selectedObjects = JSON.parse(JSON.stringify(oo));
+            this.selectedObjects = JSON.stringify(selectedObjects);
             this.selectedRows = JSON.parse(JSON.stringify(this.allIds));
             for (let id of this.allIds) {
                 let row = document.querySelector(`a[data-id="${id}"]`);
@@ -114,6 +125,7 @@ export default {
             }
         },
         unCheckAll() {
+            this.selectedObjects = '[]';
             this.selectedRows = [];
             for (let id of this.allIds) {
                 let row = document.querySelector(`a[data-id="${id}"]`);
@@ -190,6 +202,18 @@ export default {
                     this.selectedRows.splice(position, 1);
                 } else {
                     this.selectedRows.push(cb.value);
+                }
+                // push into selectedObjects, if still not present
+                const obj = this.objectsList.find((o) => o.id == cb.value);
+                if (obj) {
+                    const selectedObjects = JSON.parse(this.selectedObjects);
+                    const objPosition = selectedObjects.findIndex((o) => o.id == cb.value);
+                    if (objPosition == -1) {
+                        selectedObjects.push({id: obj.id, type: obj.type});
+                    } else {
+                        selectedObjects.splice(objPosition, 1);
+                    }
+                    this.selectedObjects = JSON.stringify(selectedObjects);
                 }
             } else {
                 let row = event.target.closest('a.table-row');

--- a/src/Controller/BulkController.php
+++ b/src/Controller/BulkController.php
@@ -313,7 +313,8 @@ class BulkController extends AppController
     protected function showResult(): void
     {
         if (empty($this->errors)) {
-            $this->Flash->success(__('Bulk action performed on {0} objects', count($this->saved) ?? count($this->ids)));
+            $count = count($this->saved) > 0 ? count($this->saved) : count($this->ids);
+            $this->Flash->success(__('Bulk action performed on {0} objects', $count));
 
             return;
         }

--- a/src/Controller/BulkController.php
+++ b/src/Controller/BulkController.php
@@ -67,6 +67,13 @@ class BulkController extends AppController
     protected $errors = [];
 
     /**
+     * Saved ids
+     *
+     * @var array
+     */
+    protected $saved = [];
+
+    /**
      * @inheritDoc
      */
     public function initialize(): void
@@ -86,6 +93,7 @@ class BulkController extends AppController
     {
         $requestData = $this->getRequest()->getData();
         $this->objects = $requestData['objects'];
+        $this->objects = is_string($this->objects) ? json_decode($this->objects, true) : $this->objects;
         $this->saveAttribute($requestData['attributes']);
         $this->showResult();
 
@@ -197,6 +205,7 @@ class BulkController extends AppController
         }
         $result = $this->apiClient->bulkEdit($itemsMap, $attributes);
         $this->errors = (array)Hash::get($result, 'data.errors');
+        $this->saved = (array)Hash::get($result, 'data.saved');
     }
 
     /**
@@ -304,7 +313,7 @@ class BulkController extends AppController
     protected function showResult(): void
     {
         if (empty($this->errors)) {
-            $this->Flash->success(__('Bulk action performed on {0} objects', count($this->ids)));
+            $this->Flash->success(__('Bulk action performed on {0} objects', count($this->saved) ?? count($this->ids)));
 
             return;
         }

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -379,4 +379,23 @@ class SchemaHelper extends Helper
 
         return $list;
     }
+
+    /**
+     * Get minimal objects list (id and type only) from full objects array
+     *
+     * @param array $objects Full objects array
+     * @return array
+     */
+    public function minimalObjectsList(array $objects): array
+    {
+        $list = [];
+        foreach ($objects as $obj) {
+            $list[] = [
+                'id' => Hash::get($obj, 'id'),
+                'type' => Hash::get($obj, 'type'),
+            ];
+        }
+
+        return $list;
+    }
 }

--- a/templates/Element/FilterBox/filter_box_common.twig
+++ b/templates/Element/FilterBox/filter_box_common.twig
@@ -58,7 +58,7 @@
                 <span class="ml-05">{{ __('Reset') }}</span>
             </button>
 
-            {% if hideFilterRelations == '' %}
+            {% if hideFilterRelations == '' and schema and schema.relations %}
             <button class="toggle-filters button button-outlined is-width-auto" type="button" @click.prevent="toggleFilterRelations()">
                 <app-icon icon="carbon:filter-edit" v-show="!editFilterRelations"></app-icon><span class="ml-05" v-show="!editFilterRelations">{{ __('Relations') }}</span>
                 <app-icon icon="carbon:filter" v-show="editFilterRelations"></app-icon><span class="ml-05" v-show="editFilterRelations">{{ __('Relations') }}</span>
@@ -73,12 +73,12 @@
         </div>
     </div>
 
-    {% if hideFilterRelations == '' %}
+    {% if hideFilterRelations == '' and schema and schema.relations %}
     <div class="more-filters" v-show="editFilterRelations">
         <div class="filter-container">
             <related-objects-filter
                 :initial-filter="{{ _view.request.getQuery('filter')|json_encode }}"
-                :relations-schema="{{ schema['relations']|json_encode }}"
+                :relations-schema="{{ schema['relations']|default({})|json_encode }}"
                 @edit-filter-relations="editFilterRelations = 1"
                 @update-filter-related="updateFilterRelations"
             >

--- a/templates/Element/Form/bulk_properties.twig
+++ b/templates/Element/Form/bulk_properties.twig
@@ -8,7 +8,9 @@
         })|raw }}
         <div class="fieldset" :disabled="!selectedRows.length">
             <input type="hidden" name="ids" v-bind:value="selectedRows">
+            <input type="text" name="objects" v-bind:value="selectedObjects">
             {% do Form.unlockField('ids') %}
+            {% do Form.unlockField('objects') %}
 
             {% set options = Schema.controlOptions(key, null, schema.properties[key]) %}
             {% set options = options|merge({

--- a/templates/Element/Form/bulk_properties.twig
+++ b/templates/Element/Form/bulk_properties.twig
@@ -8,7 +8,7 @@
         })|raw }}
         <div class="fieldset" :disabled="!selectedRows.length">
             <input type="hidden" name="ids" v-bind:value="selectedRows">
-            <input type="text" name="objects" v-bind:value="selectedObjects">
+            <input type="hidden" name="objects" v-bind:value="selectedObjects">
             {% do Form.unlockField('ids') %}
             {% do Form.unlockField('objects') %}
 

--- a/templates/Pages/Modules/index.twig
+++ b/templates/Pages/Modules/index.twig
@@ -4,7 +4,7 @@
 {{ element('Modules/index_header', { 'meta': meta, 'filter': filter, 'Schema': Schema, 'hidePagination': indexViewType == 'tree'}) }}
 
 {% set ids = Array.extract(objects, '{*}.id') %}
-<modules-index inline-template ids='{{ ids|json_encode }}'>
+<modules-index inline-template ids='{{ ids|json_encode }}' objects={{ Schema.minimalObjectsList(objects)|json_encode }}>
     <div class="module-index">
         {{ element('Modules/' ~ indexViewType) }}
         {{ element(Element.sidebar()) }}

--- a/templates/Pages/Translations/index.twig
+++ b/templates/Pages/Translations/index.twig
@@ -4,7 +4,7 @@
 {{ element('Modules/index_header', { 'meta': meta, 'filter': filter, 'Schema': Schema }) }}
 
 {% set ids = Array.extract(objects, '{*}.id') %}
-<modules-index inline-template ids='{{ ids|json_encode }}'>
+<modules-index inline-template ids='{{ ids|json_encode }}' objects={{ Schema.minimalObjectsList(objects)|json_encode }}>
 
     <div class="module-index">
 

--- a/tests/TestCase/Controller/BulkControllerTest.php
+++ b/tests/TestCase/Controller/BulkControllerTest.php
@@ -295,11 +295,11 @@ class BulkControllerTest extends BaseControllerTest
 
         // get object for test
         $o = $this->getTestObject();
-        // set $this->controller->ids
-        $property = new \ReflectionProperty(BulkController::class, 'ids');
+        // set $this->controller->objects
+        $property = new \ReflectionProperty(BulkController::class, 'objects');
         $property->setAccessible(true);
-        $property->setValue($this->controller, [$o['id']]);
-        $attributes = ['status' => 'on'];
+        $property->setValue($this->controller, [['id' => $o['id'], 'type' => $o['type']]]);
+        $attributes = ['status' => 'draft'];
 
         // do controller call
         $reflectionClass = new \ReflectionClass($this->controller);
@@ -311,10 +311,10 @@ class BulkControllerTest extends BaseControllerTest
         static::assertEmpty($this->controller->getErrors());
 
         // do controller call
-        // set $this->controller->ids
-        $property = new \ReflectionProperty(BulkController::class, 'ids');
+        // set $this->controller->objects
+        $property = new \ReflectionProperty(BulkController::class, 'objects');
         $property->setAccessible(true);
-        $property->setValue($this->controller, ['123456789']);
+        $property->setValue($this->controller, [['id' => 1, 'type' => 'users']]);
         $method->invokeArgs($this->controller, [$attributes]);
 
         // check not empty errors

--- a/tests/TestCase/View/Helper/SchemaHelperTest.php
+++ b/tests/TestCase/View/Helper/SchemaHelperTest.php
@@ -1112,4 +1112,26 @@ class SchemaHelperTest extends TestCase
         $actual = $this->Schema->filterListByType($filtersByType, $schemasByType);
         static::assertSame($expected, $actual);
     }
+
+    /**
+     * Test `minimalObjectsList` method.
+     *
+     * @return void
+     * @covers ::minimalObjectsList()
+     */
+    public function testMinimalObjectsList(): void
+    {
+        $input = [
+            ['id' => 1, 'title' => 'First', 'type' => 'documents', 'extra' => 'data'],
+            ['id' => 2, 'title' => 'Second', 'type' => 'documents', 'extra' => 'data'],
+            ['id' => 3, 'title' => 'Third', 'type' => 'images', 'extra' => 'data'],
+        ];
+        $expected = [
+            ['id' => 1, 'type' => 'documents'],
+            ['id' => 2, 'type' => 'documents'],
+            ['id' => 3, 'type' => 'images'],
+        ];
+        $actual = $this->Schema->minimalObjectsList($input);
+        static::assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
This updates bulk edit attributes to use `POST /bulk/edit` endpoint (references: https://github.com/bedita/bedita/pull/2155, https://github.com/bedita/php-sdk/pull/61, https://github.com/bedita/web-tools/pull/108).

Benefits: faster and with transactions.

It's retrocompatible (if not using BE API that provide POST /bulk/edit, it does N API calls, as before).

Bonus: 
 - node 24 in javascript github workflow
 - fix some vue warnings