### PR TITLE
Created/Modified by user columns in module index

### DIFF
--- a/config/i18n_strings.php
+++ b/config/i18n_strings.php
@@ -30,6 +30,8 @@
 //  __('title');
 //  __('All media');
 //  __('Created');
+//  __('Created By User');
+//  __('Modified By User');
 //  __('Updated');
 //  __('Trashd');
 //  __('Restored');

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2025-12-31 09:53:48 \n"
+"POT-Creation-Date: 2026-03-12 08:25:45 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -68,6 +68,9 @@ msgid "All objects"
 msgstr ""
 
 msgid "An extension stopped the file upload"
+msgstr ""
+
+msgid "Annotations"
 msgstr ""
 
 msgid "Any"
@@ -200,6 +203,9 @@ msgid "Create a new tag"
 msgstr ""
 
 msgid "Created"
+msgstr ""
+
+msgid "Created By User"
 msgstr ""
 
 msgid "Created ↑ Oldest on top"
@@ -515,6 +521,9 @@ msgid "Missing thumb url"
 msgstr ""
 
 msgid "Modified"
+msgstr ""
+
+msgid "Modified By User"
 msgstr ""
 
 msgid "Modified ↑ Oldest on top"
@@ -1778,6 +1787,9 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
+msgid "Loading"
+msgstr ""
+
 msgid "Module"
 msgstr ""
 
@@ -1977,9 +1989,6 @@ msgid "Error on deleting category"
 msgstr ""
 
 msgid "Create new"
-msgstr ""
-
-msgid "Loading"
 msgstr ""
 
 msgid "Allowed types"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2025-12-31 09:53:48 \n"
+"POT-Creation-Date: 2026-03-12 08:25:45 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -71,6 +71,9 @@ msgid "All objects"
 msgstr ""
 
 msgid "An extension stopped the file upload"
+msgstr ""
+
+msgid "Annotations"
 msgstr ""
 
 msgid "Any"
@@ -203,6 +206,9 @@ msgid "Create a new tag"
 msgstr ""
 
 msgid "Created"
+msgstr ""
+
+msgid "Created By User"
 msgstr ""
 
 msgid "Created ↑ Oldest on top"
@@ -518,6 +524,9 @@ msgid "Missing thumb url"
 msgstr ""
 
 msgid "Modified"
+msgstr ""
+
+msgid "Modified By User"
 msgstr ""
 
 msgid "Modified ↑ Oldest on top"
@@ -1781,6 +1790,9 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
+msgid "Loading"
+msgstr ""
+
 msgid "Module"
 msgstr ""
 
@@ -1980,9 +1992,6 @@ msgid "Error on deleting category"
 msgstr ""
 
 msgid "Create new"
-msgstr ""
-
-msgid "Loading"
 msgstr ""
 
 msgid "Allowed types"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2025-12-31 09:53:48 \n"
+"POT-Creation-Date: 2026-03-12 08:25:45 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -74,6 +74,9 @@ msgstr "Tutti gli oggetti"
 
 msgid "An extension stopped the file upload"
 msgstr "Un'estensione ha fermato il caricamento del file"
+
+msgid "Annotations"
+msgstr "Note"
 
 msgid "Any"
 msgstr "Qualsiasi"
@@ -206,6 +209,9 @@ msgstr "Crea nuovo tag"
 
 msgid "Created"
 msgstr "Creato"
+
+msgid "Created By User"
+msgstr "Creato da"
 
 msgid "Created ↑ Oldest on top"
 msgstr "Creazione ↑ Meno recenti in testa"
@@ -522,6 +528,9 @@ msgstr "Url miniatura mancante"
 
 msgid "Modified"
 msgstr "Modificato"
+
+msgid "Modified By User"
+msgstr "Modificato da"
 
 msgid "Modified ↑ Oldest on top"
 msgstr "Data di modifica ↑ Meno recenti in testa"
@@ -894,7 +903,9 @@ msgid "Temporary folder missing"
 msgstr "Cartella temporanea mancante"
 
 msgid "The number of folders is too high to be displayed in tree-compact view"
-msgstr "Il numero di cartelle è troppo alto per essere visualizzato nella vista ad albero compatta"
+msgstr ""
+"Il numero di cartelle è troppo alto per essere visualizzato nella vista ad "
+"albero compatta"
 
 msgid "There were errors creating the thumbnail(s)"
 msgstr "È avvenuto un errore nella creazione delle miniature"
@@ -1800,6 +1811,9 @@ msgstr "Parametri"
 msgid "Valid"
 msgstr "Valido"
 
+msgid "Loading"
+msgstr "Caricamento in corso"
+
 msgid "Module"
 msgstr ""
 
@@ -2006,9 +2020,6 @@ msgstr "Errore durante l'eliminazione della categoria"
 
 msgid "Create new"
 msgstr "Crea nuovo"
-
-msgid "Loading"
-msgstr "Caricamento in corso"
 
 msgid "Allowed types"
 msgstr "Tipi consentiti"

--- a/resources/js/app/components/index-cell/index-cell.vue
+++ b/resources/js/app/components/index-cell/index-cell.vue
@@ -40,6 +40,7 @@
                         class="ml-05"
                         v-for="f in relatedFields"
                         :key="f"
+                        @click.stop.prevent="openRelated(related?.[0])"
                     >
                         <template v-if="f == 'media_url'">
                             <img :src="thumb(0)">
@@ -48,6 +49,12 @@
                             {{ related?.[0]?.attributes?.[f] || related?.[0]?.meta?.[f] }}
                         </template>
                     </span>
+                    <span
+                        class="open-new-tab-icon"
+                        v-if="hasRelatedLink(related?.[0])"
+                    >
+                        <app-icon icon="carbon:launch" />
+                    </span>
                 </div>
                 <div
                     class="related-toggle"
@@ -55,25 +62,31 @@
                 >
                     <button
                         class="show-toggle icon icon-only-icon"
-                        :title="msgMore"
+                        :title="relatedToggleLabel()"
                         @click.stop.prevent="relatedOpen = !relatedOpen"
                         v-if="relatedOpen"
                     >
                         <app-icon icon="carbon:subtract" />
-                        <span class="is-sr-only">{{ msgMore }}</span>
+                        <span class="is-sr-only">{{ relatedToggleLabel() }}</span>
                     </button>
                     <button
                         class="show-toggle icon icon-only-icon"
-                        :title="msgMore"
+                        :title="relatedToggleLabel()"
                         @click.stop.prevent="relatedOpen = !relatedOpen"
                         v-else
                     >
                         <app-icon icon="carbon:add" />
-                        <span class="is-sr-only">{{ msgMore }}</span>
+                        <span class="is-sr-only">{{ relatedToggleLabel() }}</span>
                     </button>
+                    <span class="tag is-smallest is-black mx-05 related-count empty">
+                        {{ relatedCountLabel() }}
+                    </span>
                 </div>
             </div>
-            <template v-if="relatedOpen">
+            <div
+                class="related-list"
+                v-if="relatedOpen"
+            >
                 <template v-for="(relatedItem, index) in related">
                     <div
                         class="related-item"
@@ -85,6 +98,7 @@
                             class="ml-05"
                             v-for="f in relatedFields"
                             :key="f"
+                            @click.stop.prevent="openRelated(relatedItem)"
                         >
                             <template v-if="f == 'media_url'">
                                 <img :src="thumb(index)">
@@ -93,9 +107,15 @@
                                 {{ relatedItem?.attributes?.[f] || relatedItem?.meta?.[f] }}
                             </template>
                         </span>
+                        <span
+                            class="open-new-tab-icon"
+                            v-if="hasRelatedLink(relatedItem)"
+                        >
+                            <app-icon icon="carbon:launch" />
+                        </span>
                     </div>
                 </template>
-            </template>
+            </div>
         </template>
     </div>
 </template>
@@ -207,6 +227,34 @@ export default {
         reset() {
             this.msg = '';
         },
+        hasRelatedLink(relatedItem) {
+            if (relatedItem?.type === 'roles') {
+                return false;
+            }
+            return !!relatedItem?.id;
+        },
+        relatedCountLabel() {
+            const count = this.related?.length || 0;
+            if (!count) {
+                return '';
+            }
+
+            return `${this.relatedOpen ? count : 1}/${count}`;
+        },
+        relatedToggleLabel() {
+            return this.relatedCountLabel() || this.msgMore;
+        },
+        openRelated(relatedItem) {
+            const id = relatedItem?.id || null;
+            if (!id) {
+                return;
+            }
+            const url = this.$helpers?.buildViewUrl ? this.$helpers.buildViewUrl(id) : `/view/${id}`;
+            const newTab = window.open(url, '_blank');
+            if (newTab) {
+                newTab.focus();
+            }
+        },
         showCopyIcon() {
             if (this.settings?.copy2clipboard !== true) {
                 return false;
@@ -234,9 +282,47 @@ div.index-cell > div.msg {
 }
 div.index-cell div.related-container {
     display: flex;
+    align-items: flex-start;
 }
 div.index-cell div.related-item {
     display: flex;
+    flex-wrap: wrap;
+    min-width: 0;
+    color: #e6edf3;
+    align-items: center;
+    border-radius: 0.2rem;
+    transition: background-color 0.12s ease-in-out;
+}
+
+div.index-cell div.related-item > span {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    cursor: pointer;
+}
+div.index-cell div.related-list {
+    margin-top: 0.35rem;
+    margin-left: 0;
+}
+div.index-cell div.related-list div.related-item {
+    gap: 0.15rem 0.45rem;
+    padding: 0.2rem 0;
+}
+div.index-cell div.related-list div.related-item + div.related-item {
+    margin-top: 0.2rem;
+}
+div.index-cell div.related-item:hover {
+    background-color: #2f3943;
+}
+div.index-cell div.related-item .open-new-tab-icon {
+    opacity: 0;
+    margin-left: 0.3rem;
+    color: #c5d0db;
+    transition: opacity 0.12s ease-in-out;
+    pointer-events: none;
+}
+div.index-cell div.related-item:hover .open-new-tab-icon {
+    opacity: 1;
 }
 div.index-cell div.related-toggle {
     display: flex;
@@ -246,6 +332,9 @@ div.index-cell div.related-toggle > button {
     line-height: 1;
     height: 20px;
     cursor: cell;
+}
+div.index-cell span.related-count {
+    user-select: none;
 }
 div.index-cell img {
     margin-bottom: 0.2rem;

--- a/src/Controller/Component/QueryComponent.php
+++ b/src/Controller/Component/QueryComponent.php
@@ -35,6 +35,9 @@ class QueryComponent extends Component
         }
         $query = $this->handleInclude($query);
 
+        // add ?saved_by_refs=1 if necessary
+        $query = $this->handleSavedByRefs($query);
+
         // make sure `filter[history_editor]` is empty in order to use logged user id
         if (isset($query['filter']['history_editor'])) {
             $query['filter']['history_editor'] = '';
@@ -84,6 +87,33 @@ class QueryComponent extends Component
         }
         if (!empty($decoded)) {
             $query['include'] = implode(',', $decoded);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Add 'saved_by_refs' as query string if created_by_user or modified_by_user are
+     * in index configuration per module object type.
+     *
+     * @param array $query The query
+     * @return array
+     */
+    protected function handleSavedByRefs(array $query): array
+    {
+        $fields = array_filter(
+            (array)Configure::read(
+                sprintf(
+                    'Properties.%s.index',
+                    $this->getController()->getRequest()->getParam('object_type'),
+                ),
+            ),
+            function ($value) {
+                return in_array($value, ['created_by_user', 'modified_by_user']);
+            },
+        );
+        if (!empty($fields)) {
+            $query['saved_by_refs'] = 1;
         }
 
         return $query;

--- a/templates/Element/Modules/index_table_header.twig
+++ b/templates/Element/Modules/index_table_header.twig
@@ -9,16 +9,18 @@
     {% for prop in properties %}
         {% if prop is iterable %}
             {% for relationName,relationFields in prop %}
+                {% set s = Layout.tr(relationName) %}
                 <div>
-                    {{ Layout.tr(relationName) }}
+                    <span title="{{ s }}">{{ s|truncate(20) }}</span>
                 </div>
             {% endfor %}
         {% else %}
         <div class="{{ Link.sortClass(prop) }}">
+            {% set s = Property.fieldLabel(prop) %}
             {% if emptyQuerySearch and Schema.sortable(prop) %}
-                <a href="{{ Link.sortUrl(prop) }}">{{ Property.fieldLabel(prop) }}</a>
+                <a href="{{ Link.sortUrl(prop) }}" title="{{ s }}">{{ s|truncate(20) }}</a>
             {% else %}
-                {{ Property.fieldLabel(prop) }}
+                <span title="{{ s }}">{{ s|truncate(20) }}</span>
             {% endif %}
         </div>
         {% endif %}

--- a/tests/TestCase/Controller/Component/QueryComponentTest.php
+++ b/tests/TestCase/Controller/Component/QueryComponentTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 #[CoversClass(QueryComponent::class)]
 #[CoversMethod(QueryComponent::class, 'handleInclude')]
+#[CoversMethod(QueryComponent::class, 'handleSavedByRefs')]
 #[CoversMethod(QueryComponent::class, 'handleSort')]
 #[CoversMethod(QueryComponent::class, 'index')]
 #[CoversMethod(QueryComponent::class, 'prepare')]
@@ -218,6 +219,44 @@ class QueryComponentTest extends TestCase
     public function testPrepare(array $expected, array $query): void
     {
         $actual = $this->Query->prepare($query);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `handleSavedByRefs` method.
+     *
+     * @return void
+     */
+    public function testHandleSavedByRefs(): void
+    {
+        $controller = new Controller(
+            new ServerRequest(
+                [
+                    'query' => [],
+                    'environment' => [
+                        'REQUEST_METHOD' => 'GET',
+                    ],
+                    'params' => [
+                        'object_type' => 'test',
+                    ],
+                ],
+            ),
+        );
+        $registry = $controller->components();
+        $component = new class ($registry) extends QueryComponent {
+            public function handleSavedByRefs(array $query): array
+            {
+                return parent::handleSavedByRefs($query);
+            }
+        };
+        Configure::write('Properties.test.index', [
+            'title',
+            'created_by_user',
+            'modified_by_user',
+        ]);
+        $query = [];
+        $actual = $component->handleSavedByRefs($query);
+        $expected = ['saved_by_refs' => 1];
         static::assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
This introduces the use of saved by refs query param to fetch `created_by_user` and `modified_by_user` (available with https://github.com/bedita/bedita/releases/tag/v5.46.0).

Ui/ux:

 - truncate columns to 20 characters (full title in "title" attribute)
 - adjust css for related expandable elements in cell
 - show number of related items
 - on mouse hover of a related item, show launch icon, highlight, open in a new tab on click 

<img width="751" height="491" alt="image" src="https://github.com/user-attachments/assets/a71b49d6-b852-4c08-b8a5-3b656405d8b1" />
 