### PR TITLE
fix: skip save related on id empty string

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,6 +7,9 @@ parameters:
   level: 5
   ignoreErrors:
     -
+      message: '#^Cannot unset property App\\Test\\.* because it might have hooks in a subclass\.$#'
+      path: tests/*
+    -
       message: '#^Call to static method PHPUnit\\Framework\\Assert::assertIsArray\(\) with .* will always evaluate to true\.$#'
       path: tests/*
     -

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,9 +7,6 @@ parameters:
   level: 5
   ignoreErrors:
     -
-      message: '#^Cannot unset property App\\Test\\.* because it might have hooks in a subclass\.$#'
-      path: tests/*
-    -
       message: '#^Call to static method PHPUnit\\Framework\\Assert::assertIsArray\(\) with .* will always evaluate to true\.$#'
       path: tests/*
     -

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -546,7 +546,7 @@ class ModulesComponent extends Component
             return true;
         }
         $methods = (array)Hash::extract($relatedData, '{n}.method');
-        if (in_array('addRelated', $methods) || in_array('removeRelated', $methods) || empty($id)) {
+        if (in_array('addRelated', $methods) || in_array('removeRelated', $methods)) {
             return false;
         }
         // check replaceRelated

--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -542,7 +542,7 @@ class ModulesComponent extends Component
      */
     public function skipSaveRelated(string $id, array &$relatedData): bool
     {
-        if (empty($relatedData)) {
+        if (empty($id) || empty($relatedData)) {
             return true;
         }
         $methods = (array)Hash::extract($relatedData, '{n}.method');

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -1882,6 +1882,17 @@ class ModulesComponentTest extends TestCase
         $actual = $this->Modules->skipSaveRelated('123', $relatedData);
         static::assertTrue($actual);
 
+        // empty id => true
+        $relatedData = [
+            [
+                'method' => 'addRelated',
+                'relation' => 'see_also',
+                'relatedIds' => [['id' => '456', 'type' => 'dummies']],
+            ],
+        ];
+        $actual = $this->Modules->skipSaveRelated('', $relatedData);
+        static::assertTrue($actual);
+
         // addRelated or removeRelated => false
         $relatedData = [
             [


### PR DESCRIPTION
Same fix has been done on 5.x with https://github.com/bedita/manager/pull/1375 by @nicolocarpignoli 