### PR TITLE
Fast create user: password and roles

### DIFF
--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -103,7 +103,9 @@ const _vueInstance = new Vue({
         FieldGeoCoordinates: () => import(/* webpackChunkName: "field-geo-coordinates" */'app/components/form/field-geo-coordinates'),
         FieldInteger: () => import(/* webpackChunkName: "field-integer" */'app/components/form/field-integer'),
         FieldJson: () => import(/* webpackChunkName: "field-json" */'app/components/form/field-json'),
+        FieldMultipleCheckboxes: () => import(/* webpackChunkName: "field-multiple-checkboxes" */'app/components/form/field-multiple-checkboxes'),
         FieldNumber: () => import(/* webpackChunkName: "field-number" */'app/components/form/field-number'),
+        FieldPassword: () => import(/* webpackChunkName: "field-password" */'app/components/form/field-password'),
         FieldPlaintext: () => import(/* webpackChunkName: "field-plaintext" */'app/components/form/field-plaintext'),
         FieldRadio: () => import(/* webpackChunkName: "field-radio" */'app/components/form/field-radio'),
         FieldSelect: () => import(/* webpackChunkName: "field-select" */'app/components/form/field-select'),
@@ -633,7 +635,9 @@ Vue.component('FieldGeoCoordinates', _vueInstance.$options.components.FieldGeoCo
 Vue.component('FieldDate', _vueInstance.$options.components.FieldDate);
 Vue.component('FieldInteger', _vueInstance.$options.components.FieldInteger);
 Vue.component('FieldJson', _vueInstance.$options.components.FieldJson);
+Vue.component('FieldMultipleCheckboxes', _vueInstance.$options.components.FieldMultipleCheckboxes);
 Vue.component('FieldNumber', _vueInstance.$options.components.FieldNumber);
+Vue.component('FieldPassword', _vueInstance.$options.components.FieldPassword);
 Vue.component('FieldPlaintext', _vueInstance.$options.components.FieldPlaintext);
 Vue.component('FieldRadio', _vueInstance.$options.components.FieldRadio);
 Vue.component('FieldSelect', _vueInstance.$options.components.FieldSelect);

--- a/resources/js/app/components/fast-create/form-field.vue
+++ b/resources/js/app/components/fast-create/form-field.vue
@@ -114,6 +114,15 @@
                 @change="update"
                 v-if="fieldType === 'geo-coordinates'"
             />
+            <!-- input password -->
+            <template v-if="fieldType === 'string' && field === 'password'">
+                <field-password
+                    :id="`fast-create-${field}`"
+                    :name="`fast-${objectType}-${field}`"
+                    :reference="`fast-create-${objectType}`"
+                    @change="update"
+                />
+            </template>
             <!-- input text -->
             <field-string
                 :id="`fast-create-${field}`"
@@ -121,7 +130,7 @@
                 :reference="`fast-create-${objectType}`"
                 :value="value"
                 @change="update"
-                v-if="fieldType === 'string'"
+                v-if="fieldType === 'string' && field !== 'password'"
             />
             <!-- captions -->
             <object-captions
@@ -141,6 +150,16 @@
                 :value="value"
                 @change="update"
                 v-if="fieldType === 'json'"
+            />
+            <!-- multiple checkboxes -->
+            <field-multiple-checkboxes
+                :id="`fast-create-${field}`"
+                :json-schema="jsonSchema"
+                :name="`fast-${objectType}-${field}`"
+                :reference="`fast-create-${objectType}`"
+                :value="value"
+                @change="update"
+                v-if="fieldType === 'multiple-checkboxes'"
             />
         </div>
     </div>
@@ -227,6 +246,9 @@ export default {
             }
             if (this.field === 'date_ranges') {
                 return 'calendar';
+            }
+            if (this.jsonSchema?.type === 'array' && this.jsonSchema?.items?.type === 'string' && this.jsonSchema?.items?.enum?.length > 0) {
+                return 'multiple-checkboxes';
             }
             if (this.field === 'extra' || ['array','object'].includes(this.jsonSchema?.type) || this.jsonSchema?.oneOf?.filter(one => ['array','object'].includes(one?.type))?.length > 0) {
                 return 'json';

--- a/resources/js/app/components/form/field-multiple-checkboxes.vue
+++ b/resources/js/app/components/form/field-multiple-checkboxes.vue
@@ -1,0 +1,93 @@
+<template>
+    <div class="field-multiple-checkboxes">
+        <label
+            v-for="item in items"
+            :key="item"
+        >
+            <input
+                :id="`field-multiple-checkboxes-${item}`"
+                :name="item"
+                :data-ref="reference"
+                class="field-checkbox"
+                type="checkbox"
+                :checked="v.includes(item)"
+                @change="update($event.target)"
+            >
+            <span>{{ item }}</span>
+        </label>
+        <input
+            :id="id"
+            :name="name"
+            :data-ref="reference"
+            type="hidden"
+            v-model="serialized"
+            @change="$emit('change', serialized)"
+        >
+    </div>
+</template>
+<script>
+export default {
+    name: 'FieldMultipleCheckboxes',
+    props: {
+        id: {
+            type: String,
+            required: true
+        },
+        jsonSchema: {
+            type: Object,
+            required: true,
+        },
+        name: {
+            type: String,
+            required: true
+        },
+        reference: {
+            type: String,
+            default: ''
+        },
+        value: {
+            type: String,
+            default: ''
+        },
+    },
+    data() {
+        return {
+            items: this.jsonSchema?.items?.enum || [],
+            serialized: JSON.stringify(this.value || []),
+            v: this.value || [],
+        };
+    },
+    mounted() {
+        this.$nextTick(() => {
+            this.items.sort();
+            this.v.sort();
+        });
+    },
+    methods: {
+        update(target) {
+            const val = target.checked;
+            const targetName = target.name;
+            if (val) {
+                this.v.push(targetName);
+            } else {
+                this.v = this.v.filter(i => i !== targetName);
+            }
+            this.v.sort();
+            this.serialized = JSON.stringify(this.v);
+            this.$emit('change', this.serialized);
+        }
+    },
+}
+</script>
+<style scoped>
+div.field-multiple-checkboxes {
+    display: flex;
+    flex-direction: column;
+}
+div.field-multiple-checkboxes > label {
+    cursor: pointer;
+}
+div.field-multiple-checkboxes > label:hover {
+    text-decoration: underline;
+}
+</style>

--- a/resources/js/app/components/form/field-password.vue
+++ b/resources/js/app/components/form/field-password.vue
@@ -1,0 +1,91 @@
+<template>
+    <div class="field-password">
+        <input
+            :id="id"
+            :name="name"
+            :data-ref="reference"
+            autocomplete="new-password"
+            class="password"
+            data-original-value=""
+            :placeholder="getI18n('password', 'password')"
+            type="password"
+            value=""
+            v-model="password"
+            @change="change($event.target.value)"
+        >
+        <input
+            :id="confirmPasswordField"
+            :name="confirmPasswordField"
+            autocomplete="new-password"
+            class="password"
+            data-original-value=""
+            :placeholder="getI18n('confirm-password', 'confirm password')"
+            type="password"
+            value=""
+            v-model="confirmPassword"
+            @change="change($event.target.value)"
+        >
+        <span v-if="password && password === confirmPassword">
+            <app-icon
+                icon="carbon:checkmark"
+                color="green"
+            />
+        </span>
+        <span v-if="password !== confirmPassword">
+            <app-icon
+                icon="carbon:misuse"
+                color="red"
+            />
+        </span>
+    </div>
+</template>
+<script>
+export default {
+    name: 'FieldPassword',
+    props: {
+        id: {
+            type: String,
+            required: true
+        },
+        name: {
+            type: String,
+            required: true
+        },
+        reference: {
+            type: String,
+            default: ''
+        },
+        value: {
+            type: String,
+            default: ''
+        },
+    },
+    data() {
+        return {
+            confirmPassword: '',
+            confirmPasswordField: 'confirm-password',
+            confirmPasswordTitle: 'Confirm Password',
+            password: '',
+        };
+    },
+    methods: {
+        change(value) {
+            if (this.confirmPassword && this.password !== this.confirmPassword) {
+                return;
+            }
+            this.$emit('change', value);
+        },
+        getI18n(field, defaultValue) {
+            return BEDITA_I18N?.[field] || defaultValue;
+        },
+    },
+}
+</script>
+<style scoped>
+div.field-password {
+    display: grid;
+    grid-template-columns: 1fr 1fr 50px;
+    gap: 10px;
+    align-items: center;
+}
+</style>

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -546,7 +546,7 @@ class ModulesComponent extends Component
             return true;
         }
         $methods = (array)Hash::extract($relatedData, '{n}.method');
-        if (in_array('addRelated', $methods) || in_array('removeRelated', $methods)) {
+        if (in_array('addRelated', $methods) || in_array('removeRelated', $methods) || empty($id)) {
             return false;
         }
         // check replaceRelated

--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -145,8 +145,12 @@ class SchemaComponent extends Component
         // add special property `roles` to `users`
         if ($type === 'users') {
             $schema['properties']['roles'] = [
-                'type' => 'string',
-                'enum' => $this->fetchRoles(),
+                'type' => 'array',
+                'items' => [
+                    'type' => 'string',
+                    'enum' => $this->fetchRoles(),
+                ],
+                'uniqueItems' => true,
             ];
         }
         $categories = $this->fetchCategories($type);

--- a/src/Controller/ModulesController.php
+++ b/src/Controller/ModulesController.php
@@ -15,7 +15,6 @@ namespace App\Controller;
 use App\Utility\ApiConfigTrait;
 use App\Utility\CacheTools;
 use App\Utility\Message;
-use App\Utility\PermissionsTrait;
 use App\Utility\Schema;
 use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\Utility\ApiTools;
@@ -46,7 +45,6 @@ use Psr\Log\LogLevel;
 class ModulesController extends AppController
 {
     use ApiConfigTrait;
-    use PermissionsTrait;
 
     /**
      * Object type currently used

--- a/tests/TestCase/Controller/AppControllerTest.php
+++ b/tests/TestCase/Controller/AppControllerTest.php
@@ -56,6 +56,7 @@ use stdClass;
 #[CoversMethod(AppController::class, 'loginRedirectRoute')]
 #[CoversMethod(AppController::class, 'prepareRequest')]
 #[CoversMethod(AppController::class, 'prepareDateRanges')]
+#[CoversMethod(AppController::class, 'prepareRoles')]
 #[CoversMethod(AppController::class, 'prepareRelations')]
 #[CoversMethod(AppController::class, 'relatedIds')]
 #[CoversMethod(AppController::class, 'setupOutputTimezone')]
@@ -508,6 +509,31 @@ class AppControllerTest extends TestCase
                             'end_date' => '',
                         ],
                     ]),
+                ],
+            ],
+            'roles' => [
+                'users', // object_type
+                [ // expected
+                    'id' => '5',
+                    'username' => 'mario',
+                    '_api' => [
+                        [
+                            'method' => 'replaceRelated',
+                            'id' => '5',
+                            'relation' => 'roles',
+                            'relatedIds' => [
+                                [
+                                    'id' => '1',
+                                    'type' => 'roles',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [ // data provided
+                    'id' => '5',
+                    'username' => 'mario',
+                    'roles' => json_encode(['admin']),
                 ],
             ],
             'relations' => [

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -491,8 +491,12 @@ class SchemaComponentTest extends TestCase
         static::assertNotEmpty($result['properties']['roles']);
 
         $expected = [
-            'type' => 'string',
-            'enum' => ['admin', 'manager'],
+            'type' => 'array',
+            'items' => [
+                'type' => 'string',
+                'enum' => ['admin', 'manager'],
+            ],
+            'uniqueItems' => true,
         ];
         static::assertEquals($expected, $result['properties']['roles']);
     }


### PR DESCRIPTION
This provides an update to allow `password` and `roles` in fast create user form.

Password is handled through 2 fields (password and confirm password).

Roles are handled as checkboxes.

<img width="1235" height="583" alt="image" src="https://github.com/user-attachments/assets/6f87a1f5-a9f7-43ea-aadf-90f10b719303" />
