### PR TITLE
[6.x] use home cache key by api signature

### DIFF
--- a/src/Controller/Component/ModulesComponent.php
+++ b/src/Controller/Component/ModulesComponent.php
@@ -13,6 +13,7 @@
 namespace App\Controller\Component;
 
 use App\Core\Exception\UploadException;
+use App\Utility\CacheTools;
 use App\Utility\DateRangesTools;
 use App\Utility\OEmbed;
 use App\Utility\RelationsTools;
@@ -118,7 +119,7 @@ class ModulesComponent extends Component
         }
 
         if ($this->getConfig('clearHomeCache')) {
-            Cache::delete(sprintf('home_%d', $user->get('id')));
+            Cache::delete(CacheTools::homeCacheKey((int)$user->get('id')));
         }
 
         $project = $this->getProject();

--- a/src/Utility/CacheTools.php
+++ b/src/Utility/CacheTools.php
@@ -23,6 +23,22 @@ use Cake\Utility\Hash;
 class CacheTools
 {
     /**
+     * Create a cache key for `/home` metadata.
+     *
+     * The API signature prevents collisions when the same user id is used
+     * across different API project endpoints.
+     *
+     * @param int $userId User id.
+     * @return string
+     */
+    public static function homeCacheKey(int $userId): string
+    {
+        $apiSignature = md5(ApiClientProvider::getApiClient()->getApiBaseUrl());
+
+        return sprintf('home_%d_%s', $userId, $apiSignature);
+    }
+
+    /**
      * Create multi project cache key.
      *
      * @param string $name Cache item name.

--- a/src/Utility/SchemaTrait.php
+++ b/src/Utility/SchemaTrait.php
@@ -36,7 +36,7 @@ trait SchemaTrait
     {
         try {
             $home = Cache::remember(
-                sprintf('home_%d', $user->get('id')),
+                CacheTools::homeCacheKey((int)$user->get('id')),
                 function () {
                     $client = ApiClientProvider::getApiClient();
 

--- a/tests/TestCase/Controller/Component/ModulesComponentTest.php
+++ b/tests/TestCase/Controller/Component/ModulesComponentTest.php
@@ -18,6 +18,7 @@ use App\Controller\AppController;
 use App\Controller\Component\ModulesComponent;
 use App\Core\Exception\UploadException;
 use App\Test\TestCase\Controller\AppControllerTest;
+use App\Utility\CacheTools;
 use Authentication\AuthenticationServiceInterface;
 use Authentication\Controller\Component\AuthenticationComponent;
 use Authentication\Identity;
@@ -279,7 +280,7 @@ class ModulesComponentTest extends TestCase
         }
         ApiClientProvider::setApiClient($apiClient);
         Configure::write('Project', $config);
-        Cache::delete('home_0'); // otherwise mock is applied only on first round of test from data provider
+        Cache::delete(CacheTools::homeCacheKey(0)); // otherwise mock is applied only on first round of test from data provider
         $actual = $this->Modules->getProject();
 
         static::assertEquals($expected, $actual);

--- a/tests/TestCase/Utility/CacheToolsTest.php
+++ b/tests/TestCase/Utility/CacheToolsTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\Attributes\CoversMethod;
 #[CoversMethod(CacheTools::class, 'cacheKey')]
 #[CoversMethod(CacheTools::class, 'existsCount')]
 #[CoversMethod(CacheTools::class, 'getModuleCount')]
+#[CoversMethod(CacheTools::class, 'homeCacheKey')]
 #[CoversMethod(CacheTools::class, 'setModuleCount')]
 class CacheToolsTest extends TestCase
 {
@@ -80,6 +81,20 @@ class CacheToolsTest extends TestCase
         CacheTools::setModuleCount($response, $moduleName);
         $expected = 42;
         $actual = CacheTools::getModuleCount($moduleName);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `homeCacheKey`.
+     *
+     * @return void
+     */
+    public function testHomeCacheKey(): void
+    {
+        $userId = 123;
+        $apiSignature = md5(ApiClientProvider::getApiClient()->getApiBaseUrl());
+        $expected = sprintf('home_%d_%s', $userId, $apiSignature);
+        $actual = CacheTools::homeCacheKey($userId);
         static::assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
This fixes a bug that is reproduceable when using BEM with multi api projects.

On login BEM store a "home" cache per user; this updates the logic to include api signature in the key, to avoid unexpected behavior when same user ID logs in in a different project api.