### PR TITLE
[6.x] Force properties to be translatable

### DIFF
--- a/resources/js/app/components/module/module-properties.vue
+++ b/resources/js/app/components/module/module-properties.vue
@@ -91,6 +91,7 @@ export default {
                 'index',
                 'options',
                 'relations',
+                'translatable',
                 'view',
             ],
             jsonEditorOptions: {
@@ -108,6 +109,7 @@ export default {
                 index: '',
                 options: '',
                 relations: '',
+                translatable: '',
                 view: '',
             },
             samples: {
@@ -117,6 +119,7 @@ export default {
                 index: 'look at <a href="https://github.com/bedita/manager/wiki/Setup:-Properties-display#index" target="_new">wikidoc</a>',
                 options: 'look at <a href="https://github.com/bedita/manager/wiki/Setup:-Properties-display#options" target="_new">wikidoc</a>',
                 relations: 'look at <a href="https://github.com/bedita/manager/wiki/Setup:-Properties-display#relations" target="_new">wikidoc</a>',
+                translatable: 'look at <a href="https://github.com/bedita/manager/wiki/Setup:-Properties-display#translatable" target="_new">wikidoc</a>',
                 view: 'look at <a href="https://github.com/bedita/manager/wiki/Setup:-Properties-display#view" target="_new">wikidoc</a>',
             },
             msgProperties: t`Properties`,

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -265,6 +265,7 @@ class SchemaHelper extends Helper
      */
     public function translatableFields(array $schema): array
     {
+        $translatableForced = (array)Configure::read(sprintf('Properties.%s.translatable', $this->_View->get('objectType')));
         if (isset($schema['translatable'])) {
             $priorityFields = array_intersect(static::DEFAULT_TRANSLATABLE, (array)$schema['translatable']);
             $otherFields = array_diff((array)$schema['translatable'], $priorityFields);
@@ -277,7 +278,7 @@ class SchemaHelper extends Helper
             ));
         }
 
-        return array_unique(array_values(array_merge($priorityFields, $otherFields)));
+        return array_unique(array_values(array_merge($priorityFields, $otherFields, $translatableForced)));
     }
 
     /**


### PR DESCRIPTION
If a property is not "translatable" from API schema, you can force it to be translatable using the configuration as shown at https://github.com/bedita/manager/wiki/Setup:-Properties-display#translatable
