### PR TITLE
[6.x] schema component fetch path on same origin

### DIFF
--- a/resources/js/app/pages/model/schema.vue
+++ b/resources/js/app/pages/model/schema.vue
@@ -882,7 +882,10 @@ export default {
                 },
             };
 
-            fetch(`${BEDITA.base}/model/export`, options)
+            const basePath = `${new URL(BEDITA.base, window.location.origin).pathname}`.replace(/\/$/, '');
+            const requestUrl = `${basePath}/model/export`;
+
+            fetch(requestUrl, options)
                 .then((res) => {
                     if (!res.ok) {
                         throw new Error(`HTTP ${res.status}`);


### PR DESCRIPTION
This fixes a bug by avoiding using `BEDITA.base` and getting instead same origin.

Using `BEDITA.base` there could be an `http` request instead of `https`.