### PR TITLE
[5.x] Created/Modified by user columns in module index

### DIFF
--- a/config/i18n_strings.php
+++ b/config/i18n_strings.php
@@ -30,6 +30,8 @@
 //  __('title');
 //  __('All media');
 //  __('Created');
+//  __('Created By User');
+//  __('Modified By User');
 //  __('Updated');
 //  __('Trashd');
 //  __('Restored');

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2025-08-26 08:17:45 \n"
+"POT-Creation-Date: 2026-03-10 13:13:21 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -200,6 +200,9 @@ msgid "Create a new tag"
 msgstr ""
 
 msgid "Created"
+msgstr ""
+
+msgid "Created By User"
 msgstr ""
 
 msgid "Created ↑ Oldest on top"
@@ -512,6 +515,9 @@ msgid "Missing thumb url"
 msgstr ""
 
 msgid "Modified"
+msgstr ""
+
+msgid "Modified By User"
 msgstr ""
 
 msgid "Modified ↑ Oldest on top"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2025-08-26 08:17:45 \n"
+"POT-Creation-Date: 2026-03-10 13:13:21 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -203,6 +203,9 @@ msgid "Create a new tag"
 msgstr ""
 
 msgid "Created"
+msgstr ""
+
+msgid "Created By User"
 msgstr ""
 
 msgid "Created ↑ Oldest on top"
@@ -515,6 +518,9 @@ msgid "Missing thumb url"
 msgstr ""
 
 msgid "Modified"
+msgstr ""
+
+msgid "Modified By User"
 msgstr ""
 
 msgid "Modified ↑ Oldest on top"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2025-08-26 08:17:45 \n"
+"POT-Creation-Date: 2026-03-10 13:13:21 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -206,6 +206,9 @@ msgstr "Crea nuovo tag"
 
 msgid "Created"
 msgstr "Creato"
+
+msgid "Created By User"
+msgstr "Creato da"
 
 msgid "Created ↑ Oldest on top"
 msgstr "Creazione ↑ Meno recenti in testa"
@@ -519,6 +522,9 @@ msgstr "Url miniatura mancante"
 
 msgid "Modified"
 msgstr "Modificato"
+
+msgid "Modified By User"
+msgstr "Modificato da"
 
 msgid "Modified ↑ Oldest on top"
 msgstr "Data di modifica ↑ Meno recenti in testa"

--- a/resources/js/app/components/index-cell/index-cell.vue
+++ b/resources/js/app/components/index-cell/index-cell.vue
@@ -40,6 +40,7 @@
                         class="ml-05"
                         v-for="f in relatedFields"
                         :key="f"
+                        @click.stop.prevent="openRelated(related?.[0])"
                     >
                         <template v-if="f == 'media_url'">
                             <img :src="thumb(0)">
@@ -48,6 +49,12 @@
                             {{ related?.[0]?.attributes?.[f] || related?.[0]?.meta?.[f] }}
                         </template>
                     </span>
+                    <span
+                        class="open-new-tab-icon"
+                        v-if="hasRelatedLink(related?.[0])"
+                    >
+                        <app-icon icon="carbon:launch" />
+                    </span>
                 </div>
                 <div
                     class="related-toggle"
@@ -55,29 +62,34 @@
                 >
                     <button
                         class="show-toggle icon icon-only-icon"
-                        :title="msgMore"
+                        :title="relatedToggleLabel()"
                         @click.stop.prevent="relatedOpen = !relatedOpen"
                         v-if="relatedOpen"
                     >
                         <app-icon icon="carbon:subtract" />
-                        <span class="is-sr-only">{{ msgMore }}</span>
+                        <span class="is-sr-only">{{ relatedToggleLabel() }}</span>
                     </button>
                     <button
                         class="show-toggle icon icon-only-icon"
-                        :title="msgMore"
+                        :title="relatedToggleLabel()"
                         @click.stop.prevent="relatedOpen = !relatedOpen"
                         v-else
                     >
                         <app-icon icon="carbon:add" />
-                        <span class="is-sr-only">{{ msgMore }}</span>
+                        <span class="is-sr-only">{{ relatedToggleLabel() }}</span>
                     </button>
+                    <span class="tag is-smallest is-black mx-05 related-count empty">
+                        {{ relatedCountLabel() }}
+                    </span>
                 </div>
             </div>
-            <template v-if="relatedOpen">
+            <div
+                class="related-list"
+                v-if="relatedOpen"
+            >
                 <template v-for="(relatedItem, index) in related">
                     <div
                         class="related-item"
-                        @click.stop.prevent="relatedOpen = !relatedOpen"
                         :key="index"
                         v-if="index > 0"
                     >
@@ -85,6 +97,7 @@
                             class="ml-05"
                             v-for="f in relatedFields"
                             :key="f"
+                            @click.stop.prevent="openRelated(relatedItem)"
                         >
                             <template v-if="f == 'media_url'">
                                 <img :src="thumb(index)">
@@ -93,9 +106,15 @@
                                 {{ relatedItem?.attributes?.[f] || relatedItem?.meta?.[f] }}
                             </template>
                         </span>
+                        <span
+                            class="open-new-tab-icon"
+                            v-if="hasRelatedLink(relatedItem)"
+                        >
+                            <app-icon icon="carbon:launch" />
+                        </span>
                     </div>
                 </template>
-            </template>
+            </div>
         </template>
     </div>
 </template>
@@ -207,6 +226,34 @@ export default {
         reset() {
             this.msg = '';
         },
+        hasRelatedLink(relatedItem) {
+            if (relatedItem?.type === 'roles') {
+                return false;
+            }
+            return !!relatedItem?.id;
+        },
+        relatedCountLabel() {
+            const count = this.related?.length || 0;
+            if (!count) {
+                return '';
+            }
+
+            return `${this.relatedOpen ? count : 1}/${count}`;
+        },
+        relatedToggleLabel() {
+            return this.relatedCountLabel() || this.msgMore;
+        },
+        openRelated(relatedItem) {
+            const id = relatedItem?.id || null;
+            if (!id) {
+                return;
+            }
+            const url = this.$helpers?.buildViewUrl ? this.$helpers.buildViewUrl(id) : `/view/${id}`;
+            const newTab = window.open(url, '_blank');
+            if (newTab) {
+                newTab.focus();
+            }
+        },
         showCopyIcon() {
             if (this.settings?.copy2clipboard !== true) {
                 return false;
@@ -234,9 +281,46 @@ div.index-cell > div.msg {
 }
 div.index-cell div.related-container {
     display: flex;
+    align-items: flex-start;
 }
 div.index-cell div.related-item {
     display: flex;
+    flex-wrap: wrap;
+    min-width: 0;
+    color: #e6edf3;
+    align-items: center;
+    border-radius: 0.2rem;
+    transition: background-color 0.12s ease-in-out;
+}
+div.index-cell div.related-item > span {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    cursor: pointer;
+}
+div.index-cell div.related-list {
+    margin-top: 0.35rem;
+    margin-left: 0;
+}
+div.index-cell div.related-list div.related-item {
+    gap: 0.15rem 0.45rem;
+    padding: 0.2rem 0;
+}
+div.index-cell div.related-list div.related-item + div.related-item {
+    margin-top: 0.2rem;
+}
+div.index-cell div.related-item:hover {
+    background-color: #2f3943;
+}
+div.index-cell div.related-item .open-new-tab-icon {
+    opacity: 0;
+    margin-left: 0.3rem;
+    color: #c5d0db;
+    transition: opacity 0.12s ease-in-out;
+    pointer-events: none;
+}
+div.index-cell div.related-item:hover .open-new-tab-icon {
+    opacity: 1;
 }
 div.index-cell div.related-toggle {
     display: flex;
@@ -246,6 +330,9 @@ div.index-cell div.related-toggle > button {
     line-height: 1;
     height: 20px;
     cursor: cell;
+}
+div.index-cell span.related-count {
+    user-select: none;
 }
 div.index-cell img {
     margin-bottom: 0.2rem;

--- a/src/Controller/Component/QueryComponent.php
+++ b/src/Controller/Component/QueryComponent.php
@@ -35,6 +35,9 @@ class QueryComponent extends Component
         }
         $query = $this->handleInclude($query);
 
+        // add ?saved_by_refs=1 if necessary
+        $query = $this->handleSavedByRefs($query);
+
         // make sure `filter[history_editor]` is empty in order to use logged user id
         if (isset($query['filter']['history_editor'])) {
             $query['filter']['history_editor'] = '';
@@ -84,6 +87,33 @@ class QueryComponent extends Component
         }
         if (!empty($decoded)) {
             $query['include'] = implode(',', $decoded);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Add 'saved_by_refs' as query string if created_by_user or modified_by_user are
+     * in index configuration per module object type.
+     *
+     * @param array $query The query
+     * @return array
+     */
+    protected function handleSavedByRefs(array $query): array
+    {
+        $fields = array_filter(
+            (array)Configure::read(
+                sprintf(
+                    'Properties.%s.index',
+                    $this->getController()->getRequest()->getParam('object_type')
+                )
+            ),
+            function ($value) {
+                return in_array($value, ['created_by_user', 'modified_by_user']);
+            }
+        );
+        if (!empty($fields)) {
+            $query['saved_by_refs'] = 1;
         }
 
         return $query;

--- a/templates/Element/Modules/index_table_header.twig
+++ b/templates/Element/Modules/index_table_header.twig
@@ -9,16 +9,18 @@
     {% for prop in properties %}
         {% if prop is iterable %}
             {% for relationName,relationFields in prop %}
+                {% set s = Layout.tr(relationName) %}
                 <div>
-                    {{ Layout.tr(relationName) }}
+                    <span title="{{ s }}">{{ s|truncate(20) }}</span>
                 </div>
             {% endfor %}
         {% else %}
         <div class="{{ Link.sortClass(prop) }}">
+            {% set s = Property.fieldLabel(prop) %}
             {% if emptyQuerySearch and Schema.sortable(prop) %}
-                <a href="{{ Link.sortUrl(prop) }}">{{ Property.fieldLabel(prop) }}</a>
+                <a href="{{ Link.sortUrl(prop) }}" title="{{ s }}">{{ s|truncate(20) }}</a>
             {% else %}
-                {{ Property.fieldLabel(prop) }}
+                <span title="{{ s }}">{{ s|truncate(20) }}</span>
             {% endif %}
         </div>
         {% endif %}

--- a/tests/TestCase/Controller/Component/QueryComponentTest.php
+++ b/tests/TestCase/Controller/Component/QueryComponentTest.php
@@ -219,4 +219,43 @@ class QueryComponentTest extends TestCase
         $actual = $this->Query->prepare($query);
         static::assertEquals($expected, $actual);
     }
+
+    /**
+     * Test `handleSavedByRefs` method.
+     *
+     * @return void
+     * @covers ::handleSavedByRefs()
+     */
+    public function testHandleSavedByRefs(): void
+    {
+        $controller = new Controller(
+            new ServerRequest(
+                [
+                    'query' => [],
+                    'environment' => [
+                        'REQUEST_METHOD' => 'GET',
+                    ],
+                    'params' => [
+                        'object_type' => 'test',
+                    ],
+                ]
+            )
+        );
+        $registry = $controller->components();
+        $component = new class ($registry) extends QueryComponent {
+            public function handleSavedByRefs(array $query): array
+            {
+                return parent::handleSavedByRefs($query);
+            }
+        };
+        Configure::write('Properties.test.index', [
+            'title',
+            'created_by_user',
+            'modified_by_user',
+        ]);
+        $query = [];
+        $actual = $component->handleSavedByRefs($query);
+        $expected = ['saved_by_refs' => 1];
+        static::assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
This introduces the use of saved by refs query param to fetch `created_by_user` and `modified_by_user` (available with https://github.com/bedita/bedita/releases/tag/v5.46.0).

Ui/ux:

 - truncate columns to 20 characters (full title in "title" attribute)
 - adjust css for related expandable elements in cell
 - show number of related items
 - on mouse hover of a related item, show launch icon, highlight, open in a new tab on click 

<img width="751" height="491" alt="image" src="https://github.com/user-attachments/assets/a71b49d6-b852-4c08-b8a5-3b656405d8b1" />
 