### PR TITLE
Restore module index header

### DIFF
--- a/templates/Pages/Modules/index.twig
+++ b/templates/Pages/Modules/index.twig
@@ -1,7 +1,7 @@
 {% do _view.assign('title', __(currentModule.name|humanize)) %}
 {% set indexViewType = Layout.moduleIndexViewType() %}
 
-{% if not indexViewType in ['calendar', 'tree-compact'] %}
+{% if indexViewType not in ['calendar', 'tree-compact'] %}
     {{ element('Modules/index_header', { 'meta': meta, 'filter': filter, 'Schema': Schema, 'hidePagination': indexViewType == 'tree'}) }}
 {% endif %}
 


### PR DESCRIPTION
With https://github.com/bedita/manager/pull/1335 we introduced a bug: modules index header disappeared. This fixes the bug.