### PR TITLE
fix: set default debug mode to false

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -14,7 +14,7 @@ return [
      * Development Mode:
      * true: Errors and warnings shown.
      */
-    'debug' => filter_var(env('DEBUG', true), FILTER_VALIDATE_BOOLEAN),
+    'debug' => filter_var(env('DEBUG', false), FILTER_VALIDATE_BOOLEAN),
 
     /*
      * Development Mode:


### PR DESCRIPTION
This PR makes a minor configuration change to the `config/app.php` file, updating the default value of the `DEBUG` environment variable from `true` to `false`. 
This means that, unless explicitly set otherwise, the application will now run with debugging disabled by default.