### PR TITLE
[5.x] fix: skip save if id not found -- new object

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -519,7 +519,7 @@ class ModulesComponent extends Component
      */
     public function skipSaveRelated(string $id, array &$relatedData): bool
     {
-        if (empty($relatedData)) {
+        if (empty($id) || empty($relatedData)) {
             return true;
         }
         $methods = (array)Hash::extract($relatedData, '{n}.method');

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1867,6 +1867,17 @@ class ModulesComponentTest extends TestCase
         $actual = $this->Modules->skipSaveRelated('123', $relatedData);
         static::assertTrue($actual);
 
+        // empty id => true
+        $relatedData = [
+            [
+                'method' => 'addRelated',
+                'relation' => 'see_also',
+                'relatedIds' => [['id' => '456', 'type' => 'dummies']],
+            ],
+        ];
+        $actual = $this->Modules->skipSaveRelated('', $relatedData);
+        static::assertTrue($actual);
+
         // addRelated or removeRelated => false
         $relatedData = [
             [


### PR DESCRIPTION
Skip save related was added in https://github.com/bedita/manager/releases/tag/v5.7.3 

`skipSaveRelated` is missing a check, the method fails when creating a new object without it. The same check is instead already added on `skipSaveObject`.

The following situation might occur otherwise:
```
A route matching "/events//has_location" could not be found. in .../RouteCollection.php on line 256
Exception Attributes: array (
  'url' => '/events//has_location',
)
```

Added also a test for this case.