### PR TITLE
Development playground

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -12,6 +12,7 @@
 # development workflow over standard environment variables.
 export APP_NAME="__APP_NAME__"
 export DEBUG="false"
+export DEVELOPMENT="false"
 export APP_ENCODING="UTF-8"
 export APP_DEFAULT_LOCALE="en_US"
 

--- a/config/app.php
+++ b/config/app.php
@@ -16,6 +16,17 @@ return [
      */
     'debug' => filter_var(env('DEBUG', true), FILTER_VALIDATE_BOOLEAN),
 
+    /*
+     * Development Mode:
+     *
+     * Production Mode:
+     * false: Development mode is off.
+     *
+     * Development Mode:
+     * true: Development mode is on.
+     */
+    'development' => filter_var(env('DEVELOPMENT', false), FILTER_VALIDATE_BOOLEAN),
+
     /**
      * Configure basic information about the application.
      *

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -17,6 +17,17 @@ return [
      */
     // 'debug' => filter_var(env('DEBUG', true), FILTER_VALIDATE_BOOLEAN),
 
+    /*
+     * Development Mode:
+     *
+     * Production Mode:
+     * false: Development mode is off.
+     *
+     * Development Mode:
+     * true: Development mode is on.
+     */
+    // 'development' => filter_var(env('DEVELOPMENT', true), FILTER_VALIDATE_BOOLEAN),
+
     /**
      * Modules accesses per role(s)
      */

--- a/config/routes.php
+++ b/config/routes.php
@@ -97,6 +97,11 @@ $routes->scope('/', function (RouteBuilder $routes): void {
         ['_name' => 'dashboard:messages'],
     );
     $routes->connect(
+        '/dev/playground',
+        ['controller' => 'Playground', 'action' => 'index'],
+        ['_name' => 'playground'],
+    );
+    $routes->connect(
         '/tree',
         ['controller' => 'Tree', 'action' => 'get'],
         ['_name' => 'tree:get'],

--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -113,6 +113,7 @@ const _vueInstance = new Vue({
         FieldTextarea: () => import(/* webpackChunkName: "field-textarea" */'app/components/form/field-textarea'),
         FieldTitle: () => import(/* webpackChunkName: "field-title" */'app/components/form/field-title'),
         CalendarView: () => import(/* webpackChunkName: "calendar-view" */'app/components/calendar-view/calendar-view'),
+        ComponentsPlayground: () => import(/* webpackChunkName: "components-playground" */'app/components/components-playground'),
         ObjectInfo: () => import(/* webpackChunkName: "object-info" */'app/components/object-info/object-info'),
         RelatedObjectsFilter: () => import(/* webpackChunkName: "related-objects-filter" */'app/components/related-objects-filter/related-objects-filter'),
         ModuleProperties: () => import(/* webpackChunkName: "module-properties" */'app/components/module/module-properties'),

--- a/resources/js/app/components/components-playground.vue
+++ b/resources/js/app/components/components-playground.vue
@@ -1,0 +1,303 @@
+<template>
+    <div class="components-playground">
+        <div class="header">
+            <h3 class="title">🧪 Vue Components</h3>
+        </div>
+
+        <div class="content">
+            <!-- KeyValueList -->
+            <div class="box">
+                <div class="box-header" @click="toggleSection('keyValueList')">
+                    <h4 class="box-title">KeyValueList</h4>
+                    <button class="section-toggle-btn">
+                        {{ sections.keyValueList ? '▼' : '▶' }}
+                    </button>
+                </div>
+                <div v-if="sections.keyValueList" class="box-content">
+                    <p class="box-description">
+                        Expected: <code>"Custom Properties"</code> from "custom_properties"
+                    </p>
+                    <key-value-list
+                        name="migration_test_keyvalue"
+                        label="custom_properties"
+                        :value="keyValueListValue"
+                    />
+
+                    <div class="source-code-toggle">
+                        <button @click="toggleSource('keyValueList')" class="source-toggle-btn">
+                            {{ showSource.keyValueList ? '▼' : '▶' }} View Source Code
+                        </button>
+                    </div>
+
+                    <pre v-if="showSource.keyValueList" class="source-code"><code>&lt;key-value-list
+    name="migration_test_keyvalue"
+    label="custom_properties"
+    :value="keyValueListValue"
+/&gt;
+
+data() {
+    return {
+        keyValueListValue: '{"key1": "value1", "key2": "value2"}'
+    };
+}</code></pre>
+
+                    <div class="checklist">
+                        <strong class="checklist-title">✓ Verification</strong>
+                        <ul class="checklist-items">
+                            <li>Label is humanized (underscores → spaces, Title Case)</li>
+                            <li>Add/Remove buttons work</li>
+                            <li>No console errors (F12 → Console)</li>
+                            <li>No "unknown filter" warnings</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+
+            <!-- String List -->
+            <div class="box">
+                <div class="box-header" @click="toggleSection('stringList')">
+                    <h4 class="box-title">String List</h4>
+                    <button class="section-toggle-btn">
+                        {{ sections.stringList ? '▼' : '▶' }}
+                    </button>
+                </div>
+                <div v-if="sections.stringList" class="box-content">
+                    <p class="box-description">
+                        Expected: <code>"My Test Field"</code> from "my_test_field"
+                    </p>
+                    <string-list
+                        name="migration_test_string"
+                        label="my_test_field"
+                        :value="stringListValue"
+                    />
+
+                    <div class="source-code-toggle">
+                        <button @click="toggleSource('stringList')" class="source-toggle-btn">
+                            {{ showSource.stringList ? '▼' : '▶' }} View Source Code
+                        </button>
+                    </div>
+
+                    <pre v-if="showSource.stringList" class="source-code"><code>&lt;string-list
+    name="migration_test_string"
+    label="my_test_field"
+    :value="stringListValue"
+/&gt;
+
+data() {
+    return {
+        stringListValue: '["test item 1", "test item 2"]'
+    };
+}</code></pre>
+
+                    <div class="checklist">
+                        <strong class="checklist-title">✓ Verification</strong>
+                        <ul class="checklist-items">
+                            <li>Label is humanized (underscores → spaces, Title Case)</li>
+                            <li>Add button works</li>
+                            <li>No console errors (F12 → Console)</li>
+                            <li>No "unknown filter" warnings</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'ComponentsPlayground',
+
+    components: {
+        KeyValueList: () => import(/* webpackChunkName: "key-value-list" */ 'app/components/json-fields/key-value-list'),
+        StringList: () => import(/* webpackChunkName: "string-list" */ 'app/components/json-fields/string-list'),
+    },
+
+    data() {
+        return {
+            sections: {
+                stringList: false,
+                keyValueList: false,
+            },
+            showSource: {
+                stringList: false,
+                keyValueList: false,
+            },
+            stringListValue: '["test item 1", "test item 2"]',
+            keyValueListValue: '{"key1": "value1", "key2": "value2"}',
+        };
+    },
+
+    methods: {
+        toggleSection(section) {
+            this.sections[section] = !this.sections[section];
+        },
+        toggleSource(section) {
+            this.showSource[section] = !this.showSource[section];
+        }
+    }
+};
+</script>
+
+<style scoped>
+.components-playground {
+    background: #3c3f45;
+    border: 1px solid #52565e;
+    border-radius: 6px;
+    padding: 20px;
+    margin: 20px 0;
+    color: #ffffff;
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 15px;
+    border-bottom: 1px solid #52565e;
+    padding-bottom: 15px;
+}
+
+.title {
+    margin: 0;
+    color: #ffffff;
+    font-size: 1.1em;
+    font-weight: 500;
+}
+
+.content {
+    margin-top: 0;
+}
+
+.box {
+    background: #2e3138;
+    margin: 10px 0;
+    border-radius: 4px;
+    border: 1px solid #52565e;
+    color: #ffffff;
+}
+
+.box-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.box-header:hover {
+    background: #33363d;
+}
+
+.box-title {
+    margin: 0;
+    color: #ffffff;
+    font-size: 1em;
+    font-weight: 500;
+}
+
+.section-toggle-btn {
+    background: transparent;
+    border: none;
+    color: #ffffff;
+    font-size: 0.9em;
+    cursor: pointer;
+    padding: 0 8px;
+}
+
+.box-content {
+    padding: 0 15px 15px 15px;
+}
+
+.box-description {
+    font-size: 0.85em;
+    color: #b8bcc4;
+    margin: 0 0 10px 0;
+}
+
+.box-description code {
+    background: #52565e;
+    padding: 2px 6px;
+    border-radius: 3px;
+    color: #ffffff;
+}
+
+/* Ensure all nested content has proper text colors */
+.box ::v-deep input,
+.box ::v-deep textarea,
+.box ::v-deep label,
+.box ::v-deep div,
+.box ::v-deep span,
+.box ::v-deep button {
+    color: inherit;
+}
+
+.box ::v-deep input,
+.box ::v-deep textarea {
+    color: #212529 !important;
+    background: #f8f9fa;
+    border: 1px solid #ced4da;
+}
+
+.box ::v-deep button {
+    color: #212529 !important;
+}
+
+.source-code-toggle {
+    margin: 15px 0 10px 0;
+}
+
+.source-toggle-btn {
+    background: #3c3f45;
+    border: 1px solid #52565e;
+    color: #b8bcc4;
+    padding: 6px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+}
+
+.source-toggle-btn:hover {
+    background: #52565e;
+    color: #ffffff;
+}
+
+.source-code {
+    background: #1e1e1e;
+    border: 1px solid #52565e;
+    border-radius: 4px;
+    padding: 12px;
+    margin: 10px 0;
+    overflow-x: auto;
+    font-size: 0.85em;
+    line-height: 1.5;
+}
+
+.source-code code {
+    color: #d4d4d4;
+    font-family: 'Courier New', Courier, monospace;
+}
+
+.checklist {
+    background: #2e3e4e;
+    padding: 12px;
+    margin: 15px 0 0 0;
+    border-radius: 4px;
+    border-left: 3px solid #4a90e2;
+}
+
+.checklist-title {
+    color: #ffffff;
+    font-size: 0.9em;
+}
+
+.checklist-items {
+    margin: 8px 0 0 0;
+    padding-left: 20px;
+    color: #e0e0e0;
+    font-size: 0.85em;
+    line-height: 1.6;
+}
+</style>

--- a/src/Controller/PlaygroundController.php
+++ b/src/Controller/PlaygroundController.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2026 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace App\Controller;
+
+use Cake\Core\Configure;
+
+/**
+ * Playground controller for testing Vue components in development.
+ * Only accessible in DEVELOPMENT mode.
+ *
+ * {@codeCoverageIgnore}
+ */
+class PlaygroundController extends AppController
+{
+    /**
+     * @inheritDoc
+     */
+    public function initialize(): void
+    {
+        if (Configure::read('development') !== true) {
+            $this->redirect(['controller' => 'Dashboard', 'action' => 'index']);
+        }
+        parent::initialize();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function index(): void
+    {
+        $this->getRequest()->allowMethod(['get']);
+    }
+}

--- a/templates/Element/Menu/sidebar.twig
+++ b/templates/Element/Menu/sidebar.twig
@@ -39,9 +39,10 @@
 
     <div class="sidebar-body">
 
+        {% set devMode = config('development') %}
         {% if I18n.getLanguages|length > 1 %}
-            <div>
-                <p class="has-text-size-smaller">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <p class="has-text-size-smaller" style="margin: 0;">
                 {% for code, name in I18n.getLanguages() %}
                     {% if code != I18n.getLang() %}
                         <a href="{{ I18n.changeUrlLang(code, config('I18n.switchLangUrl')) }}">{{ name[:3] | upper }}</a>
@@ -51,6 +52,17 @@
                     {% if not loop.last %} | {% endif %}
                 {% endfor %}
                 </p>
+                {% if devMode %}
+                <a href="{{ Url.build({'_name': 'playground'}) }}" style="font-size: 0.75em; text-decoration: none; color: #999; opacity: 0.6;" title="Playground">
+                    🧪 Playground
+                </a>
+                {% endif %}
+            </div>
+        {% elseif devMode %}
+            <div>
+                <a href="{{ Url.build({'_name': 'playground'}) }}" style="font-size: 0.75em; text-decoration: none; color: #999; opacity: 0.6;">
+                    🧪 Playground
+                </a>
             </div>
         {% endif %}
 

--- a/templates/Pages/Playground/index.twig
+++ b/templates/Pages/Playground/index.twig
@@ -1,0 +1,6 @@
+{% do _view.assign('title', 'Components Playground') %}
+{% do _view.assign('bodyViewClass', 'view-playground') %}
+
+<div class="playground-page">
+    <components-playground></components-playground>
+</div>


### PR DESCRIPTION
This introduces a development playground page to test UI/UX and usage of vue components.

<img width="1022" height="972" alt="image" src="https://github.com/user-attachments/assets/d2a63404-22c4-4542-a580-ad45429b0bc9" />

This is useful to test components (also for migrating from vue2 to vue3).

To enable it locally, set `development` to `true` in local configuration (`.env` or `app_local.php`).

Ref: https://github.com/bedita/manager/issues/1147