### PR TITLE
Proxy api history get

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -457,6 +457,11 @@ $routes->scope('/', function (RouteBuilder $routes) {
     );
 
     $routes->get(
+        '/history/get',
+        ['controller' => 'History', 'action' => 'get'],
+        'history:get',
+    );
+    $routes->get(
         '/history/objects',
         ['controller' => 'History', 'action' => 'objects'],
         'history:objects',

--- a/resources/js/app/components/objects-history/objects-history.vue
+++ b/resources/js/app/components/objects-history/objects-history.vue
@@ -119,7 +119,7 @@ export default {
             const filterDate = this.filterDate ? new Date(this.filterDate).toISOString() : '';
             const query = filterDate ? `page_size=${pageSize}&page=${page}&filter[created][gt]=${filterDate}&sort=-created` : `page_size=${pageSize}&page=${page}&sort=-created`;
 
-            return fetch(`/api/history?${query}`).then((r) => r.json());
+            return fetch(`/history/get?${query}`).then((r) => r.json());
         },
         async getObjects(ids) {
             return fetch(`/history/objects?filter[id]=${ids.join(',')}`).then((r) => r.json());

--- a/resources/js/app/components/recent-activity/recent-activity.vue
+++ b/resources/js/app/components/recent-activity/recent-activity.vue
@@ -147,7 +147,7 @@ export default {
             try {
                 this.loading = true;
                 this.error = '';
-                const response = await fetch(`${API_URL}api/history?filter[user_id]=${userId}&page=${page}&page_size=${pageSize}&sort=-created`, API_OPTIONS);
+                const response = await fetch(`${API_URL}history/get?filter[user_id]=${userId}&page=${page}&page_size=${pageSize}&sort=-created`, API_OPTIONS);
                 const json = await response.json();
                 this.pagination = json.meta.pagination;
                 this.currentPage = json.meta.pagination.page;

--- a/src/Controller/HistoryController.php
+++ b/src/Controller/HistoryController.php
@@ -27,6 +27,24 @@ class HistoryController extends AppController
     }
 
     /**
+     * Get history using query parameters.
+     * This is a proxy for /api/history endpoint.
+     *
+     * @return void
+     */
+    public function get(): void
+    {
+        $this->viewBuilder()->setClassName('Json');
+        $this->getRequest()->allowMethod('get');
+        $query = $this->getRequest()->getQueryParams();
+        $response = ApiTools::cleanResponse((array)$this->apiClient->get('/history', $query));
+        $data = $response['data'];
+        $meta = $response['meta'];
+        $this->set(compact('data', 'meta'));
+        $this->setSerialize(['data', 'meta']);
+    }
+
+    /**
      * Get objects list: id, title, uname only / no relationships, no links.
      *
      * @return void

--- a/tests/TestCase/Controller/HistoryControllerTest.php
+++ b/tests/TestCase/Controller/HistoryControllerTest.php
@@ -222,7 +222,7 @@ class HistoryControllerTest extends TestCase
      */
     public function testGet(): void
     {
-        $this->HistoryController->get($this->documentId);
+        $this->HistoryController->get();
         $vars = ['data', 'meta'];
         foreach ($vars as $var) {
             static::assertNotEmpty($this->HistoryController->viewBuilder()->getVar($var));

--- a/tests/TestCase/Controller/HistoryControllerTest.php
+++ b/tests/TestCase/Controller/HistoryControllerTest.php
@@ -215,6 +215,45 @@ class HistoryControllerTest extends TestCase
     }
 
     /**
+     * Test `get` method
+     *
+     * @return void
+     * @covers ::get()
+     */
+    public function testGet(): void
+    {
+        $this->HistoryController->get($this->documentId);
+        $vars = ['data', 'meta'];
+        foreach ($vars as $var) {
+            static::assertNotEmpty($this->HistoryController->viewBuilder()->getVar($var));
+        }
+        $actual = $this->HistoryController->viewBuilder()->getVar('data')[0];
+        $vars = [
+            'id',
+            'type',
+            'meta',
+        ];
+        foreach ($vars as $var) {
+            static::assertArrayHasKey($var, $actual);
+        }
+        static::assertArrayNotHasKey('links', $actual);
+        static::assertArrayNotHasKey('relationships', $actual);
+        $meta = $actual['meta'];
+        $vars = [
+            'resource_id',
+            'resource_type',
+            'created',
+            'user_id',
+            'application_id',
+            'user_action',
+            'changed',
+        ];
+        foreach ($vars as $var) {
+            static::assertArrayHasKey($var, $meta);
+        }
+    }
+
+    /**
      * Test `objects` method
      *
      * @return void


### PR DESCRIPTION
This provides a refactor to proxy `GET /api/history` by using `GET /history/get`, to avoid unexpected 401.