### PR TITLE
Fields `start_date` and `end_date` can be "date" (or "date-time")

### DIFF
--- a/src/Form/Options.php
+++ b/src/Form/Options.php
@@ -43,11 +43,15 @@ class Options
      *
      * @param string $name The field name.
      * @param mixed|null $value The field value.
+     * @param array|null $schema Property schema.
      * @return array
      */
-    public static function customControl(string $name, mixed $value): array
+    public static function customControl(string $name, mixed $value, ?array $schema = null): array
     {
         if (!in_array($name, Options::CUSTOM_CONTROLS)) {
+            return [];
+        }
+        if (in_array($name, ['start_date', 'end_date'], true) && !self::useDateTimeControl($schema)) {
             return [];
         }
         $method = Form::getMethod(Options::class, $name);
@@ -55,6 +59,21 @@ class Options
         ksort($options);
 
         return $options;
+    }
+
+    /**
+     * Use datetime custom control for date fields only when schema type is date-time.
+     *
+     * @param array|null $schema Property schema.
+     * @return bool
+     */
+    protected static function useDateTimeControl(?array $schema): bool
+    {
+        if ($schema === null || $schema === []) {
+            return true;
+        }
+
+        return ControlType::fromSchema($schema) === 'date-time';
     }
 
     /**

--- a/src/View/Helper/SchemaHelper.php
+++ b/src/View/Helper/SchemaHelper.php
@@ -61,7 +61,7 @@ class SchemaHelper extends Helper
      */
     public function controlOptions(string $name, mixed $value, ?array $schema = null): array
     {
-        $options = Options::customControl($name, $value);
+        $options = Options::customControl($name, $value, $schema);
         $objectType = (string)$this->_View->get('objectType');
         $ctrlOptionsPath = sprintf('Properties.%s.options.%s', $objectType, $name);
         $ctrlOptions = (array)Configure::read($ctrlOptionsPath);

--- a/tests/TestCase/Form/OptionsTest.php
+++ b/tests/TestCase/Form/OptionsTest.php
@@ -171,6 +171,16 @@ class OptionsTest extends TestCase
                     ],
                 ],
             ],
+            'start_date date schema' => [
+                'start_date',
+                '2020-10-14',
+                [],
+                [],
+                [
+                    'type' => 'string',
+                    'format' => 'date',
+                ],
+            ],
             'end_date' => [
                 'end_date',
                 '2020-10-15',
@@ -243,15 +253,16 @@ class OptionsTest extends TestCase
      * @param mixed|null $value The field value.
      * @param array $expected Expected result.
      * @param array $config Configuration.
+     * @param array|null $schema Property schema.
      * @return void
      */
     #[DataProvider('customControlProvider')]
-    public function testCustomControl(string $name, $value, array $expected, array $config = []): void
+    public function testCustomControl(string $name, $value, array $expected, array $config = [], ?array $schema = null): void
     {
         if (!empty($config)) {
             Configure::write($config);
         }
-        $actual = Options::customControl($name, $value);
+        $actual = Options::customControl($name, $value, $schema);
         ksort($expected);
         static::assertSame($expected, $actual);
     }


### PR DESCRIPTION
This fixes a bug: when in schema from API there are "start_date" and "end_date" whose type is "date" (and not "date-time"), this makes it work properly.