### PR TITLE
[5.x] composer.json config policy advisories block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,11 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "phpstan/extension-installer": true,
             "php-http/discovery": true
+        },
+        "policy": {
+            "advisories": {
+                "block": false
+            }
         }
     },
     "extra": {


### PR DESCRIPTION
This set composer json policy advisories to block to avoid unexpected errors in composer install.