### PR TITLE
Fix: avoid calling GET /model/schema on translations and trash

### DIFF
--- a/src/Controller/Component/SchemaComponent.php
+++ b/src/Controller/Component/SchemaComponent.php
@@ -138,6 +138,9 @@ class SchemaComponent extends Component
      */
     protected function fetchSchema(string $type): array|bool
     {
+        if (in_array($type, ['translations', 'trash'])) {
+            return false;
+        }
         $schema = ApiClientProvider::getApiClient()->schema($type);
         if (empty($schema)) {
             return false;

--- a/tests/TestCase/Controller/Component/SchemaComponentTest.php
+++ b/tests/TestCase/Controller/Component/SchemaComponentTest.php
@@ -829,4 +829,26 @@ class SchemaComponentTest extends TestCase
         static::assertContains('documents', $actual);
         static::assertContains('images', $actual);
     }
+
+    /**
+     * Test `fetchSchema` for `trash`.
+     *
+     * @return void
+     */
+    public function testFetchTrashSchema(): void
+    {
+        $actual = $this->Schema->getSchema('trash');
+        static::assertFalse($actual);
+    }
+
+    /**
+     * Test `fetchSchema` for `translations`.
+     *
+     * @return void
+     */
+    public function testFetchTranslationsSchema(): void
+    {
+        $actual = $this->Schema->getSchema('translations');
+        static::assertFalse($actual);
+    }
 }


### PR DESCRIPTION
This provides a fix on fetchSchema to avoid some buggy calls like `GET /model/schema/translations` and `GET /model/schema/trash`.