### PR TITLE
Resolve subresource integrity warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,6 @@
     "webpack": "^5.97.0",
     "webpack-cli": "^4.9.0",
     "webpack-watch-files-plugin": "^1.2.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/resources/style.scss
+++ b/resources/style.scss
@@ -9,6 +9,10 @@
 
 BEdita Manager
 */
+
+// Google Fonts
+@import 'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,200;0,400;1,200;1,400&family=IBM+Plex+Sans:ital,wght@0,200;0,300;0,400;0,500;1,200;1,300;1,400;1,500&family=IBM+Plex+Serif:ital,wght@0,200;0,400;0,700;1,200;1,400;1,700&display=swap';
+
 @import './styles/variables';   // common variables used for color, margins, typography, media breakpoints, tag collections
 @import './styles/mixins';
 

--- a/templates/Layout/default.twig
+++ b/templates/Layout/default.twig
@@ -30,8 +30,8 @@ BEdita Manager
 
     {{ element('custom_colors') }}
 
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,200;0,400;1,200;1,400&family=IBM+Plex+Sans:ital,wght@0,200;0,300;0,400;0,500;1,200;1,300;1,400;1,500&family=IBM+Plex+Serif:ital,wght@0,200;0,400;0,700;1,200;1,400;1,700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     {{ element('json_meta_config') }}
 </head>

--- a/templates/Layout/error.twig
+++ b/templates/Layout/error.twig
@@ -25,8 +25,6 @@ BEdita Manager
     {{ Html.css(['vendors'])|raw }}
     {{ Html.css(['style'])|raw }}
 
-    <link href="https://fonts.googleapis.com/css?family=Mukta:300,400,700&amp;subset=latin-ext" rel="stylesheet">
-
     {{ element('custom_colors') }}
 
     <title>{{ Layout.title()|default(_view.fetch('title')) }} | {{ "#{project.name ?: 'BEdita Manager'}" }}</title>


### PR DESCRIPTION
This PR avoids a report of missing Subresource Integrity ([SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)).

While from a strict standpoint these changes don't actually _solve_ the issue, since the style is still loaded remotely from `fonts.googleapis.com` and we cannot compute the resource hash at build time because it is generated dynamically by Google Fonts, loading the stylesheet via `@import` as opposed to `<link rel="stylesheet">` usually silences this kind of warning.

These changes might theoretically slightly increase loading time for the styles as the chain of resources to load changes, however the impact should be negligible and most importantly this application is not really targeting end-users on unstable or slow networks.

Additionally, I found out that error pages used to load a font that was not referenced anywhere in styles. I've removed that import with no replacement.