### PR TITLE
fix: Otp middleware before auth middleware

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -148,11 +148,11 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
             // Csrf Middleware
             ->add($this->csrfMiddleware())
 
-            // Authentication middleware.
-            ->add(new AuthenticationMiddleware($this))
-
             // Otp middleware.
             ->add(new OtpMiddleware())
+
+            // Authentication middleware.
+            ->add(new AuthenticationMiddleware($this))
 
             // Authentication middleware.
             ->add(new OAuth2Middleware())

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -76,9 +76,9 @@ class ApplicationTest extends TestCase
         $middleware->next();
         static::assertInstanceOf(CsrfProtectionMiddleware::class, $middleware->current());
         $middleware->next();
-        static::assertInstanceOf(AuthenticationMiddleware::class, $middleware->current());
-        $middleware->next();
         static::assertInstanceOf(OtpMiddleware::class, $middleware->current());
+        $middleware->next();
+        static::assertInstanceOf(AuthenticationMiddleware::class, $middleware->current());
         $middleware->next();
         static::assertInstanceOf(OAuth2Middleware::class, $middleware->current());
         $middleware->next();


### PR DESCRIPTION
This ensures that Otp middleware is evaluated before Authentication middleware, fixing an unexpected behavior (when otp form is visible, if user changes the url and refresh can bypass the otp check).