### PR TITLE
Launch unit-5 (BEdita API and Core 5.x) with php 8.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -39,7 +39,7 @@ jobs:
   unit-5:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v2
     with:
-      php_versions: '["8.3"]'
+      php_versions: '["8.3","8.4"]'
       bedita_version: '5'
       coverage_min_percentage: 98
 


### PR DESCRIPTION
This updates php workflow to launch phpunit against BEdita 5 with php 8.4 too.