### PR TITLE
[5.x] Fix trash query encoding using JSON

### DIFF
--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -172,12 +172,14 @@ class TrashController extends AppController
     protected function listQuery(): array
     {
         $query = $this->getRequest()->getData('query');
-        if (empty($query)) {
+        if (!is_string($query) || $query === '') {
             return [];
         }
         $query = htmlspecialchars_decode($query);
 
-        return (array)unserialize($query);
+        $decoded = json_decode($query, true);
+
+        return is_array($decoded) ? $decoded : [];
     }
 
     /**

--- a/templates/Pages/Trash/index.twig
+++ b/templates/Pages/Trash/index.twig
@@ -4,7 +4,7 @@
 
 {% set ids = Array.extract(objects, '{*}.id') %}
 
-{% set q = _view.request.getQuery()|serialize|escape %}
+{% set q = _view.request.getQuery()|json_encode|escape %}
 
 <trash-index inline-template ids='{{ ids|json_encode }}'>
     <div class="module-index">

--- a/tests/TestCase/Controller/TrashControllerTest.php
+++ b/tests/TestCase/Controller/TrashControllerTest.php
@@ -83,9 +83,9 @@ class TrashControllerTest extends BaseControllerTest
         $id = $this->createTrashObject();
 
         // set request and trash controller
-        $serialized = serialize(['filter' => ['type' => 'documents']]);
+        $encoded = json_encode(['filter' => ['type' => 'documents']]) ?: '';
         if ($query) {
-            $query = htmlspecialchars($serialized);
+            $query = htmlspecialchars($encoded);
         } else {
             $query = [];
         }


### PR DESCRIPTION
Fix Trash page runtime error by replacing Twig query serialization with JSON encoding.

Already done for 6.x with https://github.com/bedita/manager/pull/1421