### PR TITLE
Update browser-sync-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@iconify/vue2": "^2.1.0",
     "babel-loader": "^8.0.6",
     "browser-sync": "^3.0.4",
-    "browser-sync-webpack-plugin": "^2.3.0",
+    "browser-sync-webpack-plugin": "^2.4.0",
     "css-loader": "^6.4.0",
     "css-minimizer-webpack-plugin": "^8.0.0",
     "eslint-plugin-vue": "^9.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2820,7 +2820,7 @@ browser-sync-ui@^3.0.4:
     socket.io-client "^4.4.1"
     stream-throttle "^0.1.3"
 
-browser-sync-webpack-plugin@^2.3.0:
+browser-sync-webpack-plugin@^2.4.0:
   version "2.4.0"
   resolved "https://registry.npmjs.org/browser-sync-webpack-plugin/-/browser-sync-webpack-plugin-2.4.0.tgz#f726fc424f2beeba1ef1e1b25e000e9ee6956941"
   integrity sha512-YtMW31SKo4t/32qC0GOA4ZS26W5r7W33VDS494Tn3bERX/3YbbUpBaLrUuumZpfx78fVSnODBhIDS4iN+QCqmg==


### PR DESCRIPTION
This updates dev dependency browser-sync-webpack-plugin to version 2.4