### PR TITLE
Cakephp 5.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "bedita/i18n": "^6.0.0",
         "bedita/web-tools": "^6.0.0",
         "cakephp/authentication": "^3.0.3",
-        "cakephp/cakephp": "^5.0",
+        "cakephp/cakephp": "~5.2.0",
         "cakephp/plugin-installer": "^1.3",
         "josegonzalez/dotenv": "^4.0",
         "league/flysystem": "^3.16",


### PR DESCRIPTION
Use temporarily cakephp version 5.2.x to avoid compatibility errors with version 5.3