### PR TITLE
[6.x] fix: Remove conflict in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,8 +98,5 @@
             "merge-extra-deep": false,
             "merge-scripts": false
         }
-    },
-    "conflict": {
-        "slevomat/coding-standard": ">8.18.0"
     }
 }


### PR DESCRIPTION
This removes a "conflict" condition in composer.json, to allow using recent version of slevomat coding standard.