### PR TITLE
[5.x] Handle relation param json property

### DIFF
--- a/resources/js/app/components/edit-relation-param.vue
+++ b/resources/js/app/components/edit-relation-param.vue
@@ -17,6 +17,7 @@
 
         <!-- String (date, enum, string, text) --->
         <div
+            :id="`container-${propertyKey}`"
             :class="{ datepicker: ['date', 'date-time'].includes(propertyFormat) }"
             v-if="propertyType == 'string'"
         >
@@ -41,6 +42,14 @@
                     {{ item }}
                 </option>
             </select>
+            <json-editor
+                :name="propertyKey"
+                :options="jsonEditorOptions"
+                :target="`container-${propertyKey}`"
+                :text="value"
+                @change="updateJsonEditor"
+                v-else-if="propertyFormat === 'json'"
+            />
             <input
                 type="text"
                 :value="value"
@@ -52,7 +61,7 @@
             <textarea
                 :value="value"
                 @change="update($event.target.value)"
-            ></textarea>
+            />
         </div>
 
         <!-- Number --->
@@ -80,6 +89,11 @@
 <script>
 export default {
     name: 'PropertyField',
+
+    components: {
+        JsonEditor: () => import(/* webpackChunkName: "json-editor" */'app/components/json-editor/json-editor'),
+    },
+
     props: {
         property: {
             type: Object,
@@ -93,6 +107,18 @@ export default {
             type: [String, Number, Boolean],
             default: null,
         },
+    },
+
+    data() {
+        return {
+            jsonEditorOptions: {
+                mainMenuBar: true,
+                mode: 'text',
+                navigationBar: false,
+                statusBar: false,
+                readOnly: false,
+            }
+        };
     },
 
     computed: {
@@ -131,7 +157,12 @@ export default {
     methods: {
         update(value) {
             this.$emit('input', value);
-        }
+        },
+        updateJsonEditor(field, val, prevVal, validation) {
+            if (validation?.validationErrors?.length === 0) {
+                this.$emit('input', val?.text);
+            }
+        },
     },
 }
 </script>

--- a/resources/js/app/components/relation-view/relation-view.vue
+++ b/resources/js/app/components/relation-view/relation-view.vue
@@ -875,6 +875,15 @@ export default {
                 return flatpickr.formatDate(new Date(value), 'Y-m-d h:i K');
             }
 
+            if (schema !== undefined && schema[key].format === 'json') {
+                try {
+                    return JSON.stringify(JSON.parse(value), null, 2);
+                } catch (e) {
+                    console.error(`Error parsing JSON for key "${key}": ${e}`);
+                    return value;
+                }
+            }
+
             // oneOf
             if(schema && schema[key].oneOf) {
                 const firstNotNull = schema[key].oneOf.find(p => p.type !== 'null');
@@ -884,6 +893,10 @@ export default {
             }
 
             return value;
+        },
+
+        openModal(content) {
+            BEDITA.info(content);
         },
 
         /**

--- a/templates/Element/Form/related_item.twig
+++ b/templates/Element/Form/related_item.twig
@@ -119,7 +119,16 @@
                 <div class="term-container">
                     <dt class="is-capitalized"><: key|humanize :></dt>
                     <dd>
-                        <span v-if="getParamHelper(related, key)"><: formatParam(key, getParamHelper(related, key)) :></span>
+                        <span v-if="getParamHelper(related, key)">
+                            <template v-if="param.format === 'json'">
+                                <button @click.prevent.stop="openModal(formatParam(key, getParamHelper(related, key)))" class="button is-small icon-code has-text-weight-bold">
+                                    {{ __('Json') }}
+                                </button>
+                            </template>
+                            <template v-else>
+                                <: formatParam(key, getParamHelper(related, key)) :>
+                            </template>
+                        </span>
                         <span v-else>-</span>
                     </dd>
                 </div>


### PR DESCRIPTION
This provides a way to handle relation params with type string and format json.

An example of modelled relation could be:
```
{
    "name": "has_viewed",
    "label": "User has viewed video(s)",
    "inverse_name": "viewed_by",
    "inverse_label": "Video has been viewed by user(s)",
    "params": {
        "type": "object",
        "properties": {
            "metadata": {
                "type": "string",
                "format": "json"
            }
        }
    },
    "left": [
        "users"
    ],
    "right": [
        "videos"
    ]
}
```
In this example, `metadata` is the json property.

To save it from side panel, json editor.

<img width="1008" height="743" alt="image" src="https://github.com/user-attachments/assets/d2ff94ae-173c-461d-be49-54a30e9c196a" />

To view it, as it can be a long string, there will be a button to open it an "Info" modal.

<img width="337" height="191" alt="image" src="https://github.com/user-attachments/assets/d103472a-229b-4511-9479-706997a696d3" />

<img width="1066" height="400" alt="image" src="https://github.com/user-attachments/assets/c30c4ebf-856a-4bec-b121-6975994e5d22" />

