### PR TITLE
[5.x] Review UI/UX in related item section

### DIFF
--- a/templates/Element/Form/related_item.twig
+++ b/templates/Element/Form/related_item.twig
@@ -161,7 +161,7 @@
 
     {# BUTTONS #}
     {% if Perms.canSave() %}
-    <footer class="is-flex mt-05 p-05">
+    <footer class="is-flex mt-05 p-05" :class="{ 'last-child-auto': !dataList }">
         {% if stage %}
             <a class="button button-outlined-white is-small mr-1" :href="$helpers.buildViewUrl(related.id)" target="_blank">
                 <app-icon icon="carbon:launch"></app-icon>

--- a/templates/Element/Form/related_item.twig
+++ b/templates/Element/Form/related_item.twig
@@ -57,7 +57,7 @@
                 <span class="tag is-dark"><: related.attributes.lang :></span>
             {% else %}
                 <template v-if="dataList">
-                    <span class="tag ml-2" v-bind:class="'has-background-module-' + related.type"><: related.type :></span>
+                    <span class="tag ml-2" v-bind:class="'has-background-module-' + related.type" style="min-width: 7em;"><: related.type :></span>
                 </template>
                 <template v-else>
                     <span class="tag" v-bind:class="'has-background-module-' + related.type"><: related.type :></span>
@@ -65,7 +65,7 @@
 
                 <span class="icon-calendar-check-o" v-title="datesInfo(related)"></span>
             {% endif %}
-            <span class="status is-uppercase has-text-size-smallest" :class="related.attributes.status" v-if="related.attributes.status"><: related.attributes.status :></span>
+            <span class="status is-uppercase has-text-size-smallest" :class="related.attributes.status" style="min-width: 5em;" v-if="related.attributes.status"><: related.attributes.status :></span>
 
         </div>
 
@@ -77,12 +77,12 @@
         <header class="is-flex space-between mt-05">
             <div>
 
-                <h3 class="title m-0 has-text-size-small" style="padding-bottom: 7px;">
+                <h3 class="title m-0 has-text-size-small" style="min-width: 17em; padding-bottom: 7px;">
                     {% if translation %}
-                        <span v-html="truncate(related.attributes.translated_fields.title, 50)" :title=" related.attributes.translated_fields.title" v-if=" related.attributes.translated_fields && related.attributes.translated_fields.title ">
+                        <span v-html="truncate(related.attributes.translated_fields.title, 100)" :title=" related.attributes.translated_fields.title" v-if=" related.attributes.translated_fields && related.attributes.translated_fields.title ">
                         </span>
                     {% else %}
-                        <span v-html="truncate(related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-', 50)" :title=" related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-' ">
+                        <span v-html="truncate(related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-', 100)" :title=" related?.attributes?.title || related?.attributes?.name || related?.attributes?.uname || '-' ">
                         </span>
                     {% endif %}
                 </h3>
@@ -161,7 +161,7 @@
 
     {# BUTTONS #}
     {% if Perms.canSave() %}
-    <footer class="is-flex space-between mt-05 p-05">
+    <footer class="is-flex mt-05 p-05">
         {% if stage %}
             <a class="button button-outlined-white is-small mr-1" :href="$helpers.buildViewUrl(related.id)" target="_blank">
                 <app-icon icon="carbon:launch"></app-icon>

--- a/templates/Element/Form/relations.scss
+++ b/templates/Element/Form/relations.scss
@@ -208,11 +208,6 @@
             }
         }
 
-        footer {
-            a:last-child {
-                margin-left: auto;
-            }
-        }
     }
 
     &.removed {

--- a/templates/Element/Form/relations.scss
+++ b/templates/Element/Form/relations.scss
@@ -208,6 +208,11 @@
             }
         }
 
+        footer.last-child-auto {
+            > :last-child {
+                margin-left: auto;
+            }
+        }
     }
 
     &.removed {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2015,9 +2015,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001688:
-  version "1.0.30001731"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz"
-  integrity sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==
+  version "1.0.30001776"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz"
+  integrity sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==
 
 chalk@4.1.2, chalk@^4.0.0:
   version "4.1.2"


### PR DESCRIPTION
This provides a UI/UX fix to better align elements in related item section.

Related item title occupies more space and it's truncated at 100 characters (50 characters, before this patch).

<img width="2077" height="639" alt="image" src="https://github.com/user-attachments/assets/997c9bce-1226-4b09-837a-0d53ba23c7f6" />

An example of how it was before this patch follows:

<img width="1390" height="808" alt="image" src="https://github.com/user-attachments/assets/a1c7b6f4-3716-4da0-9df2-896bc6eb8168" />

