### PR TITLE
fix: Related item param selection

### DIFF
--- a/templates/Element/Form/related_item.twig
+++ b/templates/Element/Form/related_item.twig
@@ -126,7 +126,7 @@
                                 </button>
                             </template>
                             <template v-else>
-                                <: formatparam(key, getparamhelper(related, key)) :>
+                                <: formatParam(key, getParamHelper(related, key)) :>
                             </template>
                         </span>
                         <span v-else>-</span>


### PR DESCRIPTION
This fixes a typo in `related_item.twig`, source of a javascript error that didn't allow to change a relation parameter.