### PR TITLE
Composer dependency cakephp ^5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "bedita/i18n": "^6.0.0",
         "bedita/web-tools": "^6.0.0",
         "cakephp/authentication": "^3.0.3",
-        "cakephp/cakephp": "~5.2.0",
+        "cakephp/cakephp": "^5.2",
         "cakephp/plugin-installer": "^1.3",
         "josegonzalez/dotenv": "^4.0",
         "league/flysystem": "^3.16",


### PR DESCRIPTION
After https://github.com/bedita/web-tools/releases/tag/v6.0.4 web-tools fixed a deprecation introduced by cakephp 5.3.
This restores `cakephp ^5.2` composer dependency .