### PR TITLE
View object annotations

### DIFF
--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -122,6 +122,7 @@ const _vueInstance = new Vue({
         UploadedObject: () => import(/* webpackChunkName: "uploaded-object" */'app/components/uploaded-object/uploaded-object.vue'),
         RibbonItem: () => import(/* webpackChunkName: "ribbon-item" */'./components/ribbon-item/ribbon-item.vue'),
         MailPreview: () => import(/* webpackChunkName: "mail-preview" */'./components/mail-preview/mail-preview.vue'),
+        ObjectAnnotations: () => import(/* webpackChunkName: "object-annotations" */'./components/object-annotations/object-annotations.vue'),
         AppIcon,
     },
 
@@ -657,3 +658,4 @@ Vue.component('RelatedObjectsFilter', _vueInstance.$options.components.RelatedOb
 Vue.component('Thumbnail', _vueInstance.$options.components.Thumbnail);
 Vue.component('RibbonItem', _vueInstance.$options.components.RibbonItem);
 Vue.component('UploadedObject', _vueInstance.$options.components.UploadedObject);
+Vue.component('ObjectAnnotations', _vueInstance.$options.components.ObjectAnnotations);

--- a/resources/js/app/components/module/module-setup.vue
+++ b/resources/js/app/components/module/module-setup.vue
@@ -54,6 +54,20 @@
                     @change="change"
                 />
             </div>
+            <div
+                class="input checkbox"
+                v-for="field in boolFields"
+                :key="field"
+            >
+                <input
+                    type="checkbox"
+                    :name="field"
+                    v-model="map[field]"
+                >
+                <label :for="field">
+                    {{ field }}
+                </label>
+            </div>
             <div>
                 <template v-if="success">
                     <button @click.prevent="skip">
@@ -110,6 +124,7 @@ export default {
                 'sort',
                 'route',
                 'sidebar',
+                'annotations',
             ],
             jsonEditorOptions: {
                 mainMenuBar: true,
@@ -118,6 +133,7 @@ export default {
                 statusBar: false,
                 readOnly: false,
             },
+            boolFields: ['annotations'],
             jsonFields: ['route', 'sidebar'],
             loading: false,
             otherFields: ['color', 'icon', 'shortLabel', 'sort'],
@@ -128,6 +144,7 @@ export default {
                 icon: '',
                 sidebar: '',
                 route: '',
+                annotations: false,
             },
             samples: {
                 color: 'i.e. #FF0000',
@@ -260,5 +277,15 @@ div.module-setup input {
 div.module-setup .tab {
     cursor: pointer;
     border-bottom: solid #FFF 1px;
+}
+div.module-setup .checkbox {
+    flex-direction: row;
+    align-items: center;
+}
+div.module-setup .checkbox > label {
+    margin-left: 0.5rem;
+}
+div.module-setup .checkbox > input {
+    width: auto;
 }
 </style>

--- a/resources/js/app/components/object-annotations/object-annotations.vue
+++ b/resources/js/app/components/object-annotations/object-annotations.vue
@@ -1,0 +1,103 @@
+<template>
+    <div class="object-annotations">
+        <div
+            class="loading"
+            v-if="loading"
+        >
+            <span class="is-loading-spinner" />
+            <span class="ml-05">{{ msgLoading }} ...</span>
+        </div>
+        <div v-if="list?.length === 0 && !loading">{{ msgNoItemsFound }}</div>
+        <div v-for="item in list" :key="item.id">
+            <div class="annotation-message">{{ item.attributes.description }}</div>
+            <div class="annotation-meta">
+                <a v-if="getAuthorUrl(item)" :href="getAuthorUrl(item)">
+                    {{ getAuthor(item) }}
+                </a>
+                <span v-else>{{ getAuthor(item) }}</span>,
+                {{ getCreated(item) }}
+            </div>
+        </div>
+    </div>
+</template>
+<script>
+import { t } from 'ttag';
+
+export default {
+    name: 'ObjectAnnotations',
+    props: {
+        objectId: {
+            type: Number,
+            required: true,
+        },
+        userId: {
+            type: Number,
+            required: false,
+            default: null,
+        },
+        userRoles: {
+            type: Array,
+            required: false,
+            default: () => [],
+        },
+    },
+    data() {
+        return {
+            list: [],
+            loading: false,
+            msgLoading: t`Loading`,
+            msgNoItemsFound: t`No items found`,
+            msgUser: t`User`,
+        };
+    },
+    mounted() {
+        this.fetchAnnotations();
+    },
+    methods: {
+        async fetchAnnotations() {
+            try {
+                this.loading = true;
+                const baseUrl = new URL(BEDITA.base).pathname;
+                const response = await fetch(`${baseUrl}api/annotations?filter[object_id]=${this.objectId}`, {
+                    credentials: 'same-origin',
+                    headers: {
+                        accept: 'application/json',
+                    }
+                });
+                const json = await response.json();
+                this.list = json.data;
+            } catch (error) {
+                console.error('Error fetching annotations:', error);
+            } finally {
+                this.loading = false;
+            }
+        },
+        getAuthor(item) {
+            return item.attributes.params?.author || `${this.msgUser} ${item.meta?.user_id}`;
+        },
+        getAuthorUrl(item) {
+            if (!this.userRoles.includes('admin') && !BEDITA?.canReadUsers) {
+                return null;
+            }
+            return `/users/view/${item.meta?.user_id}`;
+        },
+        getCreated(item) {
+            return this.$helpers.formatDate(item.meta.created);
+        },
+    },
+};
+</script>
+<style scoped>
+.object-annotations {
+    margin-top: 1em;
+}
+.annotation-message {
+    font-size: 1em;
+    margin-bottom: 0.25em;
+}
+.annotation-meta {
+    font-size: 0.85em;
+    color: #666;
+    margin-bottom: 1em;
+}
+</style>

--- a/templates/Element/Form/annotations.twig
+++ b/templates/Element/Form/annotations.twig
@@ -1,0 +1,16 @@
+{% set cfg = config('Modules.' ~ object.type ~ '.annotations') %}
+{% if cfg and object and object.id %}
+<property-view inline-template :tab-open="tabsOpen" tab-name="annotations" ref={{ resourceName }}>
+    <section class="fieldset order-{{ cssOrder }}" :class="isOpen? '' : 'closed'">
+        <header @click.prevent="toggleVisibility();" class="tab unselectable" :class="isOpen? 'open has-border-module-{{ currentModule.name }}' : ''">
+            <h2>
+                {{ __('Annotations') }}
+            </h2>
+        </header>
+        <div v-show="isOpen" class="tab-container">
+            <object-annotations :object-id="{{ object.id }}" :user-id="{{ user.id }}" :user-roles="{{ user.roles|json_encode }}"></object-annotations>
+        </div>
+    </section>
+</property-view>
+{% endif %}
+

--- a/templates/Pages/Modules/view.twig
+++ b/templates/Pages/Modules/view.twig
@@ -77,6 +77,8 @@
 
                 {{ element('Form/related_translations', {'resourceName': 'translations'}) }}
 
+                {{ element('Form/annotations') }}
+
                 {{ element('Form/meta') }}
 
                 {{ element('Form/advanced_properties') }}


### PR DESCRIPTION
With this, you can see objects "annotations" in a specific section, inside the object view.

<img width="333" height="253" alt="image" src="https://github.com/user-attachments/assets/5413d535-ce24-427c-8d0f-8d281490658e" />

To enable it per module, adjust module configuration.

<img width="1230" height="901" alt="image" src="https://github.com/user-attachments/assets/08224ebb-87f9-40ac-aaec-9fcdf9ce5532" />
