### PR TITLE
Fix 5.x release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     uses: bedita/github-workflows/.github/workflows/release.yml@v2
     with:
       main_branch: 'master'
-      dist_branches: '["master", "4.x"]'
+      dist_branches: '["master", "4.x", "5.x"]'
       version_bump: ${{ inputs.releaseType }}
       version_ini_path: config/version.ini
       version_ini_prefix: "[Manager]\nversion="


### PR DESCRIPTION
This is to solve a bug when merging 5.x PRs. We expect that patch release is automatically created from versions 5.m.p