### PR TITLE
Show calendar view button

### DIFF
--- a/src/View/Helper/LayoutHelper.php
+++ b/src/View/Helper/LayoutHelper.php
@@ -330,6 +330,11 @@ class LayoutHelper extends Helper
                     $icon = '';
                     $label = '';
                     switch ($t) {
+                        case 'calendar':
+                            $icon = 'carbon:calendar';
+                            $label = __('Calendar view');
+                            $append = true;
+                            break;
                         case 'tree':
                             $icon = 'carbon:tree-view';
                             $label = __('Tree view');


### PR DESCRIPTION
This fixes a bug: "calendar view" button should be visible when navigating in another mode and module provides calendar view.