### PR TITLE
OTP

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -379,6 +379,14 @@ return [
     // ],
 
     /**
+     * OTP authentication setup
+     */
+    // 'Otp' => [
+    //     'send' => '/otp',
+    //     'users_skip_otp' => [], // array of usernames to skip OTP authentication
+    // ],
+
+    /**
      * Pagination default settings
      *
      * - sizeAvailable => available page size on modules view index

--- a/config/routes.php
+++ b/config/routes.php
@@ -85,6 +85,18 @@ $routes->scope('/', function (RouteBuilder $routes): void {
         ['_name' => 'login:oauth2'],
     );
 
+    // OTP.
+    $routes->connect(
+        '/otp',
+        ['controller' => 'Login', 'action' => 'otp'],
+        ['_name' => 'otp'],
+    );
+    $routes->connect(
+        '/otp/verify',
+        ['controller' => 'Login', 'action' => 'otpVerify'],
+        ['_name' => 'otp:verify'],
+    );
+
     // Dashboard.
     $routes->connect(
         '/',

--- a/locales/default.pot
+++ b/locales/default.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 4 \n"
-"POT-Creation-Date: 2026-03-17 12:07:36 \n"
+"POT-Creation-Date: 2026-03-24 09:17:38 \n"
 "MIME-Version: 1.0 \n"
 "Content-Transfer-Encoding: 8bit \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -116,6 +116,9 @@ msgid "Bulk action performed on {0} objects"
 msgstr ""
 
 msgid "Calendar"
+msgstr ""
+
+msgid "Calendar view"
 msgstr ""
 
 msgid "Cannot create abstract objects or objects without schema"
@@ -323,6 +326,9 @@ msgid "Export Filtered"
 msgstr ""
 
 msgid "External Auth"
+msgstr ""
+
+msgid "Failed to send OTP code. Please try again later."
 msgstr ""
 
 msgid "Failed to write file to disk"
@@ -606,6 +612,9 @@ msgstr ""
 msgid "Number of updated objects"
 msgstr ""
 
+msgid "OTP code is expired or invalid"
+msgstr ""
+
 msgid "Object Types"
 msgstr ""
 
@@ -640,6 +649,9 @@ msgid "Old Password"
 msgstr ""
 
 msgid "On"
+msgstr ""
+
+msgid "One Time Password"
 msgstr ""
 
 msgid "Only my contents"
@@ -790,6 +802,9 @@ msgid "Remove"
 msgstr ""
 
 msgid "Request password"
+msgstr ""
+
+msgid "Resend OTP"
 msgstr ""
 
 msgid "Reset"
@@ -1009,6 +1024,9 @@ msgid "Vat Number"
 msgstr ""
 
 msgid "Verified"
+msgstr ""
+
+msgid "Verify"
 msgstr ""
 
 msgid "Version"

--- a/locales/en_US/default.po
+++ b/locales/en_US/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2026-03-17 12:07:36 \n"
+"POT-Creation-Date: 2026-03-24 09:17:38 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -119,6 +119,9 @@ msgid "Bulk action performed on {0} objects"
 msgstr ""
 
 msgid "Calendar"
+msgstr ""
+
+msgid "Calendar view"
 msgstr ""
 
 msgid "Cannot create abstract objects or objects without schema"
@@ -326,6 +329,9 @@ msgid "Export Filtered"
 msgstr ""
 
 msgid "External Auth"
+msgstr ""
+
+msgid "Failed to send OTP code. Please try again later."
 msgstr ""
 
 msgid "Failed to write file to disk"
@@ -609,6 +615,9 @@ msgstr ""
 msgid "Number of updated objects"
 msgstr ""
 
+msgid "OTP code is expired or invalid"
+msgstr ""
+
 msgid "Object Types"
 msgstr ""
 
@@ -643,6 +652,9 @@ msgid "Old Password"
 msgstr ""
 
 msgid "On"
+msgstr ""
+
+msgid "One Time Password"
 msgstr ""
 
 msgid "Only my contents"
@@ -793,6 +805,9 @@ msgid "Remove"
 msgstr ""
 
 msgid "Request password"
+msgstr ""
+
+msgid "Resend OTP"
 msgstr ""
 
 msgid "Reset"
@@ -1012,6 +1027,9 @@ msgid "Vat Number"
 msgstr ""
 
 msgid "Verified"
+msgstr ""
+
+msgid "Verify"
 msgstr ""
 
 msgid "Version"

--- a/locales/it_IT/default.po
+++ b/locales/it_IT/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita Manager \n"
-"POT-Creation-Date: 2026-03-17 12:07:36 \n"
+"POT-Creation-Date: 2026-03-24 09:17:38 \n"
 "PO-Revision-Date:  \n"
 "Last-Translator:  \n"
 "Language-Team: BEdita I18N & I10N Team \n"
@@ -122,6 +122,9 @@ msgstr "Operazione massiva eseguita su {0} oggetti"
 
 msgid "Calendar"
 msgstr "Calendario"
+
+msgid "Calendar view"
+msgstr "Vista calendario"
 
 msgid "Cannot create abstract objects or objects without schema"
 msgstr "Impossibile creare oggetti astratti o oggetti senza schema"
@@ -329,6 +332,9 @@ msgstr "Esporta Filtrati"
 
 msgid "External Auth"
 msgstr "Autenticazioni esterne"
+
+msgid "Failed to send OTP code. Please try again later."
+msgstr "Invio codice OTP fallito. Riprova più tardi."
 
 msgid "Failed to write file to disk"
 msgstr "Scrittura file su disco fallita"
@@ -614,6 +620,9 @@ msgstr "Numero di errori di accesso"
 msgid "Number of updated objects"
 msgstr "Numero di oggetti aggiornati"
 
+msgid "OTP code is expired or invalid"
+msgstr "Codice OTP scaduto o non valido"
+
 msgid "Object Types"
 msgstr "Tipi di Oggetto"
 
@@ -649,6 +658,9 @@ msgstr "Vecchia Password"
 
 msgid "On"
 msgstr ""
+
+msgid "One Time Password"
+msgstr "Codice monouso"
 
 msgid "Only my contents"
 msgstr "Solo i miei contenuti"
@@ -801,6 +813,9 @@ msgstr "Rimuovi"
 
 msgid "Request password"
 msgstr "Reimposta password"
+
+msgid "Resend OTP"
+msgstr "Invia nuovamente OTP"
 
 msgid "Reset"
 msgstr "Resetta"
@@ -1023,6 +1038,9 @@ msgstr "Partita Iva"
 
 msgid "Verified"
 msgstr "Verificato"
+
+msgid "Verify"
+msgstr "Verifica"
 
 msgid "Version"
 msgstr "Versione"

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl
@@ -15,6 +17,7 @@ namespace App;
 use App\Event\TreeCacheEventHandler;
 use App\Identifier\ApiIdentifier;
 use App\Middleware\ConfigurationMiddleware;
+use App\Middleware\OtpMiddleware;
 use App\Middleware\ProjectMiddleware;
 use App\Middleware\RecoveryMiddleware;
 use App\Middleware\StatusMiddleware;
@@ -152,6 +155,9 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
 
             // Authentication middleware.
             ->add(new AuthenticationMiddleware($this))
+
+            // Otp middleware.
+            ->add(new OtpMiddleware())
 
             // Authentication middleware.
             ->add(new OAuth2Middleware())

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -189,7 +189,11 @@ class LoginController extends AppController
         if (!$this->otpEnabled()) {
             return $this->redirect('/login');
         }
-        try {
+        $otpSession = (array)$this->getRequest()->getSession()->read('Otp');
+        $pending = (string)Hash::get($otpSession, 'pending');
+        $force = $this->getRequest()->getQuery('force', false);
+        if (!$pending || $force) {
+            // Send OTP code via API
             $response = $this->apiClient->post(
                 $this->getConfig('otp.send'),
                 null,
@@ -198,9 +202,8 @@ class LoginController extends AppController
             $this->getRequest()->getSession()->write('Otp', [
                 'otp_code' => $response['data']['otp_code'],
                 'expires_at' => $response['data']['expires_at'],
+                'pending' => true,
             ]);
-        } catch (Throwable $e) {
-            $this->Flash->error(__('Failed to send OTP code. Please try again later.'));
         }
 
         return null;
@@ -228,6 +231,7 @@ class LoginController extends AppController
 
             return $this->redirect('/otp');
         }
+        $this->getRequest()->getSession()->delete('Otp');
 
         return $this->redirect($this->Authentication->getLoginRedirect() ?? ['_name' => 'dashboard']);
     }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -189,21 +189,25 @@ class LoginController extends AppController
         if (!$this->otpEnabled()) {
             return $this->redirect('/login');
         }
-        $otpSession = (array)$this->getRequest()->getSession()->read('Otp');
-        $pending = (string)Hash::get($otpSession, 'pending');
-        $force = $this->getRequest()->getQuery('force', false);
-        if (!$pending || $force) {
-            // Send OTP code via API
-            $response = $this->apiClient->post(
-                $this->getConfig('otp.send'),
-                null,
-                ['Content-Type' => 'application/json'],
-            );
-            $this->getRequest()->getSession()->write('Otp', [
-                'otp_code' => $response['data']['otp_code'],
-                'expires_at' => $response['data']['expires_at'],
-                'pending' => true,
-            ]);
+        try {
+            $otpSession = (array)$this->getRequest()->getSession()->read('Otp');
+            $pending = (string)Hash::get($otpSession, 'pending');
+            $force = $this->getRequest()->getQuery('force', false);
+            if (!$pending || $force) {
+                // Send OTP code via API
+                $response = $this->apiClient->post(
+                    $this->getConfig('otp.send'),
+                    null,
+                    ['Content-Type' => 'application/json'],
+                );
+                $this->getRequest()->getSession()->write('Otp', [
+                    'otp_code' => $response['data']['otp_code'],
+                    'expires_at' => $response['data']['expires_at'],
+                    'pending' => true,
+                ]);
+            }
+        } catch (Throwable $e) {
+            $this->Flash->error(__('Failed to send OTP code. Please try again later.'));
         }
 
         return null;

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl
@@ -13,8 +15,11 @@
 namespace App\Controller;
 
 use App\Application;
+use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Http\Response;
+use Cake\Utility\Hash;
+use Throwable;
 
 /**
  * Perform basic login and logout operations.
@@ -27,7 +32,7 @@ class LoginController extends AppController
      * @inheritDoc
      */
     protected array $_defaultConfig = [
-        // Projects configuration files base path
+        'otp' => null,
         'projectsPath' => CONFIG . 'projects' . DS,
     ];
 
@@ -38,6 +43,10 @@ class LoginController extends AppController
     {
         parent::initialize();
         $this->Authentication->allowUnauthenticated(['login']);
+        $otpConfig = (array)Configure::read('Otp');
+        if (!empty($otpConfig)) {
+            $this->setConfig('otp', $otpConfig);
+        }
     }
 
     /**
@@ -82,6 +91,13 @@ class LoginController extends AppController
         if ($result->isValid()) {
             // Setup current project name.
             $this->setupCurrentProject();
+
+            $username = $result->getData()['attributes']['username'];
+
+            if ($this->otpEnabled($username)) {
+                return $this->redirect('/otp');
+            }
+
             // Redirect.
             $target = $this->Authentication->getLoginRedirect() ?? ['_name' => 'dashboard'];
 
@@ -159,5 +175,73 @@ class LoginController extends AppController
             // Remove flash messages
             $this->getRequest()->getSession()->delete('Flash');
         }
+    }
+
+    /**
+     * Otp verification page.
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function otp(): ?Response
+    {
+        $this->getRequest()->allowMethod(['get']);
+        if (!$this->otpEnabled()) {
+            return $this->redirect('/login');
+        }
+        try {
+            $response = $this->apiClient->post(
+                $this->getConfig('otp.send'),
+                null,
+                ['Content-Type' => 'application/json'],
+            );
+            $this->getRequest()->getSession()->write('Otp', [
+                'otp_code' => $response['data']['otp_code'],
+                'expires_at' => $response['data']['expires_at'],
+            ]);
+        } catch (Throwable $e) {
+            $this->Flash->error(__('Failed to send OTP code. Please try again later.'));
+        }
+
+        return null;
+    }
+
+    /**
+     * Otp verification request.
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function otpVerify(): ?Response
+    {
+        $this->getRequest()->allowMethod(['post']);
+        if (!$this->otpEnabled()) {
+            return $this->redirect('/login');
+        }
+        $requestOtpCode = (string)$this->getRequest()->getData('otp_code');
+        $sessionOtpData = $this->getRequest()->getSession()->read('Otp');
+        $sessionOtpCode = (string)Hash::get($sessionOtpData, 'otp_code');
+        $sessionExpiresAt = (string)Hash::get($sessionOtpData, 'expires_at');
+        if (empty($sessionOtpData) || $sessionOtpCode !== $requestOtpCode || strtotime($sessionExpiresAt) < time()) {
+            $reason = __('OTP code is expired or invalid');
+            $this->getRequest()->getSession()->delete('Otp');
+            $this->Flash->error(__($reason));
+
+            return $this->redirect('/otp');
+        }
+
+        return $this->redirect($this->Authentication->getLoginRedirect() ?? ['_name' => 'dashboard']);
+    }
+
+    /**
+     * Check otp is enabled
+     *
+     * @return bool
+     */
+    protected function otpEnabled(?string $username = null): bool
+    {
+        $otpConfig = (array)$this->getConfig('otp');
+        $usersSkipOtp = (array)Hash::get($otpConfig, 'users_skip_otp', []);
+        $skip = $username !== null && in_array($username, $usersSkipOtp);
+
+        return !empty($otpConfig) && !$skip;
     }
 }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -92,9 +92,10 @@ class LoginController extends AppController
             // Setup current project name.
             $this->setupCurrentProject();
 
+            $provider = $this->request->getParam('provider');
             $username = $result->getData()['attributes']['username'];
 
-            if ($this->otpEnabled($username)) {
+            if (empty($provider) && $this->otpEnabled($username)) {
                 return $this->redirect('/otp');
             }
 

--- a/src/Middleware/OtpMiddleware.php
+++ b/src/Middleware/OtpMiddleware.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use Cake\Core\Configure;
+use Cake\Http\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Otp middleware
+ */
+class OtpMiddleware implements MiddlewareInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $conf = (array)Configure::read('Otp');
+        if (empty($conf)) {
+            return $handler->handle($request);
+        }
+        $path = $request->getUri()->getPath();
+        if (in_array($path, ['/otp', '/otp/verify'])) {
+            return $handler->handle($request);
+        }
+        /** @var \Cake\Http\ServerRequest $request */
+        if (!$request->getSession()->check('Otp.pending')) {
+            return $handler->handle($request);
+        }
+
+        return (new Response())->withLocation('/otp');
+    }
+}

--- a/templates/Pages/Login/otp.twig
+++ b/templates/Pages/Login/otp.twig
@@ -25,6 +25,6 @@
                 <span class="ml-05">{{ __('Verify') }}</span>
             </button>
         {{ Form.end()|raw }}
-        <p class="mt-1">{{ Html.link(__('Resend OTP'), {'_name': 'otp'})|raw }}</p>
+        <p class="mt-1">{{ Html.link(__('Resend OTP'), {'_name': 'otp', '?': {'force': 1}})|raw }}</p>
     </div>
 </div>

--- a/templates/Pages/Login/otp.twig
+++ b/templates/Pages/Login/otp.twig
@@ -1,0 +1,30 @@
+{% do _view.assign('bodyViewClass', 'view-login') %}
+<div class="login">
+    <div class="login-title">
+        <div class="login-error">
+            {{ Flash.render()|raw }}
+        </div>
+        <div class="project-title">
+            <div class="app-module-box">
+                {{ Html.link( (config('Project.name') ?: 'BEdita Content Manager'), '/' ) | raw }}
+            </div>
+        </div>
+    </div>
+    <div class="login-form">
+        {{ Form.create(null, {
+            'url': {'_name': 'otp:verify'},
+        })|raw }}
+            {{ Form.control('otp_code', {
+                'required':'required',
+                'autocomplete': 'one-time-code',
+                'placeholder': 'e.g. 123456',
+                'label': __('One Time Password'),
+            })|raw }}
+            <button type="submit" class="button button-primary mt-2">
+                <app-icon icon="carbon:login"></app-icon>
+                <span class="ml-05">{{ __('Verify') }}</span>
+            </button>
+        {{ Form.end()|raw }}
+        <p class="mt-1">{{ Html.link(__('Resend OTP'), {'_name': 'otp'})|raw }}</p>
+    </div>
+</div>

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -14,6 +14,7 @@ namespace App\Test\TestCase;
 
 use App\Application;
 use App\Middleware\ConfigurationMiddleware;
+use App\Middleware\OtpMiddleware;
 use App\Middleware\ProjectMiddleware;
 use App\Middleware\RecoveryMiddleware;
 use App\Middleware\StatusMiddleware;
@@ -79,6 +80,8 @@ class ApplicationTest extends TestCase
         static::assertInstanceOf(CsrfProtectionMiddleware::class, $middleware->current());
         $middleware->next();
         static::assertInstanceOf(AuthenticationMiddleware::class, $middleware->current());
+        $middleware->next();
+        static::assertInstanceOf(OtpMiddleware::class, $middleware->current());
         $middleware->next();
         static::assertInstanceOf(OAuth2Middleware::class, $middleware->current());
         $middleware->next();

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -42,6 +42,7 @@ use Psr\Http\Message\ServerRequestInterface;
 #[CoversMethod(LoginController::class, 'login')]
 #[CoversMethod(LoginController::class, 'logout')]
 #[CoversMethod(LoginController::class, 'otp')]
+#[CoversMethod(LoginController::class, 'otpEnabled')]
 #[CoversMethod(LoginController::class, 'otpVerify')]
 #[CoversMethod(LoginController::class, 'setupCurrentProject')]
 class LoginControllerTest extends TestCase

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -334,6 +334,29 @@ class LoginControllerTest extends TestCase
     }
 
     /**
+     * Test `authRequest` method with otp config enabled.
+     * Should redirect to otp page.
+     *
+     * @return void
+     */
+    public function testAuthRequestOtpEnabled(): void
+    {
+        Configure::write('Otp', [
+            'send' => '/otp/send',
+        ]);
+        $this->setupController([
+            'post' => [
+                'username' => env('BEDITA_ADMIN_USR'),
+                'password' => env('BEDITA_ADMIN_PWD'),
+            ],
+        ]);
+
+        $response = $this->Login->login();
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('/otp', $response->getHeaderLine('Location'));
+    }
+
+    /**
      * Test `otp` not enabled, should redirect to login page
      *
      * @return void

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -22,6 +22,8 @@ use Authentication\AuthenticationServiceInterface;
 use Authentication\Identifier\AbstractIdentifier;
 use Authentication\Identity;
 use Authentication\IdentityInterface;
+use BEdita\SDK\BEditaClient;
+use BEdita\WebTools\ApiClientProvider;
 use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -332,14 +334,13 @@ class LoginControllerTest extends TestCase
     }
 
     /**
-     * Test `otp`
+     * Test `otp` not enabled, should redirect to login page
      *
      * @return void
      */
     public function testOtpNotEnabled(): void
     {
         Configure::delete('Otp');
-        // otp not enabled, should redirect to login page
         $this->setupController([
             'environment' => [
                 'REQUEST_METHOD' => 'GET',
@@ -357,7 +358,6 @@ class LoginControllerTest extends TestCase
      */
     public function testOtpUsersSkip(): void
     {
-        // otp enabled but user in users_skip_otp, should redirect to dashboard
         Configure::write('Otp', [
             'send' => '/otp',
             'users_skip_otp' => [env('BEDITA_ADMIN_USR')],
@@ -378,7 +378,7 @@ class LoginControllerTest extends TestCase
      *
      * @return void
      */
-    public function testOtpEnabled(): void
+    public function testOtpEnabledFailingPostOtp(): void
     {
         Configure::write('Otp', [
             'send' => '/otp/send',
@@ -392,6 +392,43 @@ class LoginControllerTest extends TestCase
         static::assertNull($response);
         $expected = 'Failed to send OTP code. Please try again later.';
         static::assertEquals($expected, $this->Login->getRequest()->getSession()->read('Flash.flash.0.message'));
+    }
+
+    /**
+     * Test `otp`, enabled scenario: should show otp page, successful POST request
+     *
+     * @return void
+     */
+    public function testOtpEnabledSuccessPostOtp(): void
+    {
+        // mock api /otp/send response
+        $safeClient = ApiClientProvider::getApiClient();
+        $expected = [
+            'otp_code' => '123456',
+            'expires_at' => date('Y-m-d H:i:s', strtotime('+1 hour')),
+        ];
+        $apiClient = $this->getMockBuilder(BEditaClient::class)
+            ->setConstructorArgs(['https://media.example.com'])
+            ->getMock();
+        $apiClient->method('post')
+            ->with('/otp/send')
+            ->willReturn([
+                'data' => $expected,
+            ]);
+        ApiClientProvider::setApiClient($apiClient);
+        Configure::write('Otp', [
+            'send' => '/otp/send',
+        ]);
+        $this->setupController([
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+        ]);
+        $response = $this->Login->otp();
+        static::assertNull($response);
+        $actual = $this->Login->getRequest()->getSession()->read('Otp');
+        static::assertEquals($expected, $actual);
+        ApiClientProvider::setApiClient($safeClient);
     }
 
     /**

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -429,6 +429,7 @@ class LoginControllerTest extends TestCase
         $expected = [
             'otp_code' => '123456',
             'expires_at' => date('Y-m-d H:i:s', strtotime('+1 hour')),
+            'pending' => true,
         ];
         $apiClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs(['https://media.example.com'])
@@ -494,6 +495,7 @@ class LoginControllerTest extends TestCase
         $this->Login->getRequest()->getSession()->write('Otp', [
             'otp_code' => '123456',
             'expires_at' => date('Y-m-d H:i:s', strtotime('+1 hour')),
+            'pending' => true,
         ]);
         $response = $this->Login->otpVerify();
         static::assertEquals(302, $response->getStatusCode());
@@ -524,6 +526,7 @@ class LoginControllerTest extends TestCase
         $this->Login->getRequest()->getSession()->write('Otp', [
             'otp_code' => '123456',
             'expires_at' => date('Y-m-d H:i:s', strtotime('-1 hour')),
+            'pending' => true,
         ]);
         $response = $this->Login->otpVerify();
         static::assertEquals(302, $response->getStatusCode());
@@ -553,6 +556,7 @@ class LoginControllerTest extends TestCase
         $this->Login->getRequest()->getSession()->write('Otp', [
             'otp_code' => '123456',
             'expires_at' => date('Y-m-d H:i:s', strtotime('+1 hour')),
+            'pending' => true,
         ]);
         $response = $this->Login->otpVerify();
         static::assertEquals(302, $response->getStatusCode());

--- a/tests/TestCase/Controller/LoginControllerTest.php
+++ b/tests/TestCase/Controller/LoginControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl
@@ -20,6 +22,7 @@ use Authentication\AuthenticationServiceInterface;
 use Authentication\Identifier\AbstractIdentifier;
 use Authentication\Identity;
 use Authentication\IdentityInterface;
+use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -38,6 +41,8 @@ use Psr\Http\Message\ServerRequestInterface;
 #[CoversMethod(LoginController::class, 'loadAvailableProjects')]
 #[CoversMethod(LoginController::class, 'login')]
 #[CoversMethod(LoginController::class, 'logout')]
+#[CoversMethod(LoginController::class, 'otp')]
+#[CoversMethod(LoginController::class, 'otpVerify')]
 #[CoversMethod(LoginController::class, 'setupCurrentProject')]
 class LoginControllerTest extends TestCase
 {
@@ -323,5 +328,173 @@ class LoginControllerTest extends TestCase
         $this->Login->handleFlashMessages(['redirect' => 'dummy']);
         $message = $this->Login->getRequest()->getSession()->read('Flash');
         static::assertEquals('something', $message);
+    }
+
+    /**
+     * Test `otp`
+     *
+     * @return void
+     */
+    public function testOtpNotEnabled(): void
+    {
+        Configure::delete('Otp');
+        // otp not enabled, should redirect to login page
+        $this->setupController([
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+        ]);
+        $response = $this->Login->otp();
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('/login', $response->getHeaderLine('Location'));
+    }
+
+    /**
+     * Test `otp` on "users_skip_otp" config set and matching.
+     *
+     * @return void
+     */
+    public function testOtpUsersSkip(): void
+    {
+        // otp enabled but user in users_skip_otp, should redirect to dashboard
+        Configure::write('Otp', [
+            'send' => '/otp',
+            'users_skip_otp' => [env('BEDITA_ADMIN_USR')],
+        ]);
+        $this->setupController([
+            'post' => [
+                'username' => env('BEDITA_ADMIN_USR'),
+                'password' => env('BEDITA_ADMIN_PWD'),
+            ],
+        ]);
+        $response = $this->Login->login();
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('/', $response->getHeaderLine('Location'));
+    }
+
+    /**
+     * Test `otp`, enabled scenario: should show otp page, failing POST request
+     *
+     * @return void
+     */
+    public function testOtpEnabled(): void
+    {
+        Configure::write('Otp', [
+            'send' => '/otp/send',
+        ]);
+        $this->setupController([
+            'environment' => [
+                'REQUEST_METHOD' => 'GET',
+            ],
+        ]);
+        $response = $this->Login->otp();
+        static::assertNull($response);
+        $expected = 'Failed to send OTP code. Please try again later.';
+        static::assertEquals($expected, $this->Login->getRequest()->getSession()->read('Flash.flash.0.message'));
+    }
+
+    /**
+     * Test `otpVerify` not enabled scenario, should redirect to login page
+     *
+     * @return void
+     */
+    public function testOtpVerifyNotEnabled(): void
+    {
+        Configure::delete('Otp');
+        $this->setupController([
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+        ]);
+        $response = $this->Login->otpVerify();
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('/login', $response->getHeaderLine('Location'));
+    }
+
+    /**
+     * Test `otpVerify` enabled scenario but non matching code.
+     * Flash error "OTP code is expired or invalid" and redirect to otp.
+     *
+     * @return void
+     */
+    public function testOtpVerifyNonMatching(): void
+    {
+        Configure::write('Otp', [
+            'send' => '/otp/send',
+        ]);
+        $this->setupController([
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [
+                'otp_code' => 'wrongcode',
+            ],
+        ]);
+        $this->Login->getRequest()->getSession()->write('Otp', [
+            'otp_code' => '123456',
+            'expires_at' => date('Y-m-d H:i:s', strtotime('+1 hour')),
+        ]);
+        $response = $this->Login->otpVerify();
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('/otp', $response->getHeaderLine('Location'));
+        $expected = 'OTP code is expired or invalid';
+        static::assertEquals($expected, $this->Login->getRequest()->getSession()->read('Flash.flash.0.message'));
+    }
+
+    /**
+     * Test `otpVerify` enabled scenario but expired code.
+     * Flash error "OTP code is expired or invalid" and redirect to otp.
+     *
+     * @return void
+     */
+    public function testOtpVerifyExpired(): void
+    {
+        Configure::write('Otp', [
+            'send' => '/otp/send',
+        ]);
+        $this->setupController([
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [
+                'otp_code' => '123456',
+            ],
+        ]);
+        $this->Login->getRequest()->getSession()->write('Otp', [
+            'otp_code' => '123456',
+            'expires_at' => date('Y-m-d H:i:s', strtotime('-1 hour')),
+        ]);
+        $response = $this->Login->otpVerify();
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('/otp', $response->getHeaderLine('Location'));
+        $expected = 'OTP code is expired or invalid';
+        static::assertEquals($expected, $this->Login->getRequest()->getSession()->read('Flash.flash.0.message'));
+    }
+
+    /**
+     * Test `otpVerify` enabled scenario and matching non-expired code.
+     *
+     * @return void
+     */
+    public function testOtpVerifyMatching(): void
+    {
+        Configure::write('Otp', [
+            'send' => '/otp/send',
+        ]);
+        $this->setupController([
+            'environment' => [
+                'REQUEST_METHOD' => 'POST',
+            ],
+            'post' => [
+                'otp_code' => '123456',
+            ],
+        ]);
+        $this->Login->getRequest()->getSession()->write('Otp', [
+            'otp_code' => '123456',
+            'expires_at' => date('Y-m-d H:i:s', strtotime('+1 hour')),
+        ]);
+        $response = $this->Login->otpVerify();
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('/', $response->getHeaderLine('Location'));
     }
 }

--- a/tests/TestCase/Middleware/OtpMiddlewareTest.php
+++ b/tests/TestCase/Middleware/OtpMiddlewareTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Middleware;
+
+use App\Middleware\OtpMiddleware;
+use Cake\Core\Configure;
+use Cake\Http\Response;
+use Cake\Http\ServerRequestFactory;
+use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * {@see \App\Middleware\OtpMiddleware} Test Case
+ */
+#[CoversClass(OtpMiddleware::class)]
+#[CoversMethod(OtpMiddleware::class, 'process')]
+class OtpMiddlewareTest extends TestCase
+{
+    /**
+     * Test process method.
+     *
+     * @return void
+     * @covers ::process()
+     */
+    public function testProcess(): void
+    {
+        // empty conf
+        $middleware = new OtpMiddleware();
+        $handler = new class () implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return (new Response())->withLocation('/');
+            }
+        };
+        $response = $middleware->process(ServerRequestFactory::fromGlobals(), $handler);
+        static::assertEquals('/', $response->getHeaderLine('Location'));
+
+        Configure::class::write('Otp', ['send' => '/otp']);
+
+        // path OTP
+        $request = ServerRequestFactory::fromGlobals();
+        $request = $request->withUri($request->getUri()->withPath('/otp'));
+        $response = $middleware->process($request, $handler);
+        static::assertEquals('/', $response->getHeaderLine('Location'));
+
+        // path non OTP
+        $request = ServerRequestFactory::fromGlobals();
+        $request = $request->withUri($request->getUri()->withPath('/test'));
+        $response = $middleware->process($request, $handler);
+        static::assertEquals('/', $response->getHeaderLine('Location'));
+
+        // path no OTP but no pending OTP
+        $request = ServerRequestFactory::fromGlobals();
+        $request = $request->withUri($request->getUri()->withPath('/test'));
+        $response = $middleware->process($request, $handler);
+        static::assertEquals('/', $response->getHeaderLine('Location'));
+
+        // path no OTP and pending OTP
+        $request = ServerRequestFactory::fromGlobals();
+        $request = $request->withUri($request->getUri()->withPath('/test'));
+        $request->getSession()->write('Otp.pending', true);
+        $response = $middleware->process($request, $handler);
+        static::assertEquals('/otp', $response->getHeaderLine('Location'));
+    }
+}

--- a/tests/TestCase/Middleware/OtpMiddlewareTest.php
+++ b/tests/TestCase/Middleware/OtpMiddlewareTest.php
@@ -25,7 +25,6 @@ class OtpMiddlewareTest extends TestCase
      * Test process method.
      *
      * @return void
-     * @covers ::process()
      */
     public function testProcess(): void
     {


### PR DESCRIPTION
This introduces OTP in BEM.

Configuration example:
```
'Otp' => [
     'send' => '/otp',
     'users_skip_otp' => [], // array of usernames to skip OTP authentication
],
```

The API endpoint `Otp.send` should send an email with the generated code and return a response containing the otp code and the expiration date:
```
'data' => [
    'otp_code' => '1234',
    'expires_at' => '2026-03-24 10:05:00',
]
```