### PR TITLE
[6.x] view children params

### DIFF
--- a/resources/js/app/app.js
+++ b/resources/js/app/app.js
@@ -69,6 +69,7 @@ const _vueInstance = new Vue({
         RelationsAdd: () => import(/* webpackChunkName: "relations-add" */'app/components/relation-view/relations-add'),
         EditChildrenParams: () => import(/* webpackChunkName: "edit-children-params" */'app/components/edit-children-params'),
         EditRelationParams: () => import(/* webpackChunkName: "edit-relation-params" */'app/components/edit-relation-params'),
+        ViewChildrenParams: () => import(/* webpackChunkName: "view-children-params" */'app/components/view-children-params'),
         HistoryInfo: () => import(/* webpackChunkName: "history-info" */'app/components/history/history-info'),
         FilterBoxView: () => import(/* webpackChunkName: "filter-box-view" */'app/components/filter-box'),
         MainMenu: () => import(/* webpackChunkName: "menu" */'app/components/menu'),
@@ -655,5 +656,6 @@ Vue.component('ObjectInfo', _vueInstance.$options.components.ObjectInfo);
 Vue.component('RelatedObjectsFilter', _vueInstance.$options.components.RelatedObjectsFilter);
 Vue.component('Thumbnail', _vueInstance.$options.components.Thumbnail);
 Vue.component('RibbonItem', _vueInstance.$options.components.RibbonItem);
+Vue.component('ViewChildrenParams', _vueInstance.$options.components.ViewChildrenParams);
 Vue.component('UploadedObject', _vueInstance.$options.components.UploadedObject);
 Vue.component('ObjectAnnotations', _vueInstance.$options.components.ObjectAnnotations);

--- a/resources/js/app/components/view-children-params.vue
+++ b/resources/js/app/components/view-children-params.vue
@@ -1,0 +1,68 @@
+<template>
+    <div class="view-children-params params p-05 has-text-size-smaller">
+        <dl class="mb-05">
+            <div
+                class="term-container"
+                v-for="item in items"
+                :key="item"
+            >
+                <dt>
+                    {{ $helpers.humanize(item) }}
+                </dt>
+                <dd>
+                    <span>
+                        {{ format(item, getVal(related, item)) }}
+                    </span>
+                </dd>
+            </div>
+        </dl>
+    </div>
+</template>
+<script>
+import flatpickr from 'flatpickr';
+
+export default {
+    name: 'ViewChildrenParams',
+
+    props: {
+        relationSchema: {
+            type: Object,
+            default: () => {},
+        },
+        related: {
+            type: Object,
+            default: () => {},
+        },
+    },
+
+    data() {
+        return {
+            items: [],
+        }
+    },
+
+    mounted() {
+        this.$nextTick(() => {
+            const schemaKeys = Object.keys(this.relationSchema || {});
+            const paramKeys = Object.keys(this.related?.meta?.relation?.params || {});
+            this.items = [...new Set([...schemaKeys, ...paramKeys])];
+        });
+    },
+
+    methods: {
+        format(key, value) {
+            if (value === null || value === undefined || value === '') {
+                return '-';
+            }
+            if (this.relationSchema && this.relationSchema[key]?.format === 'date-time') {
+                return flatpickr.formatDate(new Date(value), 'Y-m-d h:i K');
+            }
+
+            return value;
+        },
+        getVal(item, key) {
+            return item?.meta?.relation?.params?.[key] ?? null;
+        },
+    },
+}
+</script>

--- a/templates/Element/Form/related_item.twig
+++ b/templates/Element/Form/related_item.twig
@@ -142,6 +142,13 @@
         {% endif %}
     </div>
     {% endif %}
+    {% if children and config('ChildrenParams') %}
+    <view-children-params
+        :related="related"
+        :relation-schema="{{ config('ChildrenParams')|json_encode }}"
+    >
+    </view-children-params>
+    {% endif %}
     {% if not readonly and children and config('ChildrenParams') %}
     <div class="params p-05 has-text-size-smaller">
         <button


### PR DESCRIPTION
With this, "children" parameters (configuration "ChildrenParams"), are visible.

In the following example, "content_group"
```
'ChildrenParams' => [
    'content_group' => [
        'description' => 'The content group of resource',
        'type' => 'string',
    ],
],
```

<img width="1022" height="697" alt="image" src="https://github.com/user-attachments/assets/9bd83554-6f96-42ab-b2e7-475fc889088a" />
