### PR TITLE
Fix call config endpoint as authenticated

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -130,9 +130,6 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
             // Provides a `GET /status` endpoint. This must be
             ->add(new StatusMiddleware())
 
-            // Load configuration from API for the current project.
-            ->add(new ConfigurationMiddleware())
-
             // Handle plugin/theme assets like CakePHP normally does.
             ->add(new AssetMiddleware([
                 'cacheTime' => Configure::read('Asset.cacheTime'),
@@ -155,6 +152,9 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
 
             // Authentication middleware.
             ->add(new OAuth2Middleware())
+
+            // Load configuration from API for the current project.
+            ->add(new ConfigurationMiddleware())
 
             // Recovery middleware
             ->add(new RecoveryMiddleware())

--- a/src/Controller/Component/ProjectConfigurationComponent.php
+++ b/src/Controller/Component/ProjectConfigurationComponent.php
@@ -70,7 +70,12 @@ class ProjectConfigurationComponent extends Component
      */
     protected function fetchConfig(): array
     {
-        $response = (array)ApiClientProvider::getApiClient()->get('config', ['page_size' => 100]);
+        $client = ApiClientProvider::getApiClient();
+        $response = (array)$client->get('config', ['page_size' => 100], [
+            'Authorization' => sprintf('Bearer %s', Hash::get($client->getTokens(), 'jwt')),
+            'X-Api-Key' => Configure::read('API.apiKey'),
+            'Accept' => 'application/json',
+        ]);
 
         $config = Hash::combine($response, 'data.{n}.attributes.name', 'data.{n}.attributes.content');
         array_walk(

--- a/src/Middleware/ConfigurationMiddleware.php
+++ b/src/Middleware/ConfigurationMiddleware.php
@@ -13,6 +13,7 @@
 namespace App\Middleware;
 
 use App\Utility\ApiConfigTrait;
+use BEdita\WebTools\ApiClientProvider;
 use Cake\Core\Configure;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -34,6 +35,7 @@ class ConfigurationMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if (Configure::check('API.apiBaseUrl')) {
+            ApiClientProvider::getApiClient()->setupTokens($request->getAttribute('identity')->get('tokens'));
             $this->readApiConfig();
         }
 

--- a/src/Middleware/ConfigurationMiddleware.php
+++ b/src/Middleware/ConfigurationMiddleware.php
@@ -35,7 +35,10 @@ class ConfigurationMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if (Configure::check('API.apiBaseUrl')) {
-            ApiClientProvider::getApiClient()->setupTokens($request->getAttribute('identity')->get('tokens'));
+            $identity = $request->getAttribute('identity');
+            if ($identity && $identity->get('tokens')) {
+                ApiClientProvider::getApiClient()->setupTokens($identity->get('tokens'));
+            }
             $this->readApiConfig();
         }
 

--- a/src/Utility/ApiConfigTrait.php
+++ b/src/Utility/ApiConfigTrait.php
@@ -87,8 +87,12 @@ trait ApiConfigTrait
      */
     protected function fetchConfig(?string $key = null): array
     {
-        $query = ['page_size' => 100];
-        $response = (array)ApiClientProvider::getApiClient()->get('/config', $query);
+        $client = ApiClientProvider::getApiClient();
+        $response = (array)$client->get('/config', ['page_size' => 100], [
+            'Authorization' => sprintf('Bearer %s', Hash::get($client->getTokens(), 'jwt')),
+            'X-Api-Key' => Configure::read('API.apiKey'),
+            'Accept' => 'application/json',
+        ]);
         $collection = new Collection((array)Hash::get($response, 'data'));
 
         return $collection->reject(function ($item) use ($key) {

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -65,8 +65,6 @@ class ApplicationTest extends TestCase
         $middleware->next();
         static::assertInstanceOf(StatusMiddleware::class, $middleware->current());
         $middleware->next();
-        static::assertInstanceOf(ConfigurationMiddleware::class, $middleware->current());
-        $middleware->next();
         static::assertInstanceOf(AssetMiddleware::class, $middleware->current());
         $middleware->next();
         static::assertInstanceOf(I18nMiddleware::class, $middleware->current());
@@ -76,6 +74,8 @@ class ApplicationTest extends TestCase
         static::assertInstanceOf(CsrfProtectionMiddleware::class, $middleware->current());
         $middleware->next();
         static::assertInstanceOf(AuthenticationMiddleware::class, $middleware->current());
+        $middleware->next();
+        static::assertInstanceOf(ConfigurationMiddleware::class, $middleware->current());
         $middleware->next();
         static::assertInstanceOf(OAuth2Middleware::class, $middleware->current());
     }

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -84,7 +84,7 @@ class ApplicationTest extends TestCase
         static::assertInstanceOf(RecoveryMiddleware::class, $middleware->current());
         $middleware->next();
         static::assertInstanceOf(BodyParserMiddleware::class, $middleware->current());
-}
+    }
 
     /**
      * Test `csrfMiddleware` method

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -16,6 +16,7 @@ use App\Application;
 use App\Identifier\ApiIdentifier;
 use App\Middleware\ConfigurationMiddleware;
 use App\Middleware\ProjectMiddleware;
+use App\Middleware\RecoveryMiddleware;
 use App\Middleware\StatusMiddleware;
 use Authentication\AuthenticationService;
 use Authentication\Authenticator\AuthenticatorInterface;
@@ -26,6 +27,7 @@ use BEdita\I18n\Middleware\I18nMiddleware;
 use BEdita\WebTools\Middleware\OAuth2Middleware;
 use Cake\Core\Configure;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
+use Cake\Http\Middleware\BodyParserMiddleware;
 use Cake\Http\Middleware\CsrfProtectionMiddleware;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\ServerRequest;
@@ -75,10 +77,14 @@ class ApplicationTest extends TestCase
         $middleware->next();
         static::assertInstanceOf(AuthenticationMiddleware::class, $middleware->current());
         $middleware->next();
+        static::assertInstanceOf(OAuth2Middleware::class, $middleware->current());
+        $middleware->next();
         static::assertInstanceOf(ConfigurationMiddleware::class, $middleware->current());
         $middleware->next();
-        static::assertInstanceOf(OAuth2Middleware::class, $middleware->current());
-    }
+        static::assertInstanceOf(RecoveryMiddleware::class, $middleware->current());
+        $middleware->next();
+        static::assertInstanceOf(BodyParserMiddleware::class, $middleware->current());
+}
 
     /**
      * Test `csrfMiddleware` method


### PR DESCRIPTION
When API instance has endpoints "closed" for anonymous users, it's necessary to call API endpoints as authenticated users (passing proper headers).
This lets `ConfigurationMiddleware` call `GET /config` passing proper headers.