### PR TITLE
fix: Unable to coerce `num` to `mixed` for `id` in action `Trash::view()`

### DIFF
--- a/src/Controller/TrashController.php
+++ b/src/Controller/TrashController.php
@@ -95,11 +95,11 @@ class TrashController extends AppController
     /**
      * View single deleted resource.
      *
-     * @param mixed $id Resource ID.
+     * @param string|int $id Resource ID.
      * @return \Cake\Http\Response|null
      * @codeCoverageIgnore
      */
-    public function view(mixed $id): ?Response
+    public function view(string|int $id): ?Response
     {
         $this->getRequest()->allowMethod(['get']);
 


### PR DESCRIPTION
CakePHP's ControllerFactory::coerceStringToType() only handles string, float, bool, int, array — anything else (including mixed) falls to the default => null branch, and a null coercion result throws InvalidParameterException. Union types like string|int skip coercion entirely (since getType() returns a ReflectionUnionType, not ReflectionNamedType), so the raw string param is passed through fine.

Fix: updated method signature.